### PR TITLE
Accept auxiliary UI device proof evidence

### DIFF
--- a/rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
@@ -12,6 +12,11 @@ usage:
   DESKTOP_EVIDENCE=/abs/desktop.trace \
   CHANNEL_EVIDENCE=/abs/channel.trace \
   TIMELINE_EVIDENCE=/abs/timeline.trace \
+  MOBILE_EXTRA_EVIDENCE=/abs/mobile-extra.trace[:/abs/another-mobile-extra.trace] \
+  DESKTOP_EXTRA_EVIDENCE=/abs/desktop-extra.trace[:/abs/another-desktop-extra.trace] \
+  CHANNEL_EXTRA_EVIDENCE=/abs/channel-extra.trace[:/abs/another-channel-extra.trace] \
+  TIMELINE_EXTRA_EVIDENCE=/abs/timeline-extra.trace[:/abs/another-timeline-extra.trace] \
+  SHARED_EXTRA_EVIDENCE=/abs/shared-extra.trace[:/abs/another-shared-extra.trace] \
   NEGATIVE_CONTROL_EVIDENCE_FILES=/abs/negative.trace[:/abs/another-negative.trace] \
   OBSERVATIONS_MANIFEST=/abs/ui-observations-manifest.json \
   OUT=/tmp/mission-spine-ui-device-proof.json \
@@ -145,11 +150,62 @@ channel_bytes="$(file_bytes "$channel")"
 timeline_bytes="$(file_bytes "$timeline")"
 
 negative_evidence_json="$(mktemp "${TMPDIR:-/tmp}/friday-ui-negative-evidence.XXXXXX.json")"
+extra_evidence_json="$(mktemp "${TMPDIR:-/tmp}/friday-ui-extra-evidence.XXXXXX.json")"
 printf '[]\n' >"$negative_evidence_json"
-cleanup_negative_evidence_json() {
-  rm -f "$negative_evidence_json"
+printf '[]\n' >"$extra_evidence_json"
+cleanup_evidence_json() {
+  rm -f "$negative_evidence_json" "$extra_evidence_json"
 }
-trap cleanup_negative_evidence_json EXIT
+trap cleanup_evidence_json EXIT
+
+append_extra_evidence_files() {
+  local surface="$1"
+  local colon_list="$2"
+  local kind="${3:-trace}"
+  local capture_method="${4:-${surface}_extra_ui_capture}"
+  local index=0
+  local extra_input
+  [ -n "$colon_list" ] || return 0
+  IFS=':' read -r -a extra_inputs <<<"$colon_list"
+  for extra_input in "${extra_inputs[@]}"; do
+    if [[ -z "$extra_input" ]]; then
+      continue
+    fi
+    index=$((index + 1))
+    extra_path="$(abs_path "$extra_input")"
+    require_file "$extra_path" "${surface}_extra"
+    extra_sha="$(file_sha256 "$extra_path")"
+    extra_bytes="$(file_bytes "$extra_path")"
+    tmp_extra_evidence_json="${extra_evidence_json}.tmp"
+    jq \
+      --arg role "${surface}-extra-${index}" \
+      --arg path "$extra_path" \
+      --arg kind "$kind" \
+      --arg sha "$extra_sha" \
+      --argjson bytes "$extra_bytes" \
+      --arg capture_method "$capture_method" \
+      --arg captured_at "$captured_at" \
+      --arg observed_mission_id "$MISSION_ID" \
+      '. + [{
+        role: $role,
+        path: $path,
+        kind: $kind,
+        sha256: $sha,
+        bytes: $bytes,
+        real_consumption: true,
+        capture_method: $capture_method,
+        captured_at_utc: $captured_at,
+        observed_mission_id: $observed_mission_id
+      }]' "$extra_evidence_json" >"$tmp_extra_evidence_json"
+    mv "$tmp_extra_evidence_json" "$extra_evidence_json"
+  done
+}
+
+append_extra_evidence_files "mobile" "${MOBILE_EXTRA_EVIDENCE:-}" "${MOBILE_EXTRA_KIND:-trace}" "${MOBILE_EXTRA_CAPTURE_METHOD:-mobile_extra_ui_capture}"
+append_extra_evidence_files "desktop" "${DESKTOP_EXTRA_EVIDENCE:-}" "${DESKTOP_EXTRA_KIND:-trace}" "${DESKTOP_EXTRA_CAPTURE_METHOD:-desktop_extra_ui_capture}"
+append_extra_evidence_files "channel" "${CHANNEL_EXTRA_EVIDENCE:-}" "${CHANNEL_EXTRA_KIND:-trace}" "${CHANNEL_EXTRA_CAPTURE_METHOD:-channel_extra_ui_capture}"
+append_extra_evidence_files "timeline" "${TIMELINE_EXTRA_EVIDENCE:-}" "${TIMELINE_EXTRA_KIND:-trace}" "${TIMELINE_EXTRA_CAPTURE_METHOD:-timeline_extra_ui_capture}"
+append_extra_evidence_files "shared" "${SHARED_EXTRA_EVIDENCE:-}" "${SHARED_EXTRA_KIND:-trace}" "${SHARED_EXTRA_CAPTURE_METHOD:-shared_extra_ui_capture}"
 
 if [[ -n "${NEGATIVE_CONTROL_EVIDENCE_FILES:-}" ]]; then
   IFS=':' read -r -a negative_control_evidence_files <<<"${NEGATIVE_CONTROL_EVIDENCE_FILES}"
