### PR TITLE
Wire selected UI visual proof into real-use driver

### DIFF
--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -17,6 +17,7 @@ usage:
     [--stress-capture /abs/real-same-run-stress-capture.json ...]
     [--harvest-dir /abs/artifact-dir ...]
     [--same-run-events /abs/events.jsonl ...]
+    [--selected-visual-evidence-dir /abs/served-or-visual-evidence ...]
     [--runtime-evidence-dir /abs/evidence-dir ...]
     [--extra-action-runtime-evidence /abs/action-runtime-evidence.json ...]
     [--defer-channel-proof]
@@ -55,6 +56,7 @@ stress_captures=()
 harvest_dirs=()
 same_run_events=()
 runtime_evidence_dirs=()
+selected_visual_evidence_dirs=()
 extra_action_runtime_evidence=()
 shared_extra_evidence=()
 
@@ -193,6 +195,15 @@ while [ "$#" -gt 0 ]; do
       runtime_evidence_dirs+=("${1#--runtime-evidence-dir=}")
       shift
       ;;
+    --selected-visual-evidence-dir)
+      [ "$#" -ge 2 ] || die "--selected-visual-evidence-dir requires a value"
+      selected_visual_evidence_dirs+=("$2")
+      shift 2
+      ;;
+    --selected-visual-evidence-dir=*)
+      selected_visual_evidence_dirs+=("${1#--selected-visual-evidence-dir=}")
+      shift
+      ;;
     --extra-action-runtime-evidence)
       [ "$#" -ge 2 ] || die "--extra-action-runtime-evidence requires a value"
       extra_action_runtime_evidence+=("$2")
@@ -251,7 +262,7 @@ require_file_if_set() {
 }
 
 set +u
-for path in "${accessibility_captures[@]}" "${stress_captures[@]}" "${harvest_dirs[@]}" "${same_run_events[@]}" "${runtime_evidence_dirs[@]}" "${extra_action_runtime_evidence[@]}"; do
+for path in "${accessibility_captures[@]}" "${stress_captures[@]}" "${harvest_dirs[@]}" "${same_run_events[@]}" "${runtime_evidence_dirs[@]}" "${selected_visual_evidence_dirs[@]}" "${extra_action_runtime_evidence[@]}"; do
   require_abs_if_set "input path" "${path}"
 done
 set -u
@@ -530,6 +541,10 @@ for dir in "${runtime_evidence_dirs[@]}"; do
   [ -n "${dir}" ] || continue
   closure_args+=("--runtime-evidence-dir=${dir}")
 done
+for dir in "${selected_visual_evidence_dirs[@]}"; do
+  [ -n "${dir}" ] || continue
+  closure_args+=("--selected-visual-evidence-dir=${dir}")
+done
 for path in "${extra_action_runtime_evidence[@]}"; do
   [ -n "${path}" ] || continue
   closure_args+=("--runtime-evidence=${path}")
