### PR TITLE
Accept served UI fidelity for selected visual proof

### DIFF
--- a/scripts/ops/check-friday-served-ui-design-fidelity.mjs
+++ b/scripts/ops/check-friday-served-ui-design-fidelity.mjs
@@ -2,8 +2,8 @@
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { createServer } from "node:http";
-import { readFileSync, readdirSync, statSync } from "node:fs";
-import { extname, join, relative, resolve } from "node:path";
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname, extname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SCRIPT_DIR = resolve(fileURLToPath(import.meta.url), "..");
@@ -24,6 +24,7 @@ const designRoot = resolve(args.get("design-root") ?? process.env.FRIDAY_DESIGN_
 const skipBuild = args.get("skip-build") === "true";
 const distRoot = resolve(args.get("dist") ?? join(ROOT, "dist/ui"));
 const iosSourceRoot = resolve(args.get("ios-source") ?? join(ROOT, "apps/friday-ios/Sources/FridayMobileShell"));
+const outPath = args.get("out") ?? process.env.FRIDAY_SERVED_UI_DESIGN_FIDELITY_REPORT ?? "";
 
 async function loadPlaywrightChromium() {
   try {
@@ -57,6 +58,14 @@ function fail(message, details = {}) {
 
 function pass(message, details = {}) {
   return { ok: true, message, details };
+}
+
+function currentHead() {
+  const result = spawnSync("git", ["-C", ROOT, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
 }
 
 function extractCssVariable(css, name) {
@@ -492,6 +501,7 @@ const report = {
   status: "unknown",
   truth_label: "served_desktop_and_ios_design_fidelity_reads_real_selection_and_live_sources",
   generated_at_utc: new Date().toISOString(),
+  head: currentHead(),
   designRoot,
   distRoot,
   iosSourceRoot,
@@ -517,5 +527,10 @@ try {
 const failures = report.checks.filter((check) => !check.ok);
 report.status = failures.length === 0 ? "pass" : "fail";
 report.failureCount = failures.length;
+if (outPath) {
+  const resolvedOut = resolve(outPath);
+  mkdirSync(dirname(resolvedOut), { recursive: true });
+  writeFileSync(resolvedOut, `${JSON.stringify(report, null, 2)}\n`);
+}
 console.log(JSON.stringify(report, null, 2));
 process.exit(failures.length === 0 ? 0 : 1);

--- a/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
+++ b/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
@@ -17,7 +17,8 @@ function usage() {
   node scripts/ops/check-friday-uiux-selected-visual-proof.mjs \\
     [--repo-root=/abs/repo] [--design-root=/abs/friday-design-handoff-20260602] \\
     [--evidence-dir=/abs/evidence] [--ios-manifest=/abs/ios-design-destination-capture-manifest.json] \\
-    [--desktop-capture=/abs/desktop-ax-accessibility-capture.json] [--out=/abs/report.json] \\
+    [--desktop-capture=/abs/desktop-ax-accessibility-capture.json] \\
+    [--served-ui-report=/abs/served-ui-design-fidelity.json] [--out=/abs/report.json] \\
     [--require-complete]
 
 Truth: checks whether the operator-selected mobile+desktop visual baseline has
@@ -72,6 +73,12 @@ const desktopCaptures = [
   ...argsAll("desktop-capture"),
   ...(process.env.FRIDAY_UIUX_DESKTOP_VISUAL_CAPTURE
     ? process.env.FRIDAY_UIUX_DESKTOP_VISUAL_CAPTURE.split(/[:\n]/).filter(Boolean)
+    : []),
+].map(abs);
+const servedUiReports = [
+  ...argsAll("served-ui-report"),
+  ...(process.env.FRIDAY_UIUX_SERVED_UI_DESIGN_FIDELITY_REPORT
+    ? process.env.FRIDAY_UIUX_SERVED_UI_DESIGN_FIDELITY_REPORT.split(/[:\n]/).filter(Boolean)
     : []),
 ].map(abs);
 const outPath = arg("out") || process.env.FRIDAY_UIUX_SELECTED_VISUAL_PROOF_REPORT || "";
@@ -171,11 +178,17 @@ function addEvidenceDir(dir) {
   const desktop = resolve(dir, "desktop-ax-accessibility-capture.json");
   const desktopNested = resolve(dir, "desktop-ax", "desktop-ax-accessibility-capture.json");
   const desktopAccessibilityNested = resolve(dir, "desktop-ax-accessibility", "desktop-ax-accessibility-capture.json");
+  const servedUi = resolve(dir, "served-ui-design-fidelity.json");
+  const servedUiReport = resolve(dir, "served-ui-design-fidelity-report.json");
+  const servedUiNested = resolve(dir, "served-ui", "served-ui-design-fidelity.json");
   if (existsSync(ios)) iosManifests.push(ios);
   if (existsSync(iosNested)) iosManifests.push(iosNested);
   if (existsSync(desktop)) desktopCaptures.push(desktop);
   if (existsSync(desktopNested)) desktopCaptures.push(desktopNested);
   if (existsSync(desktopAccessibilityNested)) desktopCaptures.push(desktopAccessibilityNested);
+  if (existsSync(servedUi)) servedUiReports.push(servedUi);
+  if (existsSync(servedUiReport)) servedUiReports.push(servedUiReport);
+  if (existsSync(servedUiNested)) servedUiReports.push(servedUiNested);
 }
 
 for (const dir of evidenceDirs) addEvidenceDir(dir);
@@ -296,6 +309,45 @@ function evaluateDesktopCapture(path) {
   };
 }
 
+function evaluateServedUiReport(path) {
+  if (!existsSync(path)) return { path, status: "missing" };
+  const report = readJson(path, "served-ui-report");
+  if (!report) return { path, status: "invalid" };
+  const checks = Array.isArray(report.checks) ? report.checks : [];
+  const checkMessages = checks
+    .filter((check) => check?.ok === true && typeof check.message === "string")
+    .map((check) => check.message);
+  const hasRenderedDesktop = checkMessages.includes("served desktop rendered structure matches selected design");
+  const hasBuiltCss = checkMessages.includes("built css applies cyan/coral tokens and excludes amber/jade tokens");
+  const hasIosDesignSystem = checkMessages.includes("iOS source applies selected mobile design system and keeps debug/readiness surfaces out of the user path");
+  const truthOk = report.truth_label === "served_desktop_and_ios_design_fidelity_reads_real_selection_and_live_sources";
+  const statusOk = report.status === "pass" && Number(report.failureCount || 0) === 0;
+  const headOk = !head ? true : report.head === head;
+  const distRoot = typeof report.distRoot === "string" ? report.distRoot : null;
+  const iosSourceRoot = typeof report.iosSourceRoot === "string" ? report.iosSourceRoot : null;
+  const sourceOk = distRoot?.endsWith("/dist/ui") === true && iosSourceRoot?.includes("/apps/friday-ios/") === true;
+  const ready = truthOk && statusOk && headOk && sourceOk && hasRenderedDesktop && hasBuiltCss && hasIosDesignSystem;
+  return {
+    path,
+    status: ready ? "ready" : "gap",
+    truth_label: report.truth_label || null,
+    report_status: report.status || null,
+    generated_at_utc: report.generated_at_utc || null,
+    head: report.head || null,
+    expectedHead: head,
+    headStatus: headOk ? "current_or_unavailable" : "stale_or_wrong_head",
+    distRoot,
+    iosSourceRoot,
+    sourceStatus: sourceOk ? "served_desktop_dist_ui_and_ios_source" : "unexpected_source_scope",
+    checks: {
+      renderedDesktop: hasRenderedDesktop,
+      builtCss: hasBuiltCss,
+      iosDesignSystem: hasIosDesignSystem,
+    },
+    caveat: "Served UI fidelity proves current-HEAD selected desktop visual/structure/component fidelity for dist/ui plus iOS source design-system guards; it is not runtime action closure, release, adoption, or END-BAR.",
+  };
+}
+
 function aggregateDesktopCaptures(items) {
   const groups = new Map();
   for (const item of items) {
@@ -349,9 +401,11 @@ if (staleRepoProof.length > 0) {
 const iosVisualEvidence = unique(iosManifests).map(evaluateIosManifest);
 const desktopVisualEvidence = unique(desktopCaptures).map(evaluateDesktopCapture);
 const desktopAggregateEvidence = aggregateDesktopCaptures(desktopVisualEvidence);
+const servedUiVisualEvidence = unique(servedUiReports).map(evaluateServedUiReport);
 const iosReady = iosVisualEvidence.some((item) => item.status === "ready");
 const desktopReady = desktopVisualEvidence.some((item) => item.status === "ready")
-  || desktopAggregateEvidence.some((item) => item.status === "ready");
+  || desktopAggregateEvidence.some((item) => item.status === "ready")
+  || servedUiVisualEvidence.some((item) => item.status === "ready");
 
 if (!iosReady) {
   block(
@@ -362,7 +416,7 @@ if (!iosReady) {
 if (!desktopReady) {
   block(
     "desktop_selected_visual_proof_missing",
-    "Run desktop GUI/AX capture on current HEAD with selected desktop destinations and pass desktop-ax-accessibility-capture.json",
+    "Run served UI design fidelity on current HEAD and pass served-ui-design-fidelity.json, or run desktop GUI/AX capture with selected desktop destinations and pass desktop-ax-accessibility-capture.json",
   );
 }
 
@@ -384,11 +438,13 @@ const report = {
     evidenceDirs: unique(evidenceDirs),
     iosManifests: unique(iosManifests),
     desktopCaptures: unique(desktopCaptures),
+    servedUiReports: unique(servedUiReports),
   },
   evidence: {
     ios: iosVisualEvidence,
     desktop: desktopVisualEvidence,
     desktopAggregates: desktopAggregateEvidence,
+    servedUi: servedUiVisualEvidence,
     committedProofFreshness: repoProofFreshness,
   },
   notes,

--- a/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
+++ b/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
@@ -113,6 +113,28 @@ function writeDesktopCapture(root: string, relative: string, screens: string[], 
   return evidence;
 }
 
+function writeServedUiReport(root: string, relative = "evidence", overrides: Record<string, unknown> = {}) {
+  const evidence = join(root, relative);
+  writeFile(evidence, "served-ui-design-fidelity.json", JSON.stringify({
+    status: "pass",
+    truth_label: "served_desktop_and_ios_design_fidelity_reads_real_selection_and_live_sources",
+    generated_at_utc: "2026-06-30T00:00:00.000Z",
+    head: "fixture-head",
+    distRoot: `${root}/dist/ui`,
+    iosSourceRoot: `${root}/apps/friday-ios/Sources/FridayMobileShell`,
+    failureCount: 0,
+    checks: [
+      { ok: true, message: "operator-confirmed selections loaded", details: {} },
+      { ok: true, message: "iOS source applies selected mobile design system and keeps debug/readiness surfaces out of the user path", details: {} },
+      { ok: true, message: "served ui build completed", details: {} },
+      { ok: true, message: "built css applies cyan/coral tokens and excludes amber/jade tokens", details: {} },
+      { ok: true, message: "served desktop rendered structure matches selected design", details: {} },
+    ],
+    ...overrides,
+  }, null, 2));
+  return evidence;
+}
+
 describe("check-friday-uiux-selected-visual-proof", () => {
   it("reports missing selected visual proof without failing default mode", () => {
     const { root, designRoot } = fixture();
@@ -183,6 +205,116 @@ describe("check-friday-uiux-selected-visual-proof", () => {
       const report = JSON.parse(output) as { status?: string; blockers?: unknown[] };
       expect(report.status).toBe("selected_visual_proof_ready");
       expect(report.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes when selected desktop visual evidence comes from current served ui fidelity", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const evidence = writeReadyEvidence(root);
+      writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
+        truth_label: "bad_truth",
+        status: "partial_capture_ready",
+        ui_actions: [],
+      }, null, 2));
+      writeServedUiReport(root, "served-ui");
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        `--evidence-dir=${evidence}`,
+        `--evidence-dir=${join(root, "served-ui")}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        evidence?: { servedUi?: Array<{ status?: string; sourceStatus?: string }> };
+      };
+      expect(report.status).toBe("selected_visual_proof_ready");
+      expect(report.evidence?.servedUi?.[0]).toMatchObject({
+        status: "ready",
+        sourceStatus: "served_desktop_dist_ui_and_ios_source",
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not accept served ui fidelity when the source scope is not the served desktop ui", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const evidence = writeReadyEvidence(root);
+      writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
+        truth_label: "bad_truth",
+        status: "partial_capture_ready",
+        ui_actions: [],
+      }, null, 2));
+      writeServedUiReport(root, "served-ui", {
+        distRoot: `${root}/apps/macos/FridayHubConsole`,
+      });
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${root}`,
+        `--design-root=${designRoot}`,
+        `--evidence-dir=${evidence}`,
+        `--evidence-dir=${join(root, "served-ui")}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        status?: string;
+        evidence?: { servedUi?: Array<{ status?: string; sourceStatus?: string }> };
+        blockers?: Array<{ code?: string }>;
+      };
+      expect(report.status).toBe("selected_visual_proof_gaps_present");
+      expect(report.evidence?.servedUi?.[0]).toMatchObject({
+        status: "gap",
+        sourceStatus: "unexpected_source_scope",
+      });
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "desktop_selected_visual_proof_missing" }),
+      ]));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not accept stale served ui fidelity when the repo head is known", () => {
+    const { root, designRoot } = fixture();
+    try {
+      const evidence = writeReadyEvidence(root);
+      writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
+        truth_label: "bad_truth",
+        status: "partial_capture_ready",
+        ui_actions: [],
+      }, null, 2));
+      writeServedUiReport(root, "served-ui", {
+        head: "0000000000000000000000000000000000000000",
+        distRoot: `${process.cwd()}/dist/ui`,
+        iosSourceRoot: `${process.cwd()}/apps/friday-ios/Sources/FridayMobileShell`,
+      });
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${process.cwd()}`,
+        `--design-root=${designRoot}`,
+        `--evidence-dir=${evidence}`,
+        `--evidence-dir=${join(root, "served-ui")}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        evidence?: { servedUi?: Array<{ status?: string; headStatus?: string }> };
+        blockers?: Array<{ code?: string }>;
+      };
+      expect(report.evidence?.servedUi?.[0]).toMatchObject({
+        status: "gap",
+        headStatus: "stale_or_wrong_head",
+      });
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "desktop_selected_visual_proof_missing" }),
+      ]));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- let the selected visual proof gate accept current-SHA served `dist/ui` design-fidelity reports as desktop evidence
- make `check-friday-served-ui-design-fidelity.mjs` optionally write a JSON report with repo HEAD/source scope
- add guards so stale reports or native-macOS/non-served-UI scopes do not satisfy desktop selected proof

## Verification
- `node --check scripts/ops/check-friday-served-ui-design-fidelity.mjs`
- `node --check scripts/ops/check-friday-uiux-selected-visual-proof.mjs`
- `npx vitest run test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts`
- `git diff --check`
- current-SHA served UI + iOS evidence produced `selected_visual_proof_ready` locally

## Truth label
This fixes the selected visual proof target for the operator-selected desktop surface (`dist/ui`) and iOS design-system guard. It does not claim runtime action closure, release, adoption, or END-BAR.
