### PR TITLE
Add iOS XCUITest accessibility observation producer

### DIFF
--- a/apps/friday-ios/UITests/FridayIOSAXObserver.xcodeproj/project.pbxproj
+++ b/apps/friday-ios/UITests/FridayIOSAXObserver.xcodeproj/project.pbxproj
@@ -1,0 +1,310 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		000000000000000000000006 /* FridayIOSAXObserverUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000015 /* FridayIOSAXObserverUITests.swift */; };
+		000000000000000000000014 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 000000000000000000000001 /* Foundation.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		000000000000000000000001 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		000000000000000000000007 /* FridayIOSAXObserverUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FridayIOSAXObserverUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000000000000000000015 /* FridayIOSAXObserverUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FridayIOSAXObserverUITests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		000000000000000000000009 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				000000000000000000000014 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		000000000000000000000002 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000001 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		000000000000000000000003 /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000015 /* FridayIOSAXObserverUITests.swift */,
+			);
+			name = UITests;
+			sourceTree = "<group>";
+		};
+		000000000000000000000011 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000002 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		000000000000000000000013 = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000020 /* Products */,
+				000000000000000000000011 /* Frameworks */,
+				000000000000000000000003 /* UITests */,
+			);
+			sourceTree = "<group>";
+		};
+		000000000000000000000020 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000007 /* FridayIOSAXObserverUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		000000000000000000000005 /* FridayIOSAXObserverUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 000000000000000000000012 /* Build configuration list for PBXNativeTarget "FridayIOSAXObserverUITests" */;
+			buildPhases = (
+				000000000000000000000010 /* Sources */,
+				000000000000000000000009 /* Frameworks */,
+				000000000000000000000004 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FridayIOSAXObserverUITests;
+			productName = FridayIOSAXObserverUITests;
+			productReference = 000000000000000000000007 /* FridayIOSAXObserverUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		000000000000000000000016 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+			};
+			buildConfigurationList = 000000000000000000000021 /* Build configuration list for PBXProject "FridayIOSAXObserver" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 000000000000000000000013;
+			minimizedProjectReferenceProxies = 0;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 000000000000000000000020 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				000000000000000000000005 /* FridayIOSAXObserverUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		000000000000000000000004 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		000000000000000000000010 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				000000000000000000000006 /* FridayIOSAXObserverUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		000000000000000000000008 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.friday.axobserver.uitests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		000000000000000000000017 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		000000000000000000000018 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		000000000000000000000019 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.friday.axobserver.uitests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		000000000000000000000012 /* Build configuration list for PBXNativeTarget "FridayIOSAXObserverUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000000000019 /* Release */,
+				000000000000000000000008 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		000000000000000000000021 /* Build configuration list for PBXProject "FridayIOSAXObserver" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000000000017 /* Debug */,
+				000000000000000000000018 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 000000000000000000000016 /* Project object */;
+}

