### PR TITLE
Expose desktop pane children to AX proof

### DIFF
--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -41,6 +41,7 @@ struct HubConsoleShell: View {
 
       mainPane
         .frame(minWidth: 520, maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("friday.desktop.destination.\(destination.rawValue)")
 
       Divider().opacity(0.4)

--- a/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
+++ b/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
@@ -70,7 +70,9 @@ describe("friday-desktop-ax-accessibility-capture contract", () => {
     expect(source).toContain("initial_destination_ready");
     expect(source).toContain("matched_by: \"initial_destination\"");
     expect(source).toContain("perform action \"AXPress\" of e");
+    expect(navSource).toContain(".accessibilityElement(children: .contain)");
     expect(navSource).toContain(".accessibilityIdentifier(\"friday.desktop.nav.\\(destination.rawValue)\")");
+    expect(navSource).toContain(".accessibilityIdentifier(\"friday.desktop.destination.\\(destination.rawValue)\")");
   });
 
   it("applies the configured AX tree depth to navigation and targeted probes", () => {


### PR DESCRIPTION
## Summary
- expose the macOS Hub Console main destination pane as an AX container so child controls remain visible to real Accessibility proof capture
- lock the AX contract so destination and nav identifiers stay present while the child tree remains contained

## Evidence
- `npm run build:hub-console:native`
- `npx vitest run test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts`
- `git diff --check`
- Real AX before/after: operations capture improved from destination-only to observing `desktop/operations/refresh`; full selected destination pass improved from 5 to 10 observed actions, but still remains `blocked_or_empty` because additional provider/status/channel/timeline evidence is required.

Truth: this improves real macOS Accessibility visibility for strict UI/device proof. It is not END-BAR, not adoption, and does not relax any proof gate.