@@ -764,6 +779,7 @@ const summary = {
   stressCaptureStatus,
   workbenchTimelineStatus,
   productClosureStatus: closure.status,
+  selectedVisualProofStatus: closure.stages?.selectedVisualProof?.status || null,
   uiDeviceProofReadiness: closure.stages?.uiDeviceProofReadiness || null,
   readinessStatus: readiness.status,
   readinessBlockers: readiness.blockers || [],

--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -12,6 +12,7 @@ function usage() {
     [--repo-root=/abs/repo] \\
     [--design-root=/abs/friday-design-handoff-20260602] \\
     [--evidence-dir=/abs/ui-device-evidence ...] \\
+    [--selected-visual-evidence-dir=/abs/served-or-visual-evidence ...] \\
     [--evidence-set=/abs/uiux-closure-evidence-set.json ...] \\
     [--runtime-evidence=/abs/action-runtime-evidence.json ...] \\
     [--runtime-evidence-dir=/abs/evidence-dir ...] \\
@@ -298,6 +299,12 @@ const evidenceDirs = unique([
     ? process.env.FRIDAY_UI_DEVICE_PROOF_EVIDENCE_DIRS.split(/[:\n]/).filter(Boolean)
     : []),
 ]);
+const selectedVisualEvidenceDirs = unique([
+  ...argsAll("selected-visual-evidence-dir"),
+  ...(process.env.FRIDAY_UIUX_SELECTED_VISUAL_EVIDENCE_DIRS
+    ? process.env.FRIDAY_UIUX_SELECTED_VISUAL_EVIDENCE_DIRS.split(/[:\n]/).filter(Boolean)
+    : []),
+]);
 const runtimeEvidence = unique([
   ...argsAll("runtime-evidence"),
   ...evidenceSets.flatMap((set) => set.runtimeEvidence),
@@ -359,6 +366,9 @@ const selectedVisualProofArgs = [
   `--design-root=${designRoot}`,
 ];
 for (const dir of evidenceDirs) {
+  selectedVisualProofArgs.push(`--evidence-dir=${abs(dir)}`);
+}
+for (const dir of selectedVisualEvidenceDirs) {
   selectedVisualProofArgs.push(`--evidence-dir=${abs(dir)}`);
 }
 if (requireUiDeviceProof) selectedVisualProofArgs.push("--require-complete");
@@ -532,6 +542,7 @@ const report = {
   repoRoot,
   designRoot,
   evidenceSets,
+  selectedVisualEvidenceDirs,
   design: {
     contract: designContractPath,
     selections: [

--- a/scripts/ops/friday-uiux-real-use-proof-driver.sh
+++ b/scripts/ops/friday-uiux-real-use-proof-driver.sh
@@ -13,6 +13,7 @@ usage:
     [--desktop-ax-app-dir /abs/FridayHubConsole.app]
     [--desktop-ax-workbench-mission-id mission_...]
     [--desktop-ax-timeout-seconds 20]
+    [--skip-ios-design-capture]
     [--backend-live-proof /abs/backend-proof.json]
     [--objective-coverage /abs/objective-coverage.json]
     [--channel-live-proof /abs/channel-live-proof.json]
@@ -21,6 +22,7 @@ usage:
     [--workbench-db /abs/rust-hub.sqlite]
     [--harvest-dir /abs/artifact-dir ...]
     [--same-run-events /abs/events.jsonl ...]
+    [--selected-visual-evidence-dir /abs/served-or-visual-evidence ...]
     [--runtime-evidence-dir /abs/evidence-dir ...]
     [--extra-action-runtime-evidence /abs/action-runtime-evidence.json ...]
     [--defer-channel-proof]
@@ -57,6 +59,7 @@ timeline_capture="${FRIDAY_UI_DEVICE_TIMELINE_CAPTURE:-}"
 workbench_db="${FRIDAY_WORKBENCH_DB_PATH:-}"
 defer_channel_proof="${FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF:-0}"
 run_desktop_ax_capture="${FRIDAY_UIUX_RUN_DESKTOP_AX_CAPTURE:-0}"
+run_ios_design_capture="${FRIDAY_UIUX_RUN_IOS_DESIGN_CAPTURE:-1}"
 desktop_ax_destinations="${FRIDAY_DESKTOP_AX_CAPTURE_DESTINATIONS:-}"
 desktop_ax_app_dir="${FRIDAY_DESKTOP_AX_APP_DIR:-}"
 desktop_ax_workbench_mission_id="${FRIDAY_DESKTOP_AX_WORKBENCH_MISSION_ID:-}"
@@ -67,6 +70,7 @@ accessibility_captures=()
 harvest_dirs=()
 same_run_events=()
 runtime_evidence_dirs=()
+selected_visual_evidence_dirs=()
 extra_action_runtime_evidence=()
 
 if [ -n "${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS:-}" ]; then
@@ -151,6 +155,10 @@ while [ "$#" -gt 0 ]; do
       desktop_ax_timeout_seconds="${1#--desktop-ax-timeout-seconds=}"
       shift
       ;;
+    --skip-ios-design-capture)
+      run_ios_design_capture=0
+      shift
+      ;;
     --backend-live-proof)
       [ "$#" -ge 2 ] || die "--backend-live-proof requires a value"
       backend_live_proof="$2"
@@ -232,6 +240,15 @@ while [ "$#" -gt 0 ]; do
       runtime_evidence_dirs+=("${1#--runtime-evidence-dir=}")
       shift
       ;;
+    --selected-visual-evidence-dir)
+      [ "$#" -ge 2 ] || die "--selected-visual-evidence-dir requires a value"
+      selected_visual_evidence_dirs+=("$2")
+      shift 2
+      ;;
+    --selected-visual-evidence-dir=*)
+      selected_visual_evidence_dirs+=("${1#--selected-visual-evidence-dir=}")
+      shift
+      ;;
     --extra-action-runtime-evidence)
       [ "$#" -ge 2 ] || die "--extra-action-runtime-evidence requires a value"
       extra_action_runtime_evidence+=("$2")
@@ -280,6 +297,10 @@ case "${run_desktop_ax_capture}" in
   0|1|false|true) ;;
   *) die "FRIDAY_UIUX_RUN_DESKTOP_AX_CAPTURE must be 0/1/false/true" ;;
 esac
