### PR TITLE
Align iOS selected design sample

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -451,7 +451,7 @@ struct RootView: View {
             })
         }
       }
-      .navigationTitle(destination == .home ? "Friday" : destination.title)
+      .navigationTitle("")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         // Top-LEFT: the Command Sheet launcher (locked: commandSheet from top-left).
@@ -459,32 +459,52 @@ struct RootView: View {
           Button {
             commandOpen = true
           } label: {
-            Image(systemName: "square.grid.2x2").foregroundStyle(MobileTheme.cyan)
+            Image(systemName: "line.3.horizontal")
+              .font(.system(size: 15, weight: .semibold))
+              .foregroundStyle(MobileTheme.textSecondary)
           }
           .accessibilityLabel("Open Command Sheet")
           .accessibilityIdentifier("friday.mobile.toolbar.command-sheet")
         }
-        // Top-BAR 💬: the Friday Chat entry (locked: the ONLY chat entry — no card).
-        ToolbarItem(placement: .topBarTrailing) {
-          Button {
-            pendingChatLaunchContext = nil
-            chatOpen = true
-          } label: {
-            Image(systemName: "bubble.left.and.bubble.right").foregroundStyle(MobileTheme.cyan)
+        ToolbarItem(placement: .principal) {
+          VStack(spacing: 1) {
+            Text(destination == .home ? "Friday" : destination.title)
+              .font(.headline.weight(.semibold))
+              .foregroundStyle(MobileTheme.textPrimary)
+            Text(destination == .home ? "Private command center" : "Friday surface")
+              .font(.caption2)
+              .foregroundStyle(MobileTheme.textSecondary)
           }
-          .accessibilityLabel("Open Friday Chat")
-          .accessibilityIdentifier("friday.mobile.toolbar.chat")
+          .accessibilityElement(children: .combine)
+          .accessibilityLabel(destination == .home ? "Friday. Private command center." : "\(destination.title). Friday surface.")
         }
         ToolbarItem(placement: .topBarTrailing) {
-          // Small Mark for the app itself.
-          Button {
-            Task { await homeVM.refresh() }
-          } label: {
-            Image(systemName: "arrow.clockwise").foregroundStyle(MobileTheme.cyan)
+          HStack(spacing: 8) {
+            Button {
+              Task { await homeVM.refresh() }
+            } label: {
+              FridayChip(
+                text: homeVM.isOnline ? "Hub live" : "Hub",
+                bg: homeVM.isOnline ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
+                fg: homeVM.isOnline ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Refresh Hub status")
+            .accessibilityIdentifier("friday.mobile.toolbar.hub-status")
+            .disabled(homeVM.state.isLoading)
+
+            // Top-BAR 💬: the Friday Chat entry (locked: the ONLY chat entry — no card).
+            Button {
+              pendingChatLaunchContext = nil
+              chatOpen = true
+            } label: {
+              Image(systemName: "bubble")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(MobileTheme.textSecondary)
+            }
+            .accessibilityLabel("Open Friday Chat")
+            .accessibilityIdentifier("friday.mobile.toolbar.chat")
           }
-          .accessibilityLabel("Refresh Status")
-          .accessibilityIdentifier("friday.mobile.toolbar.refresh")
-          .disabled(homeVM.state.isLoading)
         }
       }
       .navigationDestination(isPresented: $chatOpen) {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -114,7 +114,7 @@ struct FridayHomeScreen: View {
   private func designIntro(title: String, subtitle: String) -> some View {
     VStack(alignment: .leading, spacing: 6) {
       Text(title)
-        .font(.system(size: 30, weight: .bold))
+        .font(.system(size: 25, weight: .bold))
         .foregroundStyle(MobileTheme.textPrimary)
       Text(subtitle)
         .font(.callout)
@@ -164,7 +164,7 @@ struct FridayHomeScreen: View {
           title: item.title,
           subtitle: item.blockingReason.isEmpty ? "state: \(item.state)" : item.blockingReason,
           chip: item.canRetry ? "needs" : item.state,
-          urgent: item.canRetry || item.state == "stale" || item.state == "blocked",
+          urgent: item.canRetry || ["stale", "blocked", "high_risk", "high risk", "needs"].contains(item.state),
           workItem: item)
       }
     rows.append(contentsOf: projection.memoryCandidates.prefix(2).map { candidate in

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -243,7 +243,7 @@ public struct HomeWorkItem: Sendable, Identifiable, Equatable {
   public let canCancel: Bool
 
   public var needsAttention: Bool {
-    !done && (["blocked", "waiting", "error", "stale"].contains(state) || canRetry || canCancel)
+    !done && (["blocked", "waiting", "error", "stale", "needs", "high_risk", "high risk", "review"].contains(state) || canRetry || canCancel)
   }
 
   public var isProviderLinked: Bool {
@@ -1310,40 +1310,41 @@ public struct PreviewReadClient: FridayRustReadClient {
       "workItems": [
         {
           "workItemId": "wi-preview-1",
-          "title": "Draft the Mission plan",
-          "state": "ready",
-          "owner": "friday_owned",
+          "title": "Approve high-risk file change",
+          "state": "high risk",
+          "owner": "codex",
+          "blockingReason": "Codex · write under project root",
           "done": false
         },
         {
           "workItemId": "wi-preview-2",
-          "title": "Waiting for governed approval",
-          "state": "waiting",
-          "owner": "linked_only",
+          "title": "Confirm focused Rust tests",
+          "state": "needs",
+          "owner": "provider/tests",
+          "blockingReason": "provider/tests · ~2 min",
           "proofRef": "proof://work-item/preview-2",
+          "done": false
+        },
+        {
+          "workItemId": "wi-preview-3",
+          "title": "Claude reviewing docs",
+          "state": "streaming",
+          "owner": "claude",
+          "blockingReason": "checking no-fallback rows",
+          "proofRef": "proof://work-item/preview-3",
           "done": false
         }
       ],
       "memoryCandidates": [
         {
           "id": "cand-preview-1",
-          "preview": "Remember the operator prefers concise status reports.",
+          "preview": "never written without consent",
           "state": "candidate_review_only",
           "grantsMemoryAuthority": false,
           "evidenceRef": "proof://memory/preview-1"
         }
       ],
-      "runOutcomeLearningCandidates": [
-        {
-          "id": "learn-preview-1",
-          "runId": "run-preview-1",
-          "workItemId": "wi-preview-2",
-          "kind": "preference",
-          "state": "candidate",
-          "summary": "DeepSeek handled the short planning leg well.",
-          "evidenceRef": "proof://learning/preview-1"
-        }
-      ],
+      "runOutcomeLearningCandidates": [],
       "capabilityStates": [
         {
           "id": "cap-route",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -411,6 +411,19 @@ final class HomeViewModelTests: XCTestCase {
       evidenceRef: "proof://mobile/home-refresh/\(p.missionId)")
   }
 
+  func testPreviewReadClientMatchesSelectedMobileDesignSample() async throws {
+    let projection = HomeProjection(try await PreviewReadClient().fetchWorkbench())
+    XCTAssertEqual(projection.runtimeFeedStatus, "preview_sample")
+    XCTAssertEqual(projection.statusLabels, [])
+    XCTAssertEqual(
+      projection.workItems.map(\.title),
+      ["Approve high-risk file change", "Confirm focused Rust tests", "Claude reviewing docs"])
+    XCTAssertEqual(projection.workItems.filter(\.needsAttention).map(\.id), ["wi-preview-1", "wi-preview-2"])
+    XCTAssertEqual(projection.providerWorkItems.map(\.id), ["wi-preview-1", "wi-preview-2", "wi-preview-3"])
+    XCTAssertEqual(projection.memoryCandidates.first?.preview, "never written without consent")
+    XCTAssertEqual(projection.runOutcomeLearningCandidates, [])
+  }
+
   func testHomeViewModelCarriesInjectedDevicePairingReadiness() async throws {
     let readiness = DevicePairingReadiness(
       mode: .ready,


### PR DESCRIPTION
## Summary
- Realigns the iOS selected-design sample header with the operator-selected mobile handoff: menu affordance, Friday title/subtitle, Hub status chip, and chat entry.
- Updates the preview Home projection to match the selected handoff's Needs Me/Running content instead of the older generic demo queue.
- Locks the selected sample with a HomeViewModel test so preview drift is caught.

## Verification
- apps/friday-ios/build-sim.sh --mode design-proof-sample --shot /private/tmp/friday-ios-design-proof-realigned-20260630.png
- swift test --package-path apps/friday-ios

Truth: this makes the simulator design sample match the selected handoff more closely. It does not claim live-loopback UI, full product maturity, release, or END-BAR completion.