### PR TITLE
Align mobile approval action evidence with product contract

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -490,7 +490,7 @@ struct RootView: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Refresh Hub status")
-            .accessibilityIdentifier("friday.mobile.toolbar.hub-status")
+            .accessibilityIdentifier("friday.mobile.toolbar.refresh")
             .disabled(homeVM.state.isLoading)
 
             // Top-BAR 💬: the Friday Chat entry (locked: the ONLY chat entry — no card).

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/FridayChatViewModelTests.swift
@@ -721,7 +721,7 @@ final class FridayChatViewModelTests: XCTestCase {
         [
           "surface": "mobile",
           "screen": "fridayChat",
-          "action_id": "check",
+          "action_id": "mobile/approval/check",
           "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
           "status": "pass",
           "evidence_ref": "swift://mobile/fridayChat/approve/\(approveReceipt.runId)",
@@ -731,7 +731,7 @@ final class FridayChatViewModelTests: XCTestCase {
         [
           "surface": "mobile",
           "screen": "fridayChat",
-          "action_id": "act",
+          "action_id": "mobile/approval/reject",
           "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
           "status": "pass",
           "evidence_ref": "swift://mobile/fridayChat/reject/\(rejectReceipt.runId)",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalApproveIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalApproveIntegrationTests.swift
@@ -120,7 +120,7 @@ private func writeMobileApprovalApproveProofIfRequested(
       [
         "surface": "mobile",
         "screen": "approval",
-        "action_id": "check",
+        "action_id": "mobile/approval/check",
         "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
         "status": "pass",
         "evidence_ref": "proof://mobile/approval-approve/\(result.runId)",
@@ -259,7 +259,7 @@ private func appendMobileFridayChatApproveEvidenceIfRequested(
   actions.append([
     "surface": "mobile",
     "screen": "fridayChat",
-    "action_id": "check",
+    "action_id": "mobile/approval/check",
     "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
     "status": "pass",
     "evidence_ref": "proof://mobile/fridaychat-approval-approve/\(result.runId)",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalRejectIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalRejectIntegrationTests.swift
@@ -109,7 +109,7 @@ private func writeMobileApprovalRejectProofIfRequested(
       [
         "surface": "mobile",
         "screen": "approval",
-        "action_id": "act",
+        "action_id": "mobile/approval/reject",
         "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
         "status": "pass",
         "evidence_ref": "proof://mobile/approval-reject/\(result.runId)",
@@ -246,7 +246,7 @@ private func appendMobileFridayChatRejectEvidenceIfRequested(
   actions.append([
     "surface": "mobile",
     "screen": "fridayChat",
-    "action_id": "act",
+    "action_id": "mobile/approval/reject",
     "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
     "status": "pass",
     "evidence_ref": "proof://mobile/fridaychat-approval-reject/\(result.runId)",

--- a/scripts/ops/friday-mobile-chat-action-evidence.sh
+++ b/scripts/ops/friday-mobile-chat-action-evidence.sh
@@ -64,8 +64,8 @@ const actions = Array.isArray(parsed.actions) ? parsed.actions : [];
 for (const expected of [
   ["mobile", "fridayChat", "chat:typing", "ask_friday_chat"],
   ["mobile", "fridayChat", "chat:approveCard", "ask_friday_chat"],
-  ["mobile", "fridayChat", "check", "security_approval_bound_principal_gate_cat10_netnew"],
-  ["mobile", "fridayChat", "act", "security_approval_bound_principal_gate_cat10_netnew"],
+  ["mobile", "fridayChat", "mobile/approval/check", "security_approval_bound_principal_gate_cat10_netnew"],
+  ["mobile", "fridayChat", "mobile/approval/reject", "security_approval_bound_principal_gate_cat10_netnew"],
   ["mobile", "fridayChat", "chat:handoffCard", "ask_friday_chat"],
   ["mobile", "fridayChat", "chat:memoryCard", "ask_friday_chat"],
   ["mobile", "fridayChat", "share", "context_passport_transfer_checklist"],


### PR DESCRIPTION
## Summary
- Align mobile approval evidence rows with product runtime action IDs (`mobile/approval/check`, `mobile/approval/reject`).
- Update live approve/reject Swift proof rows and the chat action evidence wrapper to use the same contract IDs.
- Rename the iOS Home toolbar refresh accessibility target to `friday.mobile.toolbar.refresh` so the runtime action map has a stable linked target.

## Verification
- `scripts/ops/friday-mobile-chat-action-evidence.sh` -> ready; Swift evidence test passed.
- `npm run check:ios-action-accessibility-map -- --repo-root=/private/tmp/friday-mobile-approval-check-evidence-20260630` -> `ios_actions_linked`, 38/38 linked.
- `check-friday-uiux-action-traceability` -> `product_runtime_actions_traceable`, missing runtime evidence 0.
- `check-friday-uiux-product-happy-path` with selected visual + desktop aggregate + runtime evidence -> only `residual_endbar_blockers_present=39` remains.
- Targeted vitest suite: 4 files / 9 tests passed.

Truth: this closes the action-evidence traceability gap only. It is not END-BAR, not release/adoption, and not a claim that all residual product blockers are closed.