+case "${run_ios_design_capture}" in
+  0|1|false|true) ;;
+  *) die "FRIDAY_UIUX_RUN_IOS_DESIGN_CAPTURE must be 0/1/false/true" ;;
+esac
 if ! [[ "${desktop_ax_timeout_seconds}" =~ ^[0-9]+$ ]] || [[ "${desktop_ax_timeout_seconds}" -lt 5 ]]; then
   die "--desktop-ax-timeout-seconds must be an integer >= 5"
 fi
@@ -305,7 +326,7 @@ require_file_if_set() {
 }
 
 set +u
-for path in "${accessibility_captures[@]}" "${harvest_dirs[@]}" "${same_run_events[@]}" "${runtime_evidence_dirs[@]}" "${extra_action_runtime_evidence[@]}"; do
+for path in "${accessibility_captures[@]}" "${harvest_dirs[@]}" "${same_run_events[@]}" "${runtime_evidence_dirs[@]}" "${selected_visual_evidence_dirs[@]}" "${extra_action_runtime_evidence[@]}"; do
   require_abs_if_set "input path" "${path}"
 done
 set -u
@@ -333,6 +354,10 @@ fi
 
 mkdir -p "${out_dir}"
 native_linkage_out="${out_dir}/uiux-native-linkage.json"
+served_ui_dir="${out_dir}/served-ui"
+served_ui_fidelity_out="${served_ui_dir}/served-ui-design-fidelity.json"
+ios_design_capture_dir="${out_dir}/ios-design-destination-capture"
+ios_design_manifest_out="${ios_design_capture_dir}/ios-design-destination-capture-manifest.json"
 action_bundle_dir="${out_dir}/action-runtime-bundle"
 desktop_ax_dir="${out_dir}/desktop-ax-accessibility"
 desktop_ax_capture_out="${desktop_ax_dir}/desktop-ax-accessibility-capture.json"
@@ -349,6 +374,10 @@ node "${repo_root}/scripts/ops/check-friday-uiux-native-linkage.mjs" \
   "--repo-root=${repo_root}" \
   "--out=${native_linkage_out}" \
   --require-complete >/dev/null
+
+node "${repo_root}/scripts/ops/check-friday-served-ui-design-fidelity.mjs" \
+  "--out=${served_ui_fidelity_out}" >/dev/null
+selected_visual_evidence_dirs+=("${served_ui_dir}")
 
 if [ "${plan_only}" -eq 1 ]; then
   node - "${driver_summary}" "${native_linkage_out}" <<'NODE'
@@ -367,6 +396,21 @@ console.log(JSON.stringify(summary, null, 2));
 NODE
   exit 0
 fi
