### PR TITLE
Tighten UI runtime blocker proof plumbing

### DIFF
--- a/scripts/ops/build-friday-uiux-runtime-blocker-satisfaction.mjs
+++ b/scripts/ops/build-friday-uiux-runtime-blocker-satisfaction.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/build-friday-uiux-runtime-blocker-satisfaction.mjs \\
+    --head=<current-head> \\
+    --action-traceability-report=/abs/action-traceability.json \\
+    --ui-device-proof=/abs/strict-ui-device-proof.json \\
+    [--ui-device-evidence-dir=/abs/rebuilt-capture-dir] \\
+    [--out=/abs/runtime-blocker-satisfaction.json] [--require-ready]
+
+Truth:
+  Builds ProductReadinessContract blocker-satisfaction rows only for residual
+  needsRuntimeEvidence blockers whose runtime actions are fully covered and
+  whose run has a strict same-run UI/device proof. It does not satisfy signature,
+  provider-credential, release, adoption, or human-polish blockers, and it does
+  not convert partial/screenshot/fixture evidence into END-BAR.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const head = arg("head") || process.env.FRIDAY_UIUX_RUNTIME_BLOCKER_SATISFACTION_HEAD || "";
+const tracePath = arg("action-traceability-report") || process.env.FRIDAY_UIUX_ACTION_TRACEABILITY_REPORT || "";
+const uiDeviceProofPath = arg("ui-device-proof") || process.env.FRIDAY_UI_DEVICE_PROOF_REPORT || "";
+const uiDeviceEvidenceDir = arg("ui-device-evidence-dir") || process.env.FRIDAY_UI_DEVICE_EVIDENCE_DIR || "";
+const outPath = arg("out") || process.env.FRIDAY_UIUX_RUNTIME_BLOCKER_SATISFACTION_OUT || "";
+const requireReady = args.includes("--require-ready");
+const blockers = [];
+const notes = [];
+const forbiddenOverlayTruth = /(partial|not[-_ ]?live|not[-_ ]?sim[-_ ]?tap|not[-_ ]?ui[-_ ]?device[-_ ]?proof|design[-_ ]?proof|screenshot|mock|fixture|sample|dry[-_ ]?run|offline|unavailable|placeholder)/i;
+
+function abs(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function note(code, detail) {
+  notes.push({ code, detail });
+}
+
+function requireFile(label, path) {
+  if (!path) {
+    block("missing_arg", label);
+    return "";
+  }
+  const resolved = abs(path);
+  try {
+    const stats = statSync(resolved);
+    if (!stats.isFile()) block("not_file", `${label}:${resolved}`);
+    if (stats.size <= 0) block("empty_file", `${label}:${resolved}`);
+  } catch {
+    block("unreadable_file", `${label}:${resolved}`);
+  }
+  return resolved;
+}
+
+function readJson(label, path) {
+  const file = requireFile(label, path);
+  if (!file) return null;
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    block("invalid_json", `${label}:${file}:${error.message}`);
+    return null;
+  }
+}
+
+function requireEvidenceDir(path) {
+  if (!path) return { dir: "", refs: [] };
+  const dir = abs(path);
+  try {
+    if (!statSync(dir).isDirectory()) {
+      block("evidence_dir_not_directory", dir);
+      return { dir, refs: [] };
+    }
+  } catch {
+    block("evidence_dir_unreadable", dir);
+    return { dir, refs: [] };
+  }
+  const expected = [
+    "gap-report.json",
+    "observations-manifest.json",
+    "same-run-events.with-channel.jsonl",
+    "mobile.json",
+    "desktop.json",
+    "timeline.json",
+  ];
+  const refs = [];
+  for (const relative of expected) {
+    const file = resolve(dir, relative);
+    if (!existsSync(file)) {
+      block("evidence_file_missing", file);
+      continue;
+    }
+    refs.push(file);
+  }
+  const gapReportPath = resolve(dir, "gap-report.json");
+  if (existsSync(gapReportPath)) {
+    const gapReport = readJson("ui-device-gap-report", gapReportPath);
+    const gapBlockers = Array.isArray(gapReport?.blockers) ? gapReport.blockers : [];
+    if (gapBlockers.length > 0) block("ui_device_gap_report_has_blockers", JSON.stringify(gapBlockers.slice(0, 10)));
+    if (gapReport?.status && !["pass", "ready", "gaps_present"].includes(String(gapReport.status))) {
+      block("ui_device_gap_report_status_unexpected", String(gapReport.status));
+    }
+  }
+  return { dir, refs };
+}
+
+function arrayAt(value, path) {
+  let current = value;
+  for (const key of path) current = current?.[key];
+  return Array.isArray(current) ? current : [];
+}
+
+function rowKey(row) {
+  return [
+    String(row?.surface || ""),
+    String(row?.id || row?.destination || ""),
+    String(row?.kind || row?.blockerKind || ""),
+    String(row?.label || row?.blockerLabel || ""),
+  ].join("\u001f");
+}
+
+function residualRows(trace) {
+  const rows = [];
+  for (const destination of arrayAt(trace, ["gaps", "residualEndBarBlockers"])) {
+    const overlay = destination?.evidenceOverlay || {};
+    for (const blocker of Array.isArray(destination?.blockers) ? destination.blockers : []) {
+      rows.push({
+        surface: String(destination?.surface || ""),
+        id: String(destination?.id || destination?.destination || ""),
+        title: String(destination?.title || ""),
+        tier: String(destination?.tier || ""),
+        kind: String(blocker?.kind || ""),
+        label: String(blocker?.label || ""),
+        evidenceOverlay: overlay,
+      });
+    }
+  }
+  return rows;
+}
+
+function destinationForRow(trace, row) {
+  return (Array.isArray(trace?.destinations) ? trace.destinations : [])
+    .find((destination) =>
+      String(destination?.surface || "") === row.surface
+      && String(destination?.id || destination?.destination || "") === row.id);
+}
+
+function isCleanRuntimeTruth(truthLabel) {
+  const value = String(truthLabel || "");
+  return value.length > 0 && !forbiddenOverlayTruth.test(value);
+}
+
+function cleanActionCoverage(trace, row) {
+  const destination = destinationForRow(trace, row);
+  const actionTrace = Array.isArray(destination?.actionTrace) ? destination.actionTrace : [];
+  if (actionTrace.length === 0) return null;
+
+  const missing = [];
+  const evidenceRefs = [];
+  const cleanTruthLabels = [];
+  for (const action of actionTrace) {
+    const labels = Array.isArray(action?.evidenceTruthLabels) ? action.evidenceTruthLabels : [];
+    const cleanLabels = labels.filter(isCleanRuntimeTruth);
+    if (action?.runtimeEvidenceMatched !== true || cleanLabels.length === 0) {
+      missing.push({
+        runtimeActionId: String(action?.runtimeActionId || ""),
+        runtimeEvidenceMatched: action?.runtimeEvidenceMatched === true,
+        evidenceTruthLabels: labels,
+      });
+      continue;
+    }
+    evidenceRefs.push(...(Array.isArray(action?.evidenceRefs) ? action.evidenceRefs.filter(Boolean) : []));
+    cleanTruthLabels.push(...cleanLabels);
+  }
+  return {
+    ok: missing.length === 0,
+    missing,
+    evidenceRefs: [...new Set(evidenceRefs)],
+    cleanTruthLabels: [...new Set(cleanTruthLabels)],
+  };
+}
+
+const trace = readJson("action-traceability-report", tracePath);
+const uiDeviceProof = readJson("ui-device-proof", uiDeviceProofPath);
+const uiDeviceEvidence = requireEvidenceDir(uiDeviceEvidenceDir);
+
+if (!head) block("head_missing", "provide --head");
+if (trace?.status !== "product_runtime_actions_traceable") {
+  block("action_traceability_not_product_runtime_traceable", String(trace?.status || "missing"));
+}
+if ((trace?.counts?.productActionsMissingRuntimeEvidence ?? 0) !== 0) {
+  block("product_actions_missing_runtime_evidence", String(trace?.counts?.productActionsMissingRuntimeEvidence));
+}
+if ((trace?.counts?.runtimeEvidenceInputs ?? 0) <= 0) {
+  block("runtime_evidence_inputs_missing", String(trace?.counts?.runtimeEvidenceInputs ?? 0));
+}
+if (uiDeviceProof?.truth !== "assembled_real_ui_device_proof" || uiDeviceProof?.status !== "pass") {
+  block("ui_device_proof_not_strict_pass", `${String(uiDeviceProof?.truth || "missing")}:${String(uiDeviceProof?.status || "missing")}`);
+}
+
+const proofRef = uiDeviceProofPath ? abs(uiDeviceProofPath) : "";
+const traceRef = tracePath ? abs(tracePath) : "";
+const evidenceRefs = [
+  proofRef,
+  traceRef,
+  ...uiDeviceEvidence.refs,
+].filter(Boolean);
+
+const satisfactions = [];
+const skippedRows = [];
+const byKey = new Map();
+for (const row of residualRows(trace)) {
+  const overlay = row.evidenceOverlay || {};
+  if (row.kind !== "needsRuntimeEvidence") {
+    skippedRows.push({ ...row, reason: "non_runtime_blocker" });
+    continue;
+  }
+  const actionCoverage = cleanActionCoverage(trace, row);
+  if (actionCoverage && !actionCoverage.ok) {
+    skippedRows.push({
+      ...row,
+      reason: `runtime_action_clean_coverage_missing:${JSON.stringify(actionCoverage.missing.slice(0, 8))}`,
+    });
+    continue;
+  }
+  if (overlay.status !== "runtime_action_evidence_attached_not_endbar") {
+    skippedRows.push({ ...row, reason: `runtime_overlay_not_fully_covered:${String(overlay.status || "missing")}` });
+    continue;
+  }
+  if ((overlay.runtimeActionCount ?? 0) <= 0 || overlay.runtimeActionsMissing !== 0) {
+    skippedRows.push({ ...row, reason: "runtime_action_counts_not_fully_covered" });
+    continue;
+  }
+  const overlayTruthLabels = Array.isArray(overlay.evidenceTruthLabels) ? overlay.evidenceTruthLabels : [];
+  const forbiddenTruthLabel = overlayTruthLabels.find((truthLabel) => forbiddenOverlayTruth.test(String(truthLabel || "")));
+  if (!actionCoverage && forbiddenTruthLabel) {
+    skippedRows.push({ ...row, reason: `runtime_overlay_truth_forbidden:${String(forbiddenTruthLabel)}` });
+    continue;
+  }
+  const item = {
+    surface: row.surface,
+    id: row.id,
+    kind: row.kind,
+    label: row.label,
+    status: "satisfied",
+    evidenceClass: "same_run_ui_device_product_proof",
+    evidenceRefs: [...new Set([
+      ...evidenceRefs,
+      ...((actionCoverage?.evidenceRefs || []).filter(Boolean)),
+      ...((Array.isArray(overlay.evidenceRefs) ? overlay.evidenceRefs : []).filter(Boolean)),
+    ])],
+    evidenceTruthLabels: ["assembled_real_ui_device_proof_same_run_live_connected_current_head"],
+    sameRun: true,
+    liveConnected: true,
+    currentHead: true,
+    caveat:
+      "This row satisfies a needsRuntimeEvidence ProductReadinessContract residual only when paired with strict same-run UI/device proof and full action-runtime coverage; it does not claim adoption or public release.",
+  };
+  const key = rowKey(item);
+  if (!byKey.has(key)) {
+    byKey.set(key, true);
+    satisfactions.push(item);
+  }
+}
+
+if (satisfactions.length === 0) {
+  block("no_runtime_blocker_satisfactions", "no residual needsRuntimeEvidence row had full runtime coverage plus strict UI/device proof");
+}
+if (skippedRows.length > 0) {
+  note("skipped_residual_rows", JSON.stringify(skippedRows.map(({ evidenceOverlay, ...row }) => row).slice(0, 20)));
+}
+
+const output = {
+  truth: "uiux_runtime_blocker_satisfaction_manifest",
+  status: blockers.length === 0 ? "ready" : "not_ready",
+  head,
+  sources: {
+    actionTraceabilityReport: traceRef || null,
+    uiDeviceProof: proofRef || null,
+    uiDeviceEvidenceDir: uiDeviceEvidence.dir || null,
+  },
+  counts: {
+    residualRows: residualRows(trace).length,
+    satisfactions: satisfactions.length,
+    skippedRows: skippedRows.length,
+  },
+  satisfactions,
+  skippedRows,
+  blockers,
+  notes,
+  caveat:
+    "Runtime blocker satisfaction is a strict bridge from current-head action traceability plus assembled real UI/device proof into the product happy-path gate. It does not weaken END-BAR, release, adoption, signature, provider, or semantic non-runtime gates.",
+};
+
+if (outPath) {
+  const out = abs(outPath);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, `${JSON.stringify(output, null, 2)}\n`);
+}
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(requireReady && blockers.length > 0 ? 1 : 0);

