### PR TITLE
Fail closed Anthropic OAuth product paths

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -332,7 +332,7 @@
         "filename": "src/api/http/routes/friday-provider-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 282
+        "line_number": 283
       }
     ],
     "src/api/http/routes/friday-setup-routes.ts": [
@@ -1124,5 +1124,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-29T23:12:58Z"
+  "generated_at": "2026-06-30T01:36:49Z"
 }

--- a/src/agent/runtime/friday-agent-system-prompt-builder.ts
+++ b/src/agent/runtime/friday-agent-system-prompt-builder.ts
@@ -216,7 +216,7 @@ export function buildFridayAgentSystemPrompt(
     "- For local repo and ops tasks, prefer CLI-backed starter skills before reaching for MCP or generating a new skill\n" +
     "- Diagnosis, recovery, and self-healing review requests: prefer existing starter skills such as issue review, runtime snapshot, and repair-readiness summaries before generating anything new\n" +
     "- Planning, scope review, design review, browser QA, diff review, release docs, benchmark, canary, retro, QA-fix, and security review requests: prefer the matching starter skill before inventing a new workflow or skill\n" +
-    "- For OAuth providers like Claude Max/Pro: use provider oauth_init (it can auto-create or reuse the Anthropic OAuth provider), return URL to user, then provider oauth_complete; if the user asked to switch Friday to Claude, follow with provider set_default\n" +
+    "- For provider OAuth, use provider oauth_init/oauth_complete only for supported OAuth providers such as OpenAI Codex. Anthropic/Claude OAuth is disabled in Friday; configure Anthropic with an API key instead, then validate and set_default if the user asked to switch Friday to Claude.\n" +
     "- MCP (external servers): MCP is a protocol bridge, not the primary orchestration layer. Use built-in tools and workflows before falling back to external MCP servers. Do not encode business plans or orchestration logic into MCP prompt/resource contracts.\n" +
     (messagingEnabled
       ? "- Send messages to users on other platforms: use message\n"

--- a/src/agent/tools/friday-agent-provider-tool.ts
+++ b/src/agent/tools/friday-agent-provider-tool.ts
@@ -1,8 +1,9 @@
 /**
  * Agent Provider Tool — Manage LLM providers from within the agent runtime.
  *
- * Allows the agent to list, create, update, delete providers, and handle OAuth
- * flows for providers like Anthropic (Claude Max/Pro).
+ * Allows the agent to list, create, update, delete providers, and handle
+ * supported OAuth flows. Anthropic/Claude OAuth is intentionally disabled;
+ * configure Anthropic with an API key instead.
  *
  * @module agent/tools/friday-agent-provider-tool
  */
@@ -125,7 +126,7 @@ export function createFridayAgentProviderTool(
       "Actions: list (show all providers), get (single provider by ID), " +
       "create (add new provider), update (modify provider), delete (remove provider), " +
       "doctor (provider/backend health report), auth_profiles (list auth profiles), activate_profile (switch active auth profile), " +
-      "oauth_init (start OAuth flow for Claude Max/Pro - returns authorization URL), " +
+      "oauth_init (start a supported OAuth flow such as OpenAI Codex - returns authorization URL), " +
       "oauth_complete (finish OAuth with authorization code), " +
       "set_default (set default provider and model), " +
       "validate (test provider connection), " +
@@ -416,11 +417,11 @@ export function createFridayAgentProviderTool(
       providerResolution: selection.resolution,
       instructions:
         "1. Open the authorizationUrl in your browser\n" +
-        "2. Log in with your Claude Max/Pro account\n" +
+        "2. Log in with the selected OAuth provider account\n" +
         "3. Click 'Allow' to authorize\n" +
         "4. Copy the code shown (format: code#state)\n" +
         "5. Call oauth_complete with the code\n" +
-        "6. If your goal is to switch Friday to Claude, call set_default after oauth_complete",
+        "6. If your goal is to switch Friday to this provider, call set_default after oauth_complete",
     });
   }
 

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -62,6 +62,7 @@ import {
   resolveExistingOAuthProvider,
   resolveOrProvisionOAuthProvider,
 } from "../../../providers/services/friday-provider-oauth-selection.js";
+import { FRIDAY_ANTHROPIC_OAUTH_DISABLED_MESSAGE } from "../../../providers/oauth/friday-anthropic-oauth.js";
 import {
   type FridayCanonicalApprovalResolution,
   type FridayMutatingActionActor,
@@ -1337,31 +1338,12 @@ export function createFridayProviderRoutes(
       auth: { public: true },
       rateLimitPolicyId: "provider.write",
       async handler(ctx): Promise<FridayInitiateAnthropicOAuthResponse> {
-        const ownerUserId = requireOAuthOwnerUserId(ctx.principal);
-        const raw = ctx.body as Record<string, unknown> | null;
-        const body = raw && typeof raw === "object"
-          ? stripProviderMutationControlFields(raw)
-          : raw;
-        const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.oauth.anthropic.initiate",
-          ctx,
-          body: raw,
-          resourceId: typeof body?.providerId === "string" ? body.providerId : "anthropic",
-          parameters: {
-            ownerUserId,
-            selection: readOAuthSelectionInput(body, "anthropic"),
-          },
-          surface: "api:/v1/auth/oauth/anthropic/initiate",
-        });
-        const selection = await resolveOrProvisionOAuthProvider(
-          deps.providerService,
-          readOAuthSelectionInput(body, "anthropic"),
+        requireOAuthOwnerUserId(ctx.principal);
+        throw new FridayDomainError(
+          "ANTHROPIC_OAUTH_DISABLED",
+          FRIDAY_ANTHROPIC_OAUTH_DISABLED_MESSAGE,
+          { httpStatus: 400 },
         );
-        const oauth = await deps.providerService.initiateOAuthLogin({
-          providerId: selection.provider.id,
-          ownerUserId,
-        });
-        return withCanonicalGate({ oauth }, ticket);
       },
     },
 
@@ -1373,53 +1355,12 @@ export function createFridayProviderRoutes(
       auth: { public: true },
       rateLimitPolicyId: "provider.write",
       async handler(ctx): Promise<FridayCompleteAnthropicOAuthCallbackResponse> {
-        const ownerUserId = requireOAuthOwnerUserId(ctx.principal);
-        const raw = ctx.body as Record<string, unknown> | null;
-        const body = raw && typeof raw === "object"
-          ? stripProviderMutationControlFields(raw)
-          : raw;
-        if (!body || typeof body !== "object") {
-          throw new FridayDomainError(
-            "VALIDATION_ERROR",
-            "Request body is required",
-            { httpStatus: 400 },
-          );
-        }
-        if (typeof body.authorizationCode !== "string" || body.authorizationCode.trim() === "") {
-          throw new FridayDomainError(
-            "VALIDATION_ERROR",
-            "authorizationCode is required and must be a non-empty string",
-            { httpStatus: 400 },
-          );
-        }
-        const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.oauth.anthropic.complete",
-          ctx,
-          body: raw,
-          resourceId: typeof body.providerId === "string" ? body.providerId : "anthropic",
-          parameters: {
-            ownerUserId,
-            selection: readOAuthSelectionInput(body, "anthropic"),
-            authorizationCodePresent: true,
-            statePresent: typeof body.state === "string",
-          },
-          surface: "api:/v1/auth/oauth/anthropic/callback",
-        });
-        const selection = await resolveExistingOAuthProvider(
-          deps.providerService,
-          readOAuthSelectionInput(body, "anthropic"),
-          "oauth_complete",
+        requireOAuthOwnerUserId(ctx.principal);
+        throw new FridayDomainError(
+          "ANTHROPIC_OAUTH_DISABLED",
+          FRIDAY_ANTHROPIC_OAUTH_DISABLED_MESSAGE,
+          { httpStatus: 400 },
         );
-        const providerId = selection.provider.id;
-        const authorizationCode = body.authorizationCode;
-        const state = typeof body.state === "string" ? body.state : undefined;
-        const oauth = await deps.providerService.completeOAuthLogin({
-          providerId,
-          authorizationCode,
-          state,
-          ownerUserId,
-        });
-        return withCanonicalGate({ oauth }, ticket);
       },
     },
     {

--- a/src/cli/friday-cli-auth.ts
+++ b/src/cli/friday-cli-auth.ts
@@ -2,14 +2,13 @@
  * CLI auth commands for provider credential setup.
  *
  * Supported flows:
- * - `friday auth login anthropic`
+ * - `friday auth login anthropic` (legacy command; Anthropic OAuth is disabled)
  * - `friday auth setup-token anthropic`
  * - `friday auth paste-token anthropic`
  * - `friday auth attach-cli codex|claude`
  * - `friday auth status [--provider-id <id>]`
  */
 
-import { execFile as cpExecFile } from "node:child_process";
 import {
   probeFridayCliSession,
 } from "#providers";
@@ -20,6 +19,7 @@ import type {
 } from "#providers";
 import { FridayDomainError } from "#errors";
 import { buildOpenBrowserUrlCommand } from "./friday-cli-open-url.js";
+import { FRIDAY_ANTHROPIC_OAUTH_DISABLED_MESSAGE } from "../providers/oauth/friday-anthropic-oauth.js";
 
 export {
   buildOpenBrowserUrlCommand,
@@ -144,76 +144,11 @@ export async function runFridayCliAuthLoginAnthropic(
   input: FridayCliAuthCommandInput,
   deps: FridayCliAuthCommandDeps,
 ): Promise<void> {
-  const { providerService, stdout, stderr } = deps;
+  const { stderr } = deps;
+  void input;
 
-  // ─── Resolve provider profile ───
-
-  let providerId = input.providerId;
-
-  if (!providerId) {
-    const providers = await providerService.listProviders();
-    const oauthProviders = providers.filter(
-      (p) => p.enabled && p.kind === "anthropic" && p.config.authMode === "oauth",
-    );
-
-    if (oauthProviders.length === 0) {
-      stderr("No enabled Anthropic providers with authMode 'oauth' found.");
-      stderr("Create one first with: friday provider create --kind anthropic --auth-mode oauth");
-      return;
-    }
-    if (oauthProviders.length > 1) {
-      stderr("Multiple OAuth Anthropic providers found. Please specify one with --provider-id:");
-      for (const p of oauthProviders) {
-        stderr(`  ${p.id}  ${p.name}`);
-      }
-      return;
-    }
-    providerId = oauthProviders[0]!.id;
-  }
-
-  // ─── Initiate OAuth login ───
-
-  stdout(`\n🔐 Initiating Anthropic OAuth login for provider ${providerId}…\n`);
-
-  const initiation = await providerService.initiateOAuthLogin({ providerId });
-
-  // Open browser automatically unless --no-browser was passed
-  if (!input.noBrowser) {
-    const { command, args } = buildOpenBrowserUrlCommand(initiation.authorizationUrl);
-    cpExecFile(command, args, { windowsHide: true }, (err) => {
-      if (err) {
-        stderr("Could not open browser automatically.");
-      }
-    });
-  }
-
-  stdout("Open this URL in your browser to authorize:\n");
-  stdout(`  ${initiation.authorizationUrl}\n`);
-
-  // ─── Get authorization code ───
-
-  let authCode = input.code;
-
-  if (!authCode) {
-    authCode = await readCliInput("\nAfter authorizing, paste the code (format: code#state) here:\n", stdout);
-  }
-
-  if (!authCode || authCode.trim() === "") {
-    stderr("No authorization code provided. Aborting.");
-    return;
-  }
-
-  // ─── Complete OAuth login ───
-
-  const result = await providerService.completeOAuthLogin({
-    providerId,
-    authorizationCode: authCode.trim(),
-  });
-
-  stdout(`\n✅ Connected! Provider: ${result.providerId}`);
-  stdout(`   OAuth provider: ${result.oauthProvider}`);
-  stdout(`   Token expires: ${result.expiresAt}`);
-  stdout(`   Scope: ${result.scope}\n`);
+  stderr(FRIDAY_ANTHROPIC_OAUTH_DISABLED_MESSAGE);
+  stderr("Use `friday auth setup-token anthropic` or configure an Anthropic API key provider instead.");
 }
 
 export async function runFridayCliAuthConnectAnthropicToken(

--- a/src/cli/friday-cli.ts
+++ b/src/cli/friday-cli.ts
@@ -555,13 +555,13 @@ Create a minimal local skill template with manifest, entrypoint, and SKILL.md.
 
   if (command === "auth") {
     console.log(`
-friday auth login anthropic [--provider-id <id>] [--code <code#state>] [--no-browser]
+friday auth login anthropic [legacy disabled; use setup-token or API-key provider]
 friday auth setup-token anthropic [--provider-id <id>] [--token <token>]
 friday auth paste-token anthropic [--provider-id <id>] [--token <token>]
 friday auth attach-cli codex|claude --provider-id <id> [--binary-path <path>]
 friday auth status [--provider-id <id>]
 
-Authenticate providers through OAuth, setup-token, or CLI-managed external sessions.
+Authenticate providers through supported OAuth, setup-token, or CLI-managed external sessions.
     `.trim());
     return;
   }
@@ -2088,7 +2088,7 @@ async function cmdAuth(parsed: ParsedArgs): Promise<void> {
       && (parsed.authTarget === "codex" || parsed.authTarget === "claude"))
     || (parsed.authSubcommand === "status" && parsed.authTarget === undefined);
   if (!validAuthCommand) {
-    console.error("Usage: friday auth login anthropic [--provider-id <id>] [--code <code#state>] [--no-browser]");
+    console.error("Usage: friday auth login anthropic [legacy disabled; use setup-token or API-key provider]");
     console.error("   or: friday auth setup-token anthropic [--provider-id <id>] [--token <token>]");
     console.error("   or: friday auth paste-token anthropic [--provider-id <id>] [--token <token>]");
     console.error("   or: friday auth attach-cli codex|claude --provider-id <id> [--binary-path <path>]");

--- a/src/providers/services/friday-provider-oauth-selection.ts
+++ b/src/providers/services/friday-provider-oauth-selection.ts
@@ -1,10 +1,10 @@
 import { FridayDomainError } from "#errors";
 import type { FridayProviderApi, FridayProviderKind, FridayProviderProfile } from "../model/friday-provider.types.js";
+import { FRIDAY_ANTHROPIC_OAUTH_DISABLED_MESSAGE } from "../oauth/friday-anthropic-oauth.js";
 import type { FridayProviderService } from "./friday-provider-service.types.js";
 
-const DEFAULT_OAUTH_PROVIDER_KIND: FridayProviderKind = "anthropic";
+const DEFAULT_OAUTH_PROVIDER_KIND: FridayProviderKind = "openai-codex";
 const SUPPORTED_OAUTH_PROVIDER_KINDS = new Set<FridayProviderKind>([
-  "anthropic",
   "openai-codex",
 ]);
 
@@ -178,10 +178,10 @@ function assertOAuthReadyProvider(
       { httpStatus: 400 },
     );
   }
-  if (provider.kind !== DEFAULT_OAUTH_PROVIDER_KIND) {
-    if (SUPPORTED_OAUTH_PROVIDER_KINDS.has(provider.kind)) {
-      return;
-    }
+  if (provider.kind === "anthropic") {
+    throw new FridayDomainError("UNSUPPORTED_OPERATION", FRIDAY_ANTHROPIC_OAUTH_DISABLED_MESSAGE, { httpStatus: 400 });
+  }
+  if (!SUPPORTED_OAUTH_PROVIDER_KINDS.has(provider.kind)) {
     throw new FridayDomainError("UNSUPPORTED_OPERATION",
       `OAuth automation currently supports ${[...SUPPORTED_OAUTH_PROVIDER_KINDS].join(", ")} providers only. Provider "${provider.id}" is kind "${provider.kind}".`,
       { httpStatus: 400 },
@@ -191,6 +191,9 @@ function assertOAuthReadyProvider(
 
 function readOAuthProviderKind(kind: FridayProviderKind | undefined): FridayProviderKind {
   const resolved = kind ?? DEFAULT_OAUTH_PROVIDER_KIND;
+  if (resolved === "anthropic") {
+    throw new FridayDomainError("UNSUPPORTED_OPERATION", FRIDAY_ANTHROPIC_OAUTH_DISABLED_MESSAGE, { httpStatus: 400 });
+  }
   if (!SUPPORTED_OAUTH_PROVIDER_KINDS.has(resolved)) {
     throw new FridayDomainError("UNSUPPORTED_OPERATION",
       `OAuth automation currently supports ${[...SUPPORTED_OAUTH_PROVIDER_KINDS].join(", ")} providers only.`,

--- a/test/unit/agent/tools/friday-agent-provider-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-provider-tool.test.ts
@@ -44,6 +44,27 @@ function makeProvider(
   };
 }
 
+function makeCodexOAuthProvider(
+  overrides: Partial<FridayProviderProfile> = {},
+): FridayProviderProfile {
+  return makeProvider({
+    id: "openai-codex-oauth-1",
+    kind: "openai-codex",
+    name: "OpenAI Codex OAuth",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
+    defaultModel: "gpt-5.4-mini",
+    config: {
+      api: "openai-codex-responses",
+      authMode: "oauth",
+      oauthProvider: "openai-codex",
+      keySource: { kind: "none" },
+      supportedModels: ["gpt-5.4-mini", "gpt-5.4", "gpt-5.5"],
+      validation: { status: "never" },
+    },
+    ...overrides,
+  });
+}
+
 function createMockProviderService(
   overrides: Partial<FridayProviderService> = {},
 ): FridayProviderService {
@@ -75,17 +96,17 @@ function createMockProviderService(
 }
 
 describe("createFridayAgentProviderTool", () => {
-  it("auto-creates an anthropic oauth provider for oauth_init when providerId is omitted", async () => {
-    const provider = makeProvider({ id: "anthropic-oauth-1" });
+  it("auto-creates an OpenAI Codex oauth provider for oauth_init when providerId is omitted", async () => {
+    const provider = makeCodexOAuthProvider({ id: "openai-codex-oauth-1" });
     const providerService = createMockProviderService({
       createProvider: vi.fn().mockResolvedValue(provider),
       initiateOAuthLogin: vi.fn().mockResolvedValue({
-        authorizationUrl: "https://console.anthropic.com/oauth/authorize",
+        authorizationUrl: "https://chatgpt.com/backend-api/codex/oauth/authorize",
         state: "oauth-state-1",
         codeVerifier: "pkce",
-        scopes: ["org:create_api_key", "user:profile"],
+        scopes: ["codex:run"],
         providerId: provider.id,
-        oauthProvider: "anthropic",
+        oauthProvider: "openai-codex",
       }),
     });
     const tool = createFridayAgentProviderTool({ providerService });
@@ -96,40 +117,40 @@ describe("createFridayAgentProviderTool", () => {
     expect(result.isError).toBeUndefined();
     expect(providerService.createProvider).toHaveBeenCalledWith(
       expect.objectContaining({
-        kind: "anthropic",
-        name: "Claude OAuth",
+        kind: "openai-codex",
+        name: "OpenAI Codex OAuth",
         authMode: "oauth",
-        api: "anthropic-messages",
-        baseUrl: "https://api.anthropic.com",
-        defaultModel: "claude-sonnet-4-6",
-        supportedModels: ["claude-sonnet-4-6", "claude-opus-4-8"],
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        defaultModel: "gpt-5.4-mini",
+        supportedModels: ["gpt-5.4-mini", "gpt-5.4", "gpt-5.5"],
         validateOnSave: false,
       }),
     );
     expect(providerService.initiateOAuthLogin).toHaveBeenCalledWith({
-      providerId: "anthropic-oauth-1",
+      providerId: "openai-codex-oauth-1",
     });
     expect(parsed.providerResolution).toBe("auto-created");
-    expect(parsed.providerId).toBe("anthropic-oauth-1");
+    expect(parsed.providerId).toBe("openai-codex-oauth-1");
   });
 
-  it("reuses the routed default anthropic oauth provider for oauth_init", async () => {
-    const providerOne = makeProvider({ id: "anthropic-oauth-1", name: "Claude OAuth A" });
-    const providerTwo = makeProvider({ id: "anthropic-oauth-2", name: "Claude OAuth B" });
+  it("reuses the routed default OpenAI Codex oauth provider for oauth_init", async () => {
+    const providerOne = makeCodexOAuthProvider({ id: "openai-codex-oauth-1", name: "Codex OAuth A" });
+    const providerTwo = makeCodexOAuthProvider({ id: "openai-codex-oauth-2", name: "Codex OAuth B" });
     const providerService = createMockProviderService({
       listProviders: vi.fn().mockResolvedValue([providerOne, providerTwo]),
       getRoutingConfig: vi.fn().mockResolvedValue({
-        defaultProviderId: "anthropic-oauth-2",
-        defaultModel: "claude-sonnet-4-20250514",
+        defaultProviderId: "openai-codex-oauth-2",
+        defaultModel: "gpt-5.4-mini",
         fallbackProviderIds: [],
       }),
       initiateOAuthLogin: vi.fn().mockResolvedValue({
-        authorizationUrl: "https://console.anthropic.com/oauth/authorize",
+        authorizationUrl: "https://chatgpt.com/backend-api/codex/oauth/authorize",
         state: "oauth-state-2",
         codeVerifier: "pkce",
-        scopes: ["org:create_api_key", "user:profile"],
+        scopes: ["codex:run"],
         providerId: providerTwo.id,
-        oauthProvider: "anthropic",
+        oauthProvider: "openai-codex",
       }),
     });
     const tool = createFridayAgentProviderTool({ providerService });
@@ -140,16 +161,16 @@ describe("createFridayAgentProviderTool", () => {
     expect(result.isError).toBeUndefined();
     expect(providerService.createProvider).not.toHaveBeenCalled();
     expect(providerService.initiateOAuthLogin).toHaveBeenCalledWith({
-      providerId: "anthropic-oauth-2",
+      providerId: "openai-codex-oauth-2",
     });
     expect(parsed.providerResolution).toBe("reused-routing-default");
   });
 
-  it("returns a clear error when oauth_init cannot disambiguate multiple anthropic oauth providers", async () => {
+  it("returns a clear error when oauth_init cannot disambiguate multiple OpenAI Codex oauth providers", async () => {
     const providerService = createMockProviderService({
       listProviders: vi.fn().mockResolvedValue([
-        makeProvider({ id: "anthropic-oauth-1", name: "Claude OAuth A" }),
-        makeProvider({ id: "anthropic-oauth-2", name: "Claude OAuth B" }),
+        makeCodexOAuthProvider({ id: "openai-codex-oauth-1", name: "Codex OAuth A" }),
+        makeCodexOAuthProvider({ id: "openai-codex-oauth-2", name: "Codex OAuth B" }),
       ]),
     });
     const tool = createFridayAgentProviderTool({ providerService });
@@ -157,16 +178,29 @@ describe("createFridayAgentProviderTool", () => {
     const result = await tool.execute({ action: "oauth_init" }, signal());
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("Multiple anthropic OAuth providers are available");
+    expect(result.content).toContain("Multiple openai-codex OAuth providers are available");
     expect(result.content).toContain("Specify providerId");
     expect(providerService.createProvider).not.toHaveBeenCalled();
     expect(providerService.initiateOAuthLogin).not.toHaveBeenCalled();
   });
 
-  it("auto-selects the single anthropic oauth provider for oauth_complete when providerId is omitted", async () => {
-    const provider = makeProvider({ id: "anthropic-oauth-1" });
-    const updatedProvider = makeProvider({
-      id: "anthropic-oauth-1",
+  it("fails closed when oauth_init targets Anthropic OAuth", async () => {
+    const providerService = createMockProviderService();
+    const tool = createFridayAgentProviderTool({ providerService });
+
+    const result = await tool.execute({ action: "oauth_init", kind: "anthropic" }, signal());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Anthropic OAuth/bearer authentication is disabled");
+    expect(result.content).toContain("Configure Anthropic with an API key");
+    expect(providerService.createProvider).not.toHaveBeenCalled();
+    expect(providerService.initiateOAuthLogin).not.toHaveBeenCalled();
+  });
+
+  it("auto-selects the single OpenAI Codex oauth provider for oauth_complete when providerId is omitted", async () => {
+    const provider = makeCodexOAuthProvider({ id: "openai-codex-oauth-1" });
+    const updatedProvider = makeCodexOAuthProvider({
+      id: "openai-codex-oauth-1",
       config: {
         ...provider.config,
         validation: { status: "ok", checkedAt: "2026-03-13T00:05:00.000Z" },
@@ -177,11 +211,11 @@ describe("createFridayAgentProviderTool", () => {
       getProvider: vi.fn().mockResolvedValue(updatedProvider),
       completeOAuthLogin: vi.fn().mockResolvedValue({
         providerId: provider.id,
-        oauthProvider: "anthropic",
+        oauthProvider: "openai-codex",
         connected: true as const,
         expiresAt: "2026-04-13T00:00:00.000Z",
         tokenType: "Bearer",
-        scope: "org:create_api_key user:profile",
+        scope: "codex:run",
       }),
     });
     const tool = createFridayAgentProviderTool({ providerService });
@@ -194,15 +228,15 @@ describe("createFridayAgentProviderTool", () => {
 
     expect(result.isError).toBeUndefined();
     expect(providerService.completeOAuthLogin).toHaveBeenCalledWith({
-      providerId: "anthropic-oauth-1",
+      providerId: "openai-codex-oauth-1",
       authorizationCode: "test-code#oauth-state-1",
       state: undefined,
     });
     expect(parsed.providerResolution).toBe("reused-existing");
     expect(parsed.nextRecommendedAction).toEqual({
       action: "set_default",
-      providerId: "anthropic-oauth-1",
-      defaultModel: "claude-sonnet-4-20250514",
+      providerId: "openai-codex-oauth-1",
+      defaultModel: "gpt-5.4-mini",
     });
   });
 

--- a/test/unit/cli/friday-cli-auth.test.ts
+++ b/test/unit/cli/friday-cli-auth.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { parseArgs } from "#cli";
 import {
   buildOpenAuthorizationUrlCommand,
+  runFridayCliAuthLoginAnthropic,
   runFridayCliAuthAttachCli,
 } from "../../../src/cli/friday-cli-auth.js";
 
@@ -91,6 +92,32 @@ describe("CLI auth argument parsing", () => {
     expect(() =>
       buildOpenAuthorizationUrlCommand("javascript:alert(1)", "linux"),
     ).toThrow("Browser URL must use http or https");
+  });
+});
+
+describe("CLI auth Anthropic OAuth login", () => {
+  it("fails closed without looking up or initiating Anthropic OAuth", async () => {
+    const providerService = {
+      listProviders: vi.fn(),
+      initiateOAuthLogin: vi.fn(),
+      completeOAuthLogin: vi.fn(),
+    };
+    const stderr = vi.fn();
+
+    await runFridayCliAuthLoginAnthropic(
+      { authTarget: "anthropic", providerId: "anth-001", code: "code#state" },
+      {
+        providerService: providerService as never,
+        stdout: vi.fn(),
+        stderr,
+      },
+    );
+
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("Anthropic OAuth/bearer authentication is disabled"));
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("setup-token anthropic"));
+    expect(providerService.listProviders).not.toHaveBeenCalled();
+    expect(providerService.initiateOAuthLogin).not.toHaveBeenCalled();
+    expect(providerService.completeOAuthLogin).not.toHaveBeenCalled();
   });
 });
 

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -1096,7 +1096,7 @@ describe("FridayProviderRoutes", () => {
       expect(mockService.setRoutingConfig).not.toHaveBeenCalled();
     });
 
-    it("auth.oauth.anthropic.initiate delegates to service", async () => {
+    it("auth.oauth.anthropic.initiate fails closed before calling service", async () => {
       const mockService = makeMockService();
       const routes = createFridayProviderRoutes({
         providerService: mockService,
@@ -1105,18 +1105,15 @@ describe("FridayProviderRoutes", () => {
         (r) => r.operationId === "auth.oauth.anthropic.initiate",
       )!;
 
-      const result = await initiateRoute.handler(
+      await expect(initiateRoute.handler(
         makeCtx({ principal: { userId: "user-1" } as never, body: { providerId: "anth-001" } }),
-      );
+      )).rejects.toThrow("Anthropic OAuth/bearer authentication is disabled");
 
-      expect(mockService.initiateOAuthLogin).toHaveBeenCalledWith({
-        providerId: "anth-001",
-        ownerUserId: "user-1",
-      });
-      expect(result).toHaveProperty("oauth");
+      expect(mockService.initiateOAuthLogin).not.toHaveBeenCalled();
+      expect(mockService.createProvider).not.toHaveBeenCalled();
     });
 
-    it("auth.oauth.anthropic.initiate auto-selects the routed anthropic oauth provider when providerId is omitted", async () => {
+    it("auth.oauth.anthropic.initiate fails closed when providerId is omitted", async () => {
       const mockService = makeMockService();
       const routes = createFridayProviderRoutes({
         providerService: mockService,
@@ -1125,16 +1122,15 @@ describe("FridayProviderRoutes", () => {
         (r) => r.operationId === "auth.oauth.anthropic.initiate",
       )!;
 
-      const result = await initiateRoute.handler(makeCtx({ principal: { userId: "user-1" } as never, body: {} }));
+      await expect(
+        initiateRoute.handler(makeCtx({ principal: { userId: "user-1" } as never, body: {} })),
+      ).rejects.toThrow("Anthropic OAuth/bearer authentication is disabled");
 
-      expect(mockService.initiateOAuthLogin).toHaveBeenCalledWith({
-        providerId: "anth-001",
-        ownerUserId: "user-1",
-      });
-      expect(result).toHaveProperty("oauth");
+      expect(mockService.initiateOAuthLogin).not.toHaveBeenCalled();
+      expect(mockService.createProvider).not.toHaveBeenCalled();
     });
 
-    it("auth.oauth.anthropic.callback delegates to service", async () => {
+    it("auth.oauth.anthropic.callback fails closed before calling service", async () => {
       const mockService = makeMockService();
       const routes = createFridayProviderRoutes({
         providerService: mockService,
@@ -1143,7 +1139,7 @@ describe("FridayProviderRoutes", () => {
         (r) => r.operationId === "auth.oauth.anthropic.callback",
       )!;
 
-      const result = await callbackRoute.handler(
+      await expect(callbackRoute.handler(
         makeCtx({
           body: {
             providerId: "anth-001",
@@ -1151,18 +1147,12 @@ describe("FridayProviderRoutes", () => {
           },
           principal: { userId: "user-1" } as never,
         }),
-      );
+      )).rejects.toThrow("Anthropic OAuth/bearer authentication is disabled");
 
-      expect(mockService.completeOAuthLogin).toHaveBeenCalledWith({
-        providerId: "anth-001",
-        authorizationCode: "code#state",
-        state: undefined,
-        ownerUserId: "user-1",
-      });
-      expect(result).toHaveProperty("oauth");
+      expect(mockService.completeOAuthLogin).not.toHaveBeenCalled();
     });
 
-    it("auth.oauth.anthropic.callback auto-selects the routed anthropic oauth provider when providerId is omitted", async () => {
+    it("auth.oauth.anthropic.callback fails closed when providerId is omitted", async () => {
       const mockService = makeMockService();
       const routes = createFridayProviderRoutes({
         providerService: mockService,
@@ -1171,25 +1161,19 @@ describe("FridayProviderRoutes", () => {
         (r) => r.operationId === "auth.oauth.anthropic.callback",
       )!;
 
-      const result = await callbackRoute.handler(
+      await expect(callbackRoute.handler(
         makeCtx({
           body: {
             authorizationCode: "code#state",
           },
           principal: { userId: "user-1" } as never,
         }),
-      );
+      )).rejects.toThrow("Anthropic OAuth/bearer authentication is disabled");
 
-      expect(mockService.completeOAuthLogin).toHaveBeenCalledWith({
-        providerId: "anth-001",
-        authorizationCode: "code#state",
-        state: undefined,
-        ownerUserId: "user-1",
-      });
-      expect(result).toHaveProperty("oauth");
+      expect(mockService.completeOAuthLogin).not.toHaveBeenCalled();
     });
 
-    it("auth.oauth.anthropic.initiate returns a clear ambiguity error when multiple oauth providers match", async () => {
+    it("auth.oauth.anthropic.initiate does not leak provider-selection ambiguity", async () => {
       const mockService = makeMockService();
       mockService.listProviders = vi.fn(async () => [
         anthropicOauthProfile,
@@ -1208,7 +1192,8 @@ describe("FridayProviderRoutes", () => {
 
       await expect(
         initiateRoute.handler(makeCtx({ principal: { userId: "user-1" } as never, body: {} })),
-      ).rejects.toThrow("Multiple anthropic OAuth providers are available. Specify providerId.");
+      ).rejects.toThrow("Anthropic OAuth/bearer authentication is disabled");
+      expect(mockService.listProviders).not.toHaveBeenCalled();
     });
 
     it("auth.oauth.openai.codex.device.initiate delegates to device-code service with owner user", async () => {


### PR DESCRIPTION
## Summary
- fail closed Anthropic/Claude OAuth selection at the provider-tool and HTTP route entrypoints
- update agent/CLI user-facing guidance to route Anthropic through API-key/token setup instead of Claude Max/Pro OAuth
- keep supported OpenAI Codex OAuth behavior and tests intact

## Verification
- `npx vitest run test/unit/agent/tools/friday-agent-provider-tool.test.ts test/unit/providers/api/friday-provider-routes.test.ts test/unit/cli/friday-cli-auth.test.ts test/unit/providers/oauth/friday-anthropic-oauth.test.ts test/unit/providers/oauth/friday-anthropic-oauth-sec006.test.ts test/unit/providers/validation/friday-provider-validator.test.ts test/unit/agent/runtime/friday-agent-system-prompt-builder.test.ts`
- `npx eslint src/agent/runtime/friday-agent-system-prompt-builder.ts src/agent/tools/friday-agent-provider-tool.ts src/api/http/routes/friday-provider-routes.ts src/cli/friday-cli-auth.ts src/cli/friday-cli.ts src/providers/services/friday-provider-oauth-selection.ts test/unit/agent/tools/friday-agent-provider-tool.test.ts test/unit/cli/friday-cli-auth.test.ts test/unit/providers/api/friday-provider-routes.test.ts` (0 errors; existing warnings only)
- `rg -n "Claude Max|auto-create or reuse the Anthropic OAuth|Create one first with: friday provider create --kind anthropic --auth-mode oauth|Log in with your Claude|oauth_init \\(start OAuth flow for Claude|auth.oauth.anthropic.initiate delegates|auto-selects the routed anthropic" src test/unit` (0 matches)

## Truth label
- Product-path hardening only; does not claim END-BAR, release, organic adoption, or operator-signing completion.
- Anthropic remains supported through API-key/token/BYOK paths; this PR closes the disabled Anthropic OAuth/bearer product paths.