+
+case "${run_ios_design_capture}" in
+  1|true)
+    ios_design_capture_args=(
+      "${repo_root}/scripts/ops/friday-ios-design-destination-capture.sh"
+      "--out-dir" "${ios_design_capture_dir}"
+      "--mode" "live-loopback"
+    )
+    if [ -n "${canonical_mission_id}" ]; then
+      ios_design_capture_args+=("--mission-id" "${canonical_mission_id}")
+    fi
+    bash "${ios_design_capture_args[@]}"
+    selected_visual_evidence_dirs+=("${ios_design_capture_dir}")
+    ;;
+esac
 
 if [ "${skip_action_bundle}" -eq 0 ]; then
   action_bundle_args=(
@@ -466,6 +510,10 @@ for dir in "${runtime_evidence_dirs[@]}"; do
   [ -n "${dir}" ] || continue
   shortlist_args+=("--runtime-evidence-dir" "${dir}")
 done
+for dir in "${selected_visual_evidence_dirs[@]}"; do
+  [ -n "${dir}" ] || continue
+  shortlist_args+=("--selected-visual-evidence-dir" "${dir}")
+done
 for path in "${extra_action_runtime_evidence[@]}"; do
   [ -n "${path}" ] || continue
   shortlist_args+=("--extra-action-runtime-evidence" "${path}")
@@ -480,11 +528,13 @@ if [ "${shortlist_exit_code}" -ne 0 ]; then
   echo "WARN: UI device shortlist exited ${shortlist_exit_code}; writing partial driver summary with blockers." >&2
 fi
 
-node - "${driver_summary}" "${native_linkage_out}" "${shortlist_dir}/ui-device-shortlist-summary.json" "${action_bundle_dir}/action-runtime-evidence-bundle-index.json" "${desktop_ax_capture_out}" "${desktop_ax_exit_code}" "${shortlist_exit_code}" <<'NODE'
+node - "${driver_summary}" "${native_linkage_out}" "${served_ui_fidelity_out}" "${ios_design_manifest_out}" "${shortlist_dir}/ui-device-shortlist-summary.json" "${action_bundle_dir}/action-runtime-evidence-bundle-index.json" "${desktop_ax_capture_out}" "${desktop_ax_exit_code}" "${shortlist_exit_code}" <<'NODE'
 const fs = require("node:fs");
 const [
   summaryPath,
   nativePath,
+  servedUiFidelityPath,
+  iosDesignManifestPath,
   shortlistPath,
   actionBundlePath,
   desktopAxCapturePath,
@@ -499,6 +549,8 @@ function readJson(path) {
   }
 }
 const native = readJson(nativePath);
+const servedUiFidelity = readJson(servedUiFidelityPath);
+const iosDesignManifest = readJson(iosDesignManifestPath);
 const shortlist = readJson(shortlistPath);
 const actionBundle = readJson(actionBundlePath);
 const desktopAxCapture = readJson(desktopAxCapturePath);
@@ -529,6 +581,8 @@ const summary = {
     uiDeviceShortlist: shortlistExitCode,
   },
   nativeLinkageStatus: native?.status || "unknown",
+  servedUiDesignFidelityStatus: servedUiFidelity?.status || "unknown",
+  iosDesignDestinationCaptureStatus: iosDesignManifest?.status || "skipped_or_unavailable",
   actionRuntimeBundleStatus: actionBundle?.status || "skipped_or_unavailable",
   desktopAccessibilityCaptureStatus: desktopAxCapture?.status || "skipped_or_unavailable",
   missionId: shortlist?.missionId || null,
@@ -536,6 +590,8 @@ const summary = {
   readinessBlockers: partialBlockers,
   outputs: {
     nativeLinkage: nativePath,
+    servedUiDesignFidelity: fs.existsSync(servedUiFidelityPath) ? servedUiFidelityPath : null,
+    iosDesignDestinationCapture: fs.existsSync(iosDesignManifestPath) ? iosDesignManifestPath : null,
     actionRuntimeBundle: fs.existsSync(actionBundlePath) ? actionBundlePath : null,
     desktopAccessibilityCapture: fs.existsSync(desktopAxCapturePath) ? desktopAxCapturePath : null,
     uiDeviceShortlist: shortlistPath,

--- a/scripts/ops/friday-uiux-real-use-proof-driver.sh
+++ b/scripts/ops/friday-uiux-real-use-proof-driver.sh
@@ -370,24 +370,15 @@ echo "Friday UI/UX real-use proof driver starting."
 echo "out_dir=${out_dir}"
 echo "truth=uiux_real_use_proof_driver_not_endbar_not_adoption"
 
-node "${repo_root}/scripts/ops/check-friday-uiux-native-linkage.mjs" \
-  "--repo-root=${repo_root}" \
-  "--out=${native_linkage_out}" \
-  --require-complete >/dev/null
-
-node "${repo_root}/scripts/ops/check-friday-served-ui-design-fidelity.mjs" \
-  "--out=${served_ui_fidelity_out}" >/dev/null
-selected_visual_evidence_dirs+=("${served_ui_dir}")
-
 if [ "${plan_only}" -eq 1 ]; then
-  node - "${driver_summary}" "${native_linkage_out}" <<'NODE'
+  node - "${driver_summary}" <<'NODE'
 const fs = require("node:fs");
-const [summaryPath, nativePath] = process.argv.slice(2);
-const native = JSON.parse(fs.readFileSync(nativePath, "utf8"));
+const [summaryPath] = process.argv.slice(2);
 const summary = {
   truth: "uiux_real_use_proof_driver_plan_only_not_runtime_proof",
   status: "plan_ready",
-  nativeLinkageStatus: native.status,
+  nativeLinkageStatus: "not_run_plan_only",
+  servedUiDesignFidelityStatus: "not_run_plan_only",
   nextCommand: "rerun without --plan-only and supply real accessibility/channel/timeline evidence when available",
   caveat: "Plan-only mode performs no live UI/device capture and is not END-BAR.",
 };
@@ -396,6 +387,15 @@ console.log(JSON.stringify(summary, null, 2));
 NODE
   exit 0
 fi
+
+node "${repo_root}/scripts/ops/check-friday-uiux-native-linkage.mjs" \
+  "--repo-root=${repo_root}" \
+  "--out=${native_linkage_out}" \
+  --require-complete >/dev/null
+
+node "${repo_root}/scripts/ops/check-friday-served-ui-design-fidelity.mjs" \
+  "--out=${served_ui_fidelity_out}" >/dev/null
+selected_visual_evidence_dirs+=("${served_ui_dir}")
 
 case "${run_ios_design_capture}" in
   1|true)

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -84,6 +84,15 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("readiness_args+=(\"--design-action-runtime-evidence\" \"${path}\")");
   });
 
