### PR TITLE
test(ui): add desktop destination AX markers

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -41,6 +41,7 @@ struct HubConsoleShell: View {
 
       mainPane
         .frame(minWidth: 520, maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("friday.desktop.destination.\(destination.rawValue)")
 
       Divider().opacity(0.4)
 

--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -337,10 +337,25 @@ return "not_found"`;
 
 function rawTreeHasDestination(raw, destination, title) {
   const haystack = raw || "";
-  return haystack.includes(title) || haystack.includes(`friday.desktop.${destination}`);
+  return haystack.includes(title)
+    || haystack.includes(`friday.desktop.${destination}`)
+    || haystack.includes(`friday.desktop.destination.${destination}`);
 }
 
 function waitForDestination(destination, title) {
+  const marker = captureTargetElement({
+    runtimeActionId: `desktop/${destination}/destination-marker`,
+    accessibility_id: `friday.desktop.destination.${destination}`,
+    visible_text: title,
+  });
+  if (marker) {
+    return {
+      ready: true,
+      raw: [
+        `0\t${marker.role}\t${marker.identifier}\t${marker.name}\t${marker.description}\t`,
+      ].join("\n"),
+    };
+  }
   const destinationWaitMs = Math.min(timeoutSeconds * 1000, 8_000);
   const deadline = Date.now() + destinationWaitMs;
   let lastRaw = "";


### PR DESCRIPTION
## Summary
- add a stable accessibility marker to the selected desktop main pane for each destination
- let the desktop AX proof harness look for that destination marker before falling back to a full tree scan
- fixes the Evidence destination proof path that was timing out on deep AX traversal while preserving live-connected proof requirements

## Verification
- `FRIDAY_CONSOLE_LIVE_READ_HOST=127.0.0.1 FRIDAY_CONSOLE_LIVE_READ_PORT=48751 FRIDAY_DESKTOP_AX_CAPTURE_MODE=live-loopback node scripts/ops/friday-desktop-ax-accessibility-capture.mjs --out-dir=/private/tmp/friday-desktop-ax-capture-destmarker-evidence-20260629T1050Z --mission-id=mission_desktop_ax_live_evidence_destmarker --workbench-mission-id=codex-organic-mission-aef06afa-543e-4cc5-9c8d-3352357ec3fd --destinations=evidence --timeout-seconds=20 --tree-depth=4`
- `node scripts/ops/check-friday-uiux-selected-visual-proof.mjs --ios-manifest=/private/tmp/friday-ios-design-destination-capture-6f299258-20260629T1028Z/ios-design-destination-capture-manifest.json --desktop-capture=/private/tmp/friday-desktop-ax-capture-6f299258-live-segA-20260629T1037Z/desktop-ax-accessibility-capture.json --desktop-capture=/private/tmp/friday-desktop-ax-capture-6f299258-live-segB-20260629T1038Z/desktop-ax-accessibility-capture.json --desktop-capture=/private/tmp/friday-desktop-ax-capture-destmarker-evidence-20260629T1050Z/desktop-ax-accessibility-capture.json --out=/private/tmp/friday-uiux-selected-visual-proof-destmarker-20260629T1051Z.json --require-complete`
- `swift test --package-path apps/macos/FridayHubConsole`
- `git diff --check`

Truth: this improves real desktop accessibility/proofability. It is not END-BAR by itself; same-SHA proof must be rerun after merge.