--- a/apps/friday-ios/UITests/FridayIOSAXObserver.xcodeproj/xcshareddata/xcschemes/FridayIOSAXObserver.xcscheme
+++ b/apps/friday-ios/UITests/FridayIOSAXObserver.xcodeproj/xcshareddata/xcschemes/FridayIOSAXObserver.xcscheme
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "000000000000000000000005"
+               BuildableName = "FridayIOSAXObserverUITests.xctest"
+               BlueprintName = "FridayIOSAXObserverUITests"
+               ReferencedContainer = "container:FridayIOSAXObserver.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "000000000000000000000005"
+            BuildableName = "FridayIOSAXObserverUITests.xctest"
+            BlueprintName = "FridayIOSAXObserverUITests"
+            ReferencedContainer = "container:FridayIOSAXObserver.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "000000000000000000000005"
+               BuildableName = "FridayIOSAXObserverUITests.xctest"
+               BlueprintName = "FridayIOSAXObserverUITests"
+               ReferencedContainer = "container:FridayIOSAXObserver.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "000000000000000000000005"
+            BuildableName = "FridayIOSAXObserverUITests.xctest"
+            BlueprintName = "FridayIOSAXObserverUITests"
+            ReferencedContainer = "container:FridayIOSAXObserver.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "000000000000000000000005"
+            BuildableName = "FridayIOSAXObserverUITests.xctest"
+            BlueprintName = "FridayIOSAXObserverUITests"
+            ReferencedContainer = "container:FridayIOSAXObserver.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/friday-ios/UITests/FridayIOSAXObserverUITests.swift
+++ b/apps/friday-ios/UITests/FridayIOSAXObserverUITests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+final class FridayIOSAXObserverUITests: XCTestCase {
+  func testDumpFridayAccessibilityTree() throws {
+    let app = XCUIApplication(bundleIdentifier: "com.friday.shell")
+    app.activate()
+    XCTAssertTrue(app.wait(for: .runningForeground, timeout: 10), "Friday iOS shell did not become foreground for AX observation")
+
+    let tree = app.debugDescription
+    XCTAssertFalse(tree.isEmpty, "Friday iOS shell AX tree was empty")
+
+    print("FRIDAY_AX_DESC_BEGIN")
+    print(tree)
+    print("FRIDAY_AX_DESC_END")
+  }
+}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "build:ios:sim": "bash apps/friday-ios/build-sim.sh",
     "proof:ios:live-t3": "bash scripts/ops/friday-ios-sim-live-t3-proof.sh",
     "proof:ios:design-destinations": "bash scripts/ops/friday-ios-design-destination-capture.sh --out-dir \"${FRIDAY_IOS_DESIGN_CAPTURE_OUT:-/tmp/friday-ios-design-destination-capture}\"",
+    "proof:ios:xcui-observation": "node scripts/ops/friday-ios-sim-xcui-observation.mjs --out-dir \"${FRIDAY_IOS_XCUI_OBSERVATION_OUT:-/tmp/friday-ios-sim-xcui-observation}\" --mission-id \"${FRIDAY_IOS_XCUI_OBSERVATION_MISSION_ID:-mission_ios_sim_xcui_observation}\" --normalize --require-observed",
     "proof:ios:ax-capture": "node scripts/ops/friday-ios-sim-accessibility-capture.mjs --out-dir \"${FRIDAY_IOS_AX_CAPTURE_OUT:-/tmp/friday-ios-sim-accessibility-capture}\" --mission-id \"${FRIDAY_IOS_AX_CAPTURE_MISSION_ID:-mission_ios_sim_ax_capture}\"",
     "proof:action-runtime:evidence-bundle": "bash scripts/ops/friday-action-runtime-evidence-bundle.sh --out-dir \"${FRIDAY_ACTION_RUNTIME_EVIDENCE_BUNDLE_OUT:-/tmp/friday-action-runtime-evidence-bundle}\"",
     "proof:desktop:gui-smoke": "bash scripts/ops/friday-desktop-gui-smoke-proof.sh --out-dir \"${FRIDAY_DESKTOP_GUI_SMOKE_OUT_DIR:-/tmp/friday-desktop-gui-smoke-proof}\"",

