### PR TITLE
test(ui): support multiple negative-control segments

### DIFF
--- a/scripts/ops/friday-ui-device-observations-manifest.mjs
+++ b/scripts/ops/friday-ui-device-observations-manifest.mjs
@@ -126,7 +126,7 @@ function usage() {
     --channel=/abs/channel-capture \\
     --timeline=/abs/timeline-capture \\
     [--extra-evidence-ref=/abs/real-evidence ...] \\
-    [--negative-control-events=/abs/negative-events.jsonl] \\
+    [--negative-control-events=/abs/negative-events.jsonl ...] \\
     [--negative-control-segment-id=segment-id] [--negative-control-mission-id=mission_negative_...] \\
     --events=/abs/same-run-events.jsonl \\
     --out=/abs/observations-manifest.json [--defer-channel-proof] [--require-ready]
@@ -167,7 +167,7 @@ const deferChannelProof = args.includes("--defer-channel-proof")
 const missionId = arg("mission-id");
 const out = arg("out");
 const eventsPath = arg("events");
-const negativeControlEventsPath = arg("negative-control-events");
+const negativeControlEventPaths = argsAll("negative-control-events");
 const negativeControlSegmentId = arg("negative-control-segment-id") || "negative-control-status-error-stress";
 let negativeControlMissionId = arg("negative-control-mission-id");
 const extraEvidenceRefs = argsAll("extra-evidence-ref");
@@ -262,9 +262,9 @@ function normalizedEvents(rawEvents, evidenceRefs) {
   });
 }
 
