### PR TITLE
Align mobile command sheet with product path

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -60,46 +60,45 @@ enum MobileDestination: String, CaseIterable, Identifiable {
 
   /// Route coverage only. This must not be used as a closed-loop product-completion signal.
   var isBuilt: Bool { contract.routeBuilt }
+
+  /// The operator-selected mobile product keeps ordinary users in the Friday-first
+  /// command surface. Setup/readiness/proof routes stay available, but they must not
+  /// be the default path a user falls into from Home.
+  var commandSheetLane: MobileProductCommandSurfaceLane {
+    MobileProductDestinationID(rawValue: rawValue)?.commandSurfaceLane ?? .diagnostics
+  }
 }
 
 /// The Command Sheet: a full-screen 2-column grid launcher.
 struct CommandSheet: View {
   @Binding var destination: MobileDestination
   @Binding var isOpen: Bool
+  @State private var showDiagnostics = false
 
   private let columns = [GridItem(.flexible(), spacing: 14), GridItem(.flexible(), spacing: 14)]
-  private let sections: [(String, [MobileDestination])] = [
+  private let productSections: [(String, [MobileDestination])] = [
     ("Command", [.home, .newSession, .voice, .shareIntake]),
     ("Work", [.missions, .needsMe, .activity, .workflows]),
     ("Providers", [.platform, .providerAuth, .session]),
     ("Trust", [.contextPassport, .memory, .tokenLedger]),
-    ("Setup", [.pairing, .onboarding, .settings, .petEditor]),
+  ]
+  private let diagnosticsSections: [(String, [MobileDestination])] = [
+    ("Advanced", [.pairing, .onboarding, .settings, .petEditor, .proofViewer, .entrypoints]),
   ]
 
   var body: some View {
     NavigationStack {
       ScrollView {
         VStack(alignment: .leading, spacing: 18) {
-          ForEach(sections, id: \.0) { section in
-            VStack(alignment: .leading, spacing: 10) {
-              Text(section.0.uppercased())
-                .font(.caption.weight(.bold))
-                .foregroundStyle(MobileTheme.textSecondary)
-                .tracking(3)
-                .accessibilityHidden(true)
-              LazyVGrid(columns: columns, spacing: 14) {
-                ForEach(section.1) { dest in
-                  Button {
-                    if dest.isBuilt { destination = dest }
-                    isOpen = false
-                  } label: {
-                    tile(dest)
-                  }
-                  .buttonStyle(.plain)
-                  .disabled(!dest.isBuilt)
-                  .accessibilityIdentifier("friday.command-sheet.destination.\(dest.rawValue)")
-                }
-              }
+          ForEach(productSections, id: \.0) { section in
+            sectionView(section)
+          }
+
+          diagnosticsDisclosure
+
+          if showDiagnostics {
+            ForEach(diagnosticsSections, id: \.0) { section in
+              sectionView(section)
             }
           }
         }
@@ -116,6 +115,58 @@ struct CommandSheet: View {
         }
       }
     }
+  }
+
+  private func sectionView(_ section: (String, [MobileDestination])) -> some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text(section.0.uppercased())
+        .font(.caption.weight(.bold))
+        .foregroundStyle(MobileTheme.textSecondary)
+        .tracking(3)
+        .accessibilityHidden(true)
+      LazyVGrid(columns: columns, spacing: 14) {
+        ForEach(section.1) { dest in
+          Button {
+            if dest.isBuilt { destination = dest }
+            isOpen = false
+          } label: {
+            tile(dest)
+          }
+          .buttonStyle(.plain)
+          .disabled(!dest.isBuilt)
+          .accessibilityIdentifier("friday.command-sheet.destination.\(dest.rawValue)")
+        }
+      }
+    }
+  }
+
+  private var diagnosticsDisclosure: some View {
+    Button {
+      showDiagnostics.toggle()
+    } label: {
+      HStack(spacing: 10) {
+        Image(systemName: showDiagnostics ? "chevron.down.circle" : "chevron.right.circle")
+          .font(.system(size: 18, weight: .semibold))
+          .foregroundStyle(MobileTheme.cyan)
+        VStack(alignment: .leading, spacing: 3) {
+          Text("Advanced setup")
+            .font(.headline)
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text("Pairing, readiness, proof, and entrypoint tools live here so the main Friday path stays product-first.")
+            .font(.caption)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        Spacer()
+      }
+      .padding(14)
+      .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: MobileTheme.cornerRadius, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: MobileTheme.cornerRadius, style: .continuous)
+          .strokeBorder(MobileTheme.glassPanelBorder, lineWidth: 1))
+    }
+    .buttonStyle(.plain)
+    .accessibilityIdentifier("friday.command-sheet.advanced-setup-disclosure")
   }
 
   private func tile(_ dest: MobileDestination) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -459,7 +459,7 @@ struct RootView: View {
           Button {
             commandOpen = true
           } label: {
-            Image(systemName: "line.3.horizontal")
+            Image(systemName: "square.grid.2x2")
               .font(.system(size: 15, weight: .semibold))
               .foregroundStyle(MobileTheme.textSecondary)
           }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -45,6 +45,11 @@ public enum MobileProductLoopTier: String, CaseIterable, Sendable, Equatable {
   }
 }
 
+public enum MobileProductCommandSurfaceLane: String, CaseIterable, Sendable, Equatable {
+  case product
+  case diagnostics
+}
+
 public enum MobileProductBlockerKind: String, CaseIterable, Sendable, Equatable {
   case needsLiveWrite
   case needsLiveRead
@@ -136,6 +141,17 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
   case entrypoints
 
   public var id: String { rawValue }
+
+  public var commandSurfaceLane: MobileProductCommandSurfaceLane {
+    switch self {
+    case .home, .missions, .session, .contextPassport, .tokenLedger, .shareIntake,
+         .voice, .newSession, .needsMe, .memory, .platform, .providerAuth,
+         .activity, .workflows:
+      return .product
+    case .pairing, .onboarding, .settings, .petEditor, .proofViewer, .entrypoints:
+      return .diagnostics
+    }
+  }
 
   public var contract: MobileProductDestinationContract {
     switch self {

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -202,3 +202,23 @@ func mobileProductContractTracksSelectedDesignCompanionProofAndEntrypoints() {
   #expect(!proofViewer.isEndBarReady)
   #expect(!entrypoints.isEndBarReady)
 }
+
+@Test
+func mobileProductContractKeepsDiagnosticsOutOfDefaultCommandSurface() {
+  let diagnostics: Set<MobileProductDestinationID> = [
+    .pairing,
+    .onboarding,
+    .settings,
+    .petEditor,
+    .proofViewer,
+    .entrypoints,
+  ]
+
+  #expect(diagnostics.allSatisfy { $0.commandSurfaceLane == .diagnostics })
+  #expect(MobileProductDestinationID.allCases
+    .filter { !diagnostics.contains($0) }
+    .allSatisfy { $0.commandSurfaceLane == .product })
+  #expect(MobileProductDestinationID.home.commandSurfaceLane == .product)
+  #expect(MobileProductDestinationID.newSession.commandSurfaceLane == .product)
+  #expect(MobileProductDestinationID.providerAuth.commandSurfaceLane == .product)
+}

--- a/test/unit/qa/friday-mobile-command-sheet-product-path.test.ts
+++ b/test/unit/qa/friday-mobile-command-sheet-product-path.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const commandSheet = "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift";
+const appShell = "apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift";
+
+function source() {
+  return readFileSync(commandSheet, "utf8");
+}
+
+function arrayBody(name: string) {
+  const text = source();
+  const match = text.match(new RegExp(`private let ${name}: \\[\\(String, \\[MobileDestination\\]\\)\\] = \\[([\\s\\S]*?)\\n  \\]`));
+  if (!match) throw new Error(`missing ${name}`);
+  return match[1];
+}
+
+describe("Friday mobile command sheet product path", () => {
+  it("keeps setup and proof tools out of the default user command path", () => {
+    const product = arrayBody("productSections");
+
+    for (const diagnostic of [".pairing", ".onboarding", ".settings", ".petEditor", ".proofViewer", ".entrypoints"]) {
+      expect(product).not.toContain(diagnostic);
+    }
+    expect(product).toContain(".home");
+    expect(product).toContain(".newSession");
+    expect(product).toContain(".voice");
+    expect(product).toContain(".shareIntake");
+    expect(product).toContain(".missions");
+    expect(product).toContain(".providerAuth");
+    expect(product).toContain(".contextPassport");
+  });
+
+  it("keeps advanced diagnostics reachable through an explicit disclosure", () => {
+    const diagnostics = arrayBody("diagnosticsSections");
+    const text = source();
+
+    for (const diagnostic of [".pairing", ".onboarding", ".settings", ".petEditor", ".proofViewer", ".entrypoints"]) {
+      expect(diagnostics).toContain(diagnostic);
+    }
+    expect(text).toContain("friday.command-sheet.advanced-setup-disclosure");
+    expect(text).toContain("Pairing, readiness, proof, and entrypoint tools live here");
+  });
+
+  it("keeps the selected top-left command sheet affordance as a grid launcher", () => {
+    const text = readFileSync(appShell, "utf8");
+
+    expect(text).toContain('Image(systemName: "square.grid.2x2")');
+    expect(text).toContain("friday.mobile.toolbar.command-sheet");
+    expect(text).not.toContain('Image(systemName: "line.3.horizontal")');
+  });
+
+  it("classifies command sheet lanes so future routes cannot silently leak diagnostics into product", () => {
+    const text = source();
+
+    expect(text).toContain("var commandSheetLane: MobileProductCommandSurfaceLane");
+    expect(text).toContain("?.commandSurfaceLane ?? .diagnostics");
+  });
+});


### PR DESCRIPTION
## Summary
- move mobile setup/readiness/proof surfaces behind an explicit Advanced setup disclosure so the default Command Sheet stays Friday-first
- add a core command-surface lane contract for product vs diagnostics destinations
- restore the selected-design top-left grid launcher affordance

## Truth
- does not claim END-BAR, adoption, release, or runtime proof
- screenshots remain visual verification only; real mobile UI/device proof still requires the AX observation producer

## Verification
- swift test (apps/friday-ios)
- vitest: friday-mobile-command-sheet-product-path + friday-ios-sim-accessibility-capture
- apps/friday-ios/build-sim.sh --mode design-proof-sample --destination home
