### PR TITLE
Require product closure for END-BAR selected UIUX

### DIFF
--- a/scripts/ops/check-friday-endbar-readiness.mjs
+++ b/scripts/ops/check-friday-endbar-readiness.mjs
@@ -146,9 +146,6 @@ function isPassLike(value) {
     "complete",
     "complete_inputs_observed",
     "uiux_product_closure_evidence_ready",
-    "selected_visual_proof_ready",
-    "product_runtime_actions_traceable",
-    "runtime_actions_covered",
   ].includes(status);
 }
 
@@ -168,16 +165,9 @@ function expectedStatusForGroup(groupId, report, reportPath = "") {
       : { status: "blocked", blocker: statusText(report) || "provider entitlement report not passed or not group-level" };
   }
   if (groupId === "selected_uiux_conformance") {
-    const accepted = [
-      "uiux_product_closure_evidence_ready",
-      "selected_visual_proof_ready",
-      "product_runtime_actions_traceable",
-      "runtime_actions_covered",
-      "passed",
-    ];
-    return accepted.includes(statusText(report))
+    return statusText(report) === "uiux_product_closure_evidence_ready"
       ? { status: "satisfied" }
-      : { status: "blocked", blocker: statusText(report) || "selected UI/UX report not complete" };
+      : { status: "blocked", blocker: statusText(report) || "selected UI/UX product closure report not complete" };
   }
   if (groupId === "mechanism_multiangle_stress") {
     const haystack = haystackFor(report, reportPath);

--- a/scripts/ops/check-friday-endbar-report-inputs.mjs
+++ b/scripts/ops/check-friday-endbar-report-inputs.mjs
@@ -139,18 +139,20 @@ function classifyForGroup(groupId, report, path) {
   }
 
   if (groupId === "selected_uiux_conformance") {
-    const accepted = new Set([
-      "uiux_product_closure_evidence_ready",
+    const partialStatuses = new Set([
       "selected_visual_proof_ready",
       "product_runtime_actions_traceable",
       "runtime_actions_covered",
       "passed",
     ]);
-    if (accepted.has(status) && !hasBlockers(report)) {
-      return { classification: "satisfied", score: status === "uiux_product_closure_evidence_ready" ? 95 : 85, reason: `selected UI/UX accepted status ${status}` };
+    if (status === "uiux_product_closure_evidence_ready" && !hasBlockers(report)) {
+      return { classification: "satisfied", score: 95, reason: "selected UI/UX product closure evidence is ready" };
     }
-    if (accepted.has(status)) {
-      return { classification: "candidate_with_blockers", score: 45, reason: `accepted status ${status} but blockers are present` };
+    if (status === "uiux_product_closure_evidence_ready") {
+      return { classification: "candidate_with_blockers", score: 45, reason: "product closure status is present but blockers remain" };
+    }
+    if (partialStatuses.has(status)) {
+      return { classification: "partial", score: 45, reason: `selected UI/UX partial status ${status} is not final product closure` };
     }
     return { classification: "candidate", score: 20, reason: `status=${status || "<missing>"}` };
   }

--- a/test/unit/qa/friday-endbar-readiness-aggregator.test.ts
+++ b/test/unit/qa/friday-endbar-readiness-aggregator.test.ts
@@ -6,12 +6,18 @@ import { describe, expect, it } from "vitest";
 
 const script = "scripts/ops/check-friday-endbar-readiness.mjs";
 
-function run(args: string[] = []) {
-  const stdout = execFileSync(process.execPath, [script, ...args], {
-    cwd: process.cwd(),
-    encoding: "utf8",
-  });
-  return JSON.parse(stdout);
+function run(args: string[] = [], expectFailure = false) {
+  try {
+    const stdout = execFileSync(process.execPath, [script, ...args], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    return JSON.parse(stdout);
+  } catch (error) {
+    if (!expectFailure) throw error;
+    const stdout = (error as { stdout?: Buffer | string }).stdout?.toString() || "";
+    return JSON.parse(stdout);
+  }
 }
 
 function writeJson(dir: string, name: string, value: unknown) {
@@ -45,7 +51,7 @@ describe("Friday END-BAR readiness aggregator", () => {
       truth: "provider_entitlement_readiness_report",
       status: "passed",
     });
-    const selected = writeJson(dir, "selected-uiux.json", { status: "product_runtime_actions_traceable" });
+    const selected = writeJson(dir, "selected-uiux.json", { status: "uiux_product_closure_evidence_ready" });
     const integrated = writeJson(dir, "integrated-tape.json", { status: "integrated_end_to_end_tape_ready" });
     const deferred = writeJson(dir, "deferred.json", {
       status: "blocked",
@@ -77,7 +83,7 @@ describe("Friday END-BAR readiness aggregator", () => {
       truth: "provider_entitlement_readiness_report",
       status: "passed",
     });
-    const selected = writeJson(dir, "selected-uiux.json", { status: "selected_visual_proof_ready" });
+    const selected = writeJson(dir, "selected-uiux.json", { status: "uiux_product_closure_evidence_ready" });
     const ui = writeJson(dir, "ui-real-use.json", {
       truth: "ui_real_use_mobile_desktop_report",
       status: "deferred",
@@ -134,12 +140,44 @@ describe("Friday END-BAR readiness aggregator", () => {
       `--provider-entitlement-report=${provider}`,
       `--integrated-tape-report=${integrated}`,
       "--require-complete",
-    ]);
+    ], true);
 
     expect(report.status).toBe("strict_endbar_inputs_satisfied");
     expect(report.strictEndBarReady).toBe(true);
     expect(report.counts.satisfied).toBe(5);
     expect(report.blockers).toEqual([]);
+  });
+
+  it("does not count partial selected UIUX reports as final END-BAR product closure", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-endbar-readiness-"));
+    const mechanism = writeJson(dir, "mechanism-multiangle.json", {
+      truth: "mechanism_multiangle_stress_report",
+      status: "complete_inputs_observed",
+    });
+    const ui = writeJson(dir, "ui-real-use.json", { status: "strict_uiux_real_use_ready" });
+    const provider = writeJson(dir, "provider-entitlement.json", {
+      truth: "provider_entitlement_readiness_report",
+      status: "passed",
+    });
+    const selected = writeJson(dir, "selected.json", { status: "selected_visual_proof_ready" });
+    const integrated = writeJson(dir, "integrated.json", { status: "integrated_end_to_end_tape_ready" });
+
+    const report = run([
+      `--mechanism-report=${mechanism}`,
+      `--ui-real-use-report=${ui}`,
+      `--selected-uiux-report=${selected}`,
+      `--provider-entitlement-report=${provider}`,
+      `--integrated-tape-report=${integrated}`,
+      "--require-complete",
+    ], true);
+
+    expect(report.status).toBe("blocked");
+    expect(report.strictEndBarReady).toBe(false);
+    expect(report.groups.find((group: { id: string }) => group.id === "selected_uiux_conformance").status).toBe("blocked");
+    expect(report.blockers).toContainEqual({
+      code: "acceptance_group_not_satisfied",
+      detail: "selected_uiux_conformance:blocked",
+    });
   });
 
   it("does not count unrelated pass-like reports as group-level mechanism or tape proof", () => {

--- a/test/unit/qa/friday-endbar-report-input-discovery.test.ts
+++ b/test/unit/qa/friday-endbar-report-input-discovery.test.ts
@@ -78,7 +78,7 @@ describe("Friday END-BAR report input discovery", () => {
       status: "passed",
     });
     const ui = writeJson(second, "ui-real-use.json", { status: "strict_uiux_real_use_ready" });
-    const selected = writeJson(first, "selected-uiux.json", { status: "selected_visual_proof_ready" });
+    const selected = writeJson(first, "selected-uiux.json", { status: "uiux_product_closure_evidence_ready" });
     const provider = writeJson(second, "provider-entitlement.json", { status: "passed" });
     const integrated = writeJson(first, "integrated-tape.json", { status: "integrated_end_to_end_tape_ready" });
 
@@ -125,6 +125,28 @@ describe("Friday END-BAR report input discovery", () => {
       detail: "ui_real_use_mobile_desktop:deferred",
     });
     expect(report.command).toBeNull();
+  });
+
+  it("keeps partial selected UIUX reports out of strict candidate sets", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-endbar-inputs-"));
+    const partial = writeJson(dir, "selected-uiux-partial.json", {
+      truth: "selected_uiux_conformance_report",
+      status: "selected_visual_proof_ready",
+    });
+
+    const report = run([`--search-root=${dir}`], true);
+    const group = report.groups.find((row: { id: string }) => row.id === "selected_uiux_conformance");
+
+    expect(group.selectedCandidate).toEqual(expect.objectContaining({
+      path: partial,
+      classification: "partial",
+    }));
+    expect(report.status).toBe("partial_candidate_set");
+    expect(report.command).toBeNull();
+    expect(report.blockers).toContainEqual({
+      code: "report_candidate_not_satisfied",
+      detail: "selected_uiux_conformance:partial",
+    });
   });
 
   it("discovers mechanism multiangle stress reports by truth label", () => {


### PR DESCRIPTION
## Summary
- tighten END-BAR readiness so selected UI/UX only satisfies final acceptance with uiux_product_closure_evidence_ready
- classify selected_visual_proof_ready, product_runtime_actions_traceable, runtime_actions_covered, and generic passed as partial selected-UIUX evidence, not final product closure
- update report discovery and readiness tests so partial UI evidence cannot inflate final END-BAR readiness

## Truth labels
- visual proof and runtime traceability remain valid intermediate evidence
- this does not claim END-BAR; it prevents partial evidence from satisfying final selected UIUX closure

## Verification
- vitest run --project default test/unit/qa/friday-endbar-readiness-aggregator.test.ts test/unit/qa/friday-endbar-report-input-discovery.test.ts