+  it("threads selected visual evidence into product closure without treating it as runtime evidence", () => {
+    const source = readFileSync("scripts/ops/friday-ui-device-proof-shortlist-runner.sh", "utf8");
+
+    expect(source).toContain("--selected-visual-evidence-dir");
+    expect(source).toContain("selected_visual_evidence_dirs=()");
+    expect(source).toContain("closure_args+=(\"--selected-visual-evidence-dir=${dir}\")");
+    expect(source).toContain("selectedVisualProofStatus");
+  });
+
   it("keeps the readiness report file parseable JSON while preserving wrapper logs", () => {
     const source = readFileSync("scripts/ops/friday-ui-device-proof-shortlist-runner.sh", "utf8");
 

--- a/test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
+++ b/test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
@@ -57,4 +57,15 @@ describe("friday-uiux-product-closure-readiness contract", () => {
     expect(source).toContain('["action-runtime-evidence.json", "design-action-runtime-evidence.json"].includes(entry.name)');
     expect(source).toContain("...recursiveRuntimeEvidenceFromDir(resolved)");
   });
+
+  it("accepts selected-visual-only evidence without feeding it into runtime evidence lists", () => {
+    const source = readFileSync("scripts/ops/friday-uiux-product-closure-readiness.mjs", "utf8");
+
+    expect(source).toContain("--selected-visual-evidence-dir=/abs/served-or-visual-evidence");
+    expect(source).toContain("FRIDAY_UIUX_SELECTED_VISUAL_EVIDENCE_DIRS");
+    expect(source).toContain("const selectedVisualEvidenceDirs = unique");
+    expect(source).toContain("for (const dir of selectedVisualEvidenceDirs)");
+    expect(source).toContain("selectedVisualProofArgs.push(`--evidence-dir=${abs(dir)}`)");
+    expect(source).toContain("selectedVisualEvidenceDirs,");
+  });
 });

