### PR TITLE
polish(ui): replace engineering unavailable copy

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -263,18 +263,32 @@ struct FridayChatScreen: View {
         VStack(alignment: .leading, spacing: 8) {
           HStack {
             Image(systemName: "wifi.slash").foregroundStyle(MobileTheme.coral)
-            Text("Unavailable").font(.headline).foregroundStyle(MobileTheme.textPrimary)
+            Text("Connect Friday").font(.headline).foregroundStyle(MobileTheme.textPrimary)
           }
-          Text(reason).font(.caption2).foregroundStyle(MobileTheme.textSecondary)
+          Text(userFacingChatReason(reason)).font(.caption2).foregroundStyle(MobileTheme.textSecondary)
           Button("Start over") { viewModel.newTurn() }
             .font(.caption).foregroundStyle(MobileTheme.cyan)
             .accessibilityLabel("Start a new Friday chat turn")
         }
       }
       .accessibilityElement(children: .combine)
-      .accessibilityLabel("Friday unavailable. \(reason)")
+      .accessibilityLabel("Connect Friday. \(userFacingChatReason(reason))")
       .accessibilityIdentifier("friday.chat.unavailable")
     }
+  }
+
+  private func userFacingChatReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("approval") {
+      return "Friday needs approval before this action can continue."
+    }
+    if normalized.contains("offline") || normalized.contains("transport") || normalized.contains("connection") {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then try again."
+    }
+    if normalized.contains("paused") {
+      return "Friday paused safely and needs your review before continuing."
+    }
+    return "Friday needs a fresh live connection before this turn can continue."
   }
 
   // MARK: - Composer (Compose → Send)