--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -157,10 +157,50 @@ const defaultActionMap = new Map([
   ["desktop/workflow/cancel", { destination: "workflow", screen: "workflow", accessibility_id: "friday.desktop.workflow.canvas", event: "mission_workbench_visible", interaction: "visible" }],
   ["desktop/channels/receipts", { destination: "channels", screen: "channels", accessibility_id: "friday.desktop.channels.admin", event: "same_mission_mobile_desktop_channel_visible", interaction: "visible" }],
   ["desktop/channels/surface-events", { destination: "channels", screen: "channels", accessibility_id: "friday.desktop.channels.surface-events", event: "same_mission_mobile_desktop_channel_visible", interaction: "visible" }],
+  ["desktop/providerAdmin/check", {
+    destination: "providerAdmin",
+    screen: "providerAdmin",
+    accessibility_id: "friday.desktop.provider-readiness-detail",
+    accessibility_ids: [
+      "friday.desktop.provider-readiness-detail",
+      "friday.desktop.provider-route-decision-card",
+      "friday.desktop.provider-work-items-card",
+    ],
+    event: "real_provider_execution_visible",
+    interaction: "read",
+  }],
+  ["desktop/parity/route-readiness", {
+    destination: "parity",
+    screen: "parity",
+    accessibility_id: "friday.desktop.provider-route-decision-card",
+    accessibility_ids: [
+      "friday.desktop.provider-route-decision-card",
+      "friday.desktop.provider-readiness-detail",
+    ],
+    visible_text: "Route Decision",
+    event: "real_provider_execution_visible",
+    interaction: "read",
+  }],
+  ["desktop/diagnostics/proof-refs", { destination: "diagnostics", screen: "diagnostics", accessibility_id: "friday.desktop.evidence.timeline-pages", visible_text: "Runtime Diagnostics", event: "proof_receipt_visible_before_done", interaction: "read" }],
   ["desktop/recovery/retry", { destination: "recovery", screen: "recovery", accessibility_id: "friday.desktop.recovery.retry-available", visible_text: "retry available", event: "reconnect_stale_verified", interaction: "visible" }],
   ["desktop/recovery/cancel", { destination: "recovery", screen: "recovery", accessibility_id: "friday.desktop.recovery.cancel-available", visible_text: "cancel available", event: "reconnect_stale_verified", interaction: "visible" }],
   ["desktop/memory/act", { destination: "memory", screen: "memory", accessibility_id: "friday.desktop.evidence.memory-candidate", visible_text: "Review-only memory candidate attached to this Mission.", event: "same_mission_projection_visible", interaction: "visible" }],
   ["desktop/memory/check", { destination: "memory", screen: "memory", accessibility_id: "friday.desktop.evidence.memory-candidate", visible_text: "Review-only memory candidate attached to this Mission.", event: "same_mission_projection_visible", interaction: "visible" }],
+  ["desktop/tokenLedger/run-readback", { destination: "tokenLedger", screen: "tokenLedger", accessibility_id: "friday.desktop.evidence.transcript-browser", visible_text: "Token Ledger", event: "transcript_browser_visible", interaction: "read" }],
+  ["desktop/skills/capability-matrix", { destination: "skills", screen: "skills", accessibility_id: "friday.desktop.evidence.memory-review", visible_text: "Skills / Tools Truth Matrix", event: "same_mission_projection_visible", interaction: "read" }],
+  ["desktop/media/evidence-refs", { destination: "media", screen: "media", accessibility_id: "friday.desktop.evidence.timeline-pages", visible_text: "Media / Link", event: "same_mission_projection_visible", interaction: "read" }],
+  ["desktop/settings/hub-posture", { destination: "settings", screen: "settings", accessibility_id: "friday.desktop.evidence.timeline-pages", visible_text: "Hub Settings", event: "mission_workbench_visible", interaction: "read" }],
+  ["desktop/evidence/index-read", {
+    destination: "evidence",
+    screen: "evidence",
+    accessibility_id: "friday.desktop.evidence.timeline-pages",
+    accessibility_ids: [
+      "friday.desktop.evidence.timeline-pages",
+      "friday.desktop.evidence.transcript-browser",
+    ],
+    event: "transcript_browser_visible",
+    interaction: "read",
+  }],
 ]);
 
 function actionPlan() {

--- a/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
+++ b/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
@@ -40,6 +40,30 @@ describe("friday-desktop-ax-accessibility-capture contract", () => {
         event: "mission_resolve_or_create_visible",
         interaction: "visible",
       }));