-function normalizedNegativeControlEvents(rawEvents, evidenceRefs, segmentMissionId) {
+function normalizedNegativeControlEvents(rawEvents, evidenceRefs, segmentMissionId, segmentLabel) {
   return rawEvents.map((raw, index) => {
-    const label = `negative_event_${index + 1}`;
+    const label = `${segmentLabel}:negative_event_${index + 1}`;
     const surface = stringField(raw, "surface", label);
     const event = stringField(raw, "event", label);
     const eventMissionId = stringField(raw, "mission_id", label);
@@ -317,28 +317,51 @@ if (!out) block("missing_arg", "out");
 const evidenceRefs = new Set([...Object.values(evidence).filter(Boolean), ...extraEvidence].map(evidenceKey));
 const primaryRawEvents = parseJsonl(eventFile);
 const observations = normalizedEvents(primaryRawEvents, evidenceRefs);
-const negativeRawEvents = parseJsonl(negativeControlEventsPath ? requireFile("negative-control-events", negativeControlEventsPath) : "");
-if (negativeRawEvents.length > 0 && !negativeControlMissionId) {
-  negativeControlMissionId = [...new Set(negativeRawEvents.map((event) => typeof event.mission_id === "string" ? event.mission_id.trim() : "").filter(Boolean))][0] || "";
+const negativeEventInputs = negativeControlEventPaths
+  .map((path, index) => ({
+    path: requireFile(`negative-control-events:${index + 1}`, path),
+    index,
+  }))
+  .filter((input) => input.path);
+const negativeInputs = negativeEventInputs.map((input) => ({
+  ...input,
+  rawEvents: parseJsonl(input.path),
+}));
+const negativeMissionIds = [
+  ...new Set(negativeInputs.flatMap((input) => input.rawEvents)
+    .map((event) => typeof event.mission_id === "string" ? event.mission_id.trim() : "")
+    .filter(Boolean)),
+];
+if (negativeControlMissionId && negativeMissionIds.some((id) => id !== negativeControlMissionId)) {
+  block("negative_control_mission_id_mismatch", `${negativeControlMissionId}:${negativeMissionIds.join(",")}`);
 }
-if (negativeRawEvents.length > 0 && (!negativeControlMissionId || negativeControlMissionId === missionId)) {
-  block("negative_control_mission_id_invalid", negativeControlMissionId || "<missing>");
+if (!negativeControlMissionId && negativeMissionIds.length === 1) {
+  negativeControlMissionId = negativeMissionIds[0];
 }
-const negativeControlObservations = negativeRawEvents.length > 0
-  ? normalizedNegativeControlEvents(negativeRawEvents, evidenceRefs, negativeControlMissionId)
-  : [];
-const negativeControlEvidenceRefs = [...new Set(negativeControlObservations.map((observation) => observation.evidence_ref).filter(Boolean))];
-const negativeControlSegments = negativeControlObservations.length > 0 ? [{
-  segment_id: negativeControlSegmentId,
-  mission_id: negativeControlMissionId,
-  truth_label: "real_ui_negative_control_segment_not_happy_path",
-  happy_path: false,
-  evidence_refs: negativeControlEvidenceRefs,
-  event_order: [
-    ...new Set(negativeControlObservations.map((observation) => observation.event).filter(Boolean)),
-  ],
-  observations: negativeControlObservations,
-}] : [];
+for (const id of negativeMissionIds) {
+  if (!id || id === missionId) block("negative_control_mission_id_invalid", id || "<missing>");
+}
+
+const negativeControlSegments = [];
+for (const id of negativeMissionIds) {
+  const rawEvents = negativeInputs.flatMap((input) => input.rawEvents.filter((event) => event?.mission_id === id));
+  const segmentLabel = `negative_segment_${negativeControlSegments.length + 1}`;
+  const segmentEvents = normalizedNegativeControlEvents(rawEvents, evidenceRefs, id, segmentLabel);
+  if (segmentEvents.length === 0) continue;
+  const evidenceRefsForSegment = [...new Set(segmentEvents.map((observation) => observation.evidence_ref).filter(Boolean))];
+  negativeControlSegments.push({
+    segment_id: negativeMissionIds.length === 1 ? negativeControlSegmentId : `${negativeControlSegmentId}-${negativeControlSegments.length + 1}`,
+    mission_id: id,
+    truth_label: "real_ui_negative_control_segment_not_happy_path",
+    happy_path: false,
+    evidence_refs: evidenceRefsForSegment,
+    event_order: [
+      ...new Set(segmentEvents.map((observation) => observation.event).filter(Boolean)),
+    ],
+    observations: segmentEvents,
+  });
+}
+const negativeControlObservations = negativeControlSegments.flatMap((segment) => segment.observations);
 const activeRequiredObservations = deferChannelProof
   ? requiredObservations.filter(([surface, event]) => surface !== "channel" && !event.includes("channel"))
   : requiredObservations;

--- a/test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
@@ -228,6 +228,109 @@ describe("friday-ui-device-observations-manifest", () => {
     }
   });
 
+  it("keeps multiple negative-control missions as separate fail-closed segments", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-multi-negative-"));
+    try {
+      const refs = writeEvidence(tempDir);
+      const events = join(tempDir, "same-run-events.jsonl");
+      const out = join(tempDir, "observations-manifest.json");
+      const negativeStatus = join(tempDir, "negative-status.jsonl");
+      const negativeStress = join(tempDir, "negative-stress.jsonl");
+      const statusEvidence = join(tempDir, "desktop-status.raw.txt");
+      const stressEvidence = join(tempDir, "real-stress-source-report.json");
+      writeFileSync(statusEvidence, "real desktop status negative-control evidence\n");
+      writeFileSync(stressEvidence, "real stress negative-control evidence\n");
+      writeJsonl(events, nonChannelEvents(refs).filter((row) => {
+        const eventRow = row as { event?: string };
+        return ![
+          "provider_ack_not_done_visible",
+          "pressure_20_50_consecutive_asks_visible",
+          "invalid_key_error_visible",
+          "quota_error_visible",
+          "network_error_visible",
+          "reconnect_stale_verified",
+          "stale_label_visible",
+          "offline_label_visible",
+          "error_label_visible",
+          "no_hidden_fallback_verified",
+        ].includes(String(eventRow.event || ""));
+      }));
+      writeJsonl(negativeStatus, [
+        event("desktop", "stale_label_visible", statusEvidence, "mission_negative_status"),
+        event("desktop", "offline_label_visible", statusEvidence, "mission_negative_status"),
+        event("desktop", "error_label_visible", statusEvidence, "mission_negative_status"),
+      ]);
+      writeJsonl(negativeStress, [
+        event("desktop", "provider_ack_not_done_visible", stressEvidence, "mission_negative_stress"),
+        event("desktop", "invalid_key_error_visible", stressEvidence, "mission_negative_stress"),
+        event("desktop", "quota_error_visible", stressEvidence, "mission_negative_stress"),
+        event("desktop", "network_error_visible", stressEvidence, "mission_negative_stress"),
+        event("desktop", "reconnect_stale_verified", stressEvidence, "mission_negative_stress"),
+        event("timeline", "no_hidden_fallback_verified", stressEvidence, "mission_negative_stress"),
+        ...Array.from({ length: 20 }, () => event("desktop", "pressure_20_50_consecutive_asks_visible", stressEvidence, "mission_negative_stress")),
+      ]);
+
+      const result = spawnSync("node", [
+        "scripts/ops/friday-ui-device-observations-manifest.mjs",
+        `--mission-id=${missionId}`,
+        `--mobile=${refs.mobile}`,
+        `--desktop=${refs.desktop}`,
+        `--timeline=${refs.timeline}`,
+        `--events=${events}`,
+        `--negative-control-events=${negativeStatus}`,
+        `--negative-control-events=${negativeStress}`,
+        `--extra-evidence-ref=${statusEvidence}`,
+        `--extra-evidence-ref=${stressEvidence}`,
+        `--out=${out}`,
+        "--defer-channel-proof",
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: unknown[] };
+      expect(output.status).toBe("ready");
+      expect(output.blockers).toEqual([]);
+
+      const manifest = JSON.parse(readFileSync(out, "utf8")) as {
+        negative_control_segments?: Array<{ mission_id?: string; observations?: unknown[] }>;
+        stress?: { mission_bound_ask_count?: number };
+        event_order?: string[];
+      };
+      expect(manifest.negative_control_segments).toHaveLength(2);
+      expect(manifest.negative_control_segments?.map((segment) => segment.mission_id).sort()).toEqual([
+        "mission_negative_status",
+        "mission_negative_stress",
+      ]);
+      expect(manifest.stress?.mission_bound_ask_count).toBe(20);
+      expect(manifest.event_order).not.toContain("stale_offline_error_labels_verified");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks an explicit single negative-control mission when rows contain another mission", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-negative-mismatch-"));
+    try {
+      const refs = writeEvidence(tempDir);
+      const negative = join(tempDir, "negative.jsonl");
+      writeJsonl(negative, [
+        event("desktop", "stale_label_visible", refs.desktop, "mission_negative_one"),
+        event("desktop", "offline_label_visible", refs.desktop, "mission_negative_two"),
+      ]);
+      const { result } = runManifest(tempDir, refs, completeEvents(refs), [
+        `--negative-control-events=${negative}`,
+        "--negative-control-mission-id=mission_negative_one",
+        "--require-ready",
+      ]);
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("negative_control_mission_id_mismatch");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("blocks and does not write a manifest when required observations are missing", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-observations-missing-"));
     try {


### PR DESCRIPTION
## Summary
- allow UI/device observations manifests to consume multiple negative-control event files without collapsing them into one mission
- keep explicit single negative-control mission fail-closed when another mission appears
- add coverage for split status/stress negative-control segments

## Verification
- PATH=/Users/jarvis/Projects/Friday/node_modules/.bin:$PATH vitest run --project default test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts
- current c60 evidence dry-run: action runtime covered 72/72 unique rows; multi-negative manifest ready; gap report has no non-channel missing observations/checks/order events, channel remains deferred