--- a/scripts/ops/friday-ios-sim-xcui-observation.mjs
+++ b/scripts/ops/friday-ios-sim-xcui-observation.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+
+import { mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+const forbiddenTruth = /(synthetic|fixture|sample|dry[-_ ]?run|screenshot[-_ ]?only|design[-_ ]?proof|mock|placeholder)/i;
+
+function usage() {
+  console.error(`usage:
+  node scripts/ops/friday-ios-sim-xcui-observation.mjs \\
+    --mission-id=mission_... --out-dir=/abs/out-dir
+    [--repo-root=/abs/repo] [--bundle-id=com.friday.shell]
+    [--xcode-destination='platform=iOS Simulator,name=iPhone 17 Pro']
+    [--destinations=home,fridayChat,...] [--timeout-seconds=90]
+    [--normalize] [--require-observed] [--require-all-planned]
+
+Truth:
+  Runs the checked-in Xcode UI-test bundle against an installed real iOS
+  Simulator Friday app, captures XCUIApplication.debugDescription, and converts
+  only observed accessibility identifiers into the real observation JSON consumed
+  by friday-ios-sim-accessibility-capture.mjs. It does not infer truth from
+  screenshots or static Swift source, does not click governed actions, and is
+  not END-BAR/adoption proof.`);
+}
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (value.startsWith(prefix)) return value.slice(prefix.length);
+    if (value === `--${name}` && args[index + 1]) return args[index + 1];
+  }
+  return "";
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  usage();
+  process.exit(0);
+}
+
+const repoRoot = resolve(arg("repo-root") || process.env.FRIDAY_REPO_ROOT || new URL("../..", import.meta.url).pathname);
+const missionId = arg("mission-id");
+const outDir = arg("out-dir");
+const bundleId = arg("bundle-id") || process.env.FRIDAY_IOS_SIM_BUNDLE_ID || "com.friday.shell";
+const xcodeDestination = arg("xcode-destination") || process.env.FRIDAY_IOS_XCUI_DESTINATION || "platform=iOS Simulator,name=iPhone 17 Pro";
+const destinations = (arg("destinations") || process.env.FRIDAY_IOS_XCUI_OBSERVATION_DESTINATIONS || "home")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+const timeoutSeconds = Number(arg("timeout-seconds") || process.env.FRIDAY_IOS_XCUI_OBSERVATION_TIMEOUT_SECONDS || "90");
+const normalize = args.includes("--normalize");
+const requireObserved = args.includes("--require-observed");
+const requireAllPlanned = args.includes("--require-all-planned");
+const blockers = [];
+const warnings = [];
+
+function block(code, detail) {
+  blockers.push({ code, detail });
+}
+
+function run(command, commandArgs, options = {}) {
+  return spawnSync(command, commandArgs, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    ...options,
+  });
+}
+
+function jsonOut(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function requireAbsoluteDir(label, value) {
+  if (!value) {
+    block("missing_arg", label);
+    return "";
+  }
+  if (!isAbsolute(value)) {
+    block("path_not_absolute", `${label}:${value}`);
+    return "";
+  }
+  return value;
+}
+
+function parseJson(label, text) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    block("invalid_json", `${label}:${error.message}`);
+    return null;
+  }
+}
+
+function destinationName() {
+  const match = xcodeDestination.match(/(?:^|,)name=([^,]+)/);
+  return match?.[1]?.trim() || "";
+}
+
+function resolveSimulator() {
+  const list = run("xcrun", ["simctl", "list", "devices", "--json"]);
+  if (list.status !== 0) {
+    block("simctl_list_failed", list.stderr.trim() || list.stdout.trim() || String(list.status));
+    return null;
+  }
+  const parsed = parseJson("simctl_list", list.stdout);
+  if (!parsed) return null;
+  const wantedName = destinationName();
+  const devices = Object.values(parsed.devices || {}).flat().filter((device) => device && device.isAvailable !== false);
+  const selected = wantedName
+    ? devices.find((device) => String(device.name || "") === wantedName)
+    : devices.find((device) => String(device.state || "") === "Booted" && /iPhone|iPad/i.test(String(device.name || "")));
+  if (!selected) {
+    block("ios_simulator_not_available", wantedName || "booted iPhone/iPad");
+    return null;
+  }
+  if (selected.state !== "Booted") {
+    const boot = run("xcrun", ["simctl", "boot", selected.udid]);
+    if (boot.status !== 0 && !/Unable to boot device in current state: Booted/i.test(`${boot.stderr}\n${boot.stdout}`)) {
+      block("ios_simulator_boot_failed", boot.stderr.trim() || boot.stdout.trim() || String(boot.status));
+      return null;
+    }
+    const bootstatus = run("xcrun", ["simctl", "bootstatus", selected.udid, "-b"], { timeout: 60_000 });
+    if (bootstatus.status !== 0) {
+      block("ios_simulator_bootstatus_failed", bootstatus.stderr.trim() || bootstatus.stdout.trim() || String(bootstatus.status));
+      return null;
+    }
+  }
+  return {
+    udid: selected.udid,
+    name: String(selected.name || ""),
+    destination: xcodeDestination,
+  };
+}
+
+function ensureInstalled(simulator) {
+  const container = run("xcrun", ["simctl", "get_app_container", simulator.udid, bundleId, "data"]);
+  if (container.status !== 0) {
+    block("app_container_unavailable", container.stderr.trim() || container.stdout.trim() || `${bundleId}:${simulator.udid}`);
+    return null;
+  }
+  const dataContainer = container.stdout.trim().split(/\r?\n/).at(-1) || "";
+  if (!isAbsolute(dataContainer)) block("app_container_not_absolute", dataContainer || "<missing>");
+  return dataContainer;
+}
+
+function readPlan(destination) {
+  const planDir = resolve(outDir, "plan", destination);
+  rmSync(planDir, { recursive: true, force: true });
+  const result = run("node", [
+    resolve(repoRoot, "scripts/ops/friday-ios-sim-accessibility-capture.mjs"),
+    "--plan-only",
+    `--repo-root=${repoRoot}`,
+    `--mission-id=${missionId}`,
+    `--out-dir=${planDir}`,
+    `--destinations=${destination}`,
+  ]);
+  if (result.status !== 0) {
+    block("target_plan_failed", result.stderr.trim() || result.stdout.trim() || `${destination}:${result.status}`);
+    return [];
+  }
+  const summary = parseJson(`target_plan:${destination}`, result.stdout);
+  return Array.isArray(summary?.targets) ? summary.targets : [];
+}
+
+function launchDestination(simulator, destination) {
+  const launch = run("xcrun", [
+    "simctl",
+    "launch",
+    "--terminate-running-process",
+    simulator.udid,
+    bundleId,
+    `--initial-destination=${destination}`,
+  ]);
+  if (launch.status !== 0) {
+    block("app_launch_failed", launch.stderr.trim() || launch.stdout.trim() || `${bundleId}:${destination}`);
+    return null;
+  }
+  return launch.stdout.trim();
+}
+
+function extractAxTree(log) {
+  const match = log.match(/FRIDAY_AX_DESC_BEGIN\r?\n([\s\S]*?)\r?\nFRIDAY_AX_DESC_END/);
+  return match?.[1] || "";
+}
+
+function runXcui(destination) {
+  const project = resolve(repoRoot, "apps/friday-ios/UITests/FridayIOSAXObserver.xcodeproj");
+  const result = run("xcodebuild", [
+    "-project",
+    project,
+    "-scheme",
+    "FridayIOSAXObserver",
+    "-destination",
+    xcodeDestination,
+    "-skipPackagePluginValidation",
+    "-skipMacroValidation",
+    "test",
+  ], {
+    timeout: Math.max(timeoutSeconds * 1000, 30_000),
+  });
+  const log = `${result.stdout || ""}${result.stderr || ""}`;
+  const logPath = resolve(outDir, `ios-xcui-${destination}.log`);
+  const treePath = resolve(outDir, `ios-xcui-${destination}-accessibility-tree.txt`);
+  writeFileSync(logPath, log);
+  const tree = extractAxTree(log);
+  if (result.status !== 0) block("xcodebuild_ui_test_failed", `${destination}:${result.status}:${logPath}`);
+  if (!tree.trim()) block("accessibility_tree_missing", `${destination}:${logPath}`);
+  if (tree.trim()) writeFileSync(treePath, `${tree}\n`);
+  return { logPath, treePath, tree, status: result.status };
+}
+
+function observedRows(destination, targets, tree, treePath) {
+  const rows = [];
+  const missing = [];
+  for (const target of targets) {
+    const accessibilityIds = Array.isArray(target.accessibilityIds) ? target.accessibilityIds : [];
+    const matched = accessibilityIds.find((id) => tree.includes(`identifier: '${id}'`) || tree.includes(`identifier: "${id}"`) || tree.includes(id));
+    if (!matched) {
+      missing.push(target.runtimeActionId || "<unknown>");
+      continue;
+    }
+    rows.push({
+      screen: String(target.screen || target.destination || destination),
+      runtimeActionId: String(target.runtimeActionId || ""),
+      accessibility_id: matched,
+      interaction: String(target.interaction || "visible"),
+      status: "pass",
+      event: String(target.event || "mission_workbench_visible"),
+      evidence_type: "xctest_accessibility",
+      evidence_ref: treePath,
+      captured_at: new Date().toISOString(),
+      matched_by: "xctest_debug_description_accessibility_identifier",
+    });
+  }
+  return { rows, missing };
+}
+
+if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
+  block("mission_id_unexpected_shape", missionId || "<missing>");
+}
+requireAbsoluteDir("out-dir", outDir);
+if (!Number.isFinite(timeoutSeconds) || timeoutSeconds < 10) block("timeout_seconds_invalid", String(timeoutSeconds));
+if (bundleId !== "com.friday.shell") block("bundle_id_not_supported_by_checked_in_ui_test", bundleId);
+if (destinations.length === 0) block("destinations_missing", "<empty>");
+
+let simulator = null;
+let dataContainer = null;
+const allTargets = [];
+const observations = [];
+const missingByDestination = {};
+const xcodeRuns = [];
+
+if (blockers.length === 0) {
+  mkdirSync(outDir, { recursive: true });
+  simulator = resolveSimulator();
+}
+if (blockers.length === 0 && simulator) dataContainer = ensureInstalled(simulator);
+
+if (blockers.length === 0 && simulator) {
+  for (const destination of destinations) {
+    if (!/^[A-Za-z][A-Za-z0-9]*$/.test(destination)) {
+      block("destination_invalid", destination);
+      continue;
+    }
+    const targets = readPlan(destination);
+    allTargets.push(...targets.map((target) => ({ ...target, destination })));
+    if (blockers.length > 0) break;
+    const launchStdout = launchDestination(simulator, destination);
+    if (blockers.length > 0) break;
+    const runResult = runXcui(destination);
+    xcodeRuns.push({
+      destination,
+      launch_stdout: launchStdout,
+      status: runResult.status,
+      log_path: runResult.logPath,
+      tree_path: runResult.tree.trim() ? runResult.treePath : null,
+    });
+    const { rows, missing } = observedRows(destination, targets, runResult.tree, runResult.treePath);
+    observations.push(...rows);
+    missingByDestination[destination] = missing;
+  }
+}
+
+if (requireObserved && observations.length === 0) block("observed_actions_missing", "no matching real XCUITest accessibility identifiers");
+if (requireAllPlanned) {
+  for (const [destination, missing] of Object.entries(missingByDestination)) {
+    if (missing.length > 0) block("planned_actions_missing", `${destination}:${missing.join(",")}`);
+  }
+}
+
+const evidenceRef = xcodeRuns.find((runInfo) => runInfo.tree_path)?.tree_path || xcodeRuns[0]?.log_path || "";
+let observationPath = null;
+let normalizer = null;
+if (blockers.length === 0) {
+  if (evidenceRef) {
+    const stats = statSync(evidenceRef);
+    if (!stats.isFile() || stats.size <= 0) block("evidence_ref_invalid", evidenceRef);
+  }
+}
+
+if (blockers.length === 0) {
+  const observation = {
+    truth_label: "ios_simulator_accessibility_observation_real_ui",
+    mission_id: missionId,
+    bundle_id: bundleId,
+    udid: simulator?.udid || null,
+    capture_method: "ios_simulator_accessibility",
+    evidence_type: "xctest_accessibility",
+    evidence_ref: evidenceRef,
+    source: "xcode_ui_test_xcapplication_debug_description",
+    destinations,
+    observations,
+  };
+  if (forbiddenTruth.test(observation.truth_label) || forbiddenTruth.test(observation.source)) {
+    block("truth_source_forbidden", observation.source);
+  } else {
+    observationPath = resolve(outDir, "ios-xcui-accessibility-observation.json");
+    jsonOut(observationPath, observation);
+  }
+}
+
+if (blockers.length === 0 && normalize && observationPath) {
+  const normalizedOut = resolve(outDir, "normalized");
+  const result = run("node", [
+    resolve(repoRoot, "scripts/ops/friday-ios-sim-accessibility-capture.mjs"),
+    "--real",
+    "--normalize",
+    "--require-observed",
+    `--repo-root=${repoRoot}`,
+    `--mission-id=${missionId}`,
+    `--out-dir=${resolve(outDir, "capture")}`,
+    `--normalizer-out-dir=${normalizedOut}`,
+    `--destinations=${destinations.join(",")}`,
+    `--observation=${observationPath}`,
+    `--bundle-id=${bundleId}`,
+    `--udid=${simulator?.udid || ""}`,
+  ]);
+  normalizer = {
+    status: result.status,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+    out_dir: normalizedOut,
+  };
+  if (result.status !== 0) block("normalizer_failed", result.stderr.trim() || result.stdout.trim() || String(result.status));
+}
+
+const summary = {
+  generated_at_utc: new Date().toISOString(),
+  truth: blockers.length === 0
+    ? "ios_sim_xcui_observation_real_ui_not_endbar"
+    : "ios_sim_xcui_observation_blocked_not_runtime_proof",
+  status: blockers.length === 0 ? "observation_ready" : "blocked",
+  missionId: missionId || null,
+  simulator,
+  bundle_id: bundleId,
+  data_container: dataContainer,
+  target_count: allTargets.length,
+  observed_count: observations.length,
+  destinations,
+  xcode_runs: xcodeRuns,
+  outputs: {
+    observation: observationPath,
+    normalized: normalizer?.out_dir || null,
+    summary: outDir ? resolve(outDir, "ios-xcui-observation-summary.json") : null,
+  },
+  missing_by_destination: missingByDestination,
+  warnings,
+  blockers,
+  caveats: [
+    "This is real XCUITest accessibility observation against an installed Simulator app, not a screenshot or static source proof.",
+    "It only proves identifiers visible on the launched destinations; product END-BAR still needs the broader same-run mobile+desktop proof bundle.",
+    "The UI test does not click governed actions or provide operator signatures.",
+  ],
+};
+if (outDir && isAbsolute(outDir)) jsonOut(resolve(outDir, "ios-xcui-observation-summary.json"), summary);
+console.log(JSON.stringify(summary, null, 2));
+process.exit(blockers.length > 0 ? 2 : 0);