+      expect(summary.targets).toContainEqual(expect.objectContaining({
+        runtimeActionId: "desktop/providerAdmin/check",
+        accessibility_id: "friday.desktop.provider-readiness-detail",
+        event: "real_provider_execution_visible",
+        interaction: "read",
+      }));
+      expect(summary.targets).toContainEqual(expect.objectContaining({
+        runtimeActionId: "desktop/parity/route-readiness",
+        accessibility_id: "friday.desktop.provider-route-decision-card",
+        event: "real_provider_execution_visible",
+        interaction: "read",
+      }));
+      expect(summary.targets).toContainEqual(expect.objectContaining({
+        runtimeActionId: "desktop/tokenLedger/run-readback",
+        accessibility_id: "friday.desktop.evidence.transcript-browser",
+        event: "transcript_browser_visible",
+        interaction: "read",
+      }));
+      expect(summary.targets).toContainEqual(expect.objectContaining({
+        runtimeActionId: "desktop/evidence/index-read",
+        accessibility_id: "friday.desktop.evidence.timeline-pages",
+        event: "transcript_browser_visible",
+        interaction: "read",
+      }));
     } finally {
       rmSync(outDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-uiux-runtime-blocker-satisfaction-cli.test.ts
+++ b/test/unit/qa/friday-uiux-runtime-blocker-satisfaction-cli.test.ts
@@ -1,0 +1,326 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/build-friday-uiux-runtime-blocker-satisfaction.mjs";
+const head = "abc1234";
+
+function writeJson(root: string, relative: string, value: unknown) {
+  const target = join(root, relative);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`);
+  return target;
+}
+
+function writeText(root: string, relative: string, value = "real ui/device bytes\n") {
+  const target = join(root, relative);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, value);
+  return target;
+}
+
+function writeEvidenceDir(root: string) {
+  const dir = join(root, "rebuilt-capture-dir");
+  writeJson(dir, "gap-report.json", {
+    status: "gaps_present",
+    blockers: [],
+    checks: {
+      pressureAskCountOk: true,
+      duplicateSurfaceCountOk: true,
+      timelinePageCountOk: true,
+    },
+  });
+  writeJson(dir, "observations-manifest.json", {
+    truth: "ui_device_observations_manifest_derived_from_same_run_events_not_proof",
+    mission_id: "mission_ui_device_contract",
+    observations: [{ surface: "mobile" }, { surface: "desktop" }],
+  });
+  writeText(dir, "same-run-events.with-channel.jsonl", "{\"event\":\"mission_workbench_visible\"}\n");
+  writeJson(dir, "mobile.json", { surface: "mobile", status: "ready" });
+  writeJson(dir, "desktop.json", { surface: "desktop", status: "ready" });
+  writeJson(dir, "timeline.json", { surface: "timeline", status: "ready" });
+  return dir;
+}
+
+function trace(overrides: Record<string, unknown> = {}) {
+  return {
+    truth: "uiux_action_traceability_not_endbar_not_adoption_not_gui_proof",
+    status: "product_runtime_actions_traceable",
+    counts: {
+      runtimeEvidenceInputs: 2,
+      productActionsMissingRuntimeEvidence: 0,
+    },
+    gaps: {
+      residualEndBarBlockers: [{
+        surface: "mobile",
+        id: "home",
+        title: "Friday Home",
+        tier: "liveWorkbench",
+        blockers: [{ kind: "needsRuntimeEvidence", label: "same-run user proof" }],
+        evidenceOverlay: {
+          status: "runtime_action_evidence_attached_not_endbar",
+          runtimeActionCount: 1,
+          runtimeActionsCovered: 1,
+          runtimeActionsMissing: 0,
+          evidenceRefs: ["proof://runtime/mobile-home"],
+          evidenceTruthLabels: ["accessibility_click_action_runtime_evidence_real_ui_not_endbar"],
+        },
+      }],
+    },
+    ...overrides,
+  };
+}
+
+describe("build-friday-uiux-runtime-blocker-satisfaction", () => {
+  it("creates satisfaction rows only after full runtime coverage plus strict UI/device proof", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-runtime-satisfaction-ready-"));
+    try {
+      const tracePath = writeJson(root, "trace.json", trace());
+      const proofPath = writeJson(root, "ui-device-proof.json", {
+        truth: "assembled_real_ui_device_proof",
+        status: "pass",
+      });
+      const evidenceDir = writeEvidenceDir(root);
+      const output = execFileSync("node", [
+        script,
+        `--head=${head}`,
+        `--action-traceability-report=${tracePath}`,
+        `--ui-device-proof=${proofPath}`,
+        `--ui-device-evidence-dir=${evidenceDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        truth?: string;
+        status?: string;
+        counts?: { satisfactions?: number };
+        satisfactions?: Array<{
+          evidenceClass?: string;
+          evidenceTruthLabels?: string[];
+          sameRun?: boolean;
+          liveConnected?: boolean;
+          currentHead?: boolean;
+        }>;
+        blockers?: unknown[];
+      };
+      expect(report.truth).toBe("uiux_runtime_blocker_satisfaction_manifest");
+      expect(report.status).toBe("ready");
+      expect(report.counts?.satisfactions).toBe(1);
+      expect(report.satisfactions?.[0]).toEqual(expect.objectContaining({
+        evidenceClass: "same_run_ui_device_product_proof",
+        evidenceTruthLabels: ["assembled_real_ui_device_proof_same_run_live_connected_current_head"],
+        sameRun: true,
+        liveConnected: true,
+        currentHead: true,
+      }));
+      expect(report.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not satisfy partial runtime overlays", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-runtime-satisfaction-partial-"));
+    try {
+      const tracePath = writeJson(root, "trace.json", trace({
+        gaps: {
+          residualEndBarBlockers: [{
+            surface: "desktop",
+            id: "chat",
+            blockers: [{ kind: "needsRuntimeEvidence", label: "full desktop tap proof" }],
+            evidenceOverlay: {
+              status: "partial_runtime_action_evidence_attached_not_endbar",
+              runtimeActionCount: 2,
+              runtimeActionsCovered: 1,
+              runtimeActionsMissing: 1,
+              evidenceRefs: ["proof://runtime/desktop-chat"],
+            },
+          }],
+        },
+      }));
+      const proofPath = writeJson(root, "ui-device-proof.json", {
+        truth: "assembled_real_ui_device_proof",
+        status: "pass",
+      });
+      const evidenceDir = writeEvidenceDir(root);
+      const result = spawnSync("node", [
+        script,
+        `--head=${head}`,
+        `--action-traceability-report=${tracePath}`,
+        `--ui-device-proof=${proofPath}`,
+        `--ui-device-evidence-dir=${evidenceDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        status?: string;
+        blockers?: Array<{ code?: string }>;
+        skippedRows?: Array<{ reason?: string }>;
+      };
+      expect(report.status).toBe("not_ready");
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "no_runtime_blocker_satisfactions" }),
+      ]));
+      expect(report.skippedRows?.[0]?.reason).toContain("runtime_overlay_not_fully_covered");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not satisfy provider/signature blockers", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-runtime-satisfaction-non-runtime-"));
+    try {
+      const tracePath = writeJson(root, "trace.json", trace({
+        gaps: {
+          residualEndBarBlockers: [{
+            surface: "desktop",
+            id: "providerAdmin",
+            blockers: [{ kind: "needsProviderCredential", label: "all selected provider routes" }],
+            evidenceOverlay: {
+              status: "runtime_action_evidence_attached_not_endbar",
+              runtimeActionCount: 1,
+              runtimeActionsCovered: 1,
+              runtimeActionsMissing: 0,
+              evidenceRefs: ["proof://runtime/provider-admin"],
+            },
+          }],
+        },
+      }));
+      const proofPath = writeJson(root, "ui-device-proof.json", {
+        truth: "assembled_real_ui_device_proof",
+        status: "pass",
+      });
+      const evidenceDir = writeEvidenceDir(root);
+      const result = spawnSync("node", [
+        script,
+        `--head=${head}`,
+        `--action-traceability-report=${tracePath}`,
+        `--ui-device-proof=${proofPath}`,
+        `--ui-device-evidence-dir=${evidenceDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        blockers?: Array<{ code?: string }>;
+        skippedRows?: Array<{ reason?: string }>;
+      };
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "no_runtime_blocker_satisfactions" }),
+      ]));
+      expect(report.skippedRows?.[0]?.reason).toBe("non_runtime_blocker");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not promote partial or not-live overlay truth labels", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-runtime-satisfaction-forbidden-truth-"));
+    try {
+      const tracePath = writeJson(root, "trace.json", trace({
+        gaps: {
+          residualEndBarBlockers: [{
+            surface: "mobile",
+            id: "voice",
+            blockers: [{ kind: "needsRuntimeEvidence", label: "real microphone and speech-output tap proof" }],
+            evidenceOverlay: {
+              status: "runtime_action_evidence_attached_not_endbar",
+              runtimeActionCount: 1,
+              runtimeActionsCovered: 1,
+              runtimeActionsMissing: 0,
+              evidenceRefs: ["swift://mobile/voice/partial"],
+              evidenceTruthLabels: ["swift_viewmodel_write_client_runtime_not_live_hub_not_sim_tap"],
+            },
+          }],
+        },
+      }));
+      const proofPath = writeJson(root, "ui-device-proof.json", {
+        truth: "assembled_real_ui_device_proof",
+        status: "pass",
+      });
+      const evidenceDir = writeEvidenceDir(root);
+      const result = spawnSync("node", [
+        script,
+        `--head=${head}`,
+        `--action-traceability-report=${tracePath}`,
+        `--ui-device-proof=${proofPath}`,
+        `--ui-device-evidence-dir=${evidenceDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        blockers?: Array<{ code?: string }>;
+        skippedRows?: Array<{ reason?: string }>;
+      };
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "no_runtime_blocker_satisfactions" }),
+      ]));
+      expect(report.skippedRows?.[0]?.reason).toContain("runtime_overlay_truth_forbidden");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts full per-action clean coverage even when legacy partial overlay labels are present", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-runtime-satisfaction-clean-action-trace-"));
+    try {
+      const tracePath = writeJson(root, "trace.json", trace({
+        gaps: {
+          residualEndBarBlockers: [{
+            surface: "desktop",
+            id: "tokenLedger",
+            blockers: [{ kind: "needsRuntimeEvidence", label: "run-backed ledger proof" }],
+            evidenceOverlay: {
+              status: "runtime_action_evidence_attached_not_endbar",
+              runtimeActionCount: 1,
+              runtimeActionsCovered: 1,
+              runtimeActionsMissing: 0,
+              evidenceRefs: ["swift://desktop/tokenLedger/run-readback/run-desktop", "proof://desktop-ax/token-ledger"],
+              evidenceTruthLabels: [
+                "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
+                "accessibility_click_action_runtime_evidence_real_ui_not_endbar",
+              ],
+            },
+          }],
+        },
+        destinations: [{
+          surface: "desktop",
+          id: "tokenLedger",
+          actionTrace: [{
+            runtimeActionId: "desktop/tokenLedger/run-readback",
+            runtimeEvidenceMatched: true,
+            evidenceRefs: ["proof://desktop-ax/token-ledger"],
+            evidenceTruthLabels: [
+              "swift_viewmodel_write_client_runtime_not_live_hub_not_operator_key_not_endbar",
+              "accessibility_click_action_runtime_evidence_real_ui_not_endbar",
+            ],
+          }],
+        }],
+      }));
+      const proofPath = writeJson(root, "ui-device-proof.json", {
+        truth: "assembled_real_ui_device_proof",
+        status: "pass",
+      });
+      const evidenceDir = writeEvidenceDir(root);
+      const output = execFileSync("node", [
+        script,
+        `--head=${head}`,
+        `--action-traceability-report=${tracePath}`,
+        `--ui-device-proof=${proofPath}`,
+        `--ui-device-evidence-dir=${evidenceDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        counts?: { satisfactions?: number };
+        satisfactions?: Array<{ id?: string; evidenceRefs?: string[] }>;
+      };
+      expect(report.status).toBe("ready");
+      expect(report.counts?.satisfactions).toBe(1);
+      expect(report.satisfactions?.[0]?.id).toBe("tokenLedger");
+      expect(report.satisfactions?.[0]?.evidenceRefs).toContain("proof://desktop-ax/token-ledger");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- expand desktop AX capture planning for provider/parity/diagnostics/token ledger/skills/media/settings/evidence runtime actions
- add a strict runtime blocker satisfaction builder that only emits rows when traceability is green, UI/device proof is strict pass, runtime overlay is fully covered, and each runtime action has clean real evidence when a full action trace is supplied
- add contract tests for the expanded AX plan and strict satisfaction boundary

## Truth / no-degrade
- This does not mark END-BAR, adoption, release, or organic completion.
- Existing partial/ViewModel evidence is intentionally rejected (`swift_viewmodel_*_not_live_hub_not_sim_tap` etc.).
- If future real AX evidence and old partial evidence coexist, the builder validates per-action clean coverage instead of blindly trusting destination-level overlays.
- Smoke against current artifacts reports 0/39 runtime blocker satisfactions, which is the correct red state until real UI/live evidence replaces partial rows.

## Verification
- `vitest run --project default test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts test/unit/qa/friday-uiux-runtime-blocker-satisfaction-cli.test.ts test/unit/qa/friday-uiux-product-blocker-satisfaction-builder-cli.test.ts test/unit/qa/friday-uiux-product-happy-path-cli.test.ts` (21 tests)
- `git diff --check`
- desktop AX plan smoke: 24 targets including provider/parity/diagnostics/tokenLedger/skills/media/settings/evidence
- strict satisfaction smoke: `not_ready`, 0 satisfactions, 39 skipped partial/non-runtime rows
