### PR TITLE
fix(ops): split UI/device negative controls from happy path

### DIFF
--- a/rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
@@ -12,6 +12,7 @@ usage:
   DESKTOP_EVIDENCE=/abs/desktop.trace \
   CHANNEL_EVIDENCE=/abs/channel.trace \
   TIMELINE_EVIDENCE=/abs/timeline.trace \
+  NEGATIVE_CONTROL_EVIDENCE_FILES=/abs/negative.trace[:/abs/another-negative.trace] \
   OBSERVATIONS_MANIFEST=/abs/ui-observations-manifest.json \
   OUT=/tmp/mission-spine-ui-device-proof.json \
   scripts/mission-spine-ui-device-proof-assemble.sh
@@ -108,7 +109,6 @@ if ! jq -e '
   and (.mission_workbench | type == "object")
   and (.mission_workbench.visible == true)
   and (.mission_workbench.same_mission_projection_visible == true)
-  and (.mission_workbench.provider_ack_not_done_visible == true)
   and (.mission_workbench.memory_candidate_review_only_visible == true)
   and (.mission_workbench.evidence_ref | type == "string" and length > 0)
   and (.transcript_browser | type == "object")
@@ -144,6 +144,56 @@ desktop_bytes="$(file_bytes "$desktop")"
 channel_bytes="$(file_bytes "$channel")"
 timeline_bytes="$(file_bytes "$timeline")"
 
