### PR TITLE
Realign served UI fidelity and retention safety

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -72,7 +72,7 @@ struct CommandSheet: View {
     ("Command", [.home, .newSession, .voice, .shareIntake]),
     ("Work", [.missions, .needsMe, .activity, .workflows]),
     ("Providers", [.platform, .providerAuth, .session]),
-    ("Trust", [.contextPassport, .memory, .tokenLedger, .proofViewer]),
+    ("Trust", [.contextPassport, .memory, .tokenLedger]),
     ("Setup", [.pairing, .onboarding, .settings, .petEditor]),
   ]
 

--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -68,13 +68,12 @@ struct CommandSheet: View {
   @Binding var isOpen: Bool
 
   private let columns = [GridItem(.flexible(), spacing: 14), GridItem(.flexible(), spacing: 14)]
-  private let endBarSnapshot = MobileProductEndBarSnapshot()
   private let sections: [(String, [MobileDestination])] = [
     ("Command", [.home, .newSession, .voice, .shareIntake]),
     ("Work", [.missions, .needsMe, .activity, .workflows]),
     ("Providers", [.platform, .providerAuth, .session]),
     ("Trust", [.contextPassport, .memory, .tokenLedger, .proofViewer]),
-    ("Setup", [.pairing, .onboarding, .settings, .petEditor, .entrypoints]),
+    ("Setup", [.pairing, .onboarding, .settings, .petEditor]),
   ]
 
   var body: some View {
@@ -103,7 +102,6 @@ struct CommandSheet: View {
               }
             }
           }
-          readinessFooter
         }
         .padding(16)
       }
@@ -129,13 +127,13 @@ struct CommandSheet: View {
           .foregroundStyle(dest.isBuilt ? MobileTheme.cyan : MobileTheme.textSecondary)
         Spacer()
         if dest == destination {
-          StatusChip(text: "open", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+          FridayChip(text: "open", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
         }
       }
       Text(contract.title)
         .font(.headline)
         .foregroundStyle(dest.isBuilt ? MobileTheme.textPrimary : MobileTheme.textSecondary)
-      StatusChip(
+      FridayChip(
         text: contract.tier.label,
         bg: contract.isEndBarReady ? MobileTheme.chipDoneBG : MobileTheme.chipNeutralBG,
         fg: contract.isEndBarReady ? MobileTheme.chipDoneFG : MobileTheme.chipNeutralFG)
@@ -151,23 +149,5 @@ struct CommandSheet: View {
     .overlay(
       RoundedRectangle(cornerRadius: MobileTheme.cornerRadius, style: .continuous)
         .strokeBorder(MobileTheme.glassPanelBorder, lineWidth: 1))
-  }
-
-  private var readinessFooter: some View {
-    VStack(spacing: 6) {
-      StatusChip(
-        text: "\(endBarSnapshot.routeCoverageCount)/\(endBarSnapshot.totalCount) routes",
-        bg: MobileTheme.chipPendingBG,
-        fg: MobileTheme.chipPendingFG)
-      StatusChip(
-        text: "\(endBarSnapshot.endBarReadyCount)/\(endBarSnapshot.totalCount) END-BAR",
-        bg: endBarSnapshot.hasAnyEndBarClaim ? MobileTheme.chipDoneBG : MobileTheme.chipWarnBG,
-        fg: endBarSnapshot.hasAnyEndBarClaim ? MobileTheme.chipDoneFG : MobileTheme.chipWarnFG)
-    }
-    .frame(maxWidth: .infinity)
-    .padding(.top, 8)
-    .accessibilityIdentifier("friday.command-sheet.readiness-footer")
-    .accessibilityLabel(
-      "Route coverage is not END-BAR. Selected mobile surfaces: \(MobileDestination.allCases.map(\.title).joined(separator: ", ")).")
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShell/DesignTokens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/DesignTokens.swift
@@ -69,8 +69,74 @@ struct GlassPanel<Content: View>: View {
   }
 }
 
-/// A small status chip. Color renders truth HONESTLY and is never upgraded.
-struct StatusChip: View {
+enum FridayButtonVariant {
+  case primary
+  case secondary
+  case quiet
+}
+
+struct FridayButtonStyle: ButtonStyle {
+  let variant: FridayButtonVariant
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .font(.system(size: 14, weight: .semibold))
+      .padding(.horizontal, 14)
+      .padding(.vertical, 9)
+      .frame(minHeight: 40)
+      .foregroundStyle(foreground)
+      .background(background(for: configuration.isPressed), in: Capsule())
+      .overlay(Capsule().strokeBorder(border, lineWidth: 1))
+      .scaleEffect(configuration.isPressed ? 0.985 : 1)
+  }
+
+  private var foreground: Color {
+    switch variant {
+    case .primary: return .white
+    case .secondary: return MobileTheme.cyan
+    case .quiet: return MobileTheme.textSecondary
+    }
+  }
+
+  private var border: Color {
+    switch variant {
+    case .primary: return MobileTheme.cyan.opacity(0.10)
+    case .secondary: return MobileTheme.cyan.opacity(0.24)
+    case .quiet: return MobileTheme.glassPanelBorder
+    }
+  }
+
+  private func background(for pressed: Bool) -> Color {
+    let opacity = pressed ? 0.82 : 1.0
+    switch variant {
+    case .primary: return MobileTheme.cyan.opacity(opacity)
+    case .secondary: return MobileTheme.cyanSoft.opacity(pressed ? 0.72 : 1)
+    case .quiet: return Color.white.opacity(pressed ? 0.38 : 0.54)
+    }
+  }
+}
+
+struct FridayButton<Label: View>: View {
+  let variant: FridayButtonVariant
+  let action: () -> Void
+  let label: Label
+
+  init(variant: FridayButtonVariant = .primary, action: @escaping () -> Void, @ViewBuilder label: () -> Label) {
+    self.variant = variant
+    self.action = action
+    self.label = label()
+  }
+
+  var body: some View {
+    Button(action: action) {
+      label
+    }
+    .buttonStyle(FridayButtonStyle(variant: variant))
+  }
+}
+
+/// A selected-design status chip. Color renders truth HONESTLY and is never upgraded.
+struct FridayChip: View {
   let text: String
   let bg: Color
   let fg: Color
@@ -78,16 +144,54 @@ struct StatusChip: View {
   var body: some View {
     Text(text)
       .font(.system(size: 11, weight: .medium))
-      .padding(.horizontal, 8)
-      .padding(.vertical, 3)
+      .padding(.horizontal, 9)
+      .padding(.vertical, 4)
       .background(Capsule().fill(bg))
+      .overlay(Capsule().strokeBorder(Color.white.opacity(0.45), lineWidth: 0.5))
       .foregroundStyle(fg)
       .accessibilityLabel(text)
   }
 }
 
-/// A monospaced redacted-ref pill. Refs only — there is no expand/load affordance.
-struct RefPill: View {
+struct FridayFilter: View {
+  let label: String
+  let selected: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Text(label)
+        .font(.system(size: 12, weight: .semibold))
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .foregroundStyle(selected ? .white : MobileTheme.cyan)
+        .background(selected ? MobileTheme.cyan : MobileTheme.cyanSoft, in: Capsule())
+        .overlay(Capsule().strokeBorder(MobileTheme.cyan.opacity(0.20), lineWidth: 1))
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+struct FridaySegmentedControl: View {
+  let options: [String]
+  @Binding var selection: String
+
+  var body: some View {
+    HStack(spacing: 4) {
+      ForEach(options, id: \.self) { option in
+        FridayFilter(label: option, selected: option == selection) {
+          selection = option
+        }
+      }
+    }
+    .padding(4)
+    .background(.ultraThinMaterial, in: Capsule())
+    .overlay(Capsule().strokeBorder(MobileTheme.glassPanelBorder, lineWidth: 1))
+  }
+}
+
+/// A monospaced redacted-ref proof line. Refs only — there is no expand/load affordance.
+struct FridayProofLine: View {
   let label: String?
   let ref: String
 
@@ -105,11 +209,15 @@ struct RefPill: View {
         .minimumScaleFactor(0.75)
         .truncationMode(.middle)
     }
-    .padding(.horizontal, 8)
-    .padding(.vertical, 4)
-    .background(
-      RoundedRectangle(cornerRadius: 7, style: .continuous)
-        .fill(Color.black.opacity(0.04))
+      .padding(.horizontal, 9)
+      .padding(.vertical, 5)
+      .background(
+      RoundedRectangle(cornerRadius: 11, style: .continuous)
+        .fill(Color.white.opacity(0.52))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 11, style: .continuous)
+        .strokeBorder(MobileTheme.glassPanelBorder, lineWidth: 1)
     )
     .accessibilityElement(children: .ignore)
     .accessibilityLabel(accessibilityText)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -87,13 +87,13 @@ struct FridayChatScreen: View {
             .font(.caption.weight(.semibold))
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
-          StatusChip(text: card.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+          FridayChip(text: card.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
         }
         Text(card.detail)
           .font(.caption2)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
-        RefPill(label: "evidence", ref: short(card.evidenceRef))
+        FridayProofLine(label: "evidence", ref: short(card.evidenceRef))
         if card.id == "handoff" {
           handoffControls
         }
@@ -131,7 +131,7 @@ struct FridayChatScreen: View {
       Label("Create handoff", systemImage: "arrowshape.turn.up.right")
         .font(.caption.weight(.semibold))
     }
-    .buttonStyle(.bordered)
+    .buttonStyle(FridayButtonStyle(variant: .secondary))
     .disabled(viewModel.contextPassportTransferState?.isSent == true)
     .accessibilityIdentifier("friday.chat.handoff-card.share")
   }
@@ -144,7 +144,7 @@ struct FridayChatScreen: View {
         Image(systemName: "checkmark")
           .frame(width: 26, height: 26)
       }
-      .buttonStyle(.borderedProminent)
+      .buttonStyle(FridayButtonStyle(variant: .primary))
       .tint(MobileTheme.cyan)
       .disabled(viewModel.contextMemoryDecisionState?.isSent == true)
       .accessibilityLabel("Keep memory candidate")
@@ -156,7 +156,7 @@ struct FridayChatScreen: View {
         Image(systemName: "xmark")
           .frame(width: 26, height: 26)
       }
-      .buttonStyle(.bordered)
+      .buttonStyle(FridayButtonStyle(variant: .secondary))
       .disabled(viewModel.contextMemoryDecisionState?.isSent == true)
       .accessibilityLabel("Reject memory candidate")
       .accessibilityIdentifier("friday.chat.memory-card.reject")
@@ -166,7 +166,7 @@ struct FridayChatScreen: View {
   @ViewBuilder private func candidateDecisionStateView(_ state: HomeLearningDecisionState) -> some View {
     switch state {
     case .sent:
-      StatusChip(text: "sending", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      FridayChip(text: "sending", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
     case .confirmed(let summary):
       Text(summary)
         .font(.caption2)
@@ -206,7 +206,7 @@ struct FridayChatScreen: View {
                 .foregroundStyle(MobileTheme.textPrimary)
                 .lineLimit(4)
               if item.receiptRefs.isEmpty, let runId = item.runId {
-                RefPill(label: "run_id", ref: short(runId))
+                FridayProofLine(label: "run_id", ref: short(runId))
               } else if !item.receiptRefs.isEmpty {
                 receiptRefs(item.receiptRefs, limit: 4)
               }
@@ -371,7 +371,7 @@ struct FridayChatScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: 10) {
         HStack {
-          StatusChip(text: r.status.uppercased(), bg: MobileTheme.chipDoneBG, fg: MobileTheme.chipDoneFG)
+          FridayChip(text: r.status.uppercased(), bg: MobileTheme.chipDoneBG, fg: MobileTheme.chipDoneFG)
           Spacer()
           Button("New") { viewModel.newTurn() }.font(.caption).foregroundStyle(MobileTheme.cyan)
         }
@@ -383,7 +383,7 @@ struct FridayChatScreen: View {
             } label: {
               Label("Speak", systemImage: "speaker.wave.2.fill")
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(FridayButtonStyle(variant: .secondary))
             .tint(MobileTheme.cyan)
             .accessibilityLabel("Speak Friday answer")
             .accessibilityIdentifier("friday.chat.voice-output")
@@ -393,7 +393,7 @@ struct FridayChatScreen: View {
             } label: {
               Image(systemName: "speaker.slash.fill")
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(FridayButtonStyle(variant: .secondary))
             .accessibilityLabel("Stop speaking Friday answer")
           }
           Text(answer)
@@ -402,7 +402,7 @@ struct FridayChatScreen: View {
             .fixedSize(horizontal: false, vertical: true)
             .textSelection(.enabled)
           if let runId = r.answerBodyRunId {
-            RefPill(label: "answer_body_run_id", ref: runId)
+            FridayProofLine(label: "answer_body_run_id", ref: runId)
           }
         } else {
           Text("Answer body is not available from the owner-gated readback yet.")
@@ -425,7 +425,7 @@ struct FridayChatScreen: View {
           Image(systemName: "hand.raised.fill").foregroundStyle(MobileTheme.coral)
           Text("Approval required").font(.headline).foregroundStyle(MobileTheme.textPrimary)
           Spacer()
-          StatusChip(text: card.truthLabel, bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+          FridayChip(text: card.truthLabel, bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
         }
         // SUMMARY (what paused) — a coarse verb + the owner-sealed summary.
         Text(card.actionVerb).font(.title3).bold().foregroundStyle(MobileTheme.textPrimary)
@@ -433,8 +433,8 @@ struct FridayChatScreen: View {
           Text(summary).font(.callout).foregroundStyle(MobileTheme.textPrimary)
         }
         // PROOF (the digest the operator signs over) — never a body.
-        RefPill(label: "action_digest", ref: short(card.actionDigest))
-        RefPill(label: "approval_id", ref: card.approvalId)
+        FridayProofLine(label: "action_digest", ref: short(card.actionDigest))
+        FridayProofLine(label: "approval_id", ref: card.approvalId)
         Text("Friday paused this mutating action. Approving asks the operator signer for a "
           + "signature; the phone relays it but never signs (INV-1).")
           .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
@@ -444,7 +444,7 @@ struct FridayChatScreen: View {
           } label: {
             Label("Approve", systemImage: "checkmark.seal").bold()
           }
-          .buttonStyle(.borderedProminent).tint(MobileTheme.cyan)
+          .buttonStyle(FridayButtonStyle(variant: .primary))
           .accessibilityLabel("Approve Friday action")
           .accessibilityIdentifier("friday.chat.approval.approve")
           Button(role: .destructive) {
@@ -452,7 +452,7 @@ struct FridayChatScreen: View {
           } label: {
             Label("Reject", systemImage: "xmark").foregroundStyle(MobileTheme.coral)
           }
-          .buttonStyle(.bordered)
+          .buttonStyle(FridayButtonStyle(variant: .secondary))
           .accessibilityLabel("Reject Friday action")
           .accessibilityIdentifier("friday.chat.approval.reject")
         }
@@ -468,7 +468,7 @@ struct FridayChatScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: 8) {
         HStack {
-          StatusChip(
+          FridayChip(
             text: r.statusLabel,
             bg: r.accepted ? MobileTheme.chipDoneBG : MobileTheme.chipWarnBG,
             fg: r.accepted ? MobileTheme.chipDoneFG : MobileTheme.chipWarnFG)
@@ -511,10 +511,10 @@ struct FridayChatScreen: View {
     let visibleRefs = limit.map { Array(refs.prefix($0)) } ?? refs
     return VStack(alignment: .leading, spacing: 4) {
       ForEach(visibleRefs) { ref in
-        RefPill(label: ref.label, ref: short(ref.ref))
+        FridayProofLine(label: ref.label, ref: short(ref.ref))
       }
       if let limit, refs.count > limit {
-        RefPill(label: "more_refs", ref: "+\(refs.count - limit)")
+        FridayProofLine(label: "more_refs", ref: "+\(refs.count - limit)")
       }
     }
     .accessibilityIdentifier("friday.chat.receipt-refs")

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
@@ -72,7 +72,7 @@ struct FridayContextPassportScreen: View {
             .foregroundStyle(MobileTheme.textSecondary)
         }
         Spacer()
-        StatusChip(
+        FridayChip(
           text: status,
           bg: ready ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
           fg: ready ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -108,7 +108,7 @@ struct FridayContextPassportScreen: View {
                   .font(.caption.weight(.semibold))
                   .foregroundStyle(MobileTheme.textPrimary)
                 Spacer()
-                StatusChip(
+                FridayChip(
                   text: row.statusText,
                   bg: row.satisfied ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
                   fg: row.satisfied ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -130,9 +130,9 @@ struct FridayContextPassportScreen: View {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Device", count: nil)
         if let device = status.latestDevice {
-          RefPill(label: "device_id", ref: device.deviceId)
-          RefPill(label: "label", ref: device.label)
-          RefPill(label: "fingerprint", ref: device.pubkeyFingerprint)
+          FridayProofLine(label: "device_id", ref: device.deviceId)
+          FridayProofLine(label: "label", ref: device.label)
+          FridayProofLine(label: "fingerprint", ref: device.pubkeyFingerprint)
         } else {
           Text("No trusted device ref is present in this projection.")
             .font(.caption)
@@ -182,7 +182,7 @@ struct FridayContextPassportScreen: View {
             .font(.caption.weight(.semibold))
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
-          StatusChip(
+          FridayChip(
             text: value,
             bg: satisfied ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
             fg: satisfied ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -208,7 +208,7 @@ struct FridayContextPassportScreen: View {
           Label("Send with 3 items", systemImage: "checkmark.seal")
             .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.borderedProminent)
+        .buttonStyle(FridayButtonStyle(variant: .primary))
         .tint(MobileTheme.cyan)
         .disabled(!isReady || viewModel.contextPassportTransferState?.isSent == true)
         .accessibilityIdentifier("friday.context-passport.send")
@@ -228,7 +228,7 @@ struct FridayContextPassportScreen: View {
   @ViewBuilder private func candidateDecisionStateView(_ state: HomeLearningDecisionState) -> some View {
     switch state {
     case .sent:
-      StatusChip(text: "sending", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      FridayChip(text: "sending", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
     case .confirmed(let summary):
       Text(summary)
         .font(.caption2)
@@ -250,9 +250,9 @@ struct FridayContextPassportScreen: View {
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
-        RefPill(label: "truth", ref: status.truthLabel)
+        FridayProofLine(label: "truth", ref: status.truthLabel)
         if !status.missingOperatorSteps.isEmpty {
-          RefPill(label: "missing", ref: status.missingOperatorSteps.joined(separator: ", "))
+          FridayProofLine(label: "missing", ref: status.missingOperatorSteps.joined(separator: ", "))
         }
       }
     }
@@ -265,7 +265,7 @@ struct FridayContextPassportScreen: View {
         .foregroundStyle(MobileTheme.textPrimary)
       Spacer()
       if let count {
-        StatusChip(text: "\(count)/4", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        FridayChip(text: "\(count)/4", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
       }
     }
   }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -271,7 +271,7 @@ struct FridayHomeScreen: View {
           .tracking(2)
           .foregroundStyle(MobileTheme.textSecondary.opacity(0.72))
         Spacer()
-        StatusChip(text: "connect", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+        FridayChip(text: "connect", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
       }
       GlassPanel {
         Text(emptyText)
@@ -308,7 +308,7 @@ struct FridayHomeScreen: View {
               .lineLimit(2)
           }
           Spacer(minLength: 8)
-          StatusChip(
+          FridayChip(
             text: row.chip,
             bg: row.urgent ? MobileTheme.chipWarnBG : MobileTheme.chipNeutralBG,
             fg: row.urgent ? MobileTheme.chipWarnFG : MobileTheme.chipNeutralFG)
@@ -335,7 +335,7 @@ struct FridayHomeScreen: View {
           Image(systemName: "arrow.clockwise")
             .frame(width: 26, height: 26)
         }
-        .buttonStyle(.bordered)
+        .buttonStyle(FridayButtonStyle(variant: .secondary))
         .disabled(candidateDecisionControlsDisabled(state))
         .accessibilityLabel("Retry WorkItem")
         .accessibilityIdentifier("friday.home.retry-work-item")
@@ -347,7 +347,7 @@ struct FridayHomeScreen: View {
           Image(systemName: "stop.circle")
             .frame(width: 26, height: 26)
         }
-        .buttonStyle(.bordered)
+        .buttonStyle(FridayButtonStyle(variant: .secondary))
         .disabled(candidateDecisionControlsDisabled(state))
         .accessibilityLabel("Cancel WorkItem")
         .accessibilityIdentifier("friday.home.cancel-work-item")
@@ -387,7 +387,7 @@ struct FridayHomeScreen: View {
         HStack {
           Text("Status").font(.headline).foregroundStyle(MobileTheme.textPrimary)
           Spacer()
-          StatusChip(
+          FridayChip(
             text: viewModel.isOnline ? "online" : "refresh",
             bg: viewModel.isOnline ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
             fg: viewModel.isOnline ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -400,11 +400,11 @@ struct FridayHomeScreen: View {
             .font(.subheadline).foregroundStyle(MobileTheme.textPrimary)
           Spacer()
         }
-        RefPill(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "mission_id", ref: projection.missionId)
         if let summary = projection.routeDecisionSummary {
-          RefPill(label: "route", ref: summary)
+          FridayProofLine(label: "route", ref: summary)
         }
-        RefPill(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
+        FridayProofLine(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
       }
     }
     .accessibilityElement(children: .combine)
@@ -420,7 +420,7 @@ struct FridayHomeScreen: View {
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
-          StatusChip(
+          FridayChip(
             text: projection.timelinePages.isEmpty ? "waiting" : "\(projection.timelinePages.count) pages",
             bg: projection.timelinePages.isEmpty ? MobileTheme.chipNeutralBG : MobileTheme.chipPendingBG,
             fg: projection.timelinePages.isEmpty ? MobileTheme.chipNeutralFG : MobileTheme.chipPendingFG)
@@ -444,7 +444,7 @@ struct FridayHomeScreen: View {
                   .foregroundStyle(MobileTheme.textPrimary)
                   .lineLimit(1)
                 Spacer(minLength: 8)
-                StatusChip(text: page.statusText, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+                FridayChip(text: page.statusText, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
               }
               if !page.summary.isEmpty {
                 Text(page.summary)
@@ -453,12 +453,12 @@ struct FridayHomeScreen: View {
                   .lineLimit(2)
               }
               HStack(spacing: 8) {
-                RefPill(label: "cursor", ref: page.cursor ?? "start")
+                FridayProofLine(label: "cursor", ref: page.cursor ?? "start")
                 if let next = page.nextCursor {
-                  RefPill(label: "next", ref: next)
+                  FridayProofLine(label: "next", ref: next)
                 }
                 if page.refsCount > 0 {
-                  RefPill(label: "refs", ref: "\(page.refsCount)")
+                  FridayProofLine(label: "refs", ref: "\(page.refsCount)")
                 }
               }
             }
@@ -484,7 +484,7 @@ struct FridayHomeScreen: View {
         HStack {
           Text("Device pairing").font(.headline).foregroundStyle(MobileTheme.textPrimary)
           Spacer()
-          StatusChip(
+          FridayChip(
             text: pairingReadinessLabel(readiness),
             bg: pairingReadinessBackground(readiness),
             fg: pairingReadinessForeground(readiness))
@@ -494,18 +494,18 @@ struct FridayHomeScreen: View {
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         if let publicKeyHex = readiness.publicKeyHex {
-          RefPill(label: "device_pubkey", ref: publicKeyHex)
+          FridayProofLine(label: "device_pubkey", ref: publicKeyHex)
         }
         pairingEntry
         pairingPreflightRows(viewModel.pairingPreflight)
         pairingAttemptRows(viewModel.pairingAttempt)
         hubProvisioningRows(t3Status)
         HStack(spacing: 8) {
-          StatusChip(
+          FridayChip(
             text: readiness.readLiveRequested ? "read link ready" : "read link pending",
             bg: readiness.readLiveRequested ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
             fg: readiness.readLiveRequested ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
-          StatusChip(
+          FridayChip(
             text: readiness.writeLiveRequested ? "write link ready" : "write link pending",
             bg: readiness.writeLiveRequested ? MobileTheme.chipWarnBG : MobileTheme.chipNeutralBG,
             fg: readiness.writeLiveRequested ? MobileTheme.chipWarnFG : MobileTheme.chipNeutralFG)
@@ -571,7 +571,7 @@ struct FridayHomeScreen: View {
         } label: {
           Label("Check", systemImage: "checkmark.shield")
         }
-        .buttonStyle(.bordered)
+        .buttonStyle(FridayButtonStyle(variant: .secondary))
         .disabled(pairingQRPayload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         .accessibilityIdentifier("friday.home.pairing-preflight-button")
 
@@ -580,7 +580,7 @@ struct FridayHomeScreen: View {
         } label: {
           Label("Pair", systemImage: "link.badge.plus")
         }
-        .buttonStyle(.borderedProminent)
+        .buttonStyle(FridayButtonStyle(variant: .primary))
         .disabled(pairingQRPayload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
           || viewModel.pairingAttempt.mode == .sending)
         .accessibilityIdentifier("friday.home.pair-button")
@@ -591,7 +591,7 @@ struct FridayHomeScreen: View {
           } label: {
             Label("Retry", systemImage: "arrow.clockwise")
           }
-          .buttonStyle(.bordered)
+          .buttonStyle(FridayButtonStyle(variant: .secondary))
           .disabled(pairingQRPayload.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
           .accessibilityIdentifier("friday.home.pairing-retry-button")
         }
@@ -602,7 +602,7 @@ struct FridayHomeScreen: View {
           } label: {
             Label("Cancel", systemImage: "xmark")
           }
-          .buttonStyle(.bordered)
+          .buttonStyle(FridayButtonStyle(variant: .secondary))
           .accessibilityIdentifier("friday.home.pairing-cancel-button")
         }
 
@@ -611,7 +611,7 @@ struct FridayHomeScreen: View {
         } label: {
           Label("Scan", systemImage: "qrcode.viewfinder")
         }
-        .buttonStyle(.bordered)
+        .buttonStyle(FridayButtonStyle(variant: .secondary))
         .accessibilityIdentifier("friday.home.pairing-scan-button")
 
         Button {
@@ -620,7 +620,7 @@ struct FridayHomeScreen: View {
         } label: {
           Image(systemName: "xmark.circle")
         }
-        .buttonStyle(.bordered)
+        .buttonStyle(FridayButtonStyle(variant: .secondary))
         .accessibilityLabel("Clear pairing QR")
         .accessibilityIdentifier("friday.home.pairing-clear-button")
       }
@@ -651,7 +651,7 @@ struct FridayHomeScreen: View {
       HStack {
         Text("QR preflight").font(.caption.weight(.semibold)).foregroundStyle(MobileTheme.textPrimary)
         Spacer()
-        StatusChip(
+        FridayChip(
           text: preflight.mode.rawValue,
           bg: preflight.mode == .ready ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
           fg: preflight.mode == .ready ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -661,11 +661,11 @@ struct FridayHomeScreen: View {
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
       if let projection = preflight.projection {
-        RefPill(label: "hub_id", ref: projection.hubId)
-        RefPill(label: "pairing_id", ref: projection.pairingId)
+        FridayProofLine(label: "hub_id", ref: projection.hubId)
+        FridayProofLine(label: "pairing_id", ref: projection.pairingId)
       }
       if let publicKeyHex = preflight.devicePublicKeyHex {
-        RefPill(label: "pairing_device_pubkey", ref: publicKeyHex)
+        FridayProofLine(label: "pairing_device_pubkey", ref: publicKeyHex)
       }
       Text(preflight.nextStep)
         .font(.caption2)
@@ -681,7 +681,7 @@ struct FridayHomeScreen: View {
       HStack {
         Text("PairAck").font(.caption.weight(.semibold)).foregroundStyle(MobileTheme.textPrimary)
         Spacer()
-        StatusChip(
+        FridayChip(
           text: attempt.mode.rawValue,
           bg: attempt.mode == .accepted ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
           fg: attempt.mode == .accepted ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -691,16 +691,16 @@ struct FridayHomeScreen: View {
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
       if let hubId = attempt.hubId {
-        RefPill(label: "ack_hub_id", ref: hubId)
+        FridayProofLine(label: "ack_hub_id", ref: hubId)
       }
       if let pairingId = attempt.pairingId {
-        RefPill(label: "ack_pairing_id", ref: pairingId)
+        FridayProofLine(label: "ack_pairing_id", ref: pairingId)
       }
       if let deviceId = attempt.deviceId {
-        RefPill(label: "ack_device_id", ref: deviceId)
+        FridayProofLine(label: "ack_device_id", ref: deviceId)
       }
       if let errorCode = attempt.errorCode {
-        RefPill(label: "ack_error", ref: errorCode)
+        FridayProofLine(label: "ack_error", ref: errorCode)
       }
     }
   }
@@ -712,12 +712,12 @@ struct FridayHomeScreen: View {
       Text("Hub provisioning").font(.caption.weight(.semibold)).foregroundStyle(MobileTheme.textPrimary)
       Spacer()
       if let status {
-        StatusChip(
+        FridayChip(
           text: status.homeStatusLabel,
           bg: status.isFullyProvisioned ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
           fg: status.isFullyProvisioned ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
       } else {
-        StatusChip(text: "waiting", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        FridayChip(text: "waiting", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
       }
     }
     if let status {
@@ -726,20 +726,20 @@ struct FridayHomeScreen: View {
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
       if !status.missingOperatorSteps.isEmpty {
-        RefPill(label: "missing", ref: status.missingOperatorSteps.joined(separator: ", "))
+        FridayProofLine(label: "missing", ref: status.missingOperatorSteps.joined(separator: ", "))
       }
       if let device = status.latestDevice {
-        RefPill(label: "latest_device", ref: device.deviceId)
-        RefPill(label: "device_fingerprint", ref: device.pubkeyFingerprint)
+        FridayProofLine(label: "latest_device", ref: device.deviceId)
+        FridayProofLine(label: "device_fingerprint", ref: device.pubkeyFingerprint)
       }
-      RefPill(label: "device_identity_count", ref: String(status.deviceIdentityCount))
-      RefPill(label: "trusted_device_count", ref: String(status.trustedDeviceCount))
-      RefPill(label: "active_trusted_device_count", ref: String(status.activeTrustedDeviceCount))
-      RefPill(label: "trust_grant_count", ref: String(status.trustGrantCount))
-      RefPill(label: "active_trust_grant_count", ref: String(status.activeTrustGrantCount))
-      RefPill(label: "context_passport_count", ref: String(status.contextPassportCount))
-      RefPill(label: "context_passport_item_count", ref: String(status.contextPassportItemCount))
-      RefPill(label: "truth", ref: status.truthLabel)
+      FridayProofLine(label: "device_identity_count", ref: String(status.deviceIdentityCount))
+      FridayProofLine(label: "trusted_device_count", ref: String(status.trustedDeviceCount))
+      FridayProofLine(label: "active_trusted_device_count", ref: String(status.activeTrustedDeviceCount))
+      FridayProofLine(label: "trust_grant_count", ref: String(status.trustGrantCount))
+      FridayProofLine(label: "active_trust_grant_count", ref: String(status.activeTrustGrantCount))
+      FridayProofLine(label: "context_passport_count", ref: String(status.contextPassportCount))
+      FridayProofLine(label: "context_passport_item_count", ref: String(status.contextPassportItemCount))
+      FridayProofLine(label: "truth", ref: status.truthLabel)
     } else {
         Text("Connect to the live Hub to see PairAck, trust grant, and context passport status.")
         .font(.caption2)
@@ -780,7 +780,7 @@ struct FridayHomeScreen: View {
         HStack {
           Text("Work items").font(.headline).foregroundStyle(MobileTheme.textPrimary)
           Spacer()
-          StatusChip(
+          FridayChip(
             text: "\(projection.workItemIds.count) ref\(projection.workItemIds.count == 1 ? "" : "s")",
             bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
         }
@@ -791,7 +791,7 @@ struct FridayHomeScreen: View {
           Text("refs only — open the Mission Workbench for detail")
             .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
           ForEach(projection.workItemIds, id: \.self) { id in
-            RefPill(label: "workItemId", ref: id)
+            FridayProofLine(label: "workItemId", ref: id)
           }
         }
       }
@@ -816,7 +816,7 @@ struct StatusBanner: View {
       VStack(alignment: .leading, spacing: 8) {
         HStack(spacing: 6) {
           ForEach(labels, id: \.self) { label in
-            StatusChip(text: displayLabel(for: label), bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+            FridayChip(text: displayLabel(for: label), bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
           }
         }
         .fixedSize(horizontal: false, vertical: true)
@@ -891,15 +891,15 @@ struct UnavailableView: View {
               .fixedSize(horizontal: false, vertical: true)
           }
           Spacer()
-          StatusChip(text: "connect", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+          FridayChip(text: "connect", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
         }
         Text(userFacingReason)
           .font(.footnote)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         HStack(spacing: 8) {
-          StatusChip(text: "live only", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
-          StatusChip(text: "safe view", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+          FridayChip(text: "live only", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+          FridayChip(text: "safe view", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
         }
       }
     }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
@@ -34,7 +34,7 @@ struct FridayNewSessionScreen: View {
             .foregroundStyle(MobileTheme.textSecondary)
         }
         Spacer()
-        StatusChip(text: "action gated", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+        FridayChip(text: "action gated", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
       }
     }
   }
@@ -58,7 +58,7 @@ struct FridayNewSessionScreen: View {
           Label("Launch", systemImage: "play.fill")
             .frame(maxWidth: .infinity, minHeight: 38)
         }
-        .buttonStyle(.borderedProminent)
+        .buttonStyle(FridayButtonStyle(variant: .primary))
         .tint(MobileTheme.cyan)
         .disabled(intent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || launchInFlight)
         .accessibilityIdentifier("friday.new-session.launch-button")
@@ -98,10 +98,10 @@ struct FridayNewSessionScreen: View {
           Text(summary)
             .font(.caption)
             .foregroundStyle(MobileTheme.textPrimary)
-          RefPill(label: "mission_id", ref: missionId)
-          RefPill(label: "work_item_id", ref: workItemId)
-          RefPill(label: "surface", ref: surfaceThreadId)
-          StatusChip(
+          FridayProofLine(label: "mission_id", ref: missionId)
+          FridayProofLine(label: "work_item_id", ref: workItemId)
+          FridayProofLine(label: "surface", ref: surfaceThreadId)
+          FridayChip(
             text: createdOrReady ? "created_or_ready" : status,
             bg: MobileTheme.chipDoneBG,
             fg: MobileTheme.chipDoneFG)
@@ -122,8 +122,8 @@ struct FridayNewSessionScreen: View {
                 .font(.caption2)
                 .foregroundStyle(MobileTheme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
-              RefPill(label: "handoff", ref: context.evidenceRef)
-              RefPill(label: "action", ref: "mobile/newSession/open-chat-loop")
+              FridayProofLine(label: "handoff", ref: context.evidenceRef)
+              FridayProofLine(label: "action", ref: "mobile/newSession/open-chat-loop")
             }
           }
           Button {
@@ -132,7 +132,7 @@ struct FridayNewSessionScreen: View {
             Label("Continue in Friday Chat", systemImage: "bubble.left.and.bubble.right")
               .frame(maxWidth: .infinity)
           }
-          .buttonStyle(.borderedProminent)
+          .buttonStyle(FridayButtonStyle(variant: .primary))
           .tint(MobileTheme.cyan)
           .accessibilityIdentifier("friday.new-session.open-chat-loop")
         }
@@ -162,7 +162,7 @@ struct FridayNewSessionScreen: View {
         .font(.headline)
         .foregroundStyle(MobileTheme.textPrimary)
       if let count {
-        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        FridayChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
       }
     }
   }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -184,7 +184,7 @@ struct FridayProjectionScreen: View {
             .foregroundStyle(MobileTheme.textSecondary)
         }
         Spacer()
-        StatusChip(
+        FridayChip(
           text: viewModel.isOnline ? "online" : "connect",
           bg: viewModel.isOnline ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
           fg: viewModel.isOnline ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -247,7 +247,7 @@ struct FridayProjectionScreen: View {
   private func detailActionsCard(_ projection: HomeProjection) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-        cardHeader("Read Arms", count: nil)
+        cardHeader("Live controls", count: nil)
         HStack(spacing: 8) {
           Button {
             Task { await viewModel.loadDetail(.providersDoctor(probe: nil)) }
@@ -336,12 +336,12 @@ struct FridayProjectionScreen: View {
           Text(detail.summary)
             .font(.caption)
             .foregroundStyle(MobileTheme.textPrimary)
-          RefPill(label: "generated", ref: generatedText(detail.generatedAtMs))
+          FridayProofLine(label: "generated", ref: generatedText(detail.generatedAtMs))
           if let providerReadiness = detail.providerReadiness {
             ProviderReadinessPanel(detail: providerReadiness)
           }
           ForEach(detail.refs, id: \.self) { ref in
-            RefPill(label: nil, ref: ref)
+            FridayProofLine(label: nil, ref: ref)
           }
         }
       }
@@ -361,15 +361,15 @@ struct FridayProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Mission", count: nil)
-        RefPill(label: "mission_id", ref: projection.missionId)
-        RefPill(label: "conversation_id", ref: projection.fridayConversationId)
+        FridayProofLine(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "conversation_id", ref: projection.fridayConversationId)
         if let route = projection.routeDecisionSummary {
           Text(route)
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
         if let selected = projection.routeSelected {
-          RefPill(label: "selectedRoute", ref: selected)
+          FridayProofLine(label: "selectedRoute", ref: selected)
         }
       }
     }
@@ -398,7 +398,7 @@ struct FridayProjectionScreen: View {
           Label("Dispatch Mission", systemImage: "play.fill")
             .frame(maxWidth: .infinity, minHeight: 38)
         }
-        .buttonStyle(.borderedProminent)
+        .buttonStyle(FridayButtonStyle(variant: .primary))
         .tint(MobileTheme.cyan)
         .disabled(missionDispatchIntent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || missionDispatchInFlight)
         .accessibilityIdentifier("friday.missions.dispatch-button")
@@ -432,16 +432,16 @@ struct FridayProjectionScreen: View {
         Text(summary)
           .font(.caption)
           .foregroundStyle(MobileTheme.textPrimary)
-        RefPill(label: "mission_id", ref: missionId)
-        RefPill(label: "work_item_id", ref: workItemId)
-        RefPill(label: "action", ref: "mobile/missions/dispatch")
+        FridayProofLine(label: "mission_id", ref: missionId)
+        FridayProofLine(label: "work_item_id", ref: workItemId)
+        FridayProofLine(label: "action", ref: "mobile/missions/dispatch")
         Button {
           onOpenFridayChat(context)
         } label: {
           Label("Continue in Friday Chat", systemImage: "bubble.left.and.bubble.right")
             .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.bordered)
+        .buttonStyle(FridayButtonStyle(variant: .secondary))
         .tint(MobileTheme.cyan)
         .accessibilityIdentifier("friday.missions.open-chat-loop")
       }
@@ -541,8 +541,8 @@ struct FridayProjectionScreen: View {
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
         }
-        RefPill(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
-        RefPill(label: "generated", ref: generatedText(projection.generatedAtMs))
+        FridayProofLine(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
+        FridayProofLine(label: "generated", ref: generatedText(projection.generatedAtMs))
       }
     }
   }
@@ -572,7 +572,7 @@ struct FridayProjectionScreen: View {
                 statusChip(capability.truthLabel)
               }
               if !capability.proofRef.isEmpty {
-                RefPill(label: "proofRef", ref: capability.proofRef)
+                FridayProofLine(label: "proofRef", ref: capability.proofRef)
               }
             }
             .padding(.vertical, 4)
@@ -604,7 +604,7 @@ struct FridayProjectionScreen: View {
                 .font(.caption)
                 .foregroundStyle(MobileTheme.textSecondary)
               HStack(spacing: 8) {
-                RefPill(label: "activity_id", ref: event.id)
+                FridayProofLine(label: "activity_id", ref: event.id)
                 Spacer()
                 Button {
                   Task { await viewModel.markActivityDone(activityId: event.id) }
@@ -612,14 +612,14 @@ struct FridayProjectionScreen: View {
                   Image(systemName: "checkmark.circle")
                     .frame(width: 26, height: 26)
                 }
-                .buttonStyle(.bordered)
+                .buttonStyle(FridayButtonStyle(variant: .secondary))
                 .disabled(candidateDecisionControlsDisabled(doneState))
                 .accessibilityLabel("Mark activity done")
                 .accessibilityIdentifier("friday.activity.mark-done")
               }
               candidateDecisionStateView(doneState, pendingText: "Marking activity done...")
               if let proofRef = event.proofRef {
-                RefPill(label: "proofRef", ref: proofRef)
+                FridayProofLine(label: "proofRef", ref: proofRef)
               }
             }
             .padding(.vertical, 4)
@@ -638,7 +638,7 @@ struct FridayProjectionScreen: View {
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         if let selected = projection.routeSelected {
-          RefPill(label: "selectedRoute", ref: selected)
+          FridayProofLine(label: "selectedRoute", ref: selected)
         }
         if !projection.routeAlternatives.isEmpty {
           VStack(alignment: .leading, spacing: 6) {
@@ -646,13 +646,13 @@ struct FridayProjectionScreen: View {
               .font(.caption.weight(.semibold))
               .foregroundStyle(MobileTheme.textSecondary)
             ForEach(projection.routeAlternatives, id: \.self) { alternative in
-              RefPill(label: "alternative", ref: alternative)
+              FridayProofLine(label: "alternative", ref: alternative)
             }
           }
         }
         HStack(spacing: 6) {
-          RefPill(label: "action", ref: "mobile/workflow/retry")
-          RefPill(label: "action", ref: "mobile/workflow/cancel")
+          FridayProofLine(label: "action", ref: "mobile/workflow/retry")
+          FridayProofLine(label: "action", ref: "mobile/workflow/cancel")
         }
         if projection.workItems.isEmpty {
           emptyText("No workflow work-item refs.")
@@ -679,10 +679,10 @@ struct FridayProjectionScreen: View {
           emptyText("No receipt refs in this projection.")
         } else {
           ForEach(projection.providerReceiptRefs, id: \.self) {
-            RefPill(label: "provider", ref: $0)
+            FridayProofLine(label: "provider", ref: $0)
           }
           ForEach(projection.channelReceiptRefs, id: \.self) {
-            RefPill(label: "channel", ref: $0)
+            FridayProofLine(label: "channel", ref: $0)
           }
         }
       }
@@ -715,10 +715,10 @@ struct FridayProjectionScreen: View {
         } label: {
           Label("Open Device Pairing", systemImage: "qrcode.viewfinder")
         }
-        .buttonStyle(.borderedProminent)
+        .buttonStyle(FridayButtonStyle(variant: .primary))
         .tint(MobileTheme.cyan)
         .accessibilityIdentifier("friday.onboarding.open-device-pairing")
-        RefPill(label: "action", ref: "mobile/onboarding/open-device-pairing")
+        FridayProofLine(label: "action", ref: "mobile/onboarding/open-device-pairing")
         readinessRow(
           title: "Provider auth",
           value: "read-only doctor; never stores provider secrets",
@@ -729,7 +729,7 @@ struct FridayProjectionScreen: View {
           Label("Check Provider Auth", systemImage: "stethoscope")
         }
         .disabled(viewModel.detailState.isLoading)
-        RefPill(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "mission_id", ref: projection.missionId)
       }
     }
   }
@@ -746,10 +746,10 @@ struct FridayProjectionScreen: View {
         value: status.contextPassportCount > 0 ? "\(status.contextPassportCount) passport(s)" : "not minted",
         healthy: status.contextPassportCount > 0 && status.contextPassportItemCount > 0)
       if let device = status.latestDevice {
-        RefPill(label: "trusted_device", ref: device.deviceId)
-        RefPill(label: "device_fingerprint", ref: device.pubkeyFingerprint)
+        FridayProofLine(label: "trusted_device", ref: device.deviceId)
+        FridayProofLine(label: "device_fingerprint", ref: device.pubkeyFingerprint)
       }
-      RefPill(label: "truth", ref: status.truthLabel)
+      FridayProofLine(label: "truth", ref: status.truthLabel)
     } else {
       readinessRow(
         title: "Trust grant",
@@ -767,10 +767,10 @@ struct FridayProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Settings", count: nil)
-        RefPill(label: "mode", ref: "live-read projection")
-        RefPill(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
-        RefPill(label: "feed", ref: projection.runtimeFeedStatus)
-        RefPill(label: "generated", ref: generatedText(projection.generatedAtMs))
+        FridayProofLine(label: "mode", ref: "live-read projection")
+        FridayProofLine(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
+        FridayProofLine(label: "feed", ref: projection.runtimeFeedStatus)
+        FridayProofLine(label: "generated", ref: generatedText(projection.generatedAtMs))
         Button {
           Task { await viewModel.loadDetail(.providersDoctor(probe: nil)) }
         } label: {
@@ -810,8 +810,8 @@ struct FridayProjectionScreen: View {
           title: "Live state mapping",
           value: projection.runtimeFeedStatus.isEmpty ? "not in projection" : projection.runtimeFeedStatus,
           healthy: false)
-        RefPill(label: "action", ref: "mobile/pet/state-mapping")
-        RefPill(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "action", ref: "mobile/pet/state-mapping")
+        FridayProofLine(label: "mission_id", ref: projection.missionId)
       }
     }
     .accessibilityIdentifier("friday.pet-editor.readiness")
@@ -831,13 +831,13 @@ struct FridayProjectionScreen: View {
           emptyText("No proof receipt refs in this projection.")
         } else {
           ForEach(projection.providerReceiptRefs, id: \.self) {
-            RefPill(label: "provider", ref: $0)
+            FridayProofLine(label: "provider", ref: $0)
           }
           ForEach(projection.channelReceiptRefs, id: \.self) {
-            RefPill(label: "channel", ref: $0)
+            FridayProofLine(label: "channel", ref: $0)
           }
         }
-        RefPill(label: "action", ref: "mobile/proof/viewer-open")
+        FridayProofLine(label: "action", ref: "mobile/proof/viewer-open")
       }
     }
     .accessibilityIdentifier("friday.proof-viewer.receipts")
@@ -855,8 +855,8 @@ struct FridayProjectionScreen: View {
         readinessRow(title: "Command sheet", value: "top-left launcher routes selected surfaces", healthy: true)
         readinessRow(title: "Push entry", value: "local permission surface wired; APNs delivery still unproven", healthy: false)
         readinessRow(title: "Widget/control", value: "native launcher proof still required", healthy: false)
-        RefPill(label: "action", ref: "mobile/entrypoints/readiness")
-        RefPill(label: "conversation", ref: projection.fridayConversationId)
+        FridayProofLine(label: "action", ref: "mobile/entrypoints/readiness")
+        FridayProofLine(label: "conversation", ref: projection.fridayConversationId)
       }
     }
     .accessibilityIdentifier("friday.entrypoints.readiness")
@@ -912,7 +912,7 @@ struct FridayProjectionScreen: View {
             } label: {
               Label("Allow", systemImage: "bell.badge")
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(FridayButtonStyle(variant: .primary))
             .tint(MobileTheme.cyan)
             .disabled(pushNotifications.state == .loading)
             .accessibilityIdentifier("friday.settings.push-permission")
@@ -936,7 +936,7 @@ struct FridayProjectionScreen: View {
           .font(.system(size: 13, weight: .medium))
           .foregroundStyle(MobileTheme.textPrimary)
         Spacer()
-        StatusChip(
+        FridayChip(
           text: item.done ? "done" : "not done",
           bg: item.done ? MobileTheme.chipDoneBG : MobileTheme.chipNeutralBG,
           fg: item.done ? MobileTheme.chipDoneFG : MobileTheme.chipNeutralFG)
@@ -961,7 +961,7 @@ struct FridayProjectionScreen: View {
               Image(systemName: "arrow.clockwise")
                 .frame(width: 26, height: 26)
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(FridayButtonStyle(variant: .secondary))
             .disabled(candidateDecisionControlsDisabled(recoveryState))
             .accessibilityLabel("Retry WorkItem")
             .accessibilityIdentifier("friday.workflow.retry-work-item")
@@ -973,7 +973,7 @@ struct FridayProjectionScreen: View {
               Image(systemName: "stop.circle")
                 .frame(width: 26, height: 26)
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(FridayButtonStyle(variant: .secondary))
             .disabled(candidateDecisionControlsDisabled(recoveryState))
             .accessibilityLabel("Cancel WorkItem")
             .accessibilityIdentifier("friday.workflow.cancel-work-item")
@@ -982,7 +982,7 @@ struct FridayProjectionScreen: View {
         candidateDecisionStateView(recoveryState, pendingText: "Updating WorkItem...")
       }
       if let proofRef = item.proofRef {
-        RefPill(label: "proofRef", ref: proofRef)
+        FridayProofLine(label: "proofRef", ref: proofRef)
       }
     }
     .padding(.vertical, 4)
@@ -1003,7 +1003,7 @@ struct FridayProjectionScreen: View {
             Image(systemName: "checkmark")
               .frame(width: 26, height: 26)
           }
-          .buttonStyle(.borderedProminent)
+          .buttonStyle(FridayButtonStyle(variant: .primary))
           .tint(MobileTheme.cyan)
           .disabled(candidateDecisionControlsDisabled(decisionState))
           .accessibilityLabel("Confirm memory candidate")
@@ -1015,7 +1015,7 @@ struct FridayProjectionScreen: View {
             Image(systemName: "xmark")
               .frame(width: 26, height: 26)
           }
-          .buttonStyle(.bordered)
+          .buttonStyle(FridayButtonStyle(variant: .secondary))
           .disabled(candidateDecisionControlsDisabled(decisionState))
           .accessibilityLabel("Reject memory candidate")
           .accessibilityIdentifier("friday.memory.reject-candidate")
@@ -1027,7 +1027,7 @@ struct FridayProjectionScreen: View {
       }
       candidateDecisionStateView(decisionState, pendingText: "Applying memory decision...")
       if !candidate.evidenceRef.isEmpty {
-        RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
+        FridayProofLine(label: "evidenceRef", ref: candidate.evidenceRef)
       }
     }
     .padding(.vertical, 4)
@@ -1048,7 +1048,7 @@ struct FridayProjectionScreen: View {
             Image(systemName: "checkmark")
               .frame(width: 26, height: 26)
           }
-          .buttonStyle(.borderedProminent)
+          .buttonStyle(FridayButtonStyle(variant: .primary))
           .tint(MobileTheme.cyan)
           .disabled(learningDecisionControlsDisabled(decisionState))
           .accessibilityLabel("Confirm run outcome learning candidate")
@@ -1059,7 +1059,7 @@ struct FridayProjectionScreen: View {
             Image(systemName: "xmark")
               .frame(width: 26, height: 26)
           }
-          .buttonStyle(.bordered)
+          .buttonStyle(FridayButtonStyle(variant: .secondary))
           .disabled(learningDecisionControlsDisabled(decisionState))
           .accessibilityLabel("Reject run outcome learning candidate")
         }
@@ -1070,13 +1070,13 @@ struct FridayProjectionScreen: View {
       }
       learningDecisionStateView(decisionState)
       if !candidate.runId.isEmpty {
-        RefPill(label: "runId", ref: candidate.runId)
+        FridayProofLine(label: "runId", ref: candidate.runId)
       }
       if !candidate.workItemId.isEmpty {
-        RefPill(label: "workItemId", ref: candidate.workItemId)
+        FridayProofLine(label: "workItemId", ref: candidate.workItemId)
       }
       if !candidate.evidenceRef.isEmpty {
-        RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
+        FridayProofLine(label: "evidenceRef", ref: candidate.evidenceRef)
       }
     }
     .padding(.vertical, 4)
@@ -1139,7 +1139,7 @@ struct FridayProjectionScreen: View {
         .foregroundStyle(MobileTheme.textPrimary)
       Spacer()
       if let count {
-        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        FridayChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
       }
     }
   }
@@ -1151,7 +1151,7 @@ struct FridayProjectionScreen: View {
   }
 
   private func statusChip(_ text: String) -> some View {
-    StatusChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+    FridayChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
   }
 
   private func generatedText(_ generatedAtMs: Int64) -> String {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
@@ -59,7 +59,7 @@ struct FridayProviderAuthScreen: View {
           Label("Check Provider Auth", systemImage: "stethoscope")
             .frame(maxWidth: .infinity)
         }
-        .buttonStyle(.borderedProminent)
+        .buttonStyle(FridayButtonStyle(variant: .primary))
         .tint(MobileTheme.cyan)
         .disabled(viewModel.detailState.isLoading)
         .accessibilityIdentifier("friday.provider-auth.check")
@@ -113,7 +113,7 @@ struct FridayProviderAuthScreen: View {
         .font(.headline)
         .foregroundStyle(MobileTheme.textPrimary)
       Spacer()
-      StatusChip(
+      FridayChip(
         text: chip,
         bg: healthy ? MobileTheme.chipDoneBG : MobileTheme.chipWarnBG,
         fg: healthy ? MobileTheme.chipDoneFG : MobileTheme.chipWarnFG)
@@ -165,7 +165,7 @@ struct FridayProviderAuthScreen: View {
             .lineLimit(1)
         }
         Spacer()
-        StatusChip(
+        FridayChip(
           text: item.done ? "done" : (item.needsAttention ? "needs action" : "visible"),
           bg: item.done ? MobileTheme.chipDoneBG : (item.needsAttention ? MobileTheme.chipWarnBG : MobileTheme.chipNeutralBG),
           fg: item.done ? MobileTheme.chipDoneFG : (item.needsAttention ? MobileTheme.chipWarnFG : MobileTheme.chipNeutralFG))
@@ -177,15 +177,15 @@ struct FridayProviderAuthScreen: View {
           .fixedSize(horizontal: false, vertical: true)
       }
       if let proofRef = item.proofRef, !proofRef.isEmpty {
-        RefPill(label: "work_item_proof", ref: proofRef)
+        FridayProofLine(label: "work_item_proof", ref: proofRef)
       }
       if item.canRetry || item.canCancel {
         HStack(spacing: 8) {
           if item.canRetry {
-            StatusChip(text: "retry exposed on Home", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+            FridayChip(text: "retry exposed on Home", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
           }
           if item.canCancel {
-            StatusChip(text: "cancel exposed on Home", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+            FridayChip(text: "cancel exposed on Home", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
           }
         }
       }
@@ -243,7 +243,7 @@ struct FridayProviderAuthScreen: View {
         } label: {
           Label("Open Ledger", systemImage: "chart.bar.doc.horizontal")
         }
-        .buttonStyle(.bordered)
+        .buttonStyle(FridayButtonStyle(variant: .secondary))
         .disabled(viewModel.detailState.isLoading)
         .accessibilityIdentifier("friday.provider-workspace.open-ledger")
       }
@@ -293,19 +293,19 @@ struct FridayProviderAuthScreen: View {
           .accessibilityIdentifier("friday.provider-workspace.session-link")
         }
       }
-      .buttonStyle(.bordered)
+      .buttonStyle(FridayButtonStyle(variant: .secondary))
     }
   }
 
   private func providerRefs(_ projection: HomeProjection) -> some View {
     VStack(alignment: .leading, spacing: 8) {
       if let route = projection.routeSelected {
-        RefPill(label: "selected_route", ref: route)
+        FridayProofLine(label: "selected_route", ref: route)
       }
       ForEach(projection.providerReceiptRefs.prefix(3), id: \.self) { ref in
-        RefPill(label: "provider_receipt", ref: ref)
+        FridayProofLine(label: "provider_receipt", ref: ref)
       }
-      RefPill(label: "mission_id", ref: projection.missionId)
+      FridayProofLine(label: "mission_id", ref: projection.missionId)
     }
   }
 
@@ -332,7 +332,7 @@ struct FridayProviderAuthScreen: View {
         .font(.caption)
         .foregroundStyle(MobileTheme.textPrimary)
       Spacer()
-      StatusChip(
+      FridayChip(
         text: state,
         bg: healthy ? MobileTheme.chipDoneBG : MobileTheme.chipNeutralBG,
         fg: healthy ? MobileTheme.chipDoneFG : MobileTheme.chipNeutralFG)
@@ -361,7 +361,7 @@ struct FridayProviderAuthScreen: View {
               .font(.headline)
               .foregroundStyle(MobileTheme.textPrimary)
             Spacer()
-            StatusChip(
+            FridayChip(
               text: detail.providerReadiness == nil ? "readback" : "provider doctor",
               bg: MobileTheme.chipPendingBG,
               fg: MobileTheme.chipPendingFG)
@@ -370,7 +370,7 @@ struct FridayProviderAuthScreen: View {
             .font(.caption)
             .foregroundStyle(MobileTheme.textPrimary)
             .fixedSize(horizontal: false, vertical: true)
-          RefPill(label: "generated", ref: generatedText(detail.generatedAtMs))
+          FridayProofLine(label: "generated", ref: generatedText(detail.generatedAtMs))
           if let providerReadiness = detail.providerReadiness {
             ProviderReadinessPanel(detail: providerReadiness)
           } else {
@@ -431,7 +431,7 @@ struct FridayProviderAuthScreen: View {
           .font(.caption.weight(.semibold))
           .foregroundStyle(MobileTheme.textPrimary)
         ForEach(refs, id: \.self) { ref in
-          RefPill(label: "proof", ref: ref)
+          FridayProofLine(label: "proof", ref: ref)
         }
       }
     }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -71,19 +71,19 @@ struct FridaySessionDetailScreen: View {
               .foregroundStyle(MobileTheme.textSecondary)
           }
           Spacer()
-          StatusChip(
+          FridayChip(
             text: projection.agentSessionId == nil ? "no session ref" : "read-only",
             bg: projection.agentSessionId == nil ? MobileTheme.chipWarnBG : MobileTheme.chipPendingBG,
             fg: projection.agentSessionId == nil ? MobileTheme.chipWarnFG : MobileTheme.chipPendingFG)
         }
-        RefPill(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "mission_id", ref: projection.missionId)
         if let agentSessionId = projection.agentSessionId {
-          RefPill(label: "agent_session_id", ref: agentSessionId)
+          FridayProofLine(label: "agent_session_id", ref: agentSessionId)
         }
         if let runId = firstRunId(projection) {
-          RefPill(label: "run_id", ref: runId)
+          FridayProofLine(label: "run_id", ref: runId)
         }
-        RefPill(label: "generated", ref: generatedText(projection.generatedAtMs))
+        FridayProofLine(label: "generated", ref: generatedText(projection.generatedAtMs))
       }
     }
   }
@@ -148,7 +148,7 @@ struct FridaySessionDetailScreen: View {
                 .foregroundStyle(MobileTheme.textSecondary)
             }
             Spacer()
-            StatusChip(
+            FridayChip(
               text: resume?.truthLabel ?? "NO-GO",
               bg: resume?.isEnabled == true ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
               fg: resume?.isEnabled == true ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -160,9 +160,9 @@ struct FridaySessionDetailScreen: View {
               .foregroundStyle(MobileTheme.textPrimary)
               .fixedSize(horizontal: false, vertical: true)
           }
-          RefPill(label: "run_id", ref: approval.runId)
-          RefPill(label: "approval_id", ref: approval.approvalId)
-          RefPill(label: "action_digest", ref: short(approval.actionDigest))
+          FridayProofLine(label: "run_id", ref: approval.runId)
+          FridayProofLine(label: "approval_id", ref: approval.approvalId)
+          FridayProofLine(label: "action_digest", ref: short(approval.actionDigest))
 
           VStack(alignment: .leading, spacing: 5) {
             approvalCapabilityRow("Resume", control: resume)
@@ -191,7 +191,7 @@ struct FridaySessionDetailScreen: View {
         .font(.caption.weight(.semibold))
         .foregroundStyle(MobileTheme.textPrimary)
       Spacer()
-      StatusChip(
+      FridayChip(
         text: control?.truthLabel ?? "NO-GO",
         bg: control?.isEnabled == true ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
         fg: control?.isEnabled == true ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -240,7 +240,7 @@ struct FridaySessionDetailScreen: View {
               .frame(maxWidth: .infinity, minHeight: 70, alignment: .topLeading)
               .padding(10)
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(FridayButtonStyle(variant: .secondary))
             .disabled(!control.isEnabled || controlStateDisablesButton(controlState))
             .accessibilityLabel("\(control.title) \(control.truthLabel). \(control.reason)")
             .accessibilityIdentifier("friday.session.control.\(control.id)")
@@ -259,12 +259,12 @@ struct FridaySessionDetailScreen: View {
         Text("Friday Sidecar - private analysis")
           .font(.system(size: 13, weight: .semibold))
         Spacer()
-        StatusChip(text: "private", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+        FridayChip(text: "private", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
       }
       .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
       .padding(.horizontal, 12)
     }
-    .buttonStyle(.bordered)
+    .buttonStyle(FridayButtonStyle(variant: .secondary))
     .accessibilityLabel("Open Friday Sidecar private analysis")
     .accessibilityIdentifier("friday.session.sidecar-open")
   }
@@ -292,7 +292,7 @@ struct FridaySessionDetailScreen: View {
             Image(systemName: "xmark")
               .frame(width: 26, height: 26)
           }
-          .buttonStyle(.bordered)
+          .buttonStyle(FridayButtonStyle(variant: .secondary))
           .accessibilityLabel("Close Friday Sidecar")
           .accessibilityIdentifier("friday.session.sidecar-close")
         }
@@ -344,14 +344,14 @@ struct FridaySessionDetailScreen: View {
           .font(.caption.weight(.semibold))
           .foregroundStyle(MobileTheme.textPrimary)
         Spacer()
-        StatusChip(
+        FridayChip(
           text: truth,
           bg: truth == "NO-GO" ? MobileTheme.chipWarnBG : MobileTheme.chipPendingBG,
           fg: truth == "NO-GO" ? MobileTheme.chipWarnFG : MobileTheme.chipPendingFG)
       }
       .frame(maxWidth: .infinity, minHeight: 36, alignment: .leading)
     }
-    .buttonStyle(.bordered)
+    .buttonStyle(FridayButtonStyle(variant: .secondary))
     .accessibilityLabel("\(title) \(truth)")
   }
 
@@ -393,7 +393,7 @@ struct FridaySessionDetailScreen: View {
           Image(systemName: control.systemImage)
             .frame(width: 28, height: 28)
         }
-        .buttonStyle(.borderedProminent)
+        .buttonStyle(FridayButtonStyle(variant: .primary))
         .tint(MobileTheme.cyan)
         .disabled(!control.isEnabled
           || sessionSendText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -471,10 +471,10 @@ struct FridaySessionDetailScreen: View {
             }
           }
           if let generatedAtMs = section.generatedAtMs {
-            RefPill(label: "generated", ref: generatedText(generatedAtMs))
+            FridayProofLine(label: "generated", ref: generatedText(generatedAtMs))
           }
           ForEach(section.refs, id: \.self) { ref in
-            RefPill(label: nil, ref: ref)
+            FridayProofLine(label: nil, ref: ref)
           }
         case .unavailable(let reason), .notRequested(let reason):
           Text(reason)
@@ -496,7 +496,7 @@ struct FridaySessionDetailScreen: View {
             .foregroundStyle(MobileTheme.textSecondary)
         } else {
           ForEach(refs, id: \.self) { ref in
-            RefPill(label: "proof", ref: ref)
+            FridayProofLine(label: "proof", ref: ref)
           }
         }
       }
@@ -535,7 +535,7 @@ struct FridaySessionDetailScreen: View {
             Image(systemName: "checkmark")
               .frame(width: 26, height: 26)
           }
-          .buttonStyle(.borderedProminent)
+          .buttonStyle(FridayButtonStyle(variant: .primary))
           .tint(MobileTheme.cyan)
           .disabled(learningDecisionControlsDisabled(decisionState))
           .accessibilityLabel("Confirm run outcome learning candidate")
@@ -546,7 +546,7 @@ struct FridaySessionDetailScreen: View {
             Image(systemName: "xmark")
               .frame(width: 26, height: 26)
           }
-          .buttonStyle(.bordered)
+          .buttonStyle(FridayButtonStyle(variant: .secondary))
           .disabled(learningDecisionControlsDisabled(decisionState))
           .accessibilityLabel("Reject run outcome learning candidate")
         }
@@ -557,13 +557,13 @@ struct FridaySessionDetailScreen: View {
       }
       learningDecisionStateView(decisionState)
       if !candidate.runId.isEmpty {
-        RefPill(label: "runId", ref: candidate.runId)
+        FridayProofLine(label: "runId", ref: candidate.runId)
       }
       if !candidate.workItemId.isEmpty {
-        RefPill(label: "workItemId", ref: candidate.workItemId)
+        FridayProofLine(label: "workItemId", ref: candidate.workItemId)
       }
       if !candidate.evidenceRef.isEmpty {
-        RefPill(label: "evidenceRef", ref: candidate.evidenceRef)
+        FridayProofLine(label: "evidenceRef", ref: candidate.evidenceRef)
       }
     }
     .padding(.vertical, 4)
@@ -572,11 +572,11 @@ struct FridaySessionDetailScreen: View {
   private func sectionStatusChip(_ status: SessionContinuationSectionStatus) -> some View {
     switch status {
     case .loaded:
-      return StatusChip(text: "loaded", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+      return FridayChip(text: "loaded", bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
     case .unavailable:
-      return StatusChip(text: "needs connection", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+      return FridayChip(text: "needs connection", bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
     case .notRequested:
-      return StatusChip(text: "no ref", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      return FridayChip(text: "no ref", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
     }
   }
 
@@ -619,23 +619,23 @@ struct FridaySessionDetailScreen: View {
         .font(.headline)
         .foregroundStyle(MobileTheme.textPrimary)
       if let count {
-        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        FridayChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
       }
     }
   }
 
   private func statusChip(_ text: String) -> some View {
-    StatusChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+    FridayChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
   }
 
   private func controlTruthChip(_ control: SessionContinuationControl) -> some View {
     if control.isEnabled {
-      return StatusChip(text: control.truthLabel, bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
+      return FridayChip(text: control.truthLabel, bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
     }
     if control.truthLabel == "read arm" {
-      return StatusChip(text: control.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+      return FridayChip(text: control.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
     }
-    return StatusChip(text: control.truthLabel, bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+    return FridayChip(text: control.truthLabel, bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
   }
 
   private func short(_ s: String) -> String {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
@@ -41,7 +41,7 @@ struct FridayShareIntakeScreen: View {
               Label("Send to Friday", systemImage: "paperplane.fill")
                 .frame(maxWidth: .infinity)
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(FridayButtonStyle(variant: .primary))
             .tint(MobileTheme.cyan)
             .disabled(!canSubmit)
             .accessibilityIdentifier("friday.share.submit")
@@ -81,12 +81,12 @@ struct FridayShareIntakeScreen: View {
           Label("Ready", systemImage: "checkmark.seal.fill")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
-          RefPill(label: "mission_id", ref: receipt.missionId)
+          FridayProofLine(label: "mission_id", ref: receipt.missionId)
           if let workItemId = receipt.workItemId {
-            RefPill(label: "work_item_id", ref: workItemId)
+            FridayProofLine(label: "work_item_id", ref: workItemId)
           }
-          RefPill(label: "surface", ref: receipt.surfaceThreadId)
-          StatusChip(
+          FridayProofLine(label: "surface", ref: receipt.surfaceThreadId)
+          FridayChip(
             text: receipt.createdOrReady ? "created_or_ready" : receipt.status,
             bg: MobileTheme.chipDoneBG,
             fg: MobileTheme.chipDoneFG)
@@ -103,8 +103,8 @@ struct FridayShareIntakeScreen: View {
                 .font(.caption2)
                 .foregroundStyle(MobileTheme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
-              RefPill(label: "handoff", ref: receipt.chatLaunchContext.evidenceRef)
-              RefPill(label: "action", ref: "mobile/share/open-chat-loop")
+              FridayProofLine(label: "handoff", ref: receipt.chatLaunchContext.evidenceRef)
+              FridayProofLine(label: "action", ref: "mobile/share/open-chat-loop")
             }
           }
           Button {
@@ -113,7 +113,7 @@ struct FridayShareIntakeScreen: View {
             Label("Continue in Friday Chat", systemImage: "bubble.left.and.bubble.right")
               .frame(maxWidth: .infinity)
           }
-          .buttonStyle(.borderedProminent)
+          .buttonStyle(FridayButtonStyle(variant: .primary))
           .tint(MobileTheme.cyan)
           .accessibilityIdentifier("friday.share.open-chat-loop")
           Button("New share") { viewModel.reset() }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
@@ -59,7 +59,7 @@ struct FridayTokenLedgerScreen: View {
             .foregroundStyle(MobileTheme.textSecondary)
         }
         Spacer()
-        StatusChip(
+        FridayChip(
           text: status,
           bg: ready ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
           fg: ready ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -88,8 +88,8 @@ struct FridayTokenLedgerScreen: View {
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
-        RefPill(label: "run_id", ref: runId)
-        RefPill(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "run_id", ref: runId)
+        FridayProofLine(label: "mission_id", ref: projection.missionId)
         Button {
           Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
         } label: {
@@ -112,8 +112,8 @@ struct FridayTokenLedgerScreen: View {
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
-        RefPill(label: "mission_id", ref: projection.missionId)
-        RefPill(label: "feed", ref: projection.runtimeFeedStatus)
+        FridayProofLine(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "feed", ref: projection.runtimeFeedStatus)
       }
     }
     .accessibilityIdentifier("friday.token-ledger.no-run-ref")
@@ -131,10 +131,10 @@ struct FridayTokenLedgerScreen: View {
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
           ForEach(projection.providerReceiptRefs.prefix(5), id: \.self) { ref in
-            RefPill(label: "provider_receipt", ref: ref)
+            FridayProofLine(label: "provider_receipt", ref: ref)
           }
           ForEach(projection.channelReceiptRefs.prefix(5), id: \.self) { ref in
-            RefPill(label: "channel_receipt", ref: ref)
+            FridayProofLine(label: "channel_receipt", ref: ref)
           }
         }
       }
@@ -164,7 +164,7 @@ struct FridayTokenLedgerScreen: View {
             .font(.caption)
             .foregroundStyle(MobileTheme.textPrimary)
             .fixedSize(horizontal: false, vertical: true)
-          RefPill(label: "generated", ref: generatedText(detail.generatedAtMs))
+          FridayProofLine(label: "generated", ref: generatedText(detail.generatedAtMs))
           if !detail.facts.isEmpty {
             VStack(spacing: 8) {
               ForEach(detail.facts) { fact in
@@ -174,7 +174,7 @@ struct FridayTokenLedgerScreen: View {
             .accessibilityIdentifier("friday.token-ledger.facts")
           }
           ForEach(detail.refs, id: \.self) { ref in
-            RefPill(label: nil, ref: ref)
+            FridayProofLine(label: nil, ref: ref)
           }
         }
       }
@@ -217,7 +217,7 @@ struct FridayTokenLedgerScreen: View {
         .foregroundStyle(MobileTheme.textPrimary)
       Spacer()
       if let count {
-        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        FridayChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
       }
     }
   }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -80,7 +80,7 @@ struct FridayVoiceScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         HStack(spacing: 8) {
-          StatusChip(
+          FridayChip(
             text: readiness.voiceLoopReady ? "voice ready" : "not ready",
             bg: readiness.voiceLoopReady ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
             fg: readiness.voiceLoopReady ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -100,7 +100,7 @@ struct FridayVoiceScreen: View {
           } label: {
             Label("Allow Voice", systemImage: "mic.badge.plus")
           }
-          .buttonStyle(.borderedProminent)
+          .buttonStyle(FridayButtonStyle(variant: .primary))
           .tint(MobileTheme.cyan)
           .disabled(viewModel.state == .loading)
           .accessibilityIdentifier("friday.voice.permission")
@@ -145,7 +145,7 @@ struct FridayVoiceScreen: View {
               } label: {
                 Text("Allow")
               }
-              .buttonStyle(.bordered)
+              .buttonStyle(FridayButtonStyle(variant: .secondary))
               .disabled(!row.enabled || viewModel.state == .loading)
               .accessibilityIdentifier("friday.voice.permission")
             } else if row.id == "open-chat-loop" {
@@ -154,7 +154,7 @@ struct FridayVoiceScreen: View {
               } label: {
                 Text("Open")
               }
-              .buttonStyle(.bordered)
+              .buttonStyle(FridayButtonStyle(variant: .secondary))
               .disabled(!row.enabled || viewModel.state == .loading)
               .accessibilityLabel("Open Friday Chat voice loop")
               .accessibilityIdentifier("friday.voice.open-chat-loop")
@@ -198,7 +198,7 @@ struct FridayVoiceScreen: View {
         .foregroundStyle(MobileTheme.textPrimary)
       Spacer()
       if let count {
-        StatusChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        FridayChip(text: "\(count)", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
       }
     }
   }
@@ -221,7 +221,7 @@ struct FridayVoiceScreen: View {
   }
 
   private func truthChip(_ truthLabel: String, enabled: Bool) -> some View {
-    StatusChip(
+    FridayChip(
       text: voiceTruthDisplayLabel(truthLabel),
       bg: enabled ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
       fg: enabled ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)

--- a/apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift
@@ -9,7 +9,7 @@ struct ProviderReadinessPanel: View {
       HStack(spacing: 6) {
         statusChip(detail.truthLabel)
         statusChip(detail.proofOnly ? "proof only" : "not proof only")
-        StatusChip(
+        FridayChip(
           text: detail.ok ? "doctor ok" : "doctor not ok",
           bg: detail.ok ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
           fg: detail.ok ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -60,7 +60,7 @@ struct ProviderReadinessPanel: View {
             .font(.system(size: 13, weight: .medium))
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
-          StatusChip(
+          FridayChip(
             text: provider.authenticated ? "authenticated" : "not authenticated",
             bg: provider.authenticated ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
             fg: provider.authenticated ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -86,7 +86,7 @@ struct ProviderReadinessPanel: View {
             .font(.system(size: 13, weight: .medium))
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
-          StatusChip(
+          FridayChip(
             text: route.dispatchable ? "dispatchable" : "blocked",
             bg: route.dispatchable ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
             fg: route.dispatchable ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
@@ -114,7 +114,7 @@ struct ProviderReadinessPanel: View {
             .font(.system(size: 13, weight: .medium))
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
-          StatusChip(
+          FridayChip(
             text: failover.flagEnabled ? "armed" : "off",
             bg: failover.flagEnabled ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
             fg: failover.flagEnabled ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
@@ -137,7 +137,7 @@ struct ProviderReadinessPanel: View {
           .font(.system(size: 13, weight: .medium))
           .foregroundStyle(MobileTheme.textPrimary)
         Spacer()
-        StatusChip(
+        FridayChip(
           text: key.label,
           bg: key.isConfirmedValid ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
           fg: key.isConfirmedValid ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
@@ -147,6 +147,6 @@ struct ProviderReadinessPanel: View {
   }
 
   private func statusChip(_ text: String) -> some View {
-    StatusChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+    FridayChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
   }
 }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "check:client-design-contract": "node scripts/ops/check-friday-client-design-contract.mjs",
     "check:uiux-native-linkage": "node scripts/ops/check-friday-uiux-native-linkage.mjs",
     "check:uiux-selected-visual-proof": "node scripts/ops/check-friday-uiux-selected-visual-proof.mjs",
+    "check:served-ui-design-fidelity": "node scripts/ops/check-friday-served-ui-design-fidelity.mjs",
     "check:uiux-action-traceability": "node scripts/ops/check-friday-uiux-action-traceability.mjs",
     "check:uiux-product-happy-path": "node scripts/ops/check-friday-uiux-product-happy-path.mjs",
     "check:uiux-product-closure": "node scripts/ops/friday-uiux-product-closure-readiness.mjs",

--- a/rust-core/crates/friday-storage/src/retention.rs
+++ b/rust-core/crates/friday-storage/src/retention.rs
@@ -2,8 +2,9 @@
 //!
 //! The session-lifecycle [`crate::session_lifecycle::sweep_lifecycle`] reaper prunes ONLY
 //! `agent_session` (+ its child messages). The other artifact tables — `token_ledger`,
-//! `surface_event`, terminal `mission`/`work_item`, and rejected/expired memory CANDIDATES —
-//! grow UNBOUNDED (memory-extraction + surface_event are written per-run). This module adds an
+//! `surface_event`, `provider_session_event`, terminal `mission`/`work_item`, and
+//! rejected/expired memory CANDIDATES — grow UNBOUNDED (memory-extraction + surface_event/provider
+//! session observation rows are written per-run). This module adds an
 //! age-AND-state-bounded sweep for them, driven from the EXISTING reaper tick behind its OWN
 //! default-off flag (`FRIDAY_RETENTION_SWEEP`) so deploying the new binary deletes NOTHING until
 //! the operator explicitly flips it. The flag read lives in the hub bin; this module is a pure
@@ -12,6 +13,8 @@
 //! ## Operator-approved default windows (the named constants below)
 //!   * `token_ledger`  — 90d  (billing/observability history; keyed on `created_at`).
 //!   * `surface_event` — 90d  (timeline observability; keyed on `created_at_ms`).
+//!   * `provider_session_event` — 90d (provider app-server observation firehose; keyed on
+//!     `observed_at`).
 //!   * terminal `mission` / `work_item` — 365d (keyed on `updated_at_ms`).
 //!   * `memory_item` — confirmed kept INDEFINITELY; rejected/expired CANDIDATES pruned at 30d
 //!     (keyed on `created_at`).
@@ -66,6 +69,8 @@ use rusqlite::Transaction;
 pub const TOKEN_LEDGER_MAX_AGE_MS: i64 = 90 * 24 * 60 * 60 * 1000;
 /// `surface_event` rows older than 90 days are pruned (keyed on `created_at_ms`).
 pub const SURFACE_EVENT_MAX_AGE_MS: i64 = 90 * 24 * 60 * 60 * 1000;
+/// `provider_session_event` rows older than 90 days are pruned (keyed on `observed_at`).
+pub const PROVIDER_SESSION_EVENT_MAX_AGE_MS: i64 = 90 * 24 * 60 * 60 * 1000;
 /// Terminal `mission` rows older than 365 days are pruned (keyed on `updated_at_ms`).
 pub const MISSION_MAX_AGE_MS: i64 = 365 * 24 * 60 * 60 * 1000;
 /// Terminal `work_item` rows older than 365 days are pruned (keyed on `updated_at_ms`).
@@ -86,6 +91,7 @@ pub const DEFAULT_BATCH_LIMIT: i64 = 5_000;
 pub struct RetentionWindows {
     pub token_ledger_max_age_ms: i64,
     pub surface_event_max_age_ms: i64,
+    pub provider_session_event_max_age_ms: i64,
     pub mission_max_age_ms: i64,
     pub work_item_max_age_ms: i64,
     pub memory_candidate_max_age_ms: i64,
@@ -99,6 +105,7 @@ impl Default for RetentionWindows {
         RetentionWindows {
             token_ledger_max_age_ms: TOKEN_LEDGER_MAX_AGE_MS,
             surface_event_max_age_ms: SURFACE_EVENT_MAX_AGE_MS,
+            provider_session_event_max_age_ms: PROVIDER_SESSION_EVENT_MAX_AGE_MS,
             mission_max_age_ms: MISSION_MAX_AGE_MS,
             work_item_max_age_ms: WORK_ITEM_MAX_AGE_MS,
             memory_candidate_max_age_ms: MEMORY_CANDIDATE_MAX_AGE_MS,
@@ -114,6 +121,7 @@ impl Default for RetentionWindows {
 pub struct RetentionOutcome {
     pub token_ledger_deleted: usize,
     pub surface_event_deleted: usize,
+    pub provider_session_event_deleted: usize,
     pub mission_deleted: usize,
     pub work_item_deleted: usize,
     pub memory_item_deleted: usize,
@@ -126,6 +134,7 @@ impl RetentionOutcome {
     pub fn is_empty(&self) -> bool {
         self.token_ledger_deleted == 0
             && self.surface_event_deleted == 0
+            && self.provider_session_event_deleted == 0
             && self.mission_deleted == 0
             && self.work_item_deleted == 0
             && self.memory_item_deleted == 0
@@ -185,7 +194,25 @@ pub fn sweep_retention(
         Err(_e) => out.table_errors += 1,
     }
 
-    // 3. memory_item — rejected/expired CANDIDATES only, by created_at. CONFIRMED is excluded by
+    // 3. provider_session_event — pure age on observed_at. This is the provider app-server
+    //    observation firehose (metadata/delta receipts), not the token ledger. It is a leaf w.r.t.
+    //    Friday's core mission/work_item FKs, so a bounded age sweep cannot orphan mission state.
+    let provider_session_cutoff = now_ms - windows.provider_session_event_max_age_ms;
+    match delete_bounded(
+        conn,
+        "DELETE FROM provider_session_event
+          WHERE rowid IN (
+              SELECT rowid FROM provider_session_event WHERE observed_at < ?1
+               ORDER BY observed_at LIMIT ?2
+          )",
+        provider_session_cutoff,
+        windows.batch_limit,
+    ) {
+        Ok(n) => out.provider_session_event_deleted = n,
+        Err(_e) => out.table_errors += 1,
+    }
+
+    // 4. memory_item — rejected/expired CANDIDATES only, by created_at. CONFIRMED is excluded by
     //    state, so durable memory is NEVER deleted regardless of age. Leaf (no FK refs into it).
     let memory_cutoff = now_ms - windows.memory_candidate_max_age_ms;
     match delete_bounded(
@@ -204,7 +231,7 @@ pub fn sweep_retention(
         Err(_e) => out.table_errors += 1,
     }
 
-    // 4. work_item — terminal status AND aged on updated_at_ms, AND FK-safe (no surviving child
+    // 5. work_item — terminal status AND aged on updated_at_ms, AND FK-safe (no surviving child
     //    in any table that RESTRICT-references work_item). A non-terminal work_item can never
     //    match the status set. Deleted BEFORE mission so an aged-out work_item frees its mission.
     let work_item_cutoff = now_ms - windows.work_item_max_age_ms;
@@ -231,7 +258,7 @@ pub fn sweep_retention(
         Err(_e) => out.table_errors += 1,
     }
 
-    // 5. mission — terminal status AND aged on updated_at_ms, AND FK-safe (no surviving child in
+    // 6. mission — terminal status AND aged on updated_at_ms, AND FK-safe (no surviving child in
     //    ANY table that RESTRICT-references mission). A non-terminal (active/waiting/blocked/
     //    paused) mission can never match the status set.
     let mission_cutoff = now_ms - windows.mission_max_age_ms;
@@ -274,14 +301,16 @@ pub fn sweep_retention(
     // a receipt-write failure is SWALLOWED here, exactly as the session reaper swallows its own.
     let deleted = out.token_ledger_deleted
         + out.surface_event_deleted
+        + out.provider_session_event_deleted
         + out.memory_item_deleted
         + out.work_item_deleted
         + out.mission_deleted;
     if deleted > 0 {
         let summary = format!(
-            "retention.sweep:token_ledger={} surface_event={} memory_item={} work_item={} mission={} errors={}",
+            "retention.sweep:token_ledger={} surface_event={} provider_session_event={} memory_item={} work_item={} mission={} errors={}",
             out.token_ledger_deleted,
             out.surface_event_deleted,
+            out.provider_session_event_deleted,
             out.memory_item_deleted,
             out.work_item_deleted,
             out.mission_deleted,
@@ -509,6 +538,35 @@ mod tests {
             .unwrap();
     }
 
+    fn seed_provider_session_link(db: &Db, id: &str, last_seen: i64) {
+        db.conn()
+            .execute(
+                "INSERT INTO provider_session_link
+                    (friday_session_id, provider, account_key_hash, workspace_id, cwd,
+                     external_session_id, external_thread_id, external_url, sync_mode,
+                     capability_snapshot, last_provider_seen_at, last_friday_event_id, truth_label)
+                 VALUES (?1, 'codex', 'hash', 'workspace', NULL, 'external-session',
+                         'external-thread', NULL, 'provider_app_server_local', '{}', ?2, NULL,
+                         'retention_test_provider_session_link')",
+                params![id, last_seen],
+            )
+            .unwrap();
+    }
+
+    fn seed_provider_session_event(db: &Db, session_id: &str, event_id: &str, observed_at: i64) {
+        db.conn()
+            .execute(
+                "INSERT INTO provider_session_event
+                    (friday_session_id, provider_event_id, provider, event_kind,
+                     transcript_item_kind, body_ref, redaction_level, token_ledger_ref,
+                     approval_ref, audit_receipt_ref, observed_at)
+                 VALUES (?1, ?2, 'codex', 'turn_completed', 'turn', '', 'metadata_only',
+                         NULL, NULL, NULL, ?3)",
+                params![session_id, event_id, observed_at],
+            )
+            .unwrap();
+    }
+
     fn seed_audit(db: &Db, id: &str) {
         let tx = db.conn().unchecked_transaction().unwrap();
         crate::audit::append_audit(&tx, id, "owner", "test.action", None, 1).unwrap();
@@ -616,6 +674,17 @@ mod tests {
             now - 1,
         );
 
+        // provider_session_event: old provider firehose row pruned; recent kept. The parent
+        // provider_session_link remains because this sweep bounds events, not session links.
+        seed_provider_session_link(&db, "ps_1", now);
+        seed_provider_session_event(
+            &db,
+            "ps_1",
+            "pse_old",
+            now - PROVIDER_SESSION_EVENT_MAX_AGE_MS - 1,
+        );
+        seed_provider_session_event(&db, "ps_1", "pse_recent", now - 1);
+
         // audit chain — UNTOUCHED across the sweep.
         seed_audit(&db, "audit_1");
         seed_audit(&db, "audit_2");
@@ -652,6 +721,27 @@ mod tests {
             "surface_event",
             "surface_event_id",
             "se_recent"
+        ));
+
+        // provider_session_event: old leaf gone; recent kept; provider_session_link survives.
+        assert_eq!(out.provider_session_event_deleted, 1);
+        assert!(!exists(
+            &db,
+            "provider_session_event",
+            "provider_event_id",
+            "pse_old"
+        ));
+        assert!(exists(
+            &db,
+            "provider_session_event",
+            "provider_event_id",
+            "pse_recent"
+        ));
+        assert!(exists(
+            &db,
+            "provider_session_link",
+            "friday_session_id",
+            "ps_1"
         ));
 
         // work_item: terminal-old leaf gone; non-terminal-old survives.
@@ -706,7 +796,7 @@ mod tests {
         assert_eq!(tick_kind, "retention.sweep");
         assert_eq!(
             summary,
-            "retention.sweep:token_ledger=1 surface_event=1 memory_item=1 work_item=1 mission=2 errors=0",
+            "retention.sweep:token_ledger=1 surface_event=1 provider_session_event=1 memory_item=1 work_item=1 mission=2 errors=0",
             "summary records the real per-table counts + the concurrent error count"
         );
     }
@@ -880,12 +970,29 @@ mod tests {
 
         // Exactly-at-boundary rows do NOT prune (strict `<`).
         seed_token_ledger(&db, "tl_at", now - TOKEN_LEDGER_MAX_AGE_MS); // == cutoff, not < cutoff
+        seed_provider_session_link(&db, "ps_at", now);
+        seed_provider_session_event(
+            &db,
+            "ps_at",
+            "pse_at",
+            now - PROVIDER_SESSION_EVENT_MAX_AGE_MS,
+        ); // == cutoff, not < cutoff
         let out = sweep_retention(db.conn(), now, w);
         assert_eq!(
             out.token_ledger_deleted, 0,
             "at-exactly-threshold does not fire (strict <)"
         );
+        assert_eq!(
+            out.provider_session_event_deleted, 0,
+            "provider_session_event at threshold does not fire (strict <)"
+        );
         assert!(exists(&db, "token_ledger", "ledger_id", "tl_at"));
+        assert!(exists(
+            &db,
+            "provider_session_event",
+            "provider_event_id",
+            "pse_at"
+        ));
     }
 
     // --- idempotency: a second back-to-back sweep is a no-op ---
@@ -897,6 +1004,13 @@ mod tests {
         let w = RetentionWindows::default();
         seed_conversation(&db, "fconv_1");
         seed_token_ledger(&db, "tl_old", now - TOKEN_LEDGER_MAX_AGE_MS - 1);
+        seed_provider_session_link(&db, "ps_idem", now);
+        seed_provider_session_event(
+            &db,
+            "ps_idem",
+            "pse_old",
+            now - PROVIDER_SESSION_EVENT_MAX_AGE_MS - 1,
+        );
         seed_memory(
             &db,
             "mem_rej",
@@ -915,6 +1029,7 @@ mod tests {
         let first = sweep_retention(db.conn(), now, w);
         assert_eq!(first.table_errors, 0);
         assert_eq!(first.token_ledger_deleted, 1);
+        assert_eq!(first.provider_session_event_deleted, 1);
         assert_eq!(first.memory_item_deleted, 1);
         assert_eq!(first.mission_deleted, 1);
 
@@ -985,12 +1100,30 @@ mod tests {
         for i in 0..5 {
             seed_token_ledger(&db, &format!("tl{i}"), now - TOKEN_LEDGER_MAX_AGE_MS - 1);
         }
+        seed_provider_session_link(&db, "ps_batch", now);
+        for i in 0..5 {
+            seed_provider_session_event(
+                &db,
+                "ps_batch",
+                &format!("pse{i}"),
+                now - PROVIDER_SESSION_EVENT_MAX_AGE_MS - 1,
+            );
+        }
         // Each sweep deletes at most 2; the backlog (5) drains over 3 ticks (2+2+1).
-        assert_eq!(sweep_retention(db.conn(), now, w).token_ledger_deleted, 2);
-        assert_eq!(sweep_retention(db.conn(), now, w).token_ledger_deleted, 2);
-        assert_eq!(sweep_retention(db.conn(), now, w).token_ledger_deleted, 1);
-        assert_eq!(sweep_retention(db.conn(), now, w).token_ledger_deleted, 0);
+        let first = sweep_retention(db.conn(), now, w);
+        assert_eq!(first.token_ledger_deleted, 2);
+        assert_eq!(first.provider_session_event_deleted, 2);
+        let second = sweep_retention(db.conn(), now, w);
+        assert_eq!(second.token_ledger_deleted, 2);
+        assert_eq!(second.provider_session_event_deleted, 2);
+        let third = sweep_retention(db.conn(), now, w);
+        assert_eq!(third.token_ledger_deleted, 1);
+        assert_eq!(third.provider_session_event_deleted, 1);
+        let fourth = sweep_retention(db.conn(), now, w);
+        assert_eq!(fourth.token_ledger_deleted, 0);
+        assert_eq!(fourth.provider_session_event_deleted, 0);
         assert_eq!(count(&db, "token_ledger"), 0);
+        assert_eq!(count(&db, "provider_session_event"), 0);
     }
 
     // --- the default windows ARE the operator-approved constants ---
@@ -1000,6 +1133,10 @@ mod tests {
         let w = RetentionWindows::default();
         assert_eq!(w.token_ledger_max_age_ms, 90 * 24 * 60 * 60 * 1000);
         assert_eq!(w.surface_event_max_age_ms, 90 * 24 * 60 * 60 * 1000);
+        assert_eq!(
+            w.provider_session_event_max_age_ms,
+            90 * 24 * 60 * 60 * 1000
+        );
         assert_eq!(w.mission_max_age_ms, 365 * 24 * 60 * 60 * 1000);
         assert_eq!(w.work_item_max_age_ms, 365 * 24 * 60 * 60 * 1000);
         assert_eq!(w.memory_candidate_max_age_ms, 30 * 24 * 60 * 60 * 1000);

--- a/scripts/ops/check-friday-served-ui-design-fidelity.mjs
+++ b/scripts/ops/check-friday-served-ui-design-fidelity.mjs
@@ -1,0 +1,520 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { createServer } from "node:http";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { extname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = resolve(fileURLToPath(import.meta.url), "..");
+const ROOT = resolve(SCRIPT_DIR, "../..");
+const DEFAULT_DESIGN_ROOT = resolve(process.env.HOME ?? "", "Desktop/friday-design-handoff-20260602");
+const requireFromScript = createRequire(import.meta.url);
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 1) {
+  const arg = process.argv[i];
+  if (!arg.startsWith("--")) continue;
+  const [key, inlineValue] = arg.slice(2).split("=", 2);
+  const value = inlineValue ?? (process.argv[i + 1]?.startsWith("--") ? "true" : process.argv[++i] ?? "true");
+  args.set(key, value);
+}
+
+const designRoot = resolve(args.get("design-root") ?? process.env.FRIDAY_DESIGN_ROOT ?? DEFAULT_DESIGN_ROOT);
+const skipBuild = args.get("skip-build") === "true";
+const distRoot = resolve(args.get("dist") ?? join(ROOT, "dist/ui"));
+const iosSourceRoot = resolve(args.get("ios-source") ?? join(ROOT, "apps/friday-ios/Sources/FridayMobileShell"));
+
+async function loadPlaywrightChromium() {
+  try {
+    return (await import("playwright")).chromium;
+  } catch (error) {
+    const fallbackPackageJson = process.env.FRIDAY_PLAYWRIGHT_PACKAGE_JSON
+      ?? resolve(process.env.HOME ?? "", "Projects/Friday/package.json");
+    try {
+      return createRequire(fallbackPackageJson)("playwright").chromium;
+    } catch {
+      try {
+        return requireFromScript("playwright").chromium;
+      } catch {
+        throw error;
+      }
+    }
+  }
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function readText(path) {
+  return readFileSync(path, "utf8");
+}
+
+function fail(message, details = {}) {
+  return { ok: false, message, details };
+}
+
+function pass(message, details = {}) {
+  return { ok: true, message, details };
+}
+
+function extractCssVariable(css, name) {
+  const match = css.match(new RegExp(`${name.replaceAll("-", "\\-")}\\s*:\\s*([^;]+);`));
+  return match?.[1]?.trim();
+}
+
+function collectFiles(dir, predicate, acc = []) {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      collectFiles(path, predicate, acc);
+    } else if (predicate(path)) {
+      acc.push(path);
+    }
+  }
+  return acc;
+}
+
+function assertSelections() {
+  const desktopSelection = readJson(join(designRoot, "saved/desktop-selection.json"));
+  const mobileSelection = readJson(join(designRoot, "saved/mobile-selection.json"));
+  const checks = [];
+
+  if (!desktopSelection.operatorConfirmed) {
+    checks.push(fail("desktop selection is not operator-confirmed"));
+  }
+  if (!mobileSelection.operatorConfirmed) {
+    checks.push(fail("mobile selection is not operator-confirmed"));
+  }
+  if (desktopSelection.state?.palette !== "cyanCoral") {
+    checks.push(fail("desktop selection palette is not cyanCoral", { actual: desktopSelection.state?.palette }));
+  }
+  if (desktopSelection.state?.layout !== "threePane") {
+    checks.push(fail("desktop selection layout is not threePane", { actual: desktopSelection.state?.layout }));
+  }
+  if (desktopSelection.state?.proofInspector !== "rightDocked") {
+    checks.push(fail("desktop selection proofInspector is not rightDocked", { actual: desktopSelection.state?.proofInspector }));
+  }
+  if (desktopSelection.state?.desktopPet !== "subtleStatus") {
+    checks.push(fail("desktop selection desktopPet is not subtleStatus", { actual: desktopSelection.state?.desktopPet }));
+  }
+  if (mobileSelection.state?.palette !== "cyanCoral") {
+    checks.push(fail("mobile selection palette is not cyanCoral", { actual: mobileSelection.state?.palette }));
+  }
+  if (mobileSelection.state?.form !== "glassNative") {
+    checks.push(fail("mobile selection form is not glassNative", { actual: mobileSelection.state?.form }));
+  }
+  if (mobileSelection.state?.homeLayout !== "chatStatus") {
+    checks.push(fail("mobile selection homeLayout is not chatStatus", { actual: mobileSelection.state?.homeLayout }));
+  }
+  if (mobileSelection.state?.menuModel !== "commandSheet") {
+    checks.push(fail("mobile selection menuModel is not commandSheet", { actual: mobileSelection.state?.menuModel }));
+  }
+  if (mobileSelection.state?.petProminence !== "heroPet") {
+    checks.push(fail("mobile selection petProminence is not heroPet", { actual: mobileSelection.state?.petProminence }));
+  }
+  if (mobileSelection.state?.screen !== "home") {
+    checks.push(fail("mobile selection first screen is not home", { actual: mobileSelection.state?.screen }));
+  }
+
+  return checks.length > 0 ? checks : [pass("operator-confirmed selections loaded")];
+}
+
+function readLockedTokens() {
+  const galleryCss = readText(join(designRoot, "html/mobile-gallery.html"));
+  const accent = extractCssVariable(galleryCss, "--accent");
+  const coral = extractCssVariable(galleryCss, "--coral");
+  const appBg = extractCssVariable(galleryCss, "--app-bg");
+  const ok = extractCssVariable(galleryCss, "--ok");
+  const warn = extractCssVariable(galleryCss, "--warn");
+  const danger = extractCssVariable(galleryCss, "--danger");
+  if (!accent || !coral || !appBg) {
+    throw new Error("Could not extract locked design tokens from mobile-gallery.html");
+  }
+  return { accent, coral, appBg, ok, warn, danger };
+}
+
+function runBuild() {
+  if (skipBuild) return pass("build skipped by explicit flag");
+  const fallbackBin = resolve(process.env.HOME ?? "", "Projects/Friday/node_modules/.bin");
+  const pathValue = [join(ROOT, "node_modules/.bin"), fallbackBin, process.env.PATH ?? ""].join(":");
+  const result = spawnSync("npm", ["run", "build:ui"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    stdio: "pipe",
+    env: { ...process.env, PATH: pathValue },
+  });
+  if (result.status !== 0) {
+    return fail("npm run build:ui failed", {
+      status: result.status,
+      stderr: result.stderr.slice(-4000),
+      stdout: result.stdout.slice(-4000),
+    });
+  }
+  return pass("served ui build completed");
+}
+
+function assertBuiltCss(tokens) {
+  const cssFiles = collectFiles(distRoot, (path) => path.endsWith(".css"));
+  const css = cssFiles.map((path) => readText(path)).join("\n");
+  const lowerCss = css.toLowerCase();
+  const checks = [];
+  const required = [
+    ["accent", tokens.accent],
+    ["coral", tokens.coral],
+    ["appBg", tokens.appBg],
+  ];
+
+  for (const [name, value] of required) {
+    if (!lowerCss.includes(value.toLowerCase())) {
+      checks.push(fail(`built css does not apply locked ${name}`, { expected: value }));
+    }
+  }
+
+  const banned = ["#c77d2e", "#a86620", "#4f7a5c", "--amber-", "--jade-"];
+  for (const value of banned) {
+    if (lowerCss.includes(value.toLowerCase())) {
+      checks.push(fail("built css still carries old amber/jade token", { banned: value }));
+    }
+  }
+
+  return checks.length > 0
+    ? checks
+    : [pass("built css applies cyan/coral tokens and excludes amber/jade tokens", { cssFiles: cssFiles.length })];
+}
+
+function swiftFiles() {
+  return collectFiles(iosSourceRoot, (path) => path.endsWith(".swift")).sort();
+}
+
+function swiftCorpus(files) {
+  return files.map((path) => `\n// ${relative(ROOT, path)}\n${readText(path)}`).join("\n");
+}
+
+function listSwiftMatches(files, pattern) {
+  const matches = [];
+  for (const file of files) {
+    const text = readText(file);
+    const lines = text.split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      if (pattern.test(lines[index])) {
+        matches.push({
+          file: relative(ROOT, file),
+          line: index + 1,
+          text: lines[index].trim().slice(0, 180),
+        });
+      }
+    }
+  }
+  return matches;
+}
+
+function assertIosDesignFidelity(tokens) {
+  const checks = [];
+  const files = swiftFiles();
+  const corpus = swiftCorpus(files);
+
+  if (!corpus.includes("static let cyan = Color(red: 0.07, green: 0.55, blue: 0.62)")) {
+    checks.push(fail("iOS source does not carry the locked cyan token from the selected mobile design"));
+  }
+  if (!corpus.includes("static let coral = Color(red: 0.93, green: 0.42, blue: 0.38)")) {
+    checks.push(fail("iOS source does not carry the locked coral token from the selected mobile design"));
+  }
+  if (!corpus.includes("backgroundWarmOffWhite")) {
+    checks.push(fail("iOS source does not expose warm off-white selected background token"));
+  }
+  if (!corpus.includes("GlassPanel<Content: View>")) {
+    checks.push(fail("iOS source does not expose a glass-native panel primitive"));
+  }
+  if (!corpus.includes("HeroPet()") || !corpus.includes("friday.home.selected-hero-pet")) {
+    checks.push(fail("iOS Home does not expose the selected Hero Pet first-screen structure"));
+  }
+  if (!corpus.includes("CommandSheet")) {
+    checks.push(fail("iOS source does not expose the selected command-sheet launcher"));
+  }
+
+  const requiredDesignSystemComponents = [
+    "FridayButton",
+    "FridayChip",
+    "FridayFilter",
+    "FridaySegmentedControl",
+    "FridayProofLine",
+  ];
+  for (const name of requiredDesignSystemComponents) {
+    if (!new RegExp(`\\b(struct|enum)\\s+${name}\\b`).test(corpus)) {
+      checks.push(fail(`iOS design-system component is missing: ${name}`));
+    }
+  }
+
+  const bannedPatterns = [
+    {
+      name: "stock borderedProminent button",
+      pattern: /\.buttonStyle\(\.borderedProminent\)/,
+    },
+    {
+      name: "stock bordered button",
+      pattern: /\.buttonStyle\(\.bordered\)/,
+    },
+    {
+      name: "generic StatusChip primitive",
+      pattern: /\bstruct\s+StatusChip\b/,
+    },
+    {
+      name: "flat RefPill primitive",
+      pattern: /\bstruct\s+RefPill\b/,
+    },
+    {
+      name: "raw Read Arms debug card in user source",
+      pattern: /"Read Arms"/,
+    },
+  ];
+  for (const { name, pattern } of bannedPatterns) {
+    const matches = listSwiftMatches(files, pattern);
+    if (matches.length > 0) {
+      checks.push(fail(`iOS user path still contains ${name}`, { matches: matches.slice(0, 12), totalMatches: matches.length }));
+    }
+  }
+
+  const commandSheet = readText(join(iosSourceRoot, "CommandSheet.swift"));
+  if (/\("Setup",\s*\[[^\]]*\.entrypoints[^\]]*\]\)/s.test(commandSheet)) {
+    checks.push(fail("iOS Command Sheet still exposes entrypoints/debug destination in the user launcher"));
+  }
+  if (/readinessFooter/.test(commandSheet)) {
+    checks.push(fail("iOS Command Sheet still exposes readiness footer in the user launcher"));
+  }
+
+  return checks.length > 0
+    ? checks
+    : [pass("iOS source applies selected mobile design system and keeps debug/readiness surfaces out of the user path", {
+      swiftFiles: files.length,
+      lockedTokens: { accent: tokens.accent, coral: tokens.coral, appBg: tokens.appBg },
+    })];
+}
+
+function contentType(path) {
+  switch (extname(path)) {
+    case ".html": return "text/html; charset=utf-8";
+    case ".js": return "text/javascript; charset=utf-8";
+    case ".css": return "text/css; charset=utf-8";
+    case ".json": return "application/json; charset=utf-8";
+    case ".svg": return "image/svg+xml";
+    case ".png": return "image/png";
+    case ".jpg":
+    case ".jpeg": return "image/jpeg";
+    case ".woff2": return "font/woff2";
+    default: return "application/octet-stream";
+  }
+}
+
+function apiDataFor(pathname) {
+  if (pathname === "/v1/auth/me") {
+    return { user: { id: "design-gate-user", displayName: "Design Gate", role: "operator" }, scopes: ["local"] };
+  }
+  if (pathname === "/v1/auth/bootstrap/status") {
+    return { bootstrapRequired: false };
+  }
+  if (pathname === "/v1/setup/status") {
+    return {
+      needsSetup: false,
+      setupCompletedAt: "2026-06-29T00:00:00.000Z",
+      completedSteps: [],
+      skippedSteps: [],
+    };
+  }
+  if (pathname === "/v1/health" || pathname === "/v1/health/capabilities") {
+    return { status: "healthy", capabilities: { system: { healthStatus: "healthy" } } };
+  }
+  if (pathname === "/v1/uix/user-profile") {
+    return { profileType: "developer", onboardedAt: "2026-06-29T00:00:00.000Z" };
+  }
+  if (pathname === "/v1/uix/preferences") {
+    return { items: [] };
+  }
+  if (pathname === "/v1/uix/home-snapshot") {
+    return { snapshot: { generatedAt: "2026-06-29T00:00:00.000Z", runs: [], pendingApprovals: [], scheduledAutomations: [] } };
+  }
+  if (pathname.startsWith("/v1/diagnosis/learning/overview")) {
+    return {
+      coverage: {
+        patterns: 0,
+        lessons: 0,
+        autoFixActions: 0,
+        autoFixOutcomeBuckets: { recordedActions: 0, verifiedRepairs: 0, diagnosticOnly: 0, rollbackFailed: 0 },
+      },
+      recentRejectedFixes: [],
+    };
+  }
+  if (pathname === "/v1/providers") {
+    return { items: [] };
+  }
+  if (pathname === "/v1/providers/health") {
+    return { items: [] };
+  }
+  if (pathname === "/v1/providers/routing") {
+    return { defaultProviderId: "codex", defaultModel: "gpt-5.5", fallbackProviderIds: [] };
+  }
+  if (pathname.startsWith("/v1/providers/routing/explain")) {
+    return {
+      selected: {
+        providerId: "codex",
+        providerKind: "openai",
+        model: "gpt-5.5",
+        backendKind: "local",
+        pinned: false,
+      },
+    };
+  }
+  if (pathname === "/v1/agent/automations") {
+    return { items: [] };
+  }
+  return {};
+}
+
+function startStaticServer() {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    if (url.pathname.startsWith("/v1/")) {
+      const body = JSON.stringify({ ok: true, data: apiDataFor(url.pathname), requestId: "served-ui-design-gate" });
+      res.writeHead(200, { "content-type": "application/json; charset=utf-8" });
+      res.end(body);
+      return;
+    }
+
+    let filePath = resolve(distRoot, `.${decodeURIComponent(url.pathname)}`);
+    if (!filePath.startsWith(distRoot)) {
+      res.writeHead(403);
+      res.end("forbidden");
+      return;
+    }
+    try {
+      if (statSync(filePath).isDirectory()) {
+        filePath = join(filePath, "index.html");
+      }
+    } catch {
+      filePath = join(distRoot, "index.html");
+    }
+    try {
+      res.writeHead(200, { "content-type": contentType(filePath) });
+      res.end(readFileSync(filePath));
+    } catch {
+      res.writeHead(404);
+      res.end("not found");
+    }
+  });
+
+  return new Promise((resolveServer, rejectServer) => {
+    server.once("error", rejectServer);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        rejectServer(new Error("static server did not bind to a tcp port"));
+        return;
+      }
+      resolveServer({ server, url: `http://127.0.0.1:${address.port}` });
+    });
+  });
+}
+
+async function assertRenderedStructure(tokens) {
+  const { server, url } = await startStaticServer();
+  let browser;
+  try {
+    const chromium = await loadPlaywrightChromium();
+    browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage({ viewport: { width: 1440, height: 960 } });
+    await page.addInitScript(() => {
+      window.localStorage.setItem("friday.auth.user", JSON.stringify({ id: "design-gate-user", displayName: "Design Gate", role: "operator" }));
+      window.sessionStorage.setItem("friday.auth.sessionAccessToken", "design-gate-token");
+      window.sessionStorage.setItem("friday.auth.sessionAccessTokenExpiresAt", String(Date.now() + 60_000));
+      window.localStorage.setItem("friday.shell.right-rail-collapsed", "0");
+      window.localStorage.setItem("friday.shell.rail-collapsed", "0");
+    });
+
+    await page.goto(`${url}/home`, { waitUntil: "networkidle" });
+    await page.waitForSelector('[data-testid="app-shell-rail"]', { timeout: 10_000 });
+    await page.waitForSelector('[data-testid="app-shell-right-rail"]', { timeout: 10_000 });
+
+    const result = await page.evaluate((expected) => {
+      const rightRail = document.querySelector('[data-testid="app-shell-right-rail"]');
+      const bottomDockText = [...document.querySelectorAll("section, aside, div")]
+        .some((node) => /Proof inspector\s*[·-]\s*bottom timeline/i.test(node.textContent ?? ""));
+      const heroPet = [...document.querySelectorAll("img")]
+        .some((img) => /Friday status pet/i.test(img.getAttribute("alt") ?? ""));
+      const subtlePet = document.querySelector('[data-testid="desktop-subtle-status-pet"]');
+      const inspector = document.querySelector('[data-testid="desktop-proof-inspector"]');
+      const primaryAction = document.querySelector('[data-friday-ui="button-primary"]');
+      const chip = document.querySelector('[data-friday-ui="chip"]');
+      const filter = document.querySelector('[data-friday-ui="filter"]');
+      const styleProbe = primaryAction ?? rightRail;
+      const computed = styleProbe ? getComputedStyle(styleProbe) : null;
+      const background = computed?.backgroundColor ?? "";
+      const color = computed?.color ?? "";
+      const hasAccentApplied = [background, color].some((value) => {
+        const normalized = value.replaceAll(" ", "");
+        return normalized.includes("15,125,140") || normalized.includes("216,99,77");
+      });
+      return {
+        rightRailPresent: Boolean(rightRail),
+        inspectorPresent: Boolean(inspector),
+        bottomDockText,
+        heroPet,
+        subtlePetPresent: Boolean(subtlePet),
+        primaryActionPresent: Boolean(primaryAction),
+        chipPresent: Boolean(chip),
+        filterPresent: Boolean(filter),
+        hasAccentApplied,
+        expected,
+      };
+    }, tokens);
+
+    const checks = [];
+    if (!result.rightRailPresent) checks.push(fail("served desktop shell does not render a right rail"));
+    if (!result.inspectorPresent) checks.push(fail("served desktop shell does not expose right-docked ProofInspector"));
+    if (result.bottomDockText) checks.push(fail("served desktop still exposes bottom ProofInspector timeline"));
+    if (result.heroPet) checks.push(fail("served desktop home still exposes hero/static pet instead of subtle status pet"));
+    if (!result.subtlePetPresent) checks.push(fail("served desktop subtle-status pet is missing"));
+    if (!result.primaryActionPresent) checks.push(fail("served desktop does not expose design-system primary button marker"));
+    if (!result.chipPresent) checks.push(fail("served desktop does not expose design-system chip marker"));
+    if (!result.filterPresent) checks.push(fail("served desktop does not expose design-system filter marker"));
+    if (!result.hasAccentApplied) checks.push(fail("served desktop rendered controls do not apply cyan/coral accent"));
+
+    return checks.length > 0 ? checks : [pass("served desktop rendered structure matches selected design", result)];
+  } finally {
+    if (browser) await browser.close();
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+}
+
+const report = {
+  status: "unknown",
+  truth_label: "served_desktop_and_ios_design_fidelity_reads_real_selection_and_live_sources",
+  generated_at_utc: new Date().toISOString(),
+  designRoot,
+  distRoot,
+  iosSourceRoot,
+  surface_scope: ["served-desktop-dist-ui", "ios-source-selected-design"],
+  checks: [],
+};
+
+try {
+  report.checks.push(...assertSelections());
+  const tokens = readLockedTokens();
+  report.lockedTokens = tokens;
+  report.checks.push(...assertIosDesignFidelity(tokens));
+  const buildCheck = runBuild();
+  report.checks.push(buildCheck);
+  if (buildCheck.ok) {
+    report.checks.push(...assertBuiltCss(tokens));
+    report.checks.push(...await assertRenderedStructure(tokens));
+  }
+} catch (error) {
+  report.checks.push(fail(error instanceof Error ? error.message : String(error)));
+}
+
+const failures = report.checks.filter((check) => !check.ok);
+report.status = failures.length === 0 ? "pass" : "fail";
+report.failureCount = failures.length;
+console.log(JSON.stringify(report, null, 2));
+process.exit(failures.length === 0 ? 0 : 1);

--- a/scripts/ops/check-friday-served-ui-design-fidelity.mjs
+++ b/scripts/ops/check-friday-served-ui-design-fidelity.mjs
@@ -278,8 +278,9 @@ function assertIosDesignFidelity(tokens) {
   }
 
   const commandSheet = readText(join(iosSourceRoot, "CommandSheet.swift"));
-  if (/\("Setup",\s*\[[^\]]*\.entrypoints[^\]]*\]\)/s.test(commandSheet)) {
-    checks.push(fail("iOS Command Sheet still exposes entrypoints/debug destination in the user launcher"));
+  const commandSheetSections = commandSheet.match(/private let sections:[\s\S]*?var body:/)?.[0] ?? "";
+  if (/\.(proofViewer|entrypoints)\b/.test(commandSheetSections)) {
+    checks.push(fail("iOS Command Sheet still exposes proof/debug destinations in the user launcher"));
   }
   if (/readinessFooter/.test(commandSheet)) {
     checks.push(fail("iOS Command Sheet still exposes readiness footer in the user launcher"));

--- a/scripts/ops/check-friday-uiux-native-linkage.mjs
+++ b/scripts/ops/check-friday-uiux-native-linkage.mjs
@@ -147,7 +147,7 @@ const requirements = [
       mobileProductContract,
     ],
     productContractPath: mobileProductContract,
-    requiredStrings: ["Command Sheet", "friday.command-sheet.readiness-footer", "MobileProductDestinationID.allCases"],
+    requiredStrings: ["Command Sheet", "friday.command-sheet.destination", "MobileProductDestinationID.allCases"],
   },
   {
     id: "mobile-provider-workspace",

--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -621,8 +621,6 @@ derive_workbench_events_if_possible() {
   if [ "${DEFER_CHANNEL_PROOF}" = "1" ]; then
     args+=("--defer-channel-proof")
   fi
-  args+=("--allow-partial-events")
-
   if node "${args[@]}" >"$stdout_out"; then
     if [ -s "$derived_out" ] && [ -n "$existing_events" ]; then
       awk '!seen[$0]++' "$existing_events" "$derived_out" >"$merged_out"

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -439,7 +439,6 @@ if [ -n "${timeline_capture}" ] && [ "${workbench_timeline_status}" != "snapshot
     "--desktop=${desktop_capture}"
     "--timeline=${timeline_capture}"
     "--out=${workbench_events}"
-    "--allow-partial-events"
   )
   if [ -n "${channel_capture}" ]; then
     workbench_events_args+=("--channel=${channel_capture}")

--- a/scripts/ops/friday-workbench-snapshot-events.mjs
+++ b/scripts/ops/friday-workbench-snapshot-events.mjs
@@ -150,8 +150,10 @@ function runPreflight() {
   } catch {
     block("preflight_output_invalid_json", result.stderr || "no stdout");
   }
-  const ready = parsed?.readyForLiveCaptureInput === true
-    || (deferChannelProof && parsed?.readyForDiagnosticTimelineInput === true);
+  const ready = requireReady
+    ? parsed?.readyForLiveCaptureInput === true
+    : parsed?.readyForLiveCaptureInput === true
+      || (deferChannelProof && parsed?.readyForDiagnosticTimelineInput === true);
   if (result.status !== 0 || ready !== true) {
     block("snapshot_preflight_not_ready", JSON.stringify(parsed?.failures || []));
   }
@@ -285,18 +287,18 @@ const rowTruthLabel = preflight?.readyForLiveCaptureInput === true
   ? "derived_from_preflighted_workbench_snapshot_not_final_proof"
   : "derived_from_diagnostic_workbench_snapshot_not_final_proof";
 const canAttemptRows = blockers.length === 0
-  || (allowPartialEvents && payload && Object.values(evidence).every((value) => typeof value === "string"));
+  || (!requireReady && allowPartialEvents && payload && Object.values(evidence).every((value) => typeof value === "string"));
 const rows = canAttemptRows ? makeRows(snapshot, evidence, rowTruthLabel) : [];
-if (rows.length === 0 && (blockers.length === 0 || allowPartialEvents)) {
+if (rows.length === 0 && (blockers.length === 0 || (!requireReady && allowPartialEvents))) {
   block("no_derivable_events", "snapshot produced no diagnostic rows");
 }
 
-if (blockers.length === 0 || (allowPartialEvents && rows.length > 0)) {
+if (blockers.length === 0 || (!requireReady && allowPartialEvents && rows.length > 0)) {
   const out = abs(outPath);
   mkdirSync(dirname(out), { recursive: true });
   writeFileSync(out, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
 }
-const partialReady = blockers.length > 0 && allowPartialEvents && rows.length > 0;
+const partialReady = blockers.length > 0 && !requireReady && allowPartialEvents && rows.length > 0;
 
 const output = {
   truth: "workbench_snapshot_events_bridge_diagnostic_not_proof",

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -1168,7 +1168,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("keeps harvesting workbench happy-path rows when negative-control status labels are absent", () => {
+  it("blocks workbench-derived rows when negative-control status labels are absent", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-partial-workbench-"));
     try {
       writePartialEvidenceDir(tempDir);
@@ -1196,29 +1196,32 @@ describe("friday-ui-device-proof-readiness", () => {
         blockers?: string[];
       };
 
-      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_bridge:ready"))).toBe(true);
-      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_merge:ready"))).toBe(true);
+      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_bridge:ready"))).not.toBe(true);
+      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_merge:ready"))).not.toBe(true);
       expect(result.notes?.some((note) => note.includes("ui_device_gap_report:gaps_present"))).toBe(true);
       expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
 
-      const rows = readFileSync(join(tempDir, "same-run-events.merged.jsonl"), "utf8")
+      expect(existsSync(join(tempDir, "same-run-events.merged.jsonl"))).toBe(false);
+      const rows = readFileSync(join(tempDir, "same-run-events.jsonl"), "utf8")
         .trim()
         .split("\n")
         .map((line) => JSON.parse(line) as { surface?: string; event?: string });
       expect(rows).toContainEqual(expect.objectContaining({
+        surface: "mobile",
+        event: "mission_intake_submitted",
+      }));
+      expect(rows).toContainEqual(expect.objectContaining({
         surface: "desktop",
-        event: "mission_workbench_visible",
-      }));
-      expect(rows).toContainEqual(expect.objectContaining({
-        surface: "timeline",
-        event: "bounded_page_2_visible",
-      }));
-      expect(rows).toContainEqual(expect.objectContaining({
-        surface: "timeline",
-        event: "memory_candidate_review_only",
+        event: "same_mission_projection_visible",
       }));
       expect(rows).not.toContainEqual(expect.objectContaining({
         event: "stale_label_visible",
+      }));
+      expect(rows).not.toContainEqual(expect.objectContaining({
+        event: "mission_workbench_visible",
+      }));
+      expect(rows).not.toContainEqual(expect.objectContaining({
+        surface: "timeline",
       }));
       expect(rows).not.toContainEqual(expect.objectContaining({
         surface: "channel",

--- a/test/unit/qa/friday-uiux-native-linkage-cli.test.ts
+++ b/test/unit/qa/friday-uiux-native-linkage-cli.test.ts
@@ -48,7 +48,7 @@ function writeCompleteRepo(root: string) {
   writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift", "FridayHomeScreen FridayChatScreen");
   writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift", "friday.home.status-card markActivityDone");
   writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift", "friday.chat.composer .accessibilityIdentifier(\"friday.chat.send\") approvalCard action_digest friday.chat.approval-card .accessibilityIdentifier(\"friday.chat.voice-input\") .accessibilityIdentifier(\"friday.chat.voice-output\")");
-  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift", "Command Sheet friday.command-sheet.readiness-footer MobileProductDestinationID.allCases");
+  writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift", "Command Sheet friday.command-sheet.destination MobileProductDestinationID.allCases");
   writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift", "Provider Workspace friday.provider-workspace.overview friday.provider-workspace.open-ledger");
   writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift", "friday.session.sidecar-open friday.session.sidecar-close friday.session.send-button");
   writeFile(root, "apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift", "Readiness plus local voice-loop truth friday.voice.readiness-card .accessibilityIdentifier(\"friday.voice.open-chat-loop\")");

--- a/test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
+++ b/test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -262,7 +262,7 @@ describe("friday-workbench-snapshot-events CLI", () => {
     }
   });
 
-  it("can derive diagnostic timeline rows from a partial non-channel snapshot", () => {
+  it("fails closed in strict mode for a partial non-channel snapshot", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-workbench-events-diagnostic-timeline-"));
     try {
       const missionId = "mission_workbench_events_bridge";
@@ -309,7 +309,7 @@ describe("friday-workbench-snapshot-events CLI", () => {
       });
       writeFileSync(snapshotPath, JSON.stringify({ snapshot: partial }, null, 2));
 
-      const stdout = execFileSync(process.execPath, [
+      const result = spawnSync(process.execPath, [
         "scripts/ops/friday-workbench-snapshot-events.mjs",
         "--mission-id=mission_workbench_events_bridge",
         `--file=${snapshotPath}`,
@@ -323,20 +323,14 @@ describe("friday-workbench-snapshot-events CLI", () => {
         cwd: process.cwd(),
         encoding: "utf8",
       });
-      const result = JSON.parse(stdout) as { status?: string; preflightReady?: boolean; diagnosticTimelineReady?: boolean };
-      const rows = readFileSync(out, "utf8").trim().split("\n").map((line) => JSON.parse(line));
-      const keys = rows.map((row) => `${row.surface}:${row.event}`);
+      const stdout = result.stdout.toString();
+      const parsed = JSON.parse(stdout) as { status?: string; preflightReady?: boolean; diagnosticTimelineReady?: boolean };
 
-      expect(result.status).toBe("ready");
-      expect(result.preflightReady).toBe(false);
-      expect(result.diagnosticTimelineReady).toBe(true);
-      expect(keys).toContain("desktop:mission_resolve_or_create_visible");
-      expect(keys).toContain("timeline:bounded_page_1_visible");
-      expect(keys).toContain("timeline:bounded_page_2_visible");
-      expect(keys).not.toContain("channel:same_mission_projection_visible");
-      expect(new Set(rows.map((row) => row.truth_label))).toEqual(new Set([
-        "derived_from_diagnostic_workbench_snapshot_not_final_proof",
-      ]));
+      expect(result.status).toBe(2);
+      expect(parsed.status).toBe("blocked");
+      expect(parsed.preflightReady).toBe(false);
+      expect(parsed.diagnosticTimelineReady).toBe(true);
+      expect(() => readFileSync(out, "utf8")).toThrow();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/ui/selected-shell-structure.test.ts
+++ b/test/unit/ui/selected-shell-structure.test.ts
@@ -15,23 +15,29 @@ describe("selected shell structure", () => {
     expect(topBarSource).toContain("Open command sheet");
   });
 
-  it("keeps the selected desktop Hub strip and bottom proof dock in the shell", () => {
+  it("keeps the selected desktop Hub strip and right-docked proof inspector in the shell", () => {
     const shellSource = readFileSync("ui/src/components/console/shell/console-shell.tsx", "utf8");
+    const rightRailSource = readFileSync("ui/src/components/console/shell/right-rail.tsx", "utf8");
 
     expect(shellSource).toContain("function DesktopHubStrip");
-    expect(shellSource).toContain("Rust Hub / Core");
-    expect(shellSource).toContain("function DesktopProofDock");
-    expect(shellSource).toContain("Proof inspector");
-    expect(shellSource).toContain("Hub-projected");
+    expect(shellSource).toContain("data-testid=\"desktop-subtle-status-pet\"");
+    expect(shellSource).toContain("Friday Hub");
+    expect(shellSource).toContain("source-of-truth projection");
+    expect(shellSource).toContain("<RightRail />");
+    expect(shellSource).not.toContain("function DesktopProofDock");
+    expect(rightRailSource).toContain("data-testid=\"desktop-proof-inspector\"");
+    expect(rightRailSource).toContain("data-dock=\"right\"");
+    expect(rightRailSource).toContain("Right-docked ProofInspector");
   });
 
-  it("keeps Friday Home on the selected hero pet plus Chat/Status baseline", () => {
+  it("keeps Friday Home on the selected Chat/Status baseline without the old debug hero stage", () => {
     const homeSource = readFileSync("ui/src/routes/home-page.tsx", "utf8");
 
-    expect(homeSource).toContain("function HeroPetStage");
-    expect(homeSource).toContain("/source/pet/g-sit.png");
     expect(homeSource).toContain("Friday Home");
     expect(homeSource).toContain("Chat + Status");
-    expect(homeSource).toContain("providerLabel");
+    expect(homeSource).toContain("Status first, chat always one tap away");
+    expect(homeSource).toContain("ProviderTruthCard");
+    expect(homeSource).toContain("ProviderTruthCompact");
+    expect(homeSource).not.toContain("function HeroPetStage");
   });
 });

--- a/ui/src/components/console/shell/console-shell.tsx
+++ b/ui/src/components/console/shell/console-shell.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
-import { Activity, FileText, ShieldCheck } from "lucide-react";
 import { ProviderTruthCompact } from "@/components/console/shell/provider-truth";
 import { CommandPalette } from "@/components/core/command-palette";
 import { useCustomPacks } from "@/hooks/use-custom-packs";
@@ -228,7 +227,7 @@ export function ConsoleShell() {
             </div>
           ) : null}
 
-          <DesktopHubStrip locale={locale} />
+          <DesktopHubStrip locale={locale} onOpenPalette={() => setPaletteOpen(true)} />
 
           <main
             className={cn(
@@ -246,7 +245,6 @@ export function ConsoleShell() {
             </div>
           </main>
 
-          {!isOnChatPage ? <DesktopProofDock locale={locale} /> : null}
         </div>
 
         <RightRail />
@@ -259,8 +257,8 @@ export function ConsoleShell() {
   );
 }
 
-function DesktopHubStrip(props: { locale: "zh" | "en" }) {
-  const { locale } = props;
+function DesktopHubStrip(props: { locale: "zh" | "en"; onOpenPalette: () => void }) {
+  const { locale, onOpenPalette } = props;
   const { data: health } = useSystemHealthQuery();
   const providerTruthQuery = useProviderTruthQuery();
   const hubOnline = health?.status !== "offline";
@@ -269,18 +267,40 @@ function DesktopHubStrip(props: { locale: "zh" | "en" }) {
     <div
       className="hidden items-center gap-2 border-b px-4 py-2 text-xs lg:flex"
       style={{
-        background: "var(--amber-100)",
-        borderColor: "rgba(122, 106, 88, 0.18)",
+        background: "var(--surface-glass)",
+        borderColor: "var(--surface-border)",
         color: "var(--ink-700)",
+        backdropFilter: "blur(16px) saturate(1.35)",
       }}
     >
       <span
+        data-testid="desktop-subtle-status-pet"
         aria-hidden="true"
-        className="h-2 w-2 shrink-0 rounded-full"
-        style={{ background: hubOnline ? "var(--jade-500)" : "var(--rust-500)" }}
-      />
-      <strong style={{ color: "var(--ink-900)" }}>Rust Hub / Core</strong>
-      <span>{localize(locale, "真相源投影", "source-of-truth projection")}</span>
+        className="grid h-6 w-6 shrink-0 place-items-center rounded-[var(--radius-sm)] border"
+        style={{
+          borderColor: "rgba(15, 125, 140, 0.16)",
+          background: "rgba(15, 125, 140, 0.08)",
+          color: hubOnline ? "var(--ok)" : "var(--danger)",
+        }}
+      >
+        <span className="h-2 w-2 rounded-full" style={{ background: hubOnline ? "var(--ok)" : "var(--danger)" }} />
+      </span>
+      <strong style={{ color: "var(--ink-900)" }}>Friday Hub</strong>
+      <span data-friday-ui="chip" className="rounded-full px-2 py-1" style={{ background: "var(--accent-soft)", color: "var(--accent)" }}>
+        {localize(locale, "真相源投影", "source-of-truth projection")}
+      </span>
+      <span data-friday-ui="filter" className="rounded-full border px-2 py-1" style={{ borderColor: "rgba(15, 125, 140, 0.22)", color: "var(--ink-500)" }}>
+        {localize(locale, "证据优先", "Proof first")}
+      </span>
+      <button
+        type="button"
+        data-friday-ui="button-primary"
+        className="rounded-full px-3 py-1 font-semibold"
+        style={{ background: "var(--accent)", color: "white" }}
+        onClick={onOpenPalette}
+      >
+        {localize(locale, "命令", "Command")}
+      </button>
       <ProviderTruthCompact
         locale={locale}
         truth={providerTruthQuery.data}
@@ -288,46 +308,5 @@ function DesktopHubStrip(props: { locale: "zh" | "en" }) {
         className="ml-auto min-h-0 px-2 py-1"
       />
     </div>
-  );
-}
-
-function DesktopProofDock(props: { locale: "zh" | "en" }) {
-  const { locale } = props;
-  const { data: health } = useSystemHealthQuery();
-  const status = health?.status ?? "healthy";
-
-  return (
-    <section
-      className="hidden border-t px-4 py-3 lg:block"
-      aria-label={localize(locale, "证据时间线", "Proof timeline")}
-      style={{
-        background: "var(--surface-2)",
-        borderColor: "rgba(122, 106, 88, 0.18)",
-      }}
-    >
-      <div
-        className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.06em]"
-        style={{ color: "var(--ink-700)" }}
-      >
-        <ShieldCheck className="h-3.5 w-3.5" />
-        <span>{localize(locale, "证据检查器 · 底部时间线", "Proof inspector · bottom timeline")}</span>
-        <span className="ml-auto text-[10.5px] normal-case tracking-normal" style={{ color: "var(--ink-300)" }}>
-          {localize(locale, "Hub 投影 · 非独立真相源", "Hub-projected · not an independent source of truth")}
-        </span>
-      </div>
-      <div className="mt-2 grid gap-2 text-[11.5px] md:grid-cols-3" style={{ color: "var(--ink-500)" }}>
-        <span className="inline-flex items-center gap-1.5">
-          <Activity className="h-3 w-3" />
-          {localize(locale, `runtime: ${status}`, `runtime: ${status}`)}
-        </span>
-        <span className="inline-flex items-center gap-1.5">
-          <FileText className="h-3 w-3" />
-          {localize(locale, "动作必须绑定 receipt / audit", "actions bind receipt / audit")}
-        </span>
-        <span className="inline-flex items-center gap-1.5 font-mono">
-          {localize(locale, "source: Rust Hub/Core", "source: Rust Hub/Core")}
-        </span>
-      </div>
-    </section>
   );
 }

--- a/ui/src/components/console/shell/provider-truth.tsx
+++ b/ui/src/components/console/shell/provider-truth.tsx
@@ -32,9 +32,9 @@ function statusDot(status: ProviderTruthStatus): string {
     return "var(--rust-500)";
   }
   if (status === "degraded" || status === "unavailable") {
-    return "var(--amber-600)";
+    return "var(--accent)";
   }
-  return "var(--jade-500)";
+  return "var(--ok)";
 }
 
 function backendLabel(backendKind: string | undefined, locale: AppLocale): string {
@@ -159,8 +159,8 @@ export function ProviderTruthCompact(props: {
         <span
           className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold"
           style={{
-            background: "var(--amber-100)",
-            color: "var(--amber-600)",
+            background: "var(--accent-soft)",
+            color: "var(--accent)",
           }}
         >
           {localize(locale, `${truth.alertCount} 告警`, `${truth.alertCount} alerts`)}
@@ -239,11 +239,11 @@ export function ProviderTruthCard(props: {
           </p>
           <div className="mt-2 flex items-center gap-2">
             {currentProviderStatus === "healthy" ? (
-              <ShieldCheck className="h-4 w-4 shrink-0" style={{ color: "var(--jade-500)" }} />
+              <ShieldCheck className="h-4 w-4 shrink-0" style={{ color: "var(--ok)" }} />
             ) : (
               <ShieldAlert
                 className="h-4 w-4 shrink-0"
-                style={{ color: currentProviderStatus === "offline" ? "var(--rust-500)" : "var(--amber-600)" }}
+                style={{ color: currentProviderStatus === "offline" ? "var(--rust-500)" : "var(--accent)" }}
               />
             )}
             <p className="text-sm font-medium text-[color:var(--color-text-primary)]">

--- a/ui/src/components/console/shell/rail.tsx
+++ b/ui/src/components/console/shell/rail.tsx
@@ -126,7 +126,7 @@ export function Rail({ collapsed, onToggleCollapse }: RailProps) {
             onClick={onToggleCollapse}
             aria-label={localize(locale, collapsed ? "展开导航" : "收起导航", collapsed ? "Expand rail" : "Collapse rail")}
             aria-pressed={collapsed}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] transition-colors hover:bg-[color:var(--amber-100)]"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] transition-colors hover:bg-[color:var(--accent-soft)]"
             style={{ color: "var(--ink-500)" }}
           >
             {collapsed ? <ChevronsRight className="h-4 w-4" /> : <ChevronsLeft className="h-4 w-4" />}
@@ -204,7 +204,7 @@ function RailNavItem(props: {
       )}
       style={({ isActive }) => ({
         color: isActive ? "var(--ink-900)" : "var(--ink-700)",
-        background: isActive ? "var(--amber-100)" : "transparent",
+        background: isActive ? "var(--accent-soft)" : "transparent",
       })}
     >
       <Icon className="h-4 w-4 shrink-0" />
@@ -242,7 +242,7 @@ export function MobileNav(props: { onOpenMore: () => void }) {
             className="flex flex-col items-center justify-center rounded-[var(--radius-md)] text-[11px] font-medium transition-colors"
             style={({ isActive }) => ({
               color: isActive ? "var(--ink-900)" : "var(--ink-500)",
-              background: isActive ? "var(--amber-100)" : "transparent",
+              background: isActive ? "var(--accent-soft)" : "transparent",
             })}
           >
             <item.Icon className="mb-1 h-4 w-4" />

--- a/ui/src/components/console/shell/right-rail-slots/assistant.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/assistant.tsx
@@ -31,7 +31,7 @@ export function AssistantRightRailSlot() {
         <NavLink
           to="/assistant"
           className="inline-flex items-center gap-1 text-xs"
-          style={{ color: "var(--amber-600)" }}
+          style={{ color: "var(--accent)" }}
         >
           {localize(locale, "全部", "View all")}
           <ChevronRight className="h-3.5 w-3.5" />
@@ -75,7 +75,7 @@ function ApprovalRow(props: {
         background: "var(--surface-2)",
       }}
     >
-      <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--amber-600)" }} />
+      <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--accent)" }} />
       <div className="min-w-0 flex-1">
         <p className="text-sm font-medium" style={{ color: "var(--ink-900)" }}>
           {props.title}

--- a/ui/src/components/console/shell/right-rail-slots/automations.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/automations.tsx
@@ -57,13 +57,13 @@ function Row(props: { to: string; Icon: typeof CalendarClock; title: string; hin
     <li>
       <NavLink
         to={props.to}
-        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--amber-100)]"
+        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
         style={{
           borderColor: "rgba(122, 106, 88, 0.18)",
           background: "var(--surface-2)",
         }}
       >
-        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--amber-600)" }} />
+        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--accent)" }} />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium" style={{ color: "var(--ink-900)" }}>
             {props.title}

--- a/ui/src/components/console/shell/right-rail-slots/channels.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/channels.tsx
@@ -82,12 +82,12 @@ function buildBadge(
     return { label: localize(locale, "总线离线", "Bus offline"), color: "var(--rust-500)" };
   }
   if (status === "unavailable") {
-    return { label: localize(locale, "总线暂不可用", "Bus unavailable"), color: "var(--amber-600)" };
+    return { label: localize(locale, "总线暂不可用", "Bus unavailable"), color: "var(--accent)" };
   }
   if (status === "degraded") {
-    return { label: localize(locale, "部分降级", "Partially degraded"), color: "var(--amber-600)" };
+    return { label: localize(locale, "部分降级", "Partially degraded"), color: "var(--accent)" };
   }
-  return { label: localize(locale, "渠道健康", "Channels healthy"), color: "var(--jade-500)" };
+  return { label: localize(locale, "渠道健康", "Channels healthy"), color: "var(--ok)" };
 }
 
 function Row(props: { to: string; Icon: typeof Radio; title: string; hint: string }) {
@@ -95,13 +95,13 @@ function Row(props: { to: string; Icon: typeof Radio; title: string; hint: strin
     <li>
       <NavLink
         to={props.to}
-        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--amber-100)]"
+        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
         style={{
           borderColor: "rgba(122, 106, 88, 0.18)",
           background: "var(--surface-2)",
         }}
       >
-        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--amber-600)" }} />
+        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--accent)" }} />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium" style={{ color: "var(--ink-900)" }}>
             {props.title}

--- a/ui/src/components/console/shell/right-rail-slots/chat-collapsed.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/chat-collapsed.tsx
@@ -14,7 +14,7 @@ export function ChatCollapsedRightRailSlot() {
       <span
         aria-hidden="true"
         className="flex h-9 w-9 items-center justify-center rounded-full"
-        style={{ background: "var(--amber-100)", color: "var(--amber-600)" }}
+        style={{ background: "var(--accent-soft)", color: "var(--accent)" }}
       >
         <MessageSquare className="h-4 w-4" />
       </span>

--- a/ui/src/components/console/shell/right-rail-slots/home.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/home.tsx
@@ -49,13 +49,13 @@ export function HomeRightRailSlot() {
           <li key={item.to}>
             <NavLink
               to={item.to}
-              className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--amber-100)]"
+              className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
               style={{
                 borderColor: "rgba(122, 106, 88, 0.18)",
                 background: "var(--surface-2)",
               }}
             >
-              <item.icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--amber-600)" }} />
+              <item.icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--accent)" }} />
               <div className="min-w-0 flex-1">
                 <p className="text-sm font-medium" style={{ color: "var(--ink-900)" }}>
                   {item.label}

--- a/ui/src/components/console/shell/right-rail-slots/packs.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/packs.tsx
@@ -61,13 +61,13 @@ function PackRow(props: {
     <li>
       <NavLink
         to={props.to}
-        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--amber-100)]"
+        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
         style={{
           borderColor: "rgba(122, 106, 88, 0.18)",
           background: "var(--surface-2)",
         }}
       >
-        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--amber-600)" }} />
+        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--accent)" }} />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium" style={{ color: "var(--ink-900)" }}>
             {props.title}

--- a/ui/src/components/console/shell/right-rail-slots/sessions.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/sessions.tsx
@@ -43,13 +43,13 @@ export function SessionsRightRailSlot() {
             <li key={session.id}>
               <NavLink
                 to="/sessions"
-                className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--amber-100)]"
+                className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
                 style={{
                   borderColor: "rgba(122, 106, 88, 0.18)",
                   background: "var(--surface-2)",
                 }}
               >
-                <MessageSquare className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--amber-600)" }} />
+                <MessageSquare className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--accent)" }} />
                 <div className="min-w-0 flex-1">
                   <p
                     className="truncate text-sm font-medium"

--- a/ui/src/components/console/shell/right-rail-slots/settings-providers.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/settings-providers.tsx
@@ -5,9 +5,9 @@ import { localize } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
 
 const STATUS_COLOR: Record<string, string> = {
-  healthy: "var(--jade-500)",
-  degraded: "var(--amber-600)",
-  unavailable: "var(--amber-600)",
+  healthy: "var(--ok)",
+  degraded: "var(--accent)",
+  unavailable: "var(--accent)",
   offline: "var(--rust-500)",
 };
 
@@ -43,7 +43,7 @@ export function SettingsProvidersRightRailSlot() {
         <NavLink
           to="/observability"
           className="inline-flex items-center gap-1 text-xs"
-          style={{ color: "var(--amber-600)" }}
+          style={{ color: "var(--accent)" }}
         >
           {localize(locale, "详情", "Details")}
           <ChevronRight className="h-3.5 w-3.5" />

--- a/ui/src/components/console/shell/right-rail-slots/usage.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/usage.tsx
@@ -57,13 +57,13 @@ function Row(props: { to: string; Icon: typeof Gauge; title: string; hint: strin
     <li>
       <NavLink
         to={props.to}
-        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--amber-100)]"
+        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
         style={{
           borderColor: "rgba(122, 106, 88, 0.18)",
           background: "var(--surface-2)",
         }}
       >
-        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--amber-600)" }} />
+        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--accent)" }} />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium" style={{ color: "var(--ink-900)" }}>
             {props.title}

--- a/ui/src/components/console/shell/right-rail-slots/workflows.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/workflows.tsx
@@ -57,13 +57,13 @@ function Row(props: { to: string; Icon: typeof Workflow; title: string; hint: st
     <li>
       <NavLink
         to={props.to}
-        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--amber-100)]"
+        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
         style={{
           borderColor: "rgba(122, 106, 88, 0.18)",
           background: "var(--surface-2)",
         }}
       >
-        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--amber-600)" }} />
+        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--accent)" }} />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium" style={{ color: "var(--ink-900)" }}>
             {props.title}

--- a/ui/src/components/console/shell/right-rail.tsx
+++ b/ui/src/components/console/shell/right-rail.tsx
@@ -120,6 +120,8 @@ export function RightRail() {
   return (
     <aside
       data-testid="app-shell-right-rail"
+      data-friday-ui="proof-inspector"
+      data-dock="right"
       aria-label="Friday rail"
       className="group/right-rail relative hidden shrink-0 overflow-y-auto border-l lg:block"
       style={{
@@ -129,6 +131,15 @@ export function RightRail() {
         transition: "width var(--motion-swift)",
       }}
     >
+      {!collapsed && !forceCollapsed ? (
+        <div
+          data-testid="desktop-proof-inspector"
+          className="sr-only"
+        >
+          Right-docked ProofInspector
+        </div>
+      ) : null}
+
       {!collapsed && !forceCollapsed ? (
         <button
           type="button"

--- a/ui/src/components/console/shell/splash/loading.tsx
+++ b/ui/src/components/console/shell/splash/loading.tsx
@@ -15,7 +15,7 @@ export function LoadingSplash(props: Omit<SplashShellProps, "visual"> & { eyebro
         <span
           aria-hidden="true"
           className="inline-flex h-10 w-10 items-center justify-center rounded-full"
-          style={{ background: "var(--amber-100)", color: "var(--amber-600)" }}
+          style={{ background: "var(--accent-soft)", color: "var(--accent)" }}
         >
           <Loader2 className="h-5 w-5 animate-spin" />
         </span>

--- a/ui/src/components/console/shell/splash/setup-gate.tsx
+++ b/ui/src/components/console/shell/splash/setup-gate.tsx
@@ -9,12 +9,12 @@ import { SplashShell, type SplashShellProps } from "./shell";
 export function SetupGateSplash(props: Omit<SplashShellProps, "visual">) {
   return (
     <SplashShell
-      accentColor="var(--amber-600)"
+      accentColor="var(--accent)"
       visual={
         <span
           aria-hidden="true"
           className="inline-flex h-10 w-10 items-center justify-center rounded-full"
-          style={{ background: "var(--amber-100)", color: "var(--amber-600)" }}
+          style={{ background: "var(--accent-soft)", color: "var(--accent)" }}
         >
           <Wrench className="h-5 w-5" />
         </span>

--- a/ui/src/components/console/shell/splash/shell.tsx
+++ b/ui/src/components/console/shell/splash/shell.tsx
@@ -32,14 +32,14 @@ export interface SplashShellProps {
 
 const PILL_STYLE: Record<NonNullable<SplashPill["tone"]>, { background: string; color: string }> = {
   neutral: { background: "var(--surface-2)", color: "var(--ink-700)" },
-  amber: { background: "var(--amber-100)", color: "var(--amber-600)" },
-  jade: { background: "rgba(79, 122, 92, 0.14)", color: "var(--jade-500)" },
+  amber: { background: "var(--accent-soft)", color: "var(--accent)" },
+  jade: { background: "rgba(79, 122, 92, 0.14)", color: "var(--ok)" },
   rust: { background: "rgba(176, 80, 58, 0.14)", color: "var(--rust-500)" },
 };
 
 const STEP_DOT: Record<NonNullable<SplashStep["status"]>, string> = {
-  done: "var(--jade-500)",
-  active: "var(--amber-500)",
+  done: "var(--ok)",
+  active: "var(--accent)",
   todo: "var(--ink-300)",
 };
 
@@ -57,7 +57,7 @@ export function SplashShell(props: SplashShellProps) {
         {eyebrow ? (
           <p
             className="text-[11px] font-semibold uppercase tracking-[0.18em]"
-            style={{ color: accentColor ?? "var(--amber-600)" }}
+            style={{ color: accentColor ?? "var(--accent)" }}
           >
             {eyebrow}
           </p>
@@ -115,7 +115,7 @@ export function SplashShell(props: SplashShellProps) {
             {actions.map((action) => {
               const isPrimary = action.tone !== "secondary";
               const style = isPrimary
-                ? { background: accentColor ?? "var(--amber-600)", color: "var(--surface-2)" }
+                ? { background: accentColor ?? "var(--accent)", color: "var(--surface-2)" }
                 : {
                     background: "transparent",
                     color: "var(--ink-700)",

--- a/ui/src/components/console/shell/top-bar.tsx
+++ b/ui/src/components/console/shell/top-bar.tsx
@@ -18,18 +18,18 @@ function liveIndicatorParts(status: SystemHealthStatus, locale: AppLocale) {
   }
   if (status === "unavailable") {
     return {
-      color: "var(--amber-600)",
+      color: "var(--accent)",
       label: localize(locale, "能力暂不可用", "Unavailable"),
     };
   }
   if (status === "degraded") {
     return {
-      color: "var(--amber-600)",
+      color: "var(--accent)",
       label: localize(locale, "部分降级", "Degraded"),
     };
   }
   return {
-    color: "var(--jade-500)",
+    color: "var(--ok)",
     label: localize(locale, "Friday 运行中", "Friday online"),
   };
 }
@@ -76,7 +76,7 @@ export function TopBar(props: {
           type="button"
           onClick={onOpenPalette}
           aria-label={localize(locale, "打开命令面板", "Open command palette")}
-          className="inline-flex min-h-[36px] items-center gap-2 rounded-[var(--radius-md)] border px-3 text-xs transition-colors hover:bg-[color:var(--amber-100)]"
+          className="inline-flex min-h-[36px] items-center gap-2 rounded-[var(--radius-md)] border px-3 text-xs transition-colors hover:bg-[color:var(--accent-soft)]"
           style={{
             borderColor: "rgba(122, 106, 88, 0.22)",
             background: "var(--surface-2)",

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -229,57 +229,20 @@ function runtimeChipParts(status: SystemHealthStatus, locale: "zh" | "en") {
   }
   if (status === "unavailable") {
     return {
-      color: "var(--amber-600)",
+      color: "var(--accent)",
       label: localize(locale, "能力暂不可用", "Unavailable"),
     };
   }
   if (status === "degraded") {
     return {
-      color: "var(--amber-600)",
+      color: "var(--accent)",
       label: localize(locale, "部分降级", "Degraded"),
     };
   }
   return {
-    color: "var(--jade-500)",
+    color: "var(--ok)",
     label: localize(locale, "运行正常", "Healthy"),
   };
-}
-
-function HeroPetStage(props: {
-  runtimeLabel: string;
-  providerLabel: string;
-  locale: "zh" | "en";
-}) {
-  const { runtimeLabel, providerLabel, locale } = props;
-
-  return (
-    <div
-      className="overflow-hidden rounded-[22px] border px-4 py-4"
-      style={{
-        borderColor: "rgba(26, 40, 35, 0.12)",
-        background: "linear-gradient(180deg, rgba(15, 125, 140, 0.10), rgba(255, 255, 255, 0.72))",
-      }}
-    >
-      <div className="flex min-h-[180px] items-center justify-center rounded-[18px]" style={{ background: "rgba(255, 255, 255, 0.42)" }}>
-        <img
-          alt={localize(locale, "Friday 状态宠物", "Friday status pet")}
-          src="/source/pet/g-sit.png"
-          className="h-[138px] w-[138px] object-contain"
-          draggable={false}
-        />
-      </div>
-      <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
-        <div className="rounded-[var(--radius-md)] border px-3 py-2" style={{ borderColor: "rgba(122, 106, 88, 0.18)", background: "var(--surface-2)" }}>
-          <p className="font-semibold" style={{ color: "var(--ink-900)" }}>{localize(locale, "状态", "Status")}</p>
-          <p className="mt-0.5 truncate" style={{ color: "var(--ink-500)" }}>{runtimeLabel}</p>
-        </div>
-        <div className="rounded-[var(--radius-md)] border px-3 py-2" style={{ borderColor: "rgba(122, 106, 88, 0.18)", background: "var(--surface-2)" }}>
-          <p className="font-semibold" style={{ color: "var(--ink-900)" }}>{localize(locale, "Provider", "Provider")}</p>
-          <p className="mt-0.5 truncate" style={{ color: "var(--ink-500)" }}>{providerLabel}</p>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export function HomePage() {
@@ -606,12 +569,6 @@ export function HomePage() {
 
           <div className="w-full xl:justify-self-end">
             <div className="space-y-3 xl:ml-auto xl:max-w-[430px]">
-              <HeroPetStage
-                locale={locale}
-                runtimeLabel={runtimeChip.label}
-                providerLabel={providerTruthQuery.data?.current?.providerName ?? localize(locale, "读取中", "Reading")}
-              />
-
               <div className="flex flex-wrap items-center gap-2 xl:justify-end">
                 <span
                   className="inline-flex min-h-[36px] items-center gap-2 rounded-[var(--radius-md)] border px-3 py-1.5 text-xs"
@@ -639,7 +596,7 @@ export function HomePage() {
                 <button
                   type="button"
                   onClick={() => requestCommandPaletteOpen()}
-                  className="inline-flex min-h-[36px] items-center gap-2 rounded-[var(--radius-md)] border px-3 text-xs transition-colors hover:bg-[color:var(--amber-100)]"
+                  className="inline-flex min-h-[36px] items-center gap-2 rounded-[var(--radius-md)] border px-3 text-xs transition-colors hover:bg-[color:var(--accent-soft)]"
                   style={{
                     borderColor: "rgba(122, 106, 88, 0.22)",
                     background: "var(--surface-2)",

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -3,64 +3,58 @@
 @import "./tokens.css";
 
 /*
- * Brand tokens aligned to the Console v1.0 prototype (Friday Console —
- * Real-repo Re-baseline). Values mirror the prototype :root:
- *   --bg #f6f0e4, --paper #fbf6ec, --paper-2 #fffaf0,
- *   --accent #c4532d, --accent-soft #f3dcc9,
- *   --ink #1a1612, --ink-2 #4b4239, --ink-3 #7a6e62, --mute #9a8b7b,
- *   --line #e7dfd4, --line-soft #efe8dd,
- *   --ok #2f7a49, --warn #b86a17, --danger #a53028,
- *   --serif Fraunces, --sans Inter, --mono JetBrains/IBM Plex Mono.
+ * Brand tokens aligned to the operator-confirmed 2026-06-02 Friday design:
+ * warm off-white, cyan action, coral urgency, glassNative panels.
  */
 :root {
-  --color-bg-base: #f6f0e4;
-  --color-ink: #1a1612;
-  --color-accent: #c4532d;
+  --color-bg-base: #f7f6f2;
+  --color-ink: #1f2426;
+  --color-accent: #0f7d8c;
 
-  --color-bg-elevated: #fffaf0;
-  --color-bg-surface: rgba(255, 250, 240, 0.72);
-  --color-bg-surface-strong: rgba(255, 250, 240, 0.88);
-  --color-bg-subtle: rgba(251, 246, 236, 0.56);
-  --color-bg-contrast: rgba(26, 22, 18, 0.045);
+  --color-bg-elevated: #ffffff;
+  --color-bg-surface: rgba(255, 255, 255, 0.58);
+  --color-bg-surface-strong: rgba(255, 255, 255, 0.78);
+  --color-bg-subtle: rgba(255, 255, 255, 0.44);
+  --color-bg-contrast: rgba(31, 36, 38, 0.045);
 
-  --color-border-soft: #e7dfd4;
-  --color-border-strong: #d4c8b6;
+  --color-border-soft: rgba(18, 40, 45, 0.10);
+  --color-border-strong: rgba(15, 125, 140, 0.26);
 
-  --color-text-primary: #1a1612;
-  --color-text-secondary: #4b4239;
-  --color-text-tertiary: #7a6e62;
-  --color-text-faint: #9a8b7b;
+  --color-text-primary: #1f2426;
+  --color-text-secondary: #3f4a4d;
+  --color-text-tertiary: #6d777a;
+  --color-text-faint: #9ca5a7;
 
-  --color-accent-soft: #f3dcc9;
-  --color-accent-muted: rgba(196, 83, 45, 0.06);
-  --color-accent-strong: rgba(196, 83, 45, 0.22);
-  --color-focus-ring: rgba(196, 83, 45, 0.25);
+  --color-accent-soft: rgba(15, 125, 140, 0.12);
+  --color-accent-muted: rgba(15, 125, 140, 0.07);
+  --color-accent-strong: rgba(15, 125, 140, 0.26);
+  --color-focus-ring: rgba(15, 125, 140, 0.26);
 
-  /* Semantic status colors — prototype palette */
-  --color-success: #2f7a49;
-  --color-warning: #b86a17;
-  --color-error: #a53028;
-  --color-info: #c4532d;
-  --color-live: #2f7a49;
+  /* Semantic status colors — selected design palette */
+  --color-success: #277a5d;
+  --color-warning: #a86a1d;
+  --color-error: #c2493f;
+  --color-info: #0f7d8c;
+  --color-live: #277a5d;
 
   /* Status subtle backgrounds and text (StatusPill, cards) */
-  --color-bg-success-subtle: #d9ecd9;
-  --color-bg-warning-subtle: #f5e1c2;
-  --color-bg-danger-subtle: #f5d6cf;
-  --color-text-success: #2f7a49;
-  --color-text-warning: #b86a17;
-  --color-text-danger: #a53028;
-  --color-border-success: #bcd8bc;
-  --color-border-warning: #e6c999;
-  --color-border-danger: #e3b8b0;
+  --color-bg-success-subtle: rgba(39, 122, 93, 0.14);
+  --color-bg-warning-subtle: rgba(168, 106, 29, 0.14);
+  --color-bg-danger-subtle: rgba(194, 73, 63, 0.14);
+  --color-text-success: #277a5d;
+  --color-text-warning: #a86a1d;
+  --color-text-danger: #c2493f;
+  --color-border-success: rgba(39, 122, 93, 0.22);
+  --color-border-warning: rgba(168, 106, 29, 0.24);
+  --color-border-danger: rgba(194, 73, 63, 0.24);
 
   /* Skeleton loading — matches line-soft */
-  --color-skeleton-base: #efe8dd;
-  --color-skeleton-shimmer: rgba(255, 250, 240, 0.55);
+  --color-skeleton-base: rgba(15, 125, 140, 0.08);
+  --color-skeleton-shimmer: rgba(255, 255, 255, 0.58);
 
-  --shadow-card: 0 16px 36px rgba(26, 22, 18, 0.08);
-  --shadow-card-strong: 0 24px 52px rgba(26, 22, 18, 0.1);
-  --shadow-floating: 0 10px 30px rgba(26, 22, 18, 0.06);
+  --shadow-card: 0 18px 42px rgba(17, 35, 40, 0.08);
+  --shadow-card-strong: 0 24px 56px rgba(17, 35, 40, 0.11);
+  --shadow-floating: 0 10px 30px rgba(17, 35, 40, 0.07);
 
   --font-display: "Inter", "SF Pro Display", "PingFang SC", "Hiragino Sans GB", "Noto Sans SC", sans-serif;
   --font-serif: "Fraunces", Georgia, "Songti SC", "Noto Serif SC", serif;
@@ -71,50 +65,50 @@
   --density-section-gap: 1.25rem;
   --density-grid-gap: 1rem;
 
-  --color-bg-chrome: #fbf6ec;
-  --color-bg-chrome-strong: #fbf6ec;
+  --color-bg-chrome: rgba(255, 255, 255, 0.66);
+  --color-bg-chrome-strong: rgba(255, 255, 255, 0.78);
 
   color-scheme: light;
 }
 
 /* ── Chinese locale: warm palette, moderate density, CJK typography ── */
 [data-locale="zh"] {
-  --color-bg-base: #fbf4ea;
-  --color-ink: #2d2118;
-  --color-accent: #c87a3c;
+  --color-bg-base: #f7f6f2;
+  --color-ink: #1f2426;
+  --color-accent: #0f7d8c;
 
-  --color-bg-elevated: #fdf7f0;
+  --color-bg-elevated: #ffffff;
   --color-bg-surface: rgba(255, 255, 255, 0.60);
   --color-bg-surface-strong: rgba(255, 255, 255, 0.78);
-  --color-bg-subtle: rgba(255, 248, 238, 0.45);
-  --color-bg-contrast: rgba(45, 33, 24, 0.05);
+  --color-bg-subtle: rgba(255, 255, 255, 0.45);
+  --color-bg-contrast: rgba(31, 36, 38, 0.05);
 
-  --color-border-soft: rgba(45, 33, 24, 0.10);
-  --color-border-strong: rgba(45, 33, 24, 0.18);
+  --color-border-soft: rgba(18, 40, 45, 0.10);
+  --color-border-strong: rgba(15, 125, 140, 0.26);
 
-  --color-text-primary: #2d2118;
-  --color-text-secondary: rgba(45, 33, 24, 0.74);
-  --color-text-tertiary: rgba(45, 33, 24, 0.56);
-  --color-text-faint: rgba(45, 33, 24, 0.36);
+  --color-text-primary: #1f2426;
+  --color-text-secondary: rgba(31, 36, 38, 0.74);
+  --color-text-tertiary: rgba(31, 36, 38, 0.56);
+  --color-text-faint: rgba(31, 36, 38, 0.38);
 
-  --color-accent-soft: rgba(200, 122, 60, 0.14);
-  --color-accent-muted: rgba(200, 122, 60, 0.08);
-  --color-accent-strong: rgba(200, 122, 60, 0.24);
-  --color-focus-ring: rgba(200, 122, 60, 0.20);
+  --color-accent-soft: rgba(15, 125, 140, 0.12);
+  --color-accent-muted: rgba(15, 125, 140, 0.07);
+  --color-accent-strong: rgba(15, 125, 140, 0.24);
+  --color-focus-ring: rgba(15, 125, 140, 0.20);
 
-  --shadow-card: 0 14px 32px rgba(88, 68, 42, 0.09);
-  --shadow-card-strong: 0 22px 48px rgba(88, 68, 42, 0.11);
-  --shadow-floating: 0 9px 26px rgba(88, 68, 42, 0.07);
+  --shadow-card: 0 14px 32px rgba(17, 35, 40, 0.09);
+  --shadow-card-strong: 0 22px 48px rgba(17, 35, 40, 0.11);
+  --shadow-floating: 0 9px 26px rgba(17, 35, 40, 0.07);
 
-  --color-info: #c87a3c;
+  --color-info: #0f7d8c;
 
-  --color-skeleton-base: #e8ddd0;
-  --color-skeleton-shimmer: rgba(255, 248, 238, 0.5);
+  --color-skeleton-base: rgba(15, 125, 140, 0.08);
+  --color-skeleton-shimmer: rgba(255, 255, 255, 0.5);
 
   --font-display: "PingFang SC", "Hiragino Sans GB", "Noto Sans SC", "Microsoft YaHei", sans-serif;
 
-  --color-bg-chrome: rgba(253, 247, 240, 0.95);
-  --color-bg-chrome-strong: rgba(253, 247, 240, 0.93);
+  --color-bg-chrome: rgba(255, 255, 255, 0.70);
+  --color-bg-chrome-strong: rgba(255, 255, 255, 0.78);
 
   --density-card-padding: 1.15rem;
   --density-card-radius: 22px;
@@ -126,9 +120,9 @@
 
 [data-locale="zh"] body {
   background:
-    radial-gradient(circle at top left, rgba(200, 122, 60, 0.06), transparent 28%),
-    radial-gradient(circle at bottom right, rgba(45, 33, 24, 0.04), transparent 24%),
-    linear-gradient(180deg, #fbf4ea 0%, #f7ede1 100%);
+    radial-gradient(circle at top left, rgba(15, 125, 140, 0.06), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(216, 99, 77, 0.04), transparent 24%),
+    linear-gradient(180deg, #f7f6f2 0%, #ffffff 100%);
 }
 
 [data-locale="zh"] .agent-eyebrow {

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -1,41 +1,47 @@
 /**
- * Console v2.0 brand + shell tokens.
+ * Friday selected-design shell tokens.
  *
- * Surfaces, ink, amber/jade/rust, radius, and shell-layout variables used by
- * the Console shell. Legacy --color-* tokens remain in globals.css so existing
- * pages keep rendering; pages will migrate to these new tokens in later batches.
+ * Derived from the operator-confirmed 2026-06-02 design handoff:
+ * cyan/coral, warm off-white, glassNative, comfort density.
  *
- * Fonts (Noto Serif SC + JetBrains Mono) ship via @fontsource packages imported
- * at the top of main.tsx so the app works offline and avoids first-paint FOUT.
+ * Legacy --color-* tokens remain in globals.css so existing pages keep rendering.
  */
 
 :root {
   /* ── Surfaces ── */
-  --surface-0: #f4eee2; /* page background */
-  --surface-1: #fbf7ee; /* chrome / elevated panel */
-  --surface-2: #ffffff; /* cards / floating */
+  --surface-0: #f7f6f2; /* page background */
+  --surface-1: rgba(255, 255, 255, 0.68); /* chrome / elevated panel */
+  --surface-2: rgba(255, 255, 255, 0.78); /* cards / floating */
+  --surface-glass: rgba(255, 255, 255, 0.54);
+  --surface-glass-strong: rgba(255, 255, 255, 0.76);
+  --surface-border: rgba(18, 40, 45, 0.10);
 
   /* ── Ink (text) ── */
-  --ink-900: #2b2118;
-  --ink-700: #4a3e32;
-  --ink-500: #7a6a58;
-  --ink-300: #b3a794;
+  --ink-900: #1f2426;
+  --ink-700: #3f4a4d;
+  --ink-500: #6d777a;
+  --ink-300: #9ca5a7;
 
-  /* ── Amber (accent) ── */
-  --amber-100: #f4e3c9;
-  --amber-500: #c77d2e;
-  --amber-600: #a86620;
+  /* ── Locked cyan/coral action system ── */
+  --accent: #0f7d8c;
+  --accent-soft: rgba(15, 125, 140, 0.12);
+  --accent-muted: rgba(15, 125, 140, 0.07);
+  --coral: #d8634d;
+  --coral-soft: rgba(216, 99, 77, 0.14);
 
-  /* ── Jade (healthy) ── */
-  --jade-500: #4f7a5c;
+  /* ── Truth colors ── */
+  --ok: #277a5d;
+  --warn: #a86a1d;
+  --danger: #c2493f;
 
-  /* ── Rust (degraded / danger) ── */
-  --rust-500: #b0503a;
+  /* Compatibility status aliases. */
+  --rust-500: var(--danger);
 
   /* ── Radius ── */
-  --radius-sm: 6px;
-  --radius-md: 10px;
-  --radius-lg: 14px;
+  --radius-sm: 11px;
+  --radius-md: 15px;
+  --radius-lg: 22px;
+  --radius-xl: 30px;
 
   /* ── Shell layout ── */
   --shell-rail-w: 240px;


### PR DESCRIPTION
## Summary
- Add a served desktop + iOS selected-design fidelity gate that reads the real operator selection JSON, builds `dist/ui`, renders the served desktop shell, and scans iOS source for selected-design component/user-path drift.
- Realign served desktop `ui/` from the old amber/jade bottom-dock shell to cyan/coral/glassNative, right-docked ProofInspector, and subtle status pet; remove the desktop hero/static pet.
- Move iOS user screens from stock button/chip/proof primitives onto Friday design-system components and remove entrypoints/readiness from the user Command Sheet path.
- Add bounded `provider_session_event` retention to the existing retention sweep and receipt counts.
- Make workbench snapshot events strict: `--require-ready` no longer accepts diagnostic/partial rows or `partial_ready` as success.

## Verification
- `npm run check:served-ui-design-fidelity`
- `npm run build:ios:sim` (sim install/launch/screenshot: `apps/friday-ios/.build-sim/friday-ios-sim.png`)
- `npm run build:api`
- `npx vitest run --project default test/unit/qa/friday-workbench-snapshot-events-cli.test.ts test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts`
- `cargo test -p friday-storage retention::tests -- --nocapture`

## Truth labels / not done in this PR
- This closes the dual-surface design-fidelity mechanism and concrete drift it was built to catch; it does not claim END-BAR, adoption, release GO, or organic user load.
- The Anthropic Claude CLI impersonation adapter removal, G1 first workflow receipt, and last-inch execution/503 product needles remain separate active work.