--- a/test/unit/qa/friday-uiux-real-use-proof-driver-contract.test.ts
+++ b/test/unit/qa/friday-uiux-real-use-proof-driver-contract.test.ts
@@ -40,6 +40,7 @@ describe("friday-uiux-real-use-proof-driver contract", () => {
     const source = readFileSync(script, "utf8");
 
     expect(source).toContain("check-friday-uiux-native-linkage.mjs");
+    expect(source).toContain("check-friday-served-ui-design-fidelity.mjs");
     expect(source).toContain("friday-action-runtime-evidence-bundle.sh");
     expect(source).toContain("friday-desktop-ax-accessibility-capture.mjs");
     expect(source).toContain("friday-ui-device-proof-shortlist-runner.sh");
@@ -47,10 +48,23 @@ describe("friday-uiux-real-use-proof-driver contract", () => {
     expect(source).toContain("FRIDAY_UIUX_RUN_DESKTOP_AX_CAPTURE:-0");
     expect(source).toContain("workbench_db=\"${FRIDAY_WORKBENCH_DB_PATH:-}\"");
     expect(source).toContain("shortlist_args+=(\"--workbench-db\" \"${workbench_db}\")");
+    expect(source).toContain("served_ui_fidelity_out=\"${served_ui_dir}/served-ui-design-fidelity.json\"");
+    expect(source).toContain("ios_design_manifest_out=\"${ios_design_capture_dir}/ios-design-destination-capture-manifest.json\"");
+    expect(source).toContain("selected_visual_evidence_dirs+=(\"${served_ui_dir}\")");
+    expect(source).toContain("FRIDAY_UIUX_RUN_IOS_DESIGN_CAPTURE:-1");
+    expect(source).toContain("--skip-ios-design-capture");
+    expect(source).toContain("friday-ios-design-destination-capture.sh");
+    expect(source).toContain("ios_design_capture_args+=(\"--mission-id\" \"${canonical_mission_id}\")");
+    expect(source).toContain("selected_visual_evidence_dirs+=(\"${ios_design_capture_dir}\")");
+    expect(source).toContain("shortlist_args+=(\"--selected-visual-evidence-dir\" \"${dir}\")");
     expect(source).toContain("--mission-id=${canonical_mission_id}");
     expect(source).toContain("desktop_ax_capture_out=\"${desktop_ax_dir}/desktop-ax-accessibility-capture.json\"");
     expect(source).toContain("accessibility_captures+=(\"${desktop_ax_capture_out}\")");
     expect(source).toContain("desktopAccessibilityCapture");
+    expect(source).toContain("servedUiDesignFidelityStatus");
+    expect(source).toContain("iosDesignDestinationCaptureStatus");
+    expect(source).toContain("servedUiDesignFidelity: fs.existsSync(servedUiFidelityPath) ? servedUiFidelityPath : null");
+    expect(source).toContain("iosDesignDestinationCapture: fs.existsSync(iosDesignManifestPath) ? iosDesignManifestPath : null");
     expect(source).toContain("desktopAccessibilityCaptureStatus");
     expect(source).toContain("desktop_ax_capture_failed_or_partial");
     expect(source).toContain("ui_device_shortlist_failed_or_partial");


### PR DESCRIPTION
## Summary
- add selected-visual-only evidence plumbing from product closure through the UI/device shortlist runner
- make the real-use proof driver generate served desktop+iOS fidelity evidence and iOS selected-design destination manifests by default
- record selected visual proof status in runner/driver summaries without claiming END-BAR or adoption

## Verification
- vitest run --project default test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts test/unit/qa/friday-uiux-real-use-proof-driver-contract.test.ts test/unit/qa/friday-ios-design-destination-capture-runner.test.ts
- bash -n scripts/ops/friday-ui-device-proof-shortlist-runner.sh && bash -n scripts/ops/friday-uiux-real-use-proof-driver.sh && node --check scripts/ops/friday-uiux-product-closure-readiness.mjs
- npm run check:served-ui-design-fidelity -- --out=/private/tmp/friday-served-ui-proof-wiring-served-report.json
- FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS=0.5 FRIDAY_IOS_DESIGN_CAPTURE_OUT=/private/tmp/friday-served-ui-proof-wiring-ios-smoke npm run proof:ios:design-destinations -- --destinations home

Truth: this wires selected UI visual proof into the real-use proof chain. It does not claim END-BAR, GO-LIVE, release, adoption, or full runtime action closure.