+negative_evidence_json="$(mktemp "${TMPDIR:-/tmp}/friday-ui-negative-evidence.XXXXXX.json")"
+printf '[]\n' >"$negative_evidence_json"
+cleanup_negative_evidence_json() {
+  rm -f "$negative_evidence_json"
+}
+trap cleanup_negative_evidence_json EXIT
+
+if [[ -n "${NEGATIVE_CONTROL_EVIDENCE_FILES:-}" ]]; then
+  IFS=':' read -r -a negative_control_evidence_files <<<"${NEGATIVE_CONTROL_EVIDENCE_FILES}"
+  for negative_input in "${negative_control_evidence_files[@]}"; do
+    if [[ -z "$negative_input" ]]; then
+      continue
+    fi
+    negative_path="$(abs_path "$negative_input")"
+    require_file "$negative_path" negative_control
+    negative_mission_id="$(jq -r --arg path "$negative_path" '
+      (.negative_control_segments // [])
+      | map(select((.evidence_refs // []) | index($path)))
+      | .[0].mission_id // empty
+    ' "$observations_manifest")"
+    if [[ -z "$negative_mission_id" ]]; then
+      echo "BLOCKER: negative-control evidence is not referenced by any manifest negative_control_segments entry: $negative_path" >&2
+      exit 6
+    fi
+    negative_sha="$(file_sha256 "$negative_path")"
+    negative_bytes="$(file_bytes "$negative_path")"
+    tmp_negative_evidence_json="${negative_evidence_json}.tmp"
+    jq \
+      --arg path "$negative_path" \
+      --arg kind "${NEGATIVE_CONTROL_KIND:-trace}" \
+      --arg sha "$negative_sha" \
+      --argjson bytes "$negative_bytes" \
+      --arg capture_method "${NEGATIVE_CONTROL_CAPTURE_METHOD:-negative_control_ui_capture}" \
+      --arg captured_at "$captured_at" \
+      --arg observed_mission_id "$negative_mission_id" \
+      '. + [{
+        role: "negative_control",
+        path: $path,
+        kind: $kind,
+        sha256: $sha,
+        bytes: $bytes,
+        real_consumption: true,
+        capture_method: $capture_method,
+        captured_at_utc: $captured_at,
+        observed_mission_id: $observed_mission_id
+      }]' "$negative_evidence_json" >"$tmp_negative_evidence_json"
+    mv "$tmp_negative_evidence_json" "$negative_evidence_json"
+  done
+fi
+
 mkdir -p "$(dirname "$out")"
 
 jq -n \
@@ -173,6 +223,7 @@ jq -n \
   --arg channel_capture_method "$channel_capture_method" \
   --arg timeline_capture_method "$timeline_capture_method" \
   --slurpfile manifest "$observations_manifest" \
+  --slurpfile negative_evidence "$negative_evidence_json" \
   '($manifest[0]) as $manifest |
     {
       proof: $proof,
@@ -197,7 +248,7 @@ jq -n \
           evidence_ref: $channel
         }
       },
-      evidence_files: [
+      evidence_files: ([
         {
           role: "mobile",
           path: $mobile,
@@ -242,9 +293,10 @@ jq -n \
           captured_at_utc: $captured_at,
           observed_mission_id: $mission_id
         }
-      ],
+      ] + ($negative_evidence[0] // [])),
       event_order: $manifest.event_order,
       observations: $manifest.observations,
+      negative_control_segments: ($manifest.negative_control_segments // []),
       checks: $manifest.checks,
       stress: $manifest.stress,
       timeline: {

--- a/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
@@ -414,7 +414,10 @@ mobile="$tmpdir/mobile.trace"
 desktop="$tmpdir/desktop.trace"
 channel="$tmpdir/channel.trace"
 timeline="$tmpdir/timeline.trace"
+negative="$tmpdir/negative-control.trace"
 valid="$tmpdir/valid.json"
+segmented_valid="$tmpdir/segmented-valid.json"
+segmented_missing_main="$tmpdir/segmented-missing-main.json"
 assembled="$tmpdir/assembled.json"
 observations_manifest="$tmpdir/observations-manifest.json"
 template_manifest="$tmpdir/template-observations-manifest.json"
@@ -437,6 +440,7 @@ write_evidence "$mobile" mobile
 write_evidence "$desktop" desktop
 write_evidence "$channel" channel
 write_evidence "$timeline" timeline
+write_evidence "$negative" negative-control
 write_evidence "$secret_mobile" mobile
 
 echo "[mission-spine-ui-self-test] fixture/sample proof is rejected"
@@ -514,6 +518,93 @@ echo "[mission-spine-ui-self-test] valid real-consumption-shaped proof passes"
 write_proof "$valid" "$mobile" "$desktop" "$channel" "$timeline"
 env MISSION_SPINE_UI_DEVICE_PROOF="$valid" "$gate" >"$selftest_out"
 
+echo "[mission-spine-ui-self-test] negative-control segment proof passes without polluting happy path"
+negative_sha="$(file_sha256 "$negative")"
+negative_bytes="$(file_bytes "$negative")"
+jq \
+  --arg negative "$negative" \
+  --arg negative_sha "$negative_sha" \
+  --argjson negative_bytes "$negative_bytes" \
+  --arg negative_mission "mission_ui_gate_negative_self_test" \
+  --arg captured_at "2026-06-04T21:00:00Z" \
+  '
+    def negative_event:
+      . == "provider_ack_not_done_visible"
+      or . == "pressure_20_50_consecutive_asks_visible"
+      or . == "invalid_key_error_visible"
+      or . == "quota_error_visible"
+      or . == "network_error_visible"
+      or . == "channel_replay_blocked_visible"
+      or . == "reconnect_stale_verified"
+      or . == "stale_label_visible"
+      or . == "offline_label_visible"
+      or . == "error_label_visible"
+      or . == "no_hidden_fallback_verified";
+    . as $proof
+    | .evidence_files += [{
+        role: "negative_control",
+        path: $negative,
+        kind: "trace",
+        sha256: $negative_sha,
+        bytes: $negative_bytes,
+        real_consumption: true,
+        capture_method: "self_test_real_negative_control_trace",
+        captured_at_utc: $captured_at,
+        observed_mission_id: $negative_mission
+      }]
+    | .negative_control_segments = [{
+        segment_id: "negative-status-error-stress-self-test",
+        mission_id: $negative_mission,
+        truth_label: "real_ui_negative_control_segment_not_happy_path",
+        happy_path: false,
+        evidence_refs: [$negative],
+        event_order: ["provider_ack_not_done_visible", "invalid_key_error_visible", "quota_error_visible", "network_error_visible", "stale_offline_error_labels_verified", "no_hidden_fallback_verified"],
+        observations: ($proof.observations
+          | map(select(.event | negative_event))
+          | map(.mission_id = $negative_mission | .evidence_ref = $negative | .surface = "desktop"))
+      }]
+    | .observations = (
+        .observations
+        | map(select((.event | negative_event) | not))
+        + [{
+            surface: "timeline",
+            event: "bounded_page_2_visible",
+            mission_id: "mission_ui_gate_self_test",
+            evidence_ref: $proof.timeline.evidence_ref
+          }]
+      )
+    | .event_order = [
+        "mission_intake_submitted",
+        "mission_resolve_or_create",
+        "duplicate_preflight",
+        "mission_bound_provider_action",
+        "real_provider_execution",
+        "proof_receipt",
+        "timeline_page_1",
+        "timeline_page_2",
+        "same_mission_mobile_desktop_channel",
+        "memory_candidate_review_only"
+      ]
+    | .stress.evidence_ref = $negative
+    | .mission_workbench.provider_ack_not_done_visible = false
+  ' "$valid" >"$segmented_valid"
+env MISSION_SPINE_UI_DEVICE_PROOF="$segmented_valid" "$gate" >"$selftest_out"
+
+echo "[mission-spine-ui-self-test] happy-path events cannot be satisfied by negative-control segments"
+jq \
+  --arg negative "$negative" \
+  --arg negative_mission "mission_ui_gate_negative_self_test" \
+  '
+    .negative_control_segments[0].observations += [{
+      surface: "desktop",
+      event: "mission_intake_submitted",
+      mission_id: $negative_mission,
+      evidence_ref: $negative
+    }]
+    | .observations = (.observations | map(select(.event != "mission_intake_submitted")))
+  ' "$segmented_valid" >"$segmented_missing_main"
+expect_exit 6 env MISSION_SPINE_UI_DEVICE_PROOF="$segmented_missing_main" "$gate"
+
 echo "[mission-spine-ui-self-test] assembler output passes current gate"
 jq '{checks, stress, timeline, mission_workbench, transcript_browser, status_labels, memory_candidates, event_order, observations}' "$valid" >"$observations_manifest"
 MISSION_ID="mission_ui_gate_self_test" \
@@ -553,7 +644,7 @@ expect_exit 64 env \
   OUT="$assembled" \
   scripts/mission-spine-ui-device-proof-assemble.sh
 
-rm -f "$valid" "$assembled" "$observations_manifest" "$template_manifest" "$fixture" "$organic" "$placeholder" "$pending_marker" "$missing_evidence" "$missing_metadata" "$missing_observations" "$missing_stress" "$missing_workbench" "$hash_mismatch" "$bytes_mismatch" "$secret_evidence" "$template_assembled" "$mobile" "$desktop" "$channel" "$timeline" "$secret_mobile" "$selftest_out" "$selftest_err" "$tmpdir/assembler.out" "$tmpdir/template.out"
+rm -f "$valid" "$segmented_valid" "$segmented_missing_main" "$assembled" "$observations_manifest" "$template_manifest" "$fixture" "$organic" "$placeholder" "$pending_marker" "$missing_evidence" "$missing_metadata" "$missing_observations" "$missing_stress" "$missing_workbench" "$hash_mismatch" "$bytes_mismatch" "$secret_evidence" "$template_assembled" "$mobile" "$desktop" "$channel" "$timeline" "$negative" "$secret_mobile" "$selftest_out" "$selftest_err" "$tmpdir/assembler.out" "$tmpdir/template.out"
 rmdir "$tmpdir"
 
 echo "[mission-spine-ui-self-test] PASS"

--- a/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
@@ -142,7 +142,44 @@ jq -e '
     and ((.dry_run // false) != true);
   def has_evidence_role($role; $mission_id): (.evidence_files // []) | any(evidence_file_ok($role; $mission_id));
   def evidence_ref_matches($role; $ref; $mission_id): (.evidence_files // []) | any(evidence_file_ok($role; $mission_id) and .path == $ref);
-  def evidence_ref_known($root; $ref): ($root.evidence_files // []) | any(evidence_any_ok($root.mission_id) and .path == $ref);
+  def evidence_ref_known_for_mission($root; $mission_id; $ref):
+    ($root.evidence_files // []) | any(evidence_any_ok($mission_id) and .path == $ref);
+  def evidence_ref_known($root; $ref): evidence_ref_known_for_mission($root; $root.mission_id; $ref);
+  def segment_ref_known($root; $segment; $ref):
+    (($segment.evidence_refs // []) | index($ref) != null)
+    and evidence_ref_known_for_mission($root; $segment.mission_id; $ref);
+  def negative_segment_ok($root):
+    . as $segment
+    | ($segment.segment_id | nonempty_string)
+    and ($segment.mission_id | nonempty_string)
+    and ($segment.mission_id != $root.mission_id)
+    and ($segment.happy_path == false)
+    and ($segment.truth_label | nonempty_string and test("negative_control"; "i") and not_fake_string)
+    and (($segment.evidence_refs // []) | type == "array" and length > 0)
+    and (($segment.evidence_refs // []) | all(evidence_ref_known_for_mission($root; $segment.mission_id; .)))
+    and (($segment.observations // []) | type == "array" and length > 0)
+    and (($segment.observations // []) | all(
+      (.surface | nonempty_string)
+      and (.event | nonempty_string)
+      and (.mission_id == $segment.mission_id)
+      and (.evidence_ref | nonempty_string)
+      and segment_ref_known($root; $segment; .evidence_ref)
+    ));
+  def negative_observation_any($event; $root):
+    ($root.negative_control_segments // [])
+    | any(
+      . as $segment
+      | negative_segment_ok($root)
+        and (($segment.observations // []) | any(
+          .event == $event
+          and (.mission_id == $segment.mission_id)
+          and (.evidence_ref | nonempty_string)
+          and segment_ref_known($root; $segment; .evidence_ref)
+        ))
+    );
+  def evidence_ref_known_any($root; $ref):
+    evidence_ref_known($root; $ref)
+    or (($root.negative_control_segments // []) | any(. as $segment | negative_segment_ok($root) and segment_ref_known($root; $segment; $ref)));
   def desktop_consumption_ref($root; $ref): evidence_ref_matches("desktop"; $ref; $root.mission_id);
   def observation($surface; $event; $root):
     ($root.observations // [])
@@ -161,6 +198,8 @@ jq -e '
         and (.evidence_ref | nonempty_string)
         and evidence_ref_known($root; .evidence_ref)
       );
+  def observation_or_negative_any($event; $root):
+    observation_any($event; $root) or negative_observation_any($event; $root);
   def event_before($a; $b; $root):
     (($root.event_order // []) | index($a)) as $ia
     | (($root.event_order // []) | index($b)) as $ib
@@ -182,7 +221,7 @@ jq -e '
     and (.stress.no_secret_leak == true)
     and (.stress.no_hidden_fallback == true)
     and (.stress.evidence_ref | nonempty_string)
-    and evidence_ref_known($root; .stress.evidence_ref);
+    and evidence_ref_known_any($root; .stress.evidence_ref);
   .proof == "mission_spine_ui_device_consumption"
   and .proof_source == "real_ui_device_consumption"
   and (.captured_at_utc | nonempty_string)
@@ -229,7 +268,7 @@ jq -e '
   and (.mission_workbench | type == "object")
   and (.mission_workbench.visible == true)
   and (.mission_workbench.same_mission_projection_visible == true)
-  and (.mission_workbench.provider_ack_not_done_visible == true)
+  and (. as $root | (.mission_workbench.provider_ack_not_done_visible == true or negative_observation_any("provider_ack_not_done_visible"; $root)))
   and (.mission_workbench.memory_candidate_review_only_visible == true)
   and (.mission_workbench.evidence_ref | nonempty_string)
   and (. as $root | desktop_consumption_ref($root; $root.mission_workbench.evidence_ref))
@@ -260,7 +299,14 @@ jq -e '
   and (. as $root | event_before("timeline_page_1"; "timeline_page_2"; $root))
   and (. as $root | event_before("timeline_page_2"; "same_mission_mobile_desktop_channel"; $root))
   and (. as $root | event_before("same_mission_mobile_desktop_channel"; "memory_candidate_review_only"; $root))
-  and (. as $root | event_before("memory_candidate_review_only"; "stale_offline_error_labels_verified"; $root))
+  and (. as $root |
+    event_before("memory_candidate_review_only"; "stale_offline_error_labels_verified"; $root)
+    or (
+      negative_observation_any("stale_label_visible"; $root)
+      and negative_observation_any("offline_label_visible"; $root)
+      and negative_observation_any("error_label_visible"; $root)
+    )
+  )
   and (. as $root | observation("mobile"; "mission_intake_submitted"; $root))
   and (. as $root | observation("mobile"; "mission_intake_ready"; $root))
   and (. as $root | observation_any("mission_resolve_or_create_visible"; $root))
@@ -277,18 +323,18 @@ jq -e '
   and (. as $root | observation("timeline"; "bounded_page_1_visible"; $root))
   and (. as $root | observation("timeline"; "bounded_page_2_visible"; $root))
   and (. as $root | observation("timeline"; "memory_candidate_review_only"; $root))
-  and (. as $root | observation_any("provider_ack_not_done_visible"; $root))
-  and (. as $root | observation_any("pressure_20_50_consecutive_asks_visible"; $root))
-  and (. as $root | observation_any("invalid_key_error_visible"; $root))
-  and (. as $root | observation_any("quota_error_visible"; $root))
-  and (. as $root | observation_any("network_error_visible"; $root))
-  and (. as $root | observation_any("channel_replay_blocked_visible"; $root))
-  and (. as $root | observation_any("reconnect_stale_verified"; $root))
+  and (. as $root | observation_or_negative_any("provider_ack_not_done_visible"; $root))
+  and (. as $root | observation_or_negative_any("pressure_20_50_consecutive_asks_visible"; $root))
+  and (. as $root | observation_or_negative_any("invalid_key_error_visible"; $root))
+  and (. as $root | observation_or_negative_any("quota_error_visible"; $root))
+  and (. as $root | observation_or_negative_any("network_error_visible"; $root))
+  and (. as $root | observation_or_negative_any("channel_replay_blocked_visible"; $root))
+  and (. as $root | observation_or_negative_any("reconnect_stale_verified"; $root))
   and (. as $root | observation_any("real_provider_execution_receipt_visible"; $root))
-  and (. as $root | observation_any("stale_label_visible"; $root))
-  and (. as $root | observation_any("offline_label_visible"; $root))
-  and (. as $root | observation_any("error_label_visible"; $root))
-  and (. as $root | observation_any("no_hidden_fallback_verified"; $root))
+  and (. as $root | observation_or_negative_any("stale_label_visible"; $root))
+  and (. as $root | observation_or_negative_any("offline_label_visible"; $root))
+  and (. as $root | observation_or_negative_any("error_label_visible"; $root))
+  and (. as $root | observation_or_negative_any("no_hidden_fallback_verified"; $root))
   and has_status_label("stale")
   and has_status_label("offline")
   and has_status_label("error")

--- a/scripts/ops/friday-ui-device-observations-manifest.mjs
+++ b/scripts/ops/friday-ui-device-observations-manifest.mjs
@@ -81,6 +81,20 @@ const requiredObservations = [
   ["*", "no_hidden_fallback_verified"],
 ];
 
+const negativeControlObservationEvents = new Set([
+  "provider_ack_not_done_visible",
+  "pressure_20_50_consecutive_asks_visible",
+  "invalid_key_error_visible",
+  "quota_error_visible",
+  "network_error_visible",
+  "channel_replay_blocked_visible",
+  "reconnect_stale_verified",
+  "stale_label_visible",
+  "offline_label_visible",
+  "error_label_visible",
+  "no_hidden_fallback_verified",
+]);
+
 const transcriptSearchFacets = [
   "mission",
   "work_item",
@@ -112,6 +126,8 @@ function usage() {
     --channel=/abs/channel-capture \\
     --timeline=/abs/timeline-capture \\
     [--extra-evidence-ref=/abs/real-evidence ...] \\
+    [--negative-control-events=/abs/negative-events.jsonl] \\
+    [--negative-control-segment-id=segment-id] [--negative-control-mission-id=mission_negative_...] \\
     --events=/abs/same-run-events.jsonl \\
     --out=/abs/observations-manifest.json [--defer-channel-proof] [--require-ready]
 
@@ -151,6 +167,9 @@ const deferChannelProof = args.includes("--defer-channel-proof")
 const missionId = arg("mission-id");
 const out = arg("out");
 const eventsPath = arg("events");
+const negativeControlEventsPath = arg("negative-control-events");
+const negativeControlSegmentId = arg("negative-control-segment-id") || "negative-control-status-error-stress";
+let negativeControlMissionId = arg("negative-control-mission-id");
 const extraEvidenceRefs = argsAll("extra-evidence-ref");
 const evidenceByRole = {
   mobile: arg("mobile"),
@@ -243,11 +262,40 @@ function normalizedEvents(rawEvents, evidenceRefs) {
   });
 }
 
+function normalizedNegativeControlEvents(rawEvents, evidenceRefs, segmentMissionId) {
+  return rawEvents.map((raw, index) => {
+    const label = `negative_event_${index + 1}`;
+    const surface = stringField(raw, "surface", label);
+    const event = stringField(raw, "event", label);
+    const eventMissionId = stringField(raw, "mission_id", label);
+    const evidenceRef = stringField(raw, "evidence_ref", label);
+    if (event && !negativeControlObservationEvents.has(event)) {
+      block("negative_control_event_not_allowed", `${label}:${event}`);
+    }
+    if (eventMissionId && eventMissionId !== segmentMissionId) {
+      block("negative_control_event_mission_mismatch", `${label}:${eventMissionId}`);
+    }
+    if (eventMissionId && eventMissionId === missionId) {
+      block("negative_control_reuses_happy_path_mission", `${label}:${eventMissionId}`);
+    }
+    if (evidenceRef && !evidenceRefs.has(evidenceKey(evidenceRef))) {
+      block("negative_control_event_evidence_ref_unknown", `${label}:${evidenceRef}`);
+    }
+    return { surface, event, mission_id: eventMissionId, evidence_ref: evidenceRef };
+  });
+}
+
 function hasObservation(observations, requiredSurface, event) {
   return observations.some((observation) => {
     if (observation.event !== event) return false;
     return requiredSurface === "*" || observation.surface === requiredSurface;
   });
+}
+
+function hasObservationAny(primaryObservations, negativeObservations, requiredSurface, event) {
+  if (hasObservation(primaryObservations, requiredSurface, event)) return true;
+  if (!negativeControlObservationEvents.has(event)) return false;
+  return hasObservation(negativeObservations, requiredSurface, event);
 }
 
 function evidenceRefFor(observations, surface, event, fallback) {
@@ -267,13 +315,36 @@ const eventFile = requireFile("events", eventsPath);
 if (!out) block("missing_arg", "out");
 
 const evidenceRefs = new Set([...Object.values(evidence).filter(Boolean), ...extraEvidence].map(evidenceKey));
-const observations = normalizedEvents(parseJsonl(eventFile), evidenceRefs);
+const primaryRawEvents = parseJsonl(eventFile);
+const observations = normalizedEvents(primaryRawEvents, evidenceRefs);
+const negativeRawEvents = parseJsonl(negativeControlEventsPath ? requireFile("negative-control-events", negativeControlEventsPath) : "");
+if (negativeRawEvents.length > 0 && !negativeControlMissionId) {
+  negativeControlMissionId = [...new Set(negativeRawEvents.map((event) => typeof event.mission_id === "string" ? event.mission_id.trim() : "").filter(Boolean))][0] || "";
+}
+if (negativeRawEvents.length > 0 && (!negativeControlMissionId || negativeControlMissionId === missionId)) {
+  block("negative_control_mission_id_invalid", negativeControlMissionId || "<missing>");
+}
+const negativeControlObservations = negativeRawEvents.length > 0
+  ? normalizedNegativeControlEvents(negativeRawEvents, evidenceRefs, negativeControlMissionId)
+  : [];
+const negativeControlEvidenceRefs = [...new Set(negativeControlObservations.map((observation) => observation.evidence_ref).filter(Boolean))];
+const negativeControlSegments = negativeControlObservations.length > 0 ? [{
+  segment_id: negativeControlSegmentId,
+  mission_id: negativeControlMissionId,
+  truth_label: "real_ui_negative_control_segment_not_happy_path",
+  happy_path: false,
+  evidence_refs: negativeControlEvidenceRefs,
+  event_order: [
+    ...new Set(negativeControlObservations.map((observation) => observation.event).filter(Boolean)),
+  ],
+  observations: negativeControlObservations,
+}] : [];
 const activeRequiredObservations = deferChannelProof
   ? requiredObservations.filter(([surface, event]) => surface !== "channel" && !event.includes("channel"))
   : requiredObservations;
 
 for (const [surface, event] of activeRequiredObservations) {
-  if (!hasObservation(observations, surface, event)) {
+  if (!hasObservationAny(observations, negativeControlObservations, surface, event)) {
     block("missing_observation", `${surface}:${event}`);
   }
 }
@@ -287,12 +358,19 @@ const activeRequiredStress = deferChannelProof
 const activeRequiredOrder = deferChannelProof
   ? requiredOrder.filter((event) => !event.includes("channel"))
   : requiredOrder;
+const requiredOrderAfterNegativeControls = ["stale_label_visible", "offline_label_visible", "error_label_visible"]
+  .every((event) => hasObservation(negativeControlObservations, "*", event))
+  ? activeRequiredOrder.filter((event) => event !== "stale_offline_error_labels_verified")
+  : activeRequiredOrder;
 const checks = Object.fromEntries(activeRequiredChecks.map((check) => [check, true]));
 const stress = Object.fromEntries(activeRequiredStress.map((check) => [check, true]));
-stress.mission_bound_ask_count = observations.filter((observation) => observation.event === "pressure_20_50_consecutive_asks_visible").length;
-stress.duplicate_surface_count = observations.filter((observation) => observation.event === "duplicate_preflight_visible").length;
+const combinedObservations = [...observations, ...negativeControlObservations];
+stress.mission_bound_ask_count = combinedObservations.filter((observation) => observation.event === "pressure_20_50_consecutive_asks_visible").length;
+stress.duplicate_surface_count = combinedObservations.filter((observation) => observation.event === "duplicate_preflight_visible").length;
 stress.long_timeline_page_count = observations.filter((observation) => observation.event.startsWith("bounded_page_")).length;
-stress.evidence_ref = evidence.timeline || "";
+stress.evidence_ref = negativeControlObservations.some((observation) => observation.event === "pressure_20_50_consecutive_asks_visible")
+  ? negativeControlObservations.find((observation) => observation.event === "pressure_20_50_consecutive_asks_visible")?.evidence_ref || evidence.timeline || ""
+  : evidence.timeline || "";
 
 if (stress.mission_bound_ask_count < 20 || stress.mission_bound_ask_count > 50) {
   block("stress_ask_count_out_of_range", String(stress.mission_bound_ask_count));
@@ -316,7 +394,7 @@ const manifest = {
   mission_workbench: {
     visible: hasObservation(observations, "desktop", "mission_workbench_visible"),
     same_mission_projection_visible: hasObservation(observations, "desktop", "same_mission_projection_visible"),
-    provider_ack_not_done_visible: hasObservation(observations, "*", "provider_ack_not_done_visible"),
+    provider_ack_not_done_visible: hasObservationAny(observations, negativeControlObservations, "*", "provider_ack_not_done_visible"),
     memory_candidate_review_only_visible: hasObservation(observations, "timeline", "memory_candidate_review_only"),
     evidence_ref: evidenceRefFor(observations, "desktop", "mission_workbench_visible", evidence.desktop),
   },
@@ -333,8 +411,9 @@ const manifest = {
   memory_candidates: [
     { id: "memory_candidate_review_only", confirmed: false, grants_memory_authority: false },
   ],
-  event_order: activeRequiredOrder,
+  event_order: requiredOrderAfterNegativeControls,
   observations,
+  negative_control_segments: negativeControlSegments,
   extra_evidence_refs: extraEvidence,
   deferred_inputs: deferChannelProof ? [{
     role: "channel",

--- a/scripts/ops/friday-ui-device-proof-gap-report.mjs
+++ b/scripts/ops/friday-ui-device-proof-gap-report.mjs
@@ -69,6 +69,20 @@ const requiredChecks = [
   "no_hidden_fallback",
 ];
 
+const negativeControlObservationEvents = new Set([
+  "provider_ack_not_done_visible",
+  "pressure_20_50_consecutive_asks_visible",
+  "invalid_key_error_visible",
+  "quota_error_visible",
+  "network_error_visible",
+  "channel_replay_blocked_visible",
+  "reconnect_stale_verified",
+  "stale_label_visible",
+  "offline_label_visible",
+  "error_label_visible",
+  "no_hidden_fallback_verified",
+]);
+
 function usage() {
   console.error(`usage:
   node scripts/ops/friday-ui-device-proof-gap-report.mjs \\
@@ -275,6 +289,34 @@ function hasObservation(observations, surface, event) {
   });
 }
 
+function negativeControlObservationsFromManifest(manifest) {
+  if (!manifest || !Array.isArray(manifest.negative_control_segments)) return [];
+  return manifest.negative_control_segments.flatMap((segment) => {
+    if (segment?.happy_path !== false) return [];
+    if (typeof segment?.mission_id !== "string" || segment.mission_id === missionId) return [];
+    if (typeof segment?.truth_label !== "string" || !/negative_control/i.test(segment.truth_label)) return [];
+    const evidenceRefs = Array.isArray(segment.evidence_refs) ? segment.evidence_refs.map(evidenceKey) : [];
+    if (evidenceRefs.length < 1) return [];
+    return (Array.isArray(segment.observations) ? segment.observations : [])
+      .filter((observation) => negativeControlObservationEvents.has(String(observation.event || "")))
+      .filter((observation) => observation.mission_id === segment.mission_id)
+      .filter((observation) => evidenceRefs.includes(evidenceKey(String(observation.evidence_ref || ""))))
+      .map((observation) => ({
+        surface: String(observation.surface || ""),
+        event: String(observation.event || ""),
+        mission_id: String(observation.mission_id || ""),
+        evidence_ref: String(observation.evidence_ref || ""),
+        negative_control: true,
+      }));
+  });
+}
+
+function hasObservationAny(primaryObservations, negativeObservations, surface, event) {
+  if (hasObservation(primaryObservations, surface, event)) return true;
+  if (!negativeControlObservationEvents.has(event)) return false;
+  return hasObservation(negativeObservations, surface, event);
+}
+
 function orderEventObserved(observedEvents, event) {
   if (event === "stale_offline_error_labels_verified") {
     return ["stale_label_visible", "offline_label_visible", "error_label_visible"]
@@ -326,6 +368,7 @@ const knownEvidenceRefs = new Set(Object.values(evidence).filter(Boolean).map(ev
 const eventFile = requireFile("events", eventsPath);
 const observations = parseJsonl(eventFile).map((raw, index) => normalizeEvent(raw, index, knownEvidenceRefs));
 const manifest = parseManifest(manifestPath);
+const negativeControlObservations = negativeControlObservationsFromManifest(manifest);
 const supportingProofRows = supportingProofs();
 
 const activeRequiredObservations = deferChannelProof
@@ -336,14 +379,14 @@ const deferredObservationRequirements = deferChannelProof
   : [];
 
 const missingObservations = activeRequiredObservations
-  .filter(([surface, event]) => !hasObservation(observations, surface, event))
+  .filter(([surface, event]) => !hasObservationAny(observations, negativeControlObservations, surface, event))
   .map(([surface, event]) => ({
     surface,
     event,
     preferredCapture: preferredSurface(surface, event),
   }));
 const deferredObservations = deferredObservationRequirements
-  .filter(([surface, event]) => !hasObservation(observations, surface, event))
+  .filter(([surface, event]) => !hasObservationAny(observations, negativeControlObservations, surface, event))
   .map(([surface, event]) => ({
     surface,
     event,
@@ -351,7 +394,7 @@ const deferredObservations = deferredObservationRequirements
     deferred: true,
   }));
 
-const observedEvents = new Set(observations.map((observation) => observation.event));
+const observedEvents = new Set([...observations, ...negativeControlObservations].map((observation) => observation.event));
 const activeRequiredOrder = deferChannelProof
   ? requiredOrder.filter((event) => !isChannelOrderEvent(event))
   : requiredOrder;
@@ -359,7 +402,7 @@ const deferredOrderEvents = deferChannelProof
   ? requiredOrder.filter((event) => isChannelOrderEvent(event) && !orderEventObserved(observedEvents, event))
   : [];
 const missingOrderEvents = activeRequiredOrder.filter((event) => !orderEventObserved(observedEvents, event));
-const pressureAskCount = observations.filter((observation) => observation.event === "pressure_20_50_consecutive_asks_visible").length;
+const pressureAskCount = [...observations, ...negativeControlObservations].filter((observation) => observation.event === "pressure_20_50_consecutive_asks_visible").length;
 const duplicateSurfaceCount = observations.filter((observation) => observation.event === "duplicate_preflight_visible").length;
 const timelinePageCount = observations.filter((observation) => observation.event.startsWith("bounded_page_")).length;
 
@@ -436,6 +479,7 @@ const gapReport = {
   },
   observed: {
     eventRows: observations.length,
+    negativeControlEventRows: negativeControlObservations.length,
     surfaces: [...new Set(observations.map((observation) => observation.surface).filter(Boolean))].sort(),
     pressureAskCount,
     duplicateSurfaceCount,

--- a/scripts/qa/check-mission-spine-ui-proof-inputs.mjs
+++ b/scripts/qa/check-mission-spine-ui-proof-inputs.mjs
@@ -84,6 +84,20 @@ const requiredObservations = [
   "*:no_hidden_fallback_verified",
 ];
 
+const negativeControlObservationEvents = new Set([
+  "provider_ack_not_done_visible",
+  "pressure_20_50_consecutive_asks_visible",
+  "invalid_key_error_visible",
+  "quota_error_visible",
+  "network_error_visible",
+  "channel_replay_blocked_visible",
+  "reconnect_stale_verified",
+  "stale_label_visible",
+  "offline_label_visible",
+  "error_label_visible",
+  "no_hidden_fallback_verified",
+]);
+
 const requiredTranscriptSearchFacets = [
   "mission",
   "work_item",
@@ -282,6 +296,65 @@ function observationExists(observations, requiredSurface, eventName, missionId, 
   });
 }
 
+function validateNegativeControlSegments(manifest, missionId, knownEvidenceRefs, failures) {
+  const segments = Array.isArray(manifest.negative_control_segments) ? manifest.negative_control_segments : [];
+  for (const [index, segment] of segments.entries()) {
+    const label = `negative_control_segments[${index}]`;
+    const segmentId = typeof segment.segment_id === "string" ? segment.segment_id.trim() : "";
+    const segmentMissionId = typeof segment.mission_id === "string" ? segment.mission_id.trim() : "";
+    const truthLabel = typeof segment.truth_label === "string" ? segment.truth_label.trim() : "";
+    const evidenceRefs = Array.isArray(segment.evidence_refs) ? segment.evidence_refs : [];
+    const observations = Array.isArray(segment.observations) ? segment.observations : [];
+
+    if (!segmentId) recordFailure(failures, "negative_segment_missing_id", label);
+    if (!isMissionIdProofEligible(segmentMissionId)) recordFailure(failures, "negative_segment_mission_id_invalid", `${label}:${segmentMissionId}`);
+    if (segmentMissionId === missionId) recordFailure(failures, "negative_segment_reuses_happy_path_mission", label);
+    if (segment.happy_path !== false) recordFailure(failures, "negative_segment_happy_path_not_false", label);
+    if (!/negative_control/i.test(truthLabel)) recordFailure(failures, "negative_segment_truth_label_not_negative_control", label);
+    if (evidenceRefs.length < 1) recordFailure(failures, "negative_segment_missing_evidence_refs", label);
+    for (const ref of evidenceRefs) {
+      validateKnownEvidenceRef(
+        ref,
+        knownEvidenceRefs,
+        failures,
+        "negative_segment_evidence_ref_unknown",
+        `${label}:${String(ref || "")}`,
+      );
+    }
+    if (observations.length < 1) recordFailure(failures, "negative_segment_missing_observations", label);
+    for (const observation of observations) {
+      if (!negativeControlObservationEvents.has(String(observation.event || ""))) {
+        recordFailure(failures, "negative_segment_event_not_allowed", `${label}:${String(observation.event || "")}`);
+      }
+      if (observation.mission_id !== segmentMissionId) {
+        recordFailure(failures, "negative_segment_observation_mission_mismatch", `${label}:${String(observation.event || "")}`);
+      }
+      if (!evidenceRefs.map(evidenceKey).includes(evidenceKey(String(observation.evidence_ref || "")))) {
+        recordFailure(failures, "negative_segment_observation_evidence_not_listed", `${label}:${String(observation.event || "")}`);
+      }
+      validateKnownEvidenceRef(
+        observation.evidence_ref,
+        knownEvidenceRefs,
+        failures,
+        "negative_segment_observation_evidence_ref_unknown",
+        `${label}:${String(observation.event || "")}`,
+      );
+    }
+  }
+  return segments;
+}
+
+function negativeObservationExists(segments, requiredSurface, eventName) {
+  if (!negativeControlObservationEvents.has(eventName)) return false;
+  return segments.some((segment) => {
+    const observations = Array.isArray(segment.observations) ? segment.observations : [];
+    return observations.some((observation) => {
+      if (observation.event !== eventName) return false;
+      return requiredSurface === "*" || observation.surface === requiredSurface;
+    });
+  });
+}
+
 function isMissionIdProofEligible(value) {
   if (typeof value !== "string") return false;
   const missionId = value.trim();
@@ -332,9 +405,6 @@ function validateMissionWorkbenchManifest(manifest, evidenceByRole, extraEvidenc
   }
   if (workbench.same_mission_projection_visible !== true) {
     recordFailure(failures, "mission_workbench_same_mission_missing", "mission_workbench.same_mission_projection_visible");
-  }
-  if (workbench.provider_ack_not_done_visible !== true) {
-    recordFailure(failures, "mission_workbench_provider_ack_not_done_missing", "mission_workbench.provider_ack_not_done_visible");
   }
   if (workbench.memory_candidate_review_only_visible !== true) {
     recordFailure(failures, "mission_workbench_memory_candidate_missing", "mission_workbench.memory_candidate_review_only_visible");
@@ -431,6 +501,7 @@ function validateManifest(manifestPath, missionId, evidenceByRole, extraEvidence
 
   validateMissionWorkbenchManifest(manifest, evidenceByRole, extraEvidenceByRole, knownEvidenceRefs, failures);
   validateTranscriptBrowserManifest(manifest, evidenceByRole, extraEvidenceByRole, knownEvidenceRefs, failures);
+  const negativeControlSegments = validateNegativeControlSegments(manifest, missionId, knownEvidenceRefs, failures);
 
   if (!manifest.checks || typeof manifest.checks !== "object") {
     recordFailure(failures, "manifest_missing_checks", manifestPath);
@@ -460,13 +531,18 @@ function validateManifest(manifestPath, missionId, evidenceByRole, extraEvidence
     if (!knownEvidenceRefs.has(evidenceKey(manifest.stress.evidence_ref))) {
       recordFailure(failures, "stress_evidence_ref_unknown", String(manifest.stress.evidence_ref || ""));
     }
-    validateEvidenceRoleRef(
-      manifest.stress.evidence_ref,
-      evidenceRefsForRole("timeline", evidenceByRole, extraEvidenceByRole),
-      failures,
-      "stress_evidence_ref_not_timeline",
-      String(manifest.stress.evidence_ref || ""),
-    );
+    const stressRefInNegativeSegment = negativeControlSegments.some((segment) => (
+      Array.isArray(segment.evidence_refs) && segment.evidence_refs.map(evidenceKey).includes(evidenceKey(String(manifest.stress.evidence_ref || "")))
+    ));
+    if (!stressRefInNegativeSegment) {
+      validateEvidenceRoleRef(
+        manifest.stress.evidence_ref,
+        evidenceRefsForRole("timeline", evidenceByRole, extraEvidenceByRole),
+        failures,
+        "stress_evidence_ref_not_timeline",
+        String(manifest.stress.evidence_ref || ""),
+      );
+    }
     for (const check of requiredStressTrueChecks) {
       if (manifest.stress[check] !== true) {
         recordFailure(failures, "required_stress_check_not_true", check);
@@ -502,6 +578,10 @@ function validateManifest(manifestPath, missionId, evidenceByRole, extraEvidence
   const eventOrder = Array.isArray(manifest.event_order) ? manifest.event_order : [];
   let previousIndex = -1;
   for (const event of requiredEventOrder) {
+    if (event === "stale_offline_error_labels_verified"
+      && ["stale_label_visible", "offline_label_visible", "error_label_visible"].every((name) => negativeObservationExists(negativeControlSegments, "*", name))) {
+      continue;
+    }
     const index = eventOrder.indexOf(event);
     if (index === -1) {
       recordFailure(failures, "event_order_missing", event);
@@ -535,7 +615,8 @@ function validateManifest(manifestPath, missionId, evidenceByRole, extraEvidence
   }
   for (const requirement of requiredObservations) {
     const [surface, eventName] = requirement.split(":");
-    if (!observationExists(observations, surface, eventName, missionId, knownEvidenceRefs)) {
+    if (!observationExists(observations, surface, eventName, missionId, knownEvidenceRefs)
+      && !negativeObservationExists(negativeControlSegments, surface, eventName)) {
       recordFailure(failures, "required_observation_missing", requirement);
     }
   }


### PR DESCRIPTION
## Summary

- Add explicit `negative_control_segments` support to the Mission Spine UI/device proof gate.
- Keep mobile/desktop/channel/timeline happy-path observations bound to the primary mission, while allowing only approved error/stress/no-hidden-fallback observations to be proven by separate negative-control missions.
- Thread the same model through manifest generation, gap reporting, pre-assemble input checks, and proof assembly.

## Truth label

This is proof tooling only. It does not claim END-BAR, release readiness, adoption, channel completion, or product UI polish. It prevents the strict proof model from forcing stale/offline/error states into the normal successful product path.

## Verification

- `bash rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh`
- `node --check scripts/ops/friday-ui-device-observations-manifest.mjs`
- `node --check scripts/ops/friday-ui-device-proof-gap-report.mjs`
- `node --check scripts/qa/check-mission-spine-ui-proof-inputs.mjs`
- `git diff --check`
- End-to-end temp chain: happy-path main mission + separate negative-control mission through manifest -> preflight -> assemble -> gap report, ending with `complete_inputs_observed negativeRows=30`.

## Safety

- No product runtime behavior changes.
- No DB migrations.
- No signature/key handling changes.
- Negative-control segments cannot satisfy happy-path required observations.
- Negative-control evidence must be real evidence files with hash/byte verification and a non-main mission id.