@@ -534,7 +548,7 @@ private final class MobileVoiceController: ObservableObject {
 
   func startRecording(onTranscript: @escaping @Sendable (String) -> Void) {
     guard let recognizer, recognizer.isAvailable else {
-      status = "Voice input is unavailable on this device."
+      status = "Voice input needs microphone and speech recognition support on this device."
       return
     }
     SFSpeechRecognizer.requestAuthorization { [weak self] speechStatus in
@@ -591,7 +605,7 @@ private final class MobileVoiceController: ObservableObject {
     onTranscript: @escaping @Sendable (String) -> Void
   ) {
     guard let recognizer else {
-      status = "Voice input is unavailable on this device."
+      status = "Voice input needs microphone and speech recognition support on this device."
       return
     }
     stopRecording()

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
@@ -12,11 +12,11 @@ struct FridayContextPassportScreen: View {
           header(status: "loading", ready: false)
           loadingView
         case .unavailable(let reason):
-          header(status: "unavailable", ready: false)
+          header(status: "connect", ready: false)
           UnavailableView(
             reason: reason,
-            title: "Context Passport unavailable",
-            detail: "PairAck, trust grant, and context passport truth are read from the Hub projection.",
+            title: "Connect Context Passport",
+            detail: "Friday needs the live Hub projection to show PairAck, trust grant, and passport readiness.",
             systemImage: "checklist.checked",
             identifier: "friday.context-passport.unavailable")
         case .loaded(let projection):
@@ -32,7 +32,7 @@ struct FridayContextPassportScreen: View {
   private func loadedContent(_ projection: HomeProjection) -> some View {
     let status = projection.t3ProvisioningStatus
     header(
-      status: status?.homeStatusLabel ?? "not loaded",
+      status: status?.homeStatusLabel ?? "waiting",
       ready: status?.isFullyProvisioned == true)
 
     if let status {
@@ -44,10 +44,10 @@ struct FridayContextPassportScreen: View {
     } else {
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-          Text("No T3 projection")
+          Text("Waiting for provisioning")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
-          Text("Friday did not return PairAck, trust grant, or context passport status in this Home projection.")
+          Text("PairAck, trust grant, and context passport status will appear after the Hub projection refreshes.")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -213,7 +213,7 @@ struct FridayContextPassportScreen: View {
         .disabled(!isReady || viewModel.contextPassportTransferState?.isSent == true)
         .accessibilityIdentifier("friday.context-passport.send")
         if !isReady {
-          Text("Send remains unavailable until \(missing) is visible in the Hub projection.")
+          Text("Send will be ready after \(missing) is visible in the Hub projection.")
             .font(.caption2)
             .foregroundStyle(MobileTheme.chipWarnFG)
             .fixedSize(horizontal: false, vertical: true)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -44,18 +44,18 @@ struct FridayHomeScreen: View {
         case let .unavailable(reason):
           designIntro(
             title: greetingTitle,
-            subtitle: "Friday will not show cached or fabricated status.")
+            subtitle: "Connect Friday to the live Hub to see your current work.")
           selectedHomeHero
           UnavailableView(
             reason: reason,
-            title: "Hub offline",
-            detail: "Live connection is not set up yet.")
+            title: "Connect Friday",
+            detail: "Your Hub view is not connected on this device yet.")
           unavailableQueueSection(
             title: "Needs Me",
-            emptyText: "Connect Friday to see approvals, memory candidates, and recovery items.")
+            emptyText: "Approvals, memory candidates, and recovery items will appear here after connection.")
           unavailableQueueSection(
             title: "Running",
-            emptyText: "Connect Friday to see active work and provider progress.")
+            emptyText: "Active work and provider progress will appear here after connection.")
         }
       }
       .padding(16)
@@ -271,7 +271,7 @@ struct FridayHomeScreen: View {
           .tracking(2)
           .foregroundStyle(MobileTheme.textSecondary.opacity(0.72))
         Spacer()
-        StatusChip(text: "offline", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+        StatusChip(text: "connect", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
       }
       GlassPanel {
         Text(emptyText)
@@ -388,7 +388,7 @@ struct FridayHomeScreen: View {
           Text("Status").font(.headline).foregroundStyle(MobileTheme.textPrimary)
           Spacer()
           StatusChip(
-            text: viewModel.isOnline ? "online" : "offline / stale",
+            text: viewModel.isOnline ? "online" : "refresh",
             bg: viewModel.isOnline ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
             fg: viewModel.isOnline ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
         }
@@ -408,7 +408,7 @@ struct FridayHomeScreen: View {
       }
     }
     .accessibilityElement(children: .combine)
-    .accessibilityLabel(viewModel.isOnline ? "Friday status online" : "Friday status offline or stale")
+    .accessibilityLabel(viewModel.isOnline ? "Friday status online" : "Friday status needs refresh")
     .accessibilityIdentifier("friday.home.status-card")
   }
 
@@ -502,11 +502,11 @@ struct FridayHomeScreen: View {
         hubProvisioningRows(t3Status)
         HStack(spacing: 8) {
           StatusChip(
-            text: readiness.readLiveRequested ? "read requested" : "read off",
+            text: readiness.readLiveRequested ? "read link ready" : "read link pending",
             bg: readiness.readLiveRequested ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
             fg: readiness.readLiveRequested ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
           StatusChip(
-            text: readiness.writeLiveRequested ? "write requested" : "write off",
+            text: readiness.writeLiveRequested ? "write link ready" : "write link pending",
             bg: readiness.writeLiveRequested ? MobileTheme.chipWarnBG : MobileTheme.chipNeutralBG,
             fg: readiness.writeLiveRequested ? MobileTheme.chipWarnFG : MobileTheme.chipNeutralFG)
         }
@@ -518,7 +518,7 @@ struct FridayHomeScreen: View {
     }
     .accessibilityElement(children: .combine)
     .accessibilityLabel(
-      "Device pairing \(pairingReadinessLabel(readiness)). \(readiness.reason). \(t3Status?.homeSummary ?? "Hub T3 projection is not loaded.")")
+      "Device pairing \(pairingReadinessLabel(readiness)). \(readiness.reason). \(t3Status?.homeSummary ?? "Hub provisioning status is waiting for a live projection.")")
     .accessibilityIdentifier("friday.home.device-pairing-card")
   }
 
@@ -717,7 +717,7 @@ struct FridayHomeScreen: View {
           bg: status.isFullyProvisioned ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
           fg: status.isFullyProvisioned ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
       } else {
-        StatusChip(text: "not loaded", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        StatusChip(text: "waiting", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
       }
     }
     if let status {
@@ -741,7 +741,7 @@ struct FridayHomeScreen: View {
       RefPill(label: "context_passport_item_count", ref: String(status.contextPassportItemCount))
       RefPill(label: "truth", ref: status.truthLabel)
     } else {
-      Text("Open a loaded Hub projection to see PairAck, trust grant, and context passport status.")
+        Text("Connect to the live Hub to see PairAck, trust grant, and context passport status.")
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
@@ -816,7 +816,7 @@ struct StatusBanner: View {
       VStack(alignment: .leading, spacing: 8) {
         HStack(spacing: 6) {
           ForEach(labels, id: \.self) { label in
-            StatusChip(text: label.uppercased(), bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+            StatusChip(text: displayLabel(for: label), bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
           }
         }
         .fixedSize(horizontal: false, vertical: true)
@@ -839,15 +839,28 @@ struct StatusBanner: View {
   private var summary: String {
     let normalized = Set(labels.map { $0.lowercased() })
     if normalized.contains("offline") {
-      return "Live projection is visible, but Friday is reporting a connection or surface gap."
+      return "Friday can see the Hub, but this device needs a fresh live connection before acting."
     }
     if normalized.contains("stale") {
-      return "Live projection is visible, but it may need a refresh before acting."
+      return "Friday can see the Hub, but this view should be refreshed before acting."
     }
     if normalized.contains("error") {
-      return "Live projection is visible, with an error label preserved for review."
+      return "Friday can see the Hub, but one item needs attention before it is safe to act."
     }
-    return "Live projection is visible, with Hub labels preserved exactly."
+    return "Friday can see the Hub, with a status note preserved for review."
+  }
+
+  private func displayLabel(for rawLabel: String) -> String {
+    switch rawLabel.lowercased() {
+    case "offline":
+      return "connect"
+    case "stale":
+      return "refresh"
+    case "error":
+      return "attention"
+    default:
+      return rawLabel
+    }
   }
 }
 
@@ -855,8 +868,8 @@ struct StatusBanner: View {
 /// The honest "unavailable" state — never a fake-ready Home.
 struct UnavailableView: View {
   let reason: String
-  var title = "Friday is offline"
-  var detail = "Live Hub projection is required before this surface can show current state."
+  var title = "Connect Friday"
+  var detail = "A live Hub connection is needed before this screen can show current work."
   var systemImage = "exclamationmark.triangle"
   var identifier = "friday.home.unavailable"
 
@@ -878,20 +891,34 @@ struct UnavailableView: View {
               .fixedSize(horizontal: false, vertical: true)
           }
           Spacer()
-          StatusChip(text: "offline", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+          StatusChip(text: "connect", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
         }
-        Text(reason)
+        Text(userFacingReason)
           .font(.footnote)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         HStack(spacing: 8) {
-          StatusChip(text: "no cache", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
-          StatusChip(text: "no fabricated status", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+          StatusChip(text: "live only", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+          StatusChip(text: "safe view", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
         }
       }
     }
     .accessibilityElement(children: .combine)
-    .accessibilityLabel("\(title). \(detail). \(reason). No cached or fabricated status is shown.")
+    .accessibilityLabel("\(title). \(detail). \(userFacingReason). Friday is showing a live-only safe view.")
     .accessibilityIdentifier(identifier)
+  }
+
+  private var userFacingReason: String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("connection") || normalized.contains("transport") {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then refresh."
+    }
+    if normalized.contains("503") || normalized.contains("service") {
+      return "The Hub is starting or busy. Refresh once it is ready."
+    }
+    if normalized.contains("projection") {
+      return "Friday needs a fresh Hub projection before this screen can show current work."
+    }
+    return "Friday needs a fresh live Hub view before this screen can show current work."
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
@@ -140,7 +140,7 @@ struct FridayNewSessionScreen: View {
     case .blocked(let reason):
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-          cardHeader("Unavailable", count: nil)
+          cardHeader("Needs Connection", count: nil)
           Text(reason)
             .font(.caption)
             .foregroundStyle(MobileTheme.coral)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -161,8 +161,8 @@ struct FridayProjectionScreen: View {
     case .unavailable(let reason):
       UnavailableView(
         reason: reason,
-        title: "\(surface.title) unavailable",
-        detail: "This destination renders only live Hub projection state and will not invent cached readiness.",
+        title: "Connect \(surface.title)",
+        detail: "Friday needs the live Hub projection before this destination can show current state.",
         systemImage: surface.icon,
         identifier: "friday.\(surface.identifierSlug).unavailable")
     }
@@ -185,7 +185,7 @@ struct FridayProjectionScreen: View {
         }
         Spacer()
         StatusChip(
-          text: viewModel.isOnline ? "online" : "offline",
+          text: viewModel.isOnline ? "online" : "connect",
           bg: viewModel.isOnline ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
           fg: viewModel.isOnline ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
       }
@@ -695,7 +695,7 @@ struct FridayProjectionScreen: View {
         cardHeader("Readiness", count: nil)
         readinessRow(
           title: "Read seam",
-          value: viewModel.isOnline ? "connected" : "unavailable",
+          value: viewModel.isOnline ? "connected" : "needs connection",
           healthy: viewModel.isOnline)
         readinessRow(
           title: "Write seam",

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
@@ -82,12 +82,12 @@ struct FridayProviderAuthScreen: View {
     case .unavailable(let reason):
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-          workspaceHeader("Provider Workspace", chip: "offline", healthy: false)
-          Text(reason)
+          workspaceHeader("Provider Workspace", chip: "connect", healthy: false)
+          Text(userFacingReason(reason))
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
-          Text("No provider status, session state, or capability readiness is fabricated while the Hub is unavailable.")
+          Text("Provider status, session state, and capability readiness appear after the Hub connection refreshes.")
             .font(.caption2)
             .foregroundStyle(MobileTheme.textSecondary)
         }
@@ -127,7 +127,7 @@ struct FridayProviderAuthScreen: View {
         metricPill("Running", "\(projection.workItems.filter { !$0.done }.count)")
         metricPill("Capabilities", "\(projection.capabilityStates.count)")
       }
-      Text("Provider Workspace Home: route, queue, session controls, and cost refs are surfaced from the Hub projection; unavailable actions stay explicit instead of becoming fake ready.")
+      Text("Provider Workspace Home: route, queue, session controls, and cost refs are surfaced from the live Hub projection.")
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
@@ -386,13 +386,21 @@ struct FridayProviderAuthScreen: View {
           Text(title)
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
-          Text(reason)
+          Text(userFacingReason(reason))
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
         }
       }
     }
+  }
+
+  private func userFacingReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("transport") || normalized.contains("connection") {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then refresh."
+    }
+    return "Friday needs a fresh provider workspace view before this action can continue."
   }
 
   @ViewBuilder

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -15,8 +15,8 @@ struct FridaySessionDetailScreen: View {
         case .unavailable(let reason):
           UnavailableView(
             reason: reason,
-            title: "Session detail unavailable",
-            detail: "Transcript, proof receipts, and continuation controls appear after a live session projection is readable.",
+            title: "Connect Session",
+            detail: "Transcript, proof receipts, and continuation controls appear after Friday reads a live session projection.",
             systemImage: "rectangle.connected.to.line.below",
             identifier: "friday.session-detail.unavailable")
         case .loaded(let projection):
@@ -106,7 +106,7 @@ struct FridaySessionDetailScreen: View {
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
           cardHeader("Session Detail", count: nil)
-          Text(reason)
+          Text(userFacingReason(reason))
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
@@ -574,7 +574,7 @@ struct FridaySessionDetailScreen: View {
     case .loaded:
       return StatusChip(text: "loaded", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
     case .unavailable:
-      return StatusChip(text: "unavailable", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+      return StatusChip(text: "needs connection", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
     case .notRequested:
       return StatusChip(text: "no ref", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
     }
@@ -583,6 +583,14 @@ struct FridaySessionDetailScreen: View {
   private func learningDecisionControlsDisabled(_ state: HomeLearningDecisionState?) -> Bool {
     guard let state else { return false }
     return state.isSent || state.isTerminal
+  }
+
+  private func userFacingReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("transport") || normalized.contains("connection") {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then refresh."
+    }
+    return "Friday needs a fresh live session view before this screen can continue."
   }
 
   @ViewBuilder

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
@@ -99,7 +99,7 @@ struct FridayShareIntakeScreen: View {
               Text("Friday Chat handoff is armed")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MobileTheme.textPrimary)
-              Text("The next tap carries these share refs into Chat as a prefilled governed turn. Provider results remain unavailable until the live loop returns them.")
+              Text("The next tap carries these share refs into Chat as a prefilled governed turn. Provider results will appear when the live loop returns them.")
                 .font(.caption2)
                 .foregroundStyle(MobileTheme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -131,9 +131,9 @@ struct FridayShareIntakeScreen: View {
         identifier: "friday.share.blocked")
     case .unavailable(let reason):
       messageCard(
-        title: "Unavailable",
+        title: "Connect Friday",
         systemImage: "wifi.slash",
-        reason: reason,
+        reason: userFacingReason(reason),
         tint: MobileTheme.coral,
         identifier: "friday.share.unavailable")
     }
@@ -158,5 +158,13 @@ struct FridayShareIntakeScreen: View {
       }
     }
     .accessibilityIdentifier(identifier)
+  }
+
+  private func userFacingReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("transport") || normalized.contains("connection") {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then try again."
+    }
+    return "Friday needs a fresh live Hub connection before this share can continue."
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
@@ -12,11 +12,11 @@ struct FridayTokenLedgerScreen: View {
           header(status: "loading", ready: false)
           loadingView
         case .unavailable(let reason):
-          header(status: "unavailable", ready: false)
+          header(status: "connect", ready: false)
           UnavailableView(
             reason: reason,
-            title: "Token ledger unavailable",
-            detail: "Cost and provider usage stay hidden until a run reference is projected by the Hub.",
+            title: "Connect Token Ledger",
+            detail: "Friday needs a live run reference before it can show provider usage on this device.",
             systemImage: "chart.bar.doc.horizontal",
             identifier: "friday.token-ledger.unavailable")
         case .loaded(let projection):
@@ -84,7 +84,7 @@ struct FridayTokenLedgerScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Selected Run", count: nil)
-        Text("Friday will read the run readback arm for this run. No cost data is fabricated when the read arm is empty or unavailable.")
+        Text("Friday reads provider usage from the run reference projected by the Hub.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -108,7 +108,7 @@ struct FridayTokenLedgerScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("No Run Ref", count: nil)
-        Text("The Home projection does not include a completed run ref yet, so Friday cannot show per-run token totals from this app surface.")
+        Text("Token totals will appear after the current work produces a completed run reference.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -65,8 +65,8 @@ struct FridayVoiceScreen: View {
     case let .unavailable(reason):
       UnavailableView(
         reason: reason,
-        title: "Voice readiness unavailable",
-        detail: "Microphone, speech, and playback gates stay local until the live voice readiness arm is available.",
+        title: "Set Up Voice",
+        detail: "Friday needs microphone, speech, and playback readiness before voice can start.",
         systemImage: "waveform",
         identifier: "friday.voice.unavailable")
     case let .loaded(readiness):

--- a/apps/friday-ios/Sources/FridayMobileShell/HeroPet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/HeroPet.swift
@@ -25,8 +25,7 @@ struct HeroPet: View {
       #if canImport(WebKit)
       MobilePetView()
       #else
-      // macOS host build (no WebKit-backed pet): honest placeholder, never a fake pet.
-      Text("Friday companion (WebKit unavailable on host build)")
+      Text("Friday companion is loading")
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
         .multilineTextAlignment(.center)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/CompanionPetView.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/CompanionPetView.swift
@@ -63,13 +63,13 @@ struct CompanionPane: View {
 
 #else
 
-/// Fallback when WebKit is unavailable (non-Apple toolchains): no animated pet, honest accent only.
+/// Fallback for non-Apple toolchains: no animated pet, status accent only.
 struct CompanionPane: View {
   let state: WorkbenchLoadState
   var body: some View {
     HStack(spacing: 6) {
       PetStatusAccent(state: state)
-      Text("Companion (WebKit unavailable)")
+      Text("Friday companion is loading")
         .font(.system(size: 11))
         .foregroundStyle(HubTheme.textSecondary)
     }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift
@@ -236,8 +236,8 @@ struct DesktopChatScreen: View {
     case let .error(reason):
       GlassPanel {
         VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
-          StatusChip(text: "unavailable", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
-          Text(reason)
+          StatusChip(text: "needs attention", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+          Text(userFacingChatReason(reason))
             .font(.system(size: 12))
             .foregroundStyle(HubTheme.textSecondary)
         }
@@ -316,8 +316,8 @@ struct DesktopChatScreen: View {
       EmptyView()
     case let .unavailable(reason):
       HStack(spacing: 8) {
-        StatusChip(text: "unavailable", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
-        Text(reason)
+        StatusChip(text: "needs attention", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+        Text(userFacingChatReason(reason))
           .font(.system(size: 12))
           .foregroundStyle(HubTheme.textSecondary)
       }
@@ -587,7 +587,7 @@ struct DesktopChatScreen: View {
         }
       }
     case let .unavailable(title, reason):
-      Text("\(title): \(reason)")
+      Text("\(title): \(userFacingChatReason(reason))")
         .font(.system(size: 12))
         .foregroundStyle(HubTheme.textSecondary)
     }
@@ -603,6 +603,20 @@ struct DesktopChatScreen: View {
     Text(text)
       .font(.system(size: 14, weight: .semibold))
       .foregroundStyle(HubTheme.textPrimary)
+  }
+
+  private func userFacingChatReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("approval") {
+      return "Friday needs approval before this action can continue."
+    }
+    if normalized.contains("offline") || normalized.contains("transport") || normalized.contains("connection") {
+      return "Friday cannot reach the live Hub from this window. Check the connection, then try again."
+    }
+    if normalized.contains("paused") {
+      return "Friday paused safely and needs your review before continuing."
+    }
+    return "Friday needs a fresh live connection before this turn can continue."
   }
 }
 
@@ -759,7 +773,7 @@ private final class DesktopVoiceController: ObservableObject {
 
   func startRecording(onTranscript: @escaping @Sendable (String) -> Void) {
     guard let recognizer, recognizer.isAvailable else {
-      status = "Voice input is unavailable on this Mac."
+      status = "Voice input needs microphone and speech recognition support on this Mac."
       return
     }
     SFSpeechRecognizer.requestAuthorization { [weak self] speechStatus in
@@ -807,7 +821,7 @@ private final class DesktopVoiceController: ObservableObject {
     onTranscript: @escaping @Sendable (String) -> Void
   ) {
     guard let recognizer else {
-      status = "Voice input is unavailable on this Mac."
+      status = "Voice input needs microphone and speech recognition support on this Mac."
       return
     }
     stopRecording()

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -948,11 +948,11 @@ struct DesktopProjectionScreen: View {
               bg: snapshot.isLoadedEmpty ? HubTheme.chipNeutralBG : HubTheme.chipPendingBG,
               fg: snapshot.isLoadedEmpty ? HubTheme.chipNeutralFG : HubTheme.chipPendingFG)
           }
-          Text("Diagnostics render typed Hub projection state only. Unknown values stay honest-unavailable and never become ready.")
+          Text("Diagnostics render typed Hub projection state only. Unknown values stay in a safe review state.")
             .font(.system(size: 11))
             .foregroundStyle(HubTheme.textSecondary)
           ForEach(snapshot.statusLabels, id: \.rawValue) { label in
-            label.chip
+            StatusChip(text: label.userFacingText, bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
           }
         }
       }
@@ -1060,7 +1060,7 @@ struct DesktopProjectionScreen: View {
       } else {
         unavailableFactCard(
           title: "Token Ledger",
-          reason: "No run ref is present in the current projection, so spend details stay unavailable.")
+          reason: "Token details will appear after the current projection includes a run ref.")
       }
       refsCard(title: "Provider Receipt Refs", refs: snapshot.providerReceiptRefs)
     }
@@ -1145,7 +1145,7 @@ struct DesktopProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
         cardTitle(title)
-        StatusChip(text: "NO-GO visible", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+        StatusChip(text: "needs data", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
         Text(reason)
           .font(.system(size: 12))
           .foregroundStyle(HubTheme.textSecondary)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopSessionDetailScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopSessionDetailScreen.swift
@@ -174,7 +174,7 @@ struct DesktopSessionDetailScreen: View {
       GlassPanel {
         VStack(alignment: .leading, spacing: HubTheme.rowSpacing) {
           cardTitle(title)
-          Text(reason)
+          Text(userFacingReason(reason))
             .font(.system(size: 12))
             .foregroundStyle(HubTheme.textSecondary)
         }
@@ -261,6 +261,14 @@ struct DesktopSessionDetailScreen: View {
     Text(text)
       .font(.system(size: 14, weight: .semibold))
       .foregroundStyle(HubTheme.textPrimary)
+  }
+
+  private func userFacingReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("transport") || normalized.contains("connection") {
+      return "Friday cannot reach the live Hub from this window. Check the connection, then refresh."
+    }
+    return "Friday needs a fresh live session view before this screen can continue."
   }
 }
 

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift
@@ -534,28 +534,42 @@ struct UnavailableView: View {
       Image(systemName: "exclamationmark.triangle")
         .font(.system(size: 28))
         .foregroundStyle(HubTheme.coral)
-      Text("Hub projection unavailable")
+      Text("Connect Friday Hub")
         .font(.system(size: 15, weight: .semibold))
         .foregroundStyle(HubTheme.textPrimary)
-      Text(reason)
+      Text(userFacingReason)
         .font(.system(size: 12))
         .foregroundStyle(HubTheme.textSecondary)
         .multilineTextAlignment(.center)
       HStack(spacing: 6) {
         ForEach(labels, id: \.rawValue) { label in
-          label.chip
+          StatusChip(text: label.userFacingText, bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
             .accessibilityIdentifier("friday.desktop.status-label.\(label.rawValue)")
         }
       }
-      Text("Showing this as truth — no cached or fabricated status is presented.")
+      Text("Friday is showing a live-only safe view until the Hub refreshes.")
         .font(.system(size: 10))
         .foregroundStyle(HubTheme.textSecondary)
     }
     .padding(28)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .accessibilityElement(children: .contain)
-    .accessibilityLabel("Hub projection unavailable. \(reason)")
+    .accessibilityLabel("Connect Friday Hub. \(userFacingReason)")
     .accessibilityIdentifier("friday.desktop.unavailable")
+  }
+
+  private var userFacingReason: String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("connection") || normalized.contains("transport") {
+      return "Friday cannot reach the live Hub from this window. Check the Hub connection, then refresh."
+    }
+    if normalized.contains("503") || normalized.contains("service") {
+      return "The Hub is starting or busy. Refresh once it is ready."
+    }
+    if normalized.contains("projection") {
+      return "Friday needs a fresh Hub projection before this screen can show current work."
+    }
+    return "Friday needs a fresh live Hub view before this screen can show current work."
   }
 }
 
@@ -568,14 +582,14 @@ struct StatusBanner: View {
       Image(systemName: "exclamationmark.circle")
         .foregroundStyle(HubTheme.chipWarnFG)
       ForEach(snapshot.statusLabels, id: \.rawValue) { label in
-        StatusChip(text: label.displayText, bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+        StatusChip(text: label.userFacingText, bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
       }
       if !snapshot.runtimeFeedStatus.isHealthy {
         StatusChip(
           text: snapshot.runtimeFeedStatus.displayText, bg: HubTheme.chipWarnBG,
           fg: HubTheme.chipWarnFG)
       }
-      Text("This projection is flagged — rendered as-is, not upgraded.")
+      Text("This Hub view needs attention before acting.")
         .font(.system(size: 11))
         .foregroundStyle(HubTheme.textSecondary)
       Spacer()
@@ -641,7 +655,7 @@ struct WriteActionStateView: View {
       }
     case let .error(reason):
       HStack(spacing: 8) {
-        StatusChip(text: "unavailable", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
+        StatusChip(text: "needs attention", bg: HubTheme.chipWarnBG, fg: HubTheme.chipWarnFG)
         Text(reason)
           .font(.system(size: 11))
           .foregroundStyle(HubTheme.textSecondary)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/TruthChips.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/TruthChips.swift
@@ -33,7 +33,7 @@ extension MissionLifecycleState {
     case .completedWithProof: return "completed · proof"
     case .blocked: return "blocked"
     case .error: return "error"
-    case .unknown: return "unavailable"
+    case .unknown: return "unknown"
     }
   }
 
@@ -86,7 +86,7 @@ extension MissionWorkbenchApprovalState {
     case .required: return "approval required"
     case .approved: return "approved"
     case .blocked: return "blocked"
-    case .unknown: return "unavailable"
+    case .unknown: return "pending status"
     }
   }
 }
@@ -98,6 +98,15 @@ extension MissionWorkbenchStatusLabel {
     case .offline: return "OFFLINE"
     case .error: return "ERROR"
     case .unknown: return "UNAVAILABLE"
+    }
+  }
+
+  var userFacingText: String {
+    switch self {
+    case .stale: return "refresh"
+    case .offline: return "connect"
+    case .error: return "attention"
+    case .unknown: return "checking"
     }
   }
 
@@ -116,7 +125,7 @@ extension MissionWorkbenchRuntimeFeedStatus {
     switch self {
     case .liveRustHubProjection: return "live rust hub projection"
     case .pendingRustHubProjection: return "pending rust hub projection"
-    case .unknown: return "feed unavailable"
+    case .unknown: return "feed waiting"
     }
   }
 

--- a/scripts/ops/check-friday-client-design-contract.mjs
+++ b/scripts/ops/check-friday-client-design-contract.mjs
@@ -137,7 +137,7 @@ const checks = checkSourceSet(repoRoot, [
       "settings",
     ],
     requiredStrings: [
-      "NO-GO visible",
+      "needs data",
       "never estimates spend",
       "Signing-key custody is never held by the app",
       "this screen does not execute tools",

--- a/scripts/ops/check-friday-native-action-closure.mjs
+++ b/scripts/ops/check-friday-native-action-closure.mjs
@@ -222,7 +222,7 @@ const checks = [
       "Add shared text or a URL before submitting.",
       "Share Intake is unavailable",
       "Readiness plus local voice-loop truth",
-      "No cost data is fabricated",
+      "Friday reads provider usage from the run reference projected by the Hub.",
     ]),
   ),
   check(

--- a/test/unit/qa/friday-product-facing-copy.test.ts
+++ b/test/unit/qa/friday-product-facing-copy.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(__dirname, "../../..");
+
+const productSurfaceFiles = [
+  "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/HeroPet.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/CompanionPetView.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopSessionDetailScreen.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/TruthChips.swift",
+];
+
+const visibleSwiftConstructors = /\b(Text|StatusChip|Label|Button|cardHeader|workspaceHeader|unavailableFactCard)\s*\(/;
+const forbiddenVisibleCopy = [
+  "Friday is offline",
+  "Hub offline",
+  "Hub projection unavailable",
+  "unavailable until",
+  "remains unavailable",
+  "Provider results remain unavailable",
+  "No provider status, session state, or capability readiness is fabricated",
+  "no cached or fabricated",
+  "no fabricated status",
+  "not loaded",
+  "read off",
+  "write off",
+  "WebKit unavailable",
+  "NO-GO visible",
+  "honest-unavailable",
+  "Voice readiness unavailable",
+  "Session detail unavailable",
+  "Token ledger unavailable",
+  "Context Passport unavailable",
+];
+
+describe("Friday product-facing unavailable copy", () => {
+  it("keeps engineering unavailable/offline language out of visible product UI", () => {
+    const failures: string[] = [];
+    for (const relativePath of productSurfaceFiles) {
+      const source = readFileSync(join(repoRoot, relativePath), "utf8");
+      source.split("\n").forEach((line, index) => {
+        if (!visibleSwiftConstructors.test(line)) return;
+        for (const forbidden of forbiddenVisibleCopy) {
+          if (line.includes(forbidden)) {
+            failures.push(`${relativePath}:${index + 1}: ${forbidden}`);
+          }
+        }
+      });
+    }
+
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace user-facing offline/unavailable engineering copy across mobile and desktop product surfaces with connection/refresh/review language.
- Keep internal fail-closed states, identifiers, and truth semantics intact while sanitizing visible reasons.
- Update the selected-design contract away from visible NO-GO engineering copy and add a product-facing copy guard so selected product UI does not regress.

## Verification
- PATH=/Users/jarvis/Projects/Friday/node_modules/.bin:/opt/homebrew/opt/rustup/bin:/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin:/Users/jarvis/Library/Android/sdk/emulator:/Users/jarvis/Library/Android/sdk/platform-tools:/Users/jarvis/Library/Android/sdk/cmdline-tools/latest/bin:/Users/jarvis/.cargo/bin:/Users/jarvis/.local/bin:/Users/jarvis/.nvm/versions/node/v22.22.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/jarvis/.codex/packages/standalone/releases/0.140.0-aarch64-apple-darwin/codex-path:/Users/jarvis/.codex/tmp/arg0/codex-arg0cmUNHd:/opt/homebrew/opt/rustup/bin:/Users/jarvis/.cargo/bin:/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin:/Users/jarvis/Library/Android/sdk/emulator:/Users/jarvis/Library/Android/sdk/platform-tools:/Users/jarvis/Library/Android/sdk/cmdline-tools/latest/bin:/Users/jarvis/.local/bin:/Users/jarvis/.bun/bin:/Users/jarvis/.nvm/versions/node/v22.22.0/bin vitest run --project default test/unit/qa/friday-product-facing-copy.test.ts
- swift test --package-path apps/macos/FridayHubConsole
- apps/friday-ios/build-sim.sh --mode live-loopback --shot /private/tmp/friday-product-ui-recovery-copy-check-6c7ae12c-20260629T100302Z.png
- node scripts/ops/check-friday-client-design-contract.mjs
- PATH=/Users/jarvis/Projects/Friday/node_modules/.bin:/opt/homebrew/opt/rustup/bin:/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin:/Users/jarvis/Library/Android/sdk/emulator:/Users/jarvis/Library/Android/sdk/platform-tools:/Users/jarvis/Library/Android/sdk/cmdline-tools/latest/bin:/Users/jarvis/.cargo/bin:/Users/jarvis/.local/bin:/Users/jarvis/.nvm/versions/node/v22.22.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/jarvis/.codex/packages/standalone/releases/0.140.0-aarch64-apple-darwin/codex-path:/Users/jarvis/.codex/tmp/arg0/codex-arg0cmUNHd:/opt/homebrew/opt/rustup/bin:/Users/jarvis/.cargo/bin:/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home/bin:/Users/jarvis/Library/Android/sdk/emulator:/Users/jarvis/Library/Android/sdk/platform-tools:/Users/jarvis/Library/Android/sdk/cmdline-tools/latest/bin:/Users/jarvis/.local/bin:/Users/jarvis/.bun/bin:/Users/jarvis/.nvm/versions/node/v22.22.0/bin npm run --silent check:uiux-native-linkage
- git diff --check