--- a/test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts
+++ b/test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts
@@ -1,0 +1,152 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/ops/friday-ios-sim-xcui-observation.mjs";
+const missionId = "mission_ios_sim_xcui_observation_contract";
+const fakeUdid = "11111111-2222-3333-4444-555555555555";
+
+async function writeFakeTools(binDir: string, mode: "pass" | "no-tree" | "missing-id" = "pass") {
+  await mkdir(binDir, { recursive: true });
+  const xcrun = join(binDir, "xcrun");
+  writeFileSync(xcrun, `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "simctl" ] && [ "$2" = "list" ]; then
+  cat <<'JSON'
+{"devices":{"iOS Test":[{"name":"iPhone 17 Pro","udid":"${fakeUdid}","state":"Booted","isAvailable":true}]}}
+JSON
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "get_app_container" ]; then
+  echo "/tmp/friday-ios-sim-data-container"
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "launch" ]; then
+  echo "com.friday.shell: 12345"
+  exit 0
+fi
+echo "unexpected xcrun $*" >&2
+exit 64
+`);
+  chmodSync(xcrun, 0o755);
+
+  const xcodebuild = join(binDir, "xcodebuild");
+  const tree = mode === "no-tree"
+    ? ""
+    : mode === "missing-id"
+      ? "Application, identifier: 'friday.mobile.toolbar.command-sheet', label: 'Open Command Sheet'"
+      : [
+        "Application, 0x1, identifier: 'com.friday.shell'",
+        "  Button, 0x2, identifier: 'friday.mobile.toolbar.refresh', label: 'Refresh Hub status'",
+      ].join("\\n");
+  writeFileSync(xcodebuild, `#!/usr/bin/env bash
+set -euo pipefail
+echo "Test Suite 'FridayIOSAXObserverUITests' started"
+${tree ? `echo "FRIDAY_AX_DESC_BEGIN"\nprintf '%b\\n' "${tree.replace(/"/g, "\\\"")}"\necho "FRIDAY_AX_DESC_END"` : "echo 'no tree emitted'"}
+echo "Test Suite 'FridayIOSAXObserverUITests' passed"
+`);
+  chmodSync(xcodebuild, 0o755);
+}
+
+describe("friday-ios-sim-xcui-observation", () => {
+  it("runs the checked-in UI-test harness and emits real observation JSON for visible IDs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ios-xcui-observation-"));
+    try {
+      const binDir = join(root, "bin");
+      const outDir = join(root, "out");
+      await writeFakeTools(binDir);
+      const stdout = execFileSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        "--destinations=home",
+        "--normalize",
+        "--require-observed",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      });
+      const output = JSON.parse(stdout) as {
+        truth?: string;
+        status?: string;
+        observed_count?: number;
+        outputs?: { observation?: string; normalized?: string };
+      };
+      expect(output.truth).toBe("ios_sim_xcui_observation_real_ui_not_endbar");
+      expect(output.status).toBe("observation_ready");
+      expect(output.observed_count).toBe(1);
+      expect(existsSync(output.outputs?.observation || "")).toBe(true);
+      expect(existsSync(join(output.outputs?.normalized || "", "accessibility-click-events.jsonl"))).toBe(true);
+
+      const observation = JSON.parse(readFileSync(output.outputs?.observation || "", "utf8")) as {
+        truth_label?: string;
+        evidence_type?: string;
+        observations?: Array<{ runtimeActionId?: string; accessibility_id?: string; evidence_type?: string }>;
+      };
+      expect(observation.truth_label).toBe("ios_simulator_accessibility_observation_real_ui");
+      expect(observation.evidence_type).toBe("xctest_accessibility");
+      expect(observation.observations).toContainEqual(expect.objectContaining({
+        runtimeActionId: "mobile/home/refresh",
+        accessibility_id: "friday.mobile.toolbar.refresh",
+        evidence_type: "xctest_accessibility",
+      }));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the UI-test output does not contain a real AX tree", async () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ios-xcui-observation-blocked-"));
+    try {
+      const binDir = join(root, "bin");
+      const outDir = join(root, "out");
+      await writeFakeTools(binDir, "no-tree");
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        "--destinations=home",
+        "--require-observed",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("accessibility_tree_missing");
+      expect(existsSync(join(outDir, "ios-xcui-accessibility-observation.json"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps require-all-planned red when planned IDs are not visible on that destination", async () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ios-xcui-observation-missing-"));
+    try {
+      const binDir = join(root, "bin");
+      const outDir = join(root, "out");
+      await writeFakeTools(binDir, "missing-id");
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        "--destinations=home",
+        "--require-all-planned",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("planned_actions_missing");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a checked-in Xcode UI-test harness that attaches to the installed iOS Simulator Friday app and dumps the real XCUIApplication accessibility tree
- add a Node runner that launches selected mobile destinations, converts observed accessibility IDs into the existing iOS AX capture JSON, and optionally normalizes through friday-ui-device-accessibility-click-capture
- add focused contract coverage and an npm proof entry for the real XCUITest observation path

## Truth labels
- this is real Simulator/XCUITest accessibility observation, not screenshot/static-source proof
- it does not click governed actions, provide operator signatures, claim END-BAR, or claim adoption

## Verification
- vitest run --project default test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts test/unit/qa/friday-ios-sim-accessibility-capture-cli.test.ts test/unit/qa/friday-ui-device-accessibility-click-capture-cli.test.ts
- npm run proof:ios:xcui-observation -- --destinations=home
- node scripts/ops/friday-ios-sim-xcui-observation.mjs --mission-id=mission_ios_xcui_real_product_probe_20260630 --out-dir=/private/tmp/friday-ios-xcui-real-product-probe-20260630 --destinations=home,missions,newSession,providerAuth,contextPassport,tokenLedger --normalize --require-observed