### PR TITLE
Separate UI status label negative controls

### DIFF
--- a/scripts/ops/friday-ui-device-real-stress-capture.mjs
+++ b/scripts/ops/friday-ui-device-real-stress-capture.mjs
@@ -126,6 +126,12 @@ function hasEvent(events, surface, name) {
   });
 }
 
+const negativeStatusLabelEvents = new Set([
+  "stale_label_visible",
+  "offline_label_visible",
+  "error_label_visible",
+]);
+
 function validateEvents(events) {
   if (events.length === 0) {
     block("events_empty", eventsPath || "<missing>");
@@ -137,6 +143,9 @@ function validateEvents(events) {
     const truth = String(event.truth_label || "");
     if (truth && forbiddenTruth.test(truth)) block("event_truth_label_forbidden", `${label}:${truth}`);
     if (typeof event.evidence_ref !== "string" || !event.evidence_ref.trim()) block("event_missing_evidence_ref", label);
+    if (negativeStatusLabelEvents.has(String(event.event || ""))) {
+      block("negative_status_label_in_happy_path_events", `${label}:${String(event.event || "")}`);
+    }
   }
 
   const requiredVisibleEvents = [
@@ -146,9 +155,6 @@ function validateEvents(events) {
     ["timeline", "bounded_page_1_visible"],
     ["timeline", "bounded_page_2_visible"],
     ["timeline", "memory_candidate_review_only"],
-    ["desktop", "stale_label_visible"],
-    ["desktop", "offline_label_visible"],
-    ["desktop", "error_label_visible"],
   ];
   for (const [surface, event] of requiredVisibleEvents) {
     if (!hasEvent(events, surface, event)) block("required_visible_event_missing", `${surface}:${event}`);
@@ -249,6 +255,7 @@ if (blockers.length === 0 && outDir) {
       memory_candidate_review_only: hasEvent(events, "timeline", "memory_candidate_review_only"),
     },
     caveat: "This report binds real backend pressure/negative proof to same-mission UI/workbench events. It is not strict UI/device proof and does not satisfy channel proof.",
+    status_label_negative_controls: "stale/offline/error label observations are required by friday-ui-device-observations-manifest.mjs as separate negative-control segments, not in the connected happy-path mission events.",
   };
   writeFileSync(rawReportPath, `${JSON.stringify(rawReport, null, 2)}\n`);
   const stressCapture = {
@@ -265,6 +272,7 @@ if (blockers.length === 0 && outDir) {
     reconnect_stale_verified: true,
     no_secret_leak: true,
     no_hidden_fallback: true,
+    status_label_negative_controls: "stale/offline/error label observations are required by friday-ui-device-observations-manifest.mjs as separate negative-control segments, not in the connected happy-path mission events.",
     captured_at: generatedAt,
     caveat: "Stress capture input only; generated from real backend pressure proof plus same-mission UI/workbench events, not from synthetic rows.",
   };

--- a/test/unit/qa/friday-ui-device-real-stress-capture-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-real-stress-capture-cli.test.ts
@@ -33,11 +33,13 @@ function writeEvents(path: string, evidenceRef: string, overrides: { mission?: s
     event("timeline", "memory_candidate_review_only", evidenceRef, overrides.truth),
     event("desktop", "duplicate_preflight_visible", evidenceRef, overrides.truth),
     event("mobile", "duplicate_preflight_visible", evidenceRef, overrides.truth),
-    event("desktop", "stale_label_visible", evidenceRef, overrides.truth),
-    event("desktop", "offline_label_visible", evidenceRef, overrides.truth),
-    event("desktop", "error_label_visible", evidenceRef, overrides.truth),
   ].map((row) => overrides.mission ? { ...row, mission_id: overrides.mission } : row);
   writeFileSync(path, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+}
+
+function appendEvents(path: string, rows: Array<Record<string, unknown>>) {
+  const existing = readFileSync(path, "utf8").trim();
+  writeFileSync(path, `${existing}${existing ? "\n" : ""}${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
 }
 
 function writeBackend(path: string, overrides: Record<string, unknown> = {}) {
@@ -115,10 +117,12 @@ describe("friday-ui-device-real-stress-capture", () => {
         truth_label?: string;
         mission_bound_ask_count?: number;
         evidence_ref?: string;
+        status_label_negative_controls?: string;
       };
       expect(stress.truth_label).toBe("ui_device_stress_capture_real_same_run_not_endbar");
       expect(stress.mission_bound_ask_count).toBe(20);
       expect(stress.evidence_ref).toBe(result.rawReport);
+      expect(stress.status_label_negative_controls).toContain("negative-control segments");
 
       const bridgeOut = join(root, "stress-events.jsonl");
       const bridgeStdout = execFileSync("node", [
@@ -132,6 +136,32 @@ describe("friday-ui-device-real-stress-capture", () => {
       const rows = readFileSync(bridgeOut, "utf8").trim().split("\n").map((line) => JSON.parse(line));
       expect(rows.filter((row) => row.event === "pressure_20_50_consecutive_asks_visible")).toHaveLength(20);
       expect(rows).toContainEqual(expect.objectContaining({ event: "network_error_visible" }));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects stale/offline/error labels in the connected happy-path mission events", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-real-stress-capture-negative-labels-"));
+    try {
+      const inputs = writeInputs(root);
+      appendEvents(inputs.events, [
+        event("desktop", "stale_label_visible", inputs.evidence),
+        event("desktop", "offline_label_visible", inputs.evidence),
+        event("desktop", "error_label_visible", inputs.evidence),
+      ]);
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--backend-live-proof=${inputs.backend}`,
+        `--objective-coverage=${inputs.objective}`,
+        `--events=${inputs.events}`,
+        `--out-dir=${join(root, "out")}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string; detail?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("negative_status_label_in_happy_path_events");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Move stale/offline/error status-label checks out of the connected happy-path stress capture requirements.
- Fail closed if those negative status-label events appear in same-mission happy-path events.
- Document the intended lane: status labels are required through `friday-ui-device-observations-manifest.mjs` negative-control segments.

## Verification
- `npx vitest run test/unit/qa/friday-ui-device-real-stress-capture-cli.test.ts test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts test/unit/qa/friday-workbench-snapshot-events-cli.test.ts`
- `npx vitest run test/unit/qa/friday-ui-device-real-stress-capture-cli.test.ts`
- Current strict mission replay: `friday-ui-device-real-stress-capture.mjs` now returns `status=ready` with `blockers=[]` for `/private/tmp/friday-ui-device-strict-b917-fresh-20260630T031127Z/merged-live-ax-workbench-after-provider-events.jsonl`.
- Current observations manifest assembly returns `status=ready` with one negative-control segment; readiness is blocked only by `channel_deferred_strict_assembly_blocked`.