@@ -224,6 +280,7 @@ jq -n \
   --arg timeline_capture_method "$timeline_capture_method" \
   --slurpfile manifest "$observations_manifest" \
   --slurpfile negative_evidence "$negative_evidence_json" \
+  --slurpfile extra_evidence "$extra_evidence_json" \
   '($manifest[0]) as $manifest |
     {
       proof: $proof,
@@ -293,7 +350,7 @@ jq -n \
           captured_at_utc: $captured_at,
           observed_mission_id: $mission_id
         }
-      ] + ($negative_evidence[0] // [])),
+      ] + ($extra_evidence[0] // []) + ($negative_evidence[0] // [])),
       event_order: $manifest.event_order,
       observations: $manifest.observations,
       negative_control_segments: ($manifest.negative_control_segments // []),

--- a/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
@@ -113,8 +113,12 @@ jq -e '
     . as $values
     | ($values | type == "array")
     and ($items | all($values | index(.) != null));
-  def evidence_file_ok($role; $mission_id):
+  def evidence_role_matches($role):
     .role == $role
+    or ((.role // "") | startswith($role + "-extra-"))
+    or ((.role // "") | startswith("shared-extra-"));
+  def evidence_file_ok($role; $mission_id):
+    evidence_role_matches($role)
     and (.path | nonempty_string)
     and (.kind | safe_kind)
     and (.sha256 | sha256_hex)
@@ -140,7 +144,10 @@ jq -e '
     and ((.synthetic // false) != true)
     and ((.sample // false) != true)
     and ((.dry_run // false) != true);
-  def has_evidence_role($role; $mission_id): (.evidence_files // []) | any(evidence_file_ok($role; $mission_id));
+  def core_evidence_file_ok($role; $mission_id):
+    .role == $role
+    and evidence_any_ok($mission_id);
+  def has_evidence_role($role; $mission_id): (.evidence_files // []) | any(core_evidence_file_ok($role; $mission_id));
   def evidence_ref_matches($role; $ref; $mission_id): (.evidence_files // []) | any(evidence_file_ok($role; $mission_id) and .path == $ref);
   def evidence_ref_known_for_mission($root; $mission_id; $ref):
     ($root.evidence_files // []) | any(evidence_any_ok($mission_id) and .path == $ref);

--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -356,6 +356,77 @@ infer_capture_index_path() {
   jq -r "$query // empty" "$index" 2>/dev/null || true
 }
 
+append_colon_list() {
+  local current="$1"
+  shift
+  local candidate
+  for candidate in "$@"; do
+    [ -n "$candidate" ] || continue
+    if [ -s "$candidate" ]; then
+      candidate="$(abs_path "$candidate")"
+      case ":${current}:" in
+        *":${candidate}:"*) ;;
+        *)
+          if [ -z "$current" ]; then
+            current="$candidate"
+          else
+            current="${current}:$candidate"
+          fi
+          ;;
+      esac
+    fi
+  done
+  printf '%s\n' "$current"
+}
+
+remove_colon_list_entries() {
+  local current="$1"
+  local remove="$2"
+  local result=""
+  local entry
+  [ -n "$current" ] || return 0
+  IFS=':' read -r -a entries <<<"$current"
+  for entry in "${entries[@]}"; do
+    [ -n "$entry" ] || continue
+    case ":${remove}:" in
+      *":${entry}:"*) ;;
+      *)
+        if [ -z "$result" ]; then
+          result="$entry"
+        else
+          result="${result}:$entry"
+        fi
+        ;;
+    esac
+  done
+  printf '%s\n' "$result"
+}
+
+infer_capture_index_extra_paths() {
+  local index="$1"
+  local surface="$2"
+  [ -n "$index" ] && [ -s "$index" ] || return 0
+  jq -r --arg surface "$surface" '
+    def path_value:
+      .target // .proof // .capture // .path // .file // empty;
+    (.extraCaptures // [])
+    | map(select((.role // "") | startswith($surface + "-extra-")))
+    | .[]
+    | path_value
+  ' "$index" 2>/dev/null || true
+}
+
+infer_negative_control_evidence_paths() {
+  local manifest="$1"
+  [ -n "$manifest" ] && [ -s "$manifest" ] || return 0
+  jq -r '
+    (.negative_control_segments // [])
+    | .[]
+    | (.evidence_refs // [])
+    | .[]
+  ' "$manifest" 2>/dev/null || true
+}
+
 discover_evidence_dir() {
   local dir="$1"
   local manifest
@@ -445,6 +516,23 @@ discover_evidence_dir() {
       "$(infer_capture_index_path "$capture_index" '.timeline.proof')" \
       "$(infer_capture_index_path "$capture_index" '.timeline.capture')" || true)"
   fi
+  if [ -n "$capture_index" ]; then
+    MOBILE_EXTRA_EVIDENCE="$(append_colon_list "${MOBILE_EXTRA_EVIDENCE:-}" $(infer_capture_index_extra_paths "$capture_index" mobile))"
+    DESKTOP_EXTRA_EVIDENCE="$(append_colon_list "${DESKTOP_EXTRA_EVIDENCE:-}" $(infer_capture_index_extra_paths "$capture_index" desktop))"
+    CHANNEL_EXTRA_EVIDENCE="$(append_colon_list "${CHANNEL_EXTRA_EVIDENCE:-}" $(infer_capture_index_extra_paths "$capture_index" channel))"
+    TIMELINE_EXTRA_EVIDENCE="$(append_colon_list "${TIMELINE_EXTRA_EVIDENCE:-}" $(infer_capture_index_extra_paths "$capture_index" timeline))"
+    SHARED_EXTRA_EVIDENCE="$(append_colon_list "${SHARED_EXTRA_EVIDENCE:-}" $(infer_capture_index_extra_paths "$capture_index" shared))"
+  fi
+  if [ -n "$manifest" ] && [ -z "${NEGATIVE_CONTROL_EVIDENCE_FILES:-}" ]; then
+    NEGATIVE_CONTROL_EVIDENCE_FILES="$(append_colon_list "" $(infer_negative_control_evidence_paths "$manifest"))"
+  fi
+  if [ -n "${NEGATIVE_CONTROL_EVIDENCE_FILES:-}" ]; then
+    MOBILE_EXTRA_EVIDENCE="$(remove_colon_list_entries "${MOBILE_EXTRA_EVIDENCE:-}" "$NEGATIVE_CONTROL_EVIDENCE_FILES")"
+    DESKTOP_EXTRA_EVIDENCE="$(remove_colon_list_entries "${DESKTOP_EXTRA_EVIDENCE:-}" "$NEGATIVE_CONTROL_EVIDENCE_FILES")"
+    CHANNEL_EXTRA_EVIDENCE="$(remove_colon_list_entries "${CHANNEL_EXTRA_EVIDENCE:-}" "$NEGATIVE_CONTROL_EVIDENCE_FILES")"
+    TIMELINE_EXTRA_EVIDENCE="$(remove_colon_list_entries "${TIMELINE_EXTRA_EVIDENCE:-}" "$NEGATIVE_CONTROL_EVIDENCE_FILES")"
+    SHARED_EXTRA_EVIDENCE="$(remove_colon_list_entries "${SHARED_EXTRA_EVIDENCE:-}" "$NEGATIVE_CONTROL_EVIDENCE_FILES")"
+  fi
   if [ -z "${SAME_RUN_EVENTS:-}" ]; then
     SAME_RUN_EVENTS="$(first_existing \
       "$dir/same-run-events.normalized.jsonl" \
@@ -531,6 +619,12 @@ export DESKTOP_EVIDENCE="${DESKTOP_EVIDENCE:-}"
 export CHANNEL_EVIDENCE="${CHANNEL_EVIDENCE:-}"
 export TIMELINE_EVIDENCE="${TIMELINE_EVIDENCE:-}"
 export OBSERVATIONS_MANIFEST="${OBSERVATIONS_MANIFEST:-}"
+export MOBILE_EXTRA_EVIDENCE="${MOBILE_EXTRA_EVIDENCE:-}"
+export DESKTOP_EXTRA_EVIDENCE="${DESKTOP_EXTRA_EVIDENCE:-}"
+export CHANNEL_EXTRA_EVIDENCE="${CHANNEL_EXTRA_EVIDENCE:-}"
+export TIMELINE_EXTRA_EVIDENCE="${TIMELINE_EXTRA_EVIDENCE:-}"
+export SHARED_EXTRA_EVIDENCE="${SHARED_EXTRA_EVIDENCE:-}"
+export NEGATIVE_CONTROL_EVIDENCE_FILES="${NEGATIVE_CONTROL_EVIDENCE_FILES:-}"
 export SAME_RUN_EVENTS="${SAME_RUN_EVENTS:-}"
 export FRIDAY_WORKBENCH_SNAPSHOT_FILE="${FRIDAY_WORKBENCH_SNAPSHOT_FILE:-}"
 export WORKBENCH_DB="${WORKBENCH_DB:-}"
@@ -723,6 +817,11 @@ for name in MISSION_ID MOBILE_EVIDENCE DESKTOP_EVIDENCE CHANNEL_EVIDENCE TIMELIN
     notes+=("resolved_${name}:${!name}")
   fi
 done
+for name in MOBILE_EXTRA_EVIDENCE DESKTOP_EXTRA_EVIDENCE CHANNEL_EXTRA_EVIDENCE TIMELINE_EXTRA_EVIDENCE SHARED_EXTRA_EVIDENCE NEGATIVE_CONTROL_EVIDENCE_FILES; do
+  if [ -n "${!name:-}" ]; then
+    notes+=("resolved_${name}:${!name}")
+  fi
+done
 if [ -n "${SAME_RUN_EVENTS:-}" ]; then
   notes+=("resolved_SAME_RUN_EVENTS:${SAME_RUN_EVENTS}")
 fi
@@ -736,7 +835,7 @@ fi
 run_step() {
   local label="$1"
   shift
-  if "$@"; then
+  if "$@" >&2; then
     notes+=("${label}:pass")
   else
     local rc=$?
@@ -748,7 +847,7 @@ run_step() {
 run_note_step() {
   local label="$1"
   shift
-  if "$@"; then
+  if "$@" >&2; then
     notes+=("${label}:pass")
   else
     local rc=$?
@@ -945,7 +1044,7 @@ if [ "${have_all_evidence}" = "1" ]; then
       "--timeline=${TIMELINE_EVIDENCE}" \
       "--manifest=${OBSERVATIONS_MANIFEST}"
   if [ "${#blockers[@]}" -eq 0 ]; then
-    (cd "${REPO_ROOT}/rust-core" && scripts/mission-spine-ui-device-proof-assemble.sh)
+    (cd "${REPO_ROOT}/rust-core" && scripts/mission-spine-ui-device-proof-assemble.sh) >&2
     echo '{"truth":"assembled_real_ui_device_proof","status":"pass"}'
     exit 0
   fi

--- a/scripts/qa/check-mission-spine-ui-proof-inputs.mjs
+++ b/scripts/qa/check-mission-spine-ui-proof-inputs.mjs
@@ -128,7 +128,6 @@ const forbiddenMarkers = [
   "raw-chat",
   "raw transcript",
   "/Users/",
-  "/private/",
 ];
 
 const placeholderMarkers = [
@@ -152,6 +151,7 @@ function usage() {
     [--mobile-extra-evidence=/abs/file ...] [--desktop-extra-evidence=/abs/file ...] \\
     [--channel-extra-evidence=/abs/file ...] [--timeline-extra-evidence=/abs/file ...] \\
     [--shared-extra-evidence=/abs/file ...] \\
+    [--negative-control-evidence=/abs/file ...] \\
     --manifest=/abs/observations-manifest.json
 
 This is a pre-assemble readiness check only. It does not write a
@@ -386,6 +386,27 @@ function expectedEvidenceRefsForSurface(surface, evidenceByRole, extraEvidenceBy
   return [];
 }
 
+const desktopEventsAllowedToUseTimelineEvidence = new Set([
+  "duplicate_preflight_visible",
+  "provider_ack_not_done_visible",
+  "pressure_20_50_consecutive_asks_visible",
+  "invalid_key_error_visible",
+  "quota_error_visible",
+  "network_error_visible",
+  "reconnect_stale_verified",
+]);
+
+function expectedEvidenceRefsForObservation(observation, evidenceByRole, extraEvidenceByRole) {
+  const expected = expectedEvidenceRefsForSurface(observation.surface, evidenceByRole, extraEvidenceByRole);
+  if (
+    observation.surface === "desktop"
+    && desktopEventsAllowedToUseTimelineEvidence.has(String(observation.event || ""))
+  ) {
+    return [...expected, ...evidenceRefsForRole("timeline", evidenceByRole, extraEvidenceByRole)];
+  }
+  return expected;
+}
+
 function validateEvidenceRoleRef(value, expectedValue, failures, code, detail) {
   const expectedValues = Array.isArray(expectedValue) ? expectedValue : [expectedValue].filter(Boolean);
   if (expectedValues.length > 0 && !expectedValues.map(evidenceKey).includes(evidenceKey(value))) {
@@ -602,7 +623,7 @@ function validateManifest(manifestPath, missionId, evidenceByRole, extraEvidence
     if (!knownEvidenceRefs.has(evidenceKey(observation.evidence_ref))) {
       recordFailure(failures, "observation_evidence_ref_unknown", String(observation.event || "unknown"));
     }
-    const expectedEvidenceRefs = expectedEvidenceRefsForSurface(observation.surface, evidenceByRole, extraEvidenceByRole);
+    const expectedEvidenceRefs = expectedEvidenceRefsForObservation(observation, evidenceByRole, extraEvidenceByRole);
     if (expectedEvidenceRefs.length > 0) {
       validateEvidenceRoleRef(
         observation.evidence_ref,
@@ -652,6 +673,7 @@ const extraEvidenceArgs = {
   timeline: pathsFor("timeline-extra-evidence", "TIMELINE_EXTRA_EVIDENCE"),
   shared: pathsFor("shared-extra-evidence", "SHARED_EXTRA_EVIDENCE"),
 };
+const negativeControlEvidenceArgs = pathsFor("negative-control-evidence", "NEGATIVE_CONTROL_EVIDENCE_FILES");
 const manifestPath = pathFor("manifest", "OBSERVATIONS_MANIFEST");
 
 const evidence = Object.entries(evidenceArgs)
@@ -665,7 +687,10 @@ const extraEvidenceByRole = Object.fromEntries(Object.keys(extraEvidenceArgs).ma
   role,
   extraEvidence.filter((entry) => entry.role.startsWith(`${role}-extra-`) || entry.role.startsWith(`${role}-shared-extra-`)),
 ]));
-const knownEvidenceRefs = new Set([...evidence, ...extraEvidence].map((entry) => evidenceKey(entry.path)));
+const negativeControlEvidence = negativeControlEvidenceArgs
+  .map((path, index) => validateEvidence(`negative-control-${index + 1}`, path, failures))
+  .filter(Boolean);
+const knownEvidenceRefs = new Set([...evidence, ...extraEvidence, ...negativeControlEvidence].map((entry) => evidenceKey(entry.path)));
 validateManifest(manifestPath, missionId, evidenceByRole, extraEvidenceByRole, knownEvidenceRefs, failures);
 
 const readyForAssemble = failures.length === 0;
@@ -674,7 +699,7 @@ const result = {
   proof_source: "pre_assemble_readiness_only_not_ui_device_proof",
   readyForAssemble,
   missionId: missionId || null,
-  evidence: [...evidence, ...extraEvidence],
+  evidence: [...evidence, ...extraEvidence, ...negativeControlEvidence],
   manifestPath: manifestPath || null,
   failures,
 };

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -557,7 +557,7 @@ describe("friday-ui-device-proof-readiness", () => {
         encoding: "utf8",
       });
 
-      expect(stdout).toContain('"truth":"assembled_real_ui_device_proof"');
+      expect(JSON.parse(stdout)).toEqual({ truth: "assembled_real_ui_device_proof", status: "pass" });
       const proof = JSON.parse(readFileSync(files.out, "utf8")) as {
         proof?: string;
         mission_id?: string;

--- a/test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts
+++ b/test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts
@@ -316,6 +316,65 @@ describe("check-mission-spine-ui-proof-inputs CLI", () => {
     }
   });
 
+  it("accepts timeline extra evidence for desktop stress rows and separate negative-control evidence", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-proof-inputs-timeline-extra-negative-"));
+    try {
+      const files = writeEvidenceFiles(tempDir);
+      const stressReport = join(tempDir, "real-stress-source-report.json");
+      const negativeEvidence = join(tempDir, "negative-status-labels.txt");
+      writeFileSync(stressReport, "real same-run timeline stress report bytes\n");
+      writeFileSync(negativeEvidence, "real negative-control status-label bytes\n");
+      const negativeMissionId = "mission_negative_status_labels";
+      const baseManifest = makeManifest(files);
+      const manifest = makeManifest(files, {
+        stress: {
+          ...baseManifest.stress,
+          evidence_ref: stressReport,
+        },
+        observations: baseManifest.observations.map((observation) => {
+          if (
+            observation.event === "duplicate_preflight_visible"
+            || observation.event === "provider_ack_not_done_visible"
+            || observation.event === "pressure_20_50_consecutive_asks_visible"
+            || observation.event === "invalid_key_error_visible"
+            || observation.event === "quota_error_visible"
+            || observation.event === "network_error_visible"
+            || observation.event === "reconnect_stale_verified"
+          ) {
+            return { ...observation, evidence_ref: stressReport };
+          }
+          return observation;
+        }),
+        negative_control_segments: [{
+          segment_id: "negative-control-status-error-stress",
+          mission_id: negativeMissionId,
+          truth_label: "real_ui_negative_control_segment_not_happy_path",
+          happy_path: false,
+          evidence_refs: [negativeEvidence],
+          observations: [
+            makeObservation("desktop", "stale_label_visible", negativeEvidence, negativeMissionId),
+            makeObservation("desktop", "offline_label_visible", negativeEvidence, negativeMissionId),
+            makeObservation("desktop", "error_label_visible", negativeEvidence, negativeMissionId),
+          ],
+        }],
+      });
+      const manifestPath = join(tempDir, "observations-manifest-timeline-extra-negative.json");
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const result = runInputsCli(files, manifestPath, [
+        `--timeline-extra-evidence=${stressReport}`,
+        `--negative-control-evidence=${negativeEvidence}`,
+      ]);
+
+      expect(result.readyForAssemble).toBe(true);
+      expect(result.failures).toEqual([]);
+      expect(result.evidence.map((entry) => entry.role)).toContain("timeline-extra-1");
+      expect(result.evidence.map((entry) => entry.role)).toContain("negative-control-1");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed for template or weak manifest inputs in expect-not-ready mode", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-proof-inputs-invalid-"));
     try {


### PR DESCRIPTION
## Summary
- Auto-discovers auxiliary mobile/desktop/channel/timeline/shared evidence from capture indexes and carries it through readiness, assembler, and final UI/device gate.
- Keeps negative-control evidence separated from happy-path evidence so stale/offline/error labels cannot satisfy live proof.
- Keeps readiness stdout machine-readable JSON in strict proof mode; self-test/assembler/gate logs go to stderr.

## Verification
- git diff --check
- node --check scripts/qa/check-mission-spine-ui-proof-inputs.mjs
- bash -n scripts/ops/friday-ui-device-proof-readiness.sh
- bash -n rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
- bash -n rust-core/scripts/mission-spine-ui-device-proof-gate.sh
- npx vitest run test/unit/qa/mission-spine-ui-proof-inputs-cli.test.ts test/unit/qa/mission-spine-ui-device-proof-assemble-cli.test.ts test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
- strict artifact re-run: /private/tmp/friday-ui-device-strict-a18157e8-with-channel-20260630T040000Z/readiness-after-extra-evidence-rebased-clean-20260630T042908Z.json => {"truth":"assembled_real_ui_device_proof","status":"pass"}

Truth: this strengthens proof ingestion/gating. It does not claim selected mobile/desktop UI realign is complete.