### PR TITLE
Fail closed on partial workbench event bridges

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -622,6 +622,12 @@ derive_workbench_events_if_possible() {
     args+=("--defer-channel-proof")
   fi
   if node "${args[@]}" >"$stdout_out"; then
+    local bridge_status
+    bridge_status="$(jq -r '.status // "unknown"' "$stdout_out" 2>/dev/null || printf 'unknown')"
+    if [ "$bridge_status" != "ready" ]; then
+      notes+=("workbench_snapshot_events_bridge:${bridge_status}:${stdout_out}")
+      return 0
+    fi
     if [ -s "$derived_out" ] && [ -n "$existing_events" ]; then
       awk '!seen[$0]++' "$existing_events" "$derived_out" >"$merged_out"
       SAME_RUN_EVENTS="$merged_out"
@@ -636,6 +642,12 @@ derive_workbench_events_if_possible() {
     export SAME_RUN_EVENTS
   else
     local rc=$?
+    local bridge_status
+    bridge_status="$(jq -r '.status // "unknown"' "$stdout_out" 2>/dev/null || printf 'unknown')"
+    if [ "$bridge_status" != "unknown" ]; then
+      notes+=("workbench_snapshot_events_bridge:${bridge_status}:${stdout_out}")
+      return 0
+    fi
     blockers+=("workbench_snapshot_events_bridge:exit_${rc}")
   fi
 }

--- a/scripts/ops/friday-workbench-snapshot-events.mjs
+++ b/scripts/ops/friday-workbench-snapshot-events.mjs
@@ -319,4 +319,4 @@ const output = {
 };
 
 console.log(JSON.stringify(output, null, 2));
-process.exit(blockers.length === 0 || partialReady || !requireReady ? 0 : 2);
+process.exit(blockers.length === 0 || (!requireReady && !allowPartialEvents) ? 0 : 2);

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -1258,9 +1258,10 @@ describe("friday-ui-device-proof-readiness", () => {
         blockers?: string[];
       };
 
-      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_bridge:no_derived_events"))).toBe(true);
+      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_bridge:blocked"))).toBe(true);
       expect(result.notes?.some((note) => note.includes(`resolved_SAME_RUN_EVENTS:${files.events}`))).toBe(true);
       expect(result.blockers).toContain("ui_device_proof_evidence:missing_required_real_evidence_env");
+      expect(result.blockers ?? []).not.toContain("workbench_snapshot_events_bridge:exit_2");
       expect(result.blockers ?? []).not.toContain("ui_device_gap_report:exit_2");
       expect(existsSync(join(tempDir, "same-run-events.merged.jsonl"))).toBe(false);
 

--- a/test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
+++ b/test/unit/qa/friday-workbench-snapshot-events-cli.test.ts
@@ -335,4 +335,77 @@ describe("friday-workbench-snapshot-events CLI", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("does not return exit 0 for partial events even when explicitly allowed", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-workbench-events-partial-ready-"));
+    try {
+      const missionId = "mission_workbench_events_bridge";
+      const snapshotPath = join(tempDir, "snapshot.json");
+      const out = join(tempDir, "workbench-derived-events.jsonl");
+      const files = writeEvidence(tempDir);
+      const partial = makeSnapshot({
+        runtimeFeedStatus: "prep_contract_fallback",
+        providerReceiptRefs: [],
+        channelReceiptRefs: [],
+        memoryCandidates: [],
+        workItems: [
+          {
+            id: "work_timeline",
+            title: "Bounded timeline read",
+            state: "timeline_read",
+            owner: "friday_owned",
+            proofRef: "proof://timeline/page-2/cursor",
+            done: false,
+            blockingReason: "bounded timeline read only; no WorkItem recovery action applies",
+            recoveryKind: "none",
+            canRetry: false,
+            canCancel: false,
+          },
+        ],
+        timelinePages: [
+          { page: 1, cursor: "cursor_1", nextCursor: "cursor_2", eventRefs: ["event_mobile_intake", "event_desktop_projection"] },
+          { page: 2, cursor: "cursor_2", eventRefs: ["event_timeline_read"] },
+        ],
+        transcriptSections: [
+          {
+            id: "section_workbench_events_bridge",
+            title: "Mission projection",
+            groupKind: "mission",
+            missionId,
+            truthLabel: "friday_owned",
+            status: "waiting",
+            events: [
+              transcriptEvent("event_mobile_intake", "mobile", "ready", { surfaceThreadRef: "surface://mobile/thread", workflowRef: "workflow://mission/intake", timelineRef: "timeline://mission/page-1/event-mobile-intake" }),
+              transcriptEvent("event_desktop_projection", "desktop", "waiting", { surfaceThreadRef: "surface://desktop/thread", timelineRef: "timeline://mission/page-1/event-desktop-projection" }),
+              transcriptEvent("event_timeline_read", "timeline", "timeline_read", { workflowRef: "workflow://mission/timeline", timelineRef: "timeline://mission/page-2/cursor" }, "work_timeline"),
+            ],
+          },
+        ],
+      });
+      writeFileSync(snapshotPath, JSON.stringify({ snapshot: partial }, null, 2));
+
+      const result = spawnSync(process.execPath, [
+        "scripts/ops/friday-workbench-snapshot-events.mjs",
+        "--mission-id=mission_workbench_events_bridge",
+        `--file=${snapshotPath}`,
+        `--mobile=${files.mobile}`,
+        `--desktop=${files.desktop}`,
+        `--timeline=${files.timeline}`,
+        `--out=${out}`,
+        "--defer-channel-proof",
+        "--allow-partial-events",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const parsed = JSON.parse(result.stdout) as { status?: string; derivedEvents?: number };
+
+      expect(result.status).toBe(2);
+      expect(parsed.status).toBe("partial_ready");
+      expect(parsed.derivedEvents).toBeGreaterThan(0);
+      expect(readFileSync(out, "utf8")).toContain("mission_workbench_visible");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Make `friday-workbench-snapshot-events` return non-zero for `partial_ready` output so partial diagnostic rows cannot masquerade as ready proof input.
- Make `friday-ui-device-proof-readiness` parse the bridge JSON `.status` before merging derived rows into `SAME_RUN_EVENTS`.
- Add regression coverage for explicit partial events and blocked bridge handling.

## Verification
- `npx vitest run test/unit/qa/friday-workbench-snapshot-events-cli.test.ts test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts`
- `npm run check:served-ui-design-fidelity`
- `npm run check:ios-design-destination-capture-contract`

Truth: this hardens proof readiness against partial workbench-derived events. It does not claim END-BAR, release approval, channel proof completion, or organic adoption.