### PR TITLE
Harden UI device readiness bridge status

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -626,6 +626,9 @@ derive_workbench_events_if_possible() {
     bridge_status="$(jq -r '.status // "unknown"' "$stdout_out" 2>/dev/null || printf 'unknown')"
     if [ "$bridge_status" != "ready" ]; then
       notes+=("workbench_snapshot_events_bridge:${bridge_status}:${stdout_out}")
+      if [ "${MODE}" = "require-proof" ]; then
+        blockers+=("workbench_snapshot_events_bridge:${bridge_status}")
+      fi
       return 0
     fi
     if [ -s "$derived_out" ] && [ -n "$existing_events" ]; then
@@ -646,6 +649,9 @@ derive_workbench_events_if_possible() {
     bridge_status="$(jq -r '.status // "unknown"' "$stdout_out" 2>/dev/null || printf 'unknown')"
     if [ "$bridge_status" != "unknown" ]; then
       notes+=("workbench_snapshot_events_bridge:${bridge_status}:${stdout_out}")
+      if [ "${MODE}" = "require-proof" ]; then
+        blockers+=("workbench_snapshot_events_bridge:${bridge_status}")
+      fi
       return 0
     fi
     blockers+=("workbench_snapshot_events_bridge:exit_${rc}")

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1226,6 +1226,45 @@ describe("friday-ui-device-proof-readiness", () => {
       expect(rows).not.toContainEqual(expect.objectContaining({
         surface: "channel",
       }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("treats non-ready workbench bridge status as a hard blocker in final proof mode", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-workbench-proof-blocker-"));
+    try {
+      writePartialEvidenceDir(tempDir);
+      const partial = makeWorkbenchSnapshot();
+      partial.statusLabels = [];
+      partial.channelReceiptRefs = [];
+      partial.workItems = partial.workItems.filter((item) => item.state !== "provider_ack");
+      partial.transcriptSections = partial.transcriptSections.map((section) => ({
+        ...section,
+        events: section.events.filter((event) => event.surface !== "telegram" && event.status !== "provider_ack"),
+      }));
+      writeFileSync(join(tempDir, "workbench-snapshot.json"), JSON.stringify({ snapshot: partial }, null, 2));
+
+      const resultRun = spawnSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+        "--defer-channel-proof",
+        "--require-proof",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      });
+      const result = JSON.parse(resultRun.stdout.slice(resultRun.stdout.indexOf("{"))) as {
+        notes?: string[];
+        blockers?: string[];
+      };
+
+      expect(resultRun.status).toBe(2);
+      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_bridge:blocked"))).toBe(true);
+      expect(result.blockers).toContain("workbench_snapshot_events_bridge:blocked");
+      expect(result.notes?.some((note) => note.includes("workbench_snapshot_events_merge:ready"))).not.toBe(true);
+      expect(existsSync(join(tempDir, "same-run-events.merged.jsonl"))).toBe(false);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Treat non-ready workbench snapshot bridge status as a hard blocker when UI/device readiness runs in final `--require-proof` mode.
- Preserve diagnostic/report-only behavior for existing same-run events while preventing blocked or partial bridge output from being silently note-only in proof mode.
- Add a regression test for final proof mode so a blocked workbench bridge cannot be promoted to readiness.

## Verification
- `npx vitest run --project default test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts -t "treats non-ready workbench bridge status"`
- `npm test -- --run test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts test/unit/qa/friday-workbench-snapshot-events-cli.test.ts`
- `git diff --check`

Truth: this is a readiness hardening PR only. It does not claim END-BAR, organic adoption, channel proof, release, or UI design fidelity completion.