### PR TITLE
Generalize channel proof bridge for strict UI evidence

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/mission_bound_channel_live_projection.rs
+++ b/rust-core/crates/friday-hub/src/bin/mission_bound_channel_live_projection.rs
@@ -1,0 +1,401 @@
+//! Attach a verified live channel proof to one Mission graph and immediately project it.
+//!
+//! This is an ops-only proof bridge for the last-inch UI/device gate. It does not claim the
+//! channel proof by itself is END-BAR; it proves that a real, schema-validated channel live proof
+//! can be consumed by the canonical Mission Workbench projection as a refs-only ChannelInbound
+//! event for the same Mission mobile/desktop surfaces.
+
+use friday_core::{
+    ApprovalState, HandoffJudgmentMemory, Mission, Risk, SurfaceEvent, SurfaceEventKind,
+    SurfaceKind, SurfaceThread, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
+};
+use friday_hub::channels::RedactedInbound;
+use friday_hub::mission_context::MissionContextLookup;
+use friday_hub::mission_runtime::{ingest_channel_inbound_for_mission, MissionBoundChannelOutcome};
+use friday_hub::workbench_projection::project_workbench;
+use friday_storage::{Db, StorageError};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const ACK_ENV: &str = "FRIDAY_MISSION_BOUND_CHANNEL_ATTACH_ACK";
+const ACK_VALUE: &str = "attach-verified-channel-proof-to-mission";
+
+#[derive(Debug, Deserialize)]
+struct ChannelLiveWrapper {
+    proof: String,
+    status: String,
+    capture_mode: Option<String>,
+    telegram_live: TelegramLive,
+    secret_policy: SecretPolicy,
+}
+
+#[derive(Debug, Deserialize)]
+struct TelegramLive {
+    status: String,
+    proof: String,
+    sender_id_present: bool,
+    sender_allowlisted: bool,
+    bearer_auth_accepted_correct: bool,
+    forged_bearer_rejected: bool,
+    non_allowlisted_sender_rejected: bool,
+    bot_identity_verified: bool,
+    channel_binding_created: bool,
+    raw_text_chars: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SecretPolicy {
+    token_logged: bool,
+    token_written_to_artifact: bool,
+    provider_or_channel_id_written: bool,
+    raw_sender_id_written: bool,
+    artifact_contains_redacted_text_only: bool,
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("mission_bound_channel_live_projection_unavailable: {err}");
+        std::process::exit(2);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args = env::args().collect::<Vec<_>>();
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        usage();
+        return Ok(());
+    }
+    if env::var(ACK_ENV).ok().as_deref() != Some(ACK_VALUE) {
+        return Err(format!(
+            "{ACK_ENV}={ACK_VALUE} required; refusing to write Mission graph"
+        ));
+    }
+    let db_path = arg_value(&args, "--db").ok_or("--db is required")?;
+    let mission_id = arg_value(&args, "--mission-id").ok_or("--mission-id is required")?;
+    let channel_live_proof =
+        arg_value(&args, "--channel-live-proof").ok_or("--channel-live-proof is required")?;
+    let out_path = arg_value(&args, "--out").ok_or("--out is required")?;
+    if !Path::new(&db_path).is_file() {
+        return Err(format!("db not found: {db_path}"));
+    }
+    if !Path::new(&channel_live_proof).is_file() {
+        return Err(format!(
+            "channel live proof not found: {channel_live_proof}"
+        ));
+    }
+
+    let wrapper = load_and_validate_wrapper(&channel_live_proof)?;
+    let now_ms = now_ms();
+    let proof_hash = file_sha256_hex(&channel_live_proof).map_err(|err| err.to_string())?;
+    let mut db = Db::open_hub(&db_path).map_err(|err| err.to_string())?;
+    let outcome = attach_to_mission(&mut db, &mission_id, &wrapper, &proof_hash, now_ms)
+        .map_err(|err| err.to_string())?;
+    let snapshot = project_workbench(&db, Some(&mission_id))?;
+    let has_channel_refs = snapshot
+        .get("channelReceiptRefs")
+        .and_then(Value::as_array)
+        .is_some_and(|refs| !refs.is_empty());
+    let has_channel_surface = snapshot
+        .get("transcriptSections")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .flat_map(|section| {
+            section
+                .get("events")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+        })
+        .any(|event| event.get("surface").and_then(Value::as_str) == Some("telegram"));
+    let status = if has_channel_refs && has_channel_surface {
+        "ready"
+    } else {
+        "blocked"
+    };
+    let report = json!({
+        "truth": "mission_bound_channel_live_projection_refs_only",
+        "status": status,
+        "missionId": mission_id,
+        "channelProofSha256": proof_hash,
+        "captureMode": wrapper.capture_mode,
+        "attachment": outcome,
+        "checks": {
+            "channelReceiptRefs": has_channel_refs,
+            "telegramTranscriptSurface": has_channel_surface
+        },
+        "caveat": "This attaches a verified live channel proof to the Mission graph for UI/device consumption; it does not claim END-BAR, release, adoption, or raw transcript sync."
+    });
+    fs::write(
+        &out_path,
+        serde_json::to_string_pretty(&report).map_err(|err| err.to_string())? + "\n",
+    )
+    .map_err(|err| err.to_string())?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).map_err(|err| err.to_string())?
+    );
+    if status == "ready" {
+        Ok(())
+    } else {
+        Err("mission projection did not surface channel refs".into())
+    }
+}
+
+fn usage() {
+    eprintln!(
+        "usage: {ACK_ENV}={ACK_VALUE} mission_bound_channel_live_projection \\
+  --db=/abs/rust-hub.sqlite --mission-id=mission... \\
+  --channel-live-proof=/abs/mission_spine_channel_live_proof.json --out=/abs/report.json"
+    );
+}
+
+fn attach_to_mission(
+    db: &mut Db,
+    mission_id: &str,
+    wrapper: &ChannelLiveWrapper,
+    proof_hash: &str,
+    now_ms: i64,
+) -> Result<Value, StorageError> {
+    let mut mission = db
+        .get_mission(mission_id)?
+        .ok_or_else(|| StorageError::Unsupported(format!("unknown mission '{mission_id}'")))?;
+    let channel_id = format!("telegram-live-proof:{}", &proof_hash[..12]);
+    let work_item_id = format!("work-channel-live-proof-{}", &proof_hash[..16]);
+    let surface_thread_id = format!("surface-telegram-live-proof-{}", &proof_hash[..16]);
+    let proof_ref = format!("proof://channel-live/sha256/{proof_hash}");
+    let body_ref = format!("friday://body/channel-live-proof/{}", &proof_hash[..16]);
+
+    upsert_channel_work_item(db, &mission, &work_item_id, &channel_id, &proof_ref, now_ms)?;
+    db.upsert_surface_thread(&SurfaceThread {
+        surface_thread_id: surface_thread_id.clone(),
+        friday_conversation_id: mission.friday_conversation_id.clone(),
+        mission_id: Some(mission_id.to_string()),
+        surface_kind: SurfaceKind::Telegram,
+        channel_binding_id: None,
+        delivery_route: "ops://verified-channel-live-proof".into(),
+        visibility_policy: VisibilityPolicy::StatusOnly,
+        allowed_actions: vec!["open".into()],
+        last_seen_at_ms: Some(now_ms),
+        last_delivered_event_seq: None,
+        created_at_ms: now_ms,
+        updated_at_ms: now_ms,
+    })?;
+
+    let redacted = RedactedInbound {
+        channel_id: channel_id.clone(),
+        sender_id: "allowlisted_telegram_user".into(),
+        bound_principal_id: "owner_channel_live_proof".into(),
+        text: format!(
+            "validated Telegram live proof with {} chars after redaction",
+            wrapper.telegram_live.raw_text_chars
+        ),
+        pii_redacted: Vec::new(),
+    };
+    let channel_msg_id = &proof_hash[..16];
+    let recorded = ingest_channel_inbound_for_mission(
+        db,
+        MissionContextLookup::by_mission_work_item(
+            &mission.friday_conversation_id,
+            mission_id,
+            &work_item_id,
+        ),
+        &redacted,
+        channel_msg_id,
+        "message",
+        false,
+        Risk::Low,
+        &[],
+        now_ms,
+    )?;
+
+    let MissionBoundChannelOutcome::Recorded {
+        receipt,
+        attachment: runtime_attachment,
+        ..
+    } = recorded
+    else {
+        return Err(StorageError::Unsupported(
+            "mission-bound channel runtime blocked before recording".into(),
+        ));
+    };
+    db.upsert_surface_event(&SurfaceEvent {
+        surface_event_id: format!("surface-event-channel-live-proof-{}", &proof_hash[..16]),
+        friday_conversation_id: mission.friday_conversation_id.clone(),
+        mission_id: mission_id.to_string(),
+        work_item_id: Some(work_item_id.clone()),
+        surface_thread_id,
+        source_surface: SurfaceKind::Telegram,
+        event_kind: SurfaceEventKind::ChannelInbound,
+        body_ref: Some(body_ref),
+        visibility_policy: VisibilityPolicy::StatusOnly,
+        proof_ref: Some(proof_ref.clone()),
+        created_at_ms: now_ms,
+    })?;
+    let attachment = json!({
+        "runtimeOutcome": "recorded",
+        "activityId": receipt.activity_id,
+        "disposition": receipt.disposition,
+        "replayed": receipt.replayed,
+        "missionAttachment": format!("{runtime_attachment:?}")
+    });
+
+    push_unique(&mut mission.work_item_ids, work_item_id);
+    push_unique(&mut mission.proof_refs, proof_ref);
+    mission.updated_at_ms = now_ms;
+    db.upsert_mission(&mission)?;
+    Ok(attachment)
+}
+
+fn upsert_channel_work_item(
+    db: &Db,
+    mission: &Mission,
+    work_item_id: &str,
+    channel_id: &str,
+    proof_ref: &str,
+    now_ms: i64,
+) -> Result<(), StorageError> {
+    db.upsert_work_item(&WorkItem {
+        work_item_id: work_item_id.to_string(),
+        mission_id: mission.mission_id.clone(),
+        lane: WorkLane::Channel,
+        target_provider_or_agent: Some(channel_id.to_string()),
+        status: WorkItemStatus::ReadyToDispatch,
+        owner_claim_ids: Vec::new(),
+        workspace_refs: Vec::new(),
+        capability_id: Some("capability.channel.live-proof-consumption".into()),
+        risk_level: Risk::Low,
+        approval_state: ApprovalState::NotRequired,
+        blocking_reason: None,
+        input_refs: vec![proof_ref.to_string()],
+        output_refs: Vec::new(),
+        proof_requirements: vec!["channel live proof must remain redacted and refs-only".into()],
+        proof_receipts: Vec::new(),
+        judgment_memory: HandoffJudgmentMemory {
+            task: "Attach verified channel live proof to the Mission graph".into(),
+            current_blocker: None,
+            target_lane_thread_agent_provider: "bound telegram channel live proof".into(),
+            read_first_files: vec![proof_ref.to_string()],
+            required_output: "Mission Workbench projection surfaces a redacted ChannelInbound ref".into(),
+            done_criteria: vec![
+                "channelReceiptRefs is non-empty".into(),
+                "telegram transcript event is visible".into(),
+            ],
+            red_lines: vec![
+                "do not store raw Telegram token/sender/text".into(),
+                "do not claim END-BAR from channel proof alone".into(),
+            ],
+            why_this_route: "The UI/device strict gate needs the same Mission graph to carry a channel evidence leg.".into(),
+            considered_options: vec![
+                "attach a fake UI observation".into(),
+                "attach verified channel proof through Mission graph".into(),
+            ],
+            deferred_options: vec!["release/adoption proof remains separate".into()],
+            previous_pitfalls: vec!["channel proof file alone is not UI consumption proof".into()],
+            inheritable_context: vec!["refs-only workbench projection is the source of truth".into()],
+            proof_requirements: vec!["schema-validated live channel proof".into()],
+            ownership_claim_ids: Vec::new(),
+        },
+        created_at_ms: now_ms,
+        updated_at_ms: now_ms,
+    })
+}
+
+fn load_and_validate_wrapper(path: &str) -> Result<ChannelLiveWrapper, String> {
+    let text = fs::read_to_string(path).map_err(|err| err.to_string())?;
+    let wrapper: ChannelLiveWrapper = serde_json::from_str(&text).map_err(|err| err.to_string())?;
+    let mut failures = Vec::new();
+    if wrapper.proof != "mission_spine_channel_live_proof" {
+        failures.push("wrapper_proof_mismatch");
+    }
+    if wrapper.status != "passed" {
+        failures.push("wrapper_status_not_passed");
+    }
+    let telegram = &wrapper.telegram_live;
+    if telegram.status != "passed" {
+        failures.push("telegram_status_not_passed");
+    }
+    if telegram.proof != "telegram_inbound_through_rust_channels_pipeline" {
+        failures.push("telegram_proof_mismatch");
+    }
+    for (ok, name) in [
+        (telegram.sender_id_present, "sender_id_missing"),
+        (telegram.sender_allowlisted, "sender_not_allowlisted"),
+        (
+            telegram.bearer_auth_accepted_correct,
+            "bearer_auth_not_accepted",
+        ),
+        (
+            telegram.forged_bearer_rejected,
+            "forged_bearer_not_rejected",
+        ),
+        (
+            telegram.non_allowlisted_sender_rejected,
+            "non_allowlisted_sender_not_rejected",
+        ),
+        (telegram.bot_identity_verified, "bot_identity_not_verified"),
+        (telegram.channel_binding_created, "channel_binding_missing"),
+        (
+            wrapper.secret_policy.artifact_contains_redacted_text_only,
+            "artifact_not_redacted_only",
+        ),
+    ] {
+        if !ok {
+            failures.push(name);
+        }
+    }
+    if wrapper.secret_policy.token_logged
+        || wrapper.secret_policy.token_written_to_artifact
+        || wrapper.secret_policy.provider_or_channel_id_written
+        || wrapper.secret_policy.raw_sender_id_written
+    {
+        failures.push("secret_policy_leak");
+    }
+    if telegram.raw_text_chars == 0 {
+        failures.push("raw_text_chars_missing");
+    }
+    if failures.is_empty() {
+        Ok(wrapper)
+    } else {
+        Err(format!(
+            "channel live proof blocked: {}",
+            failures.join(",")
+        ))
+    }
+}
+
+fn file_sha256_hex(path: &str) -> std::io::Result<String> {
+    let bytes = fs::read(path)?;
+    let digest = Sha256::digest(bytes);
+    Ok(format!("{digest:x}"))
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(i64::MAX)
+}
+
+fn arg_value(args: &[String], name: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|pair| (pair[0] == name).then(|| pair[1].clone()))
+        .or_else(|| {
+            let prefix = format!("{name}=");
+            args.iter()
+                .find_map(|arg| arg.strip_prefix(&prefix).map(str::to_string))
+        })
+}

--- a/scripts/ops/friday-channel-proof-events.mjs
+++ b/scripts/ops/friday-channel-proof-events.mjs
@@ -13,8 +13,10 @@ function usage() {
     --channel-capture=/abs/channel-capture.json \\
     --out=/abs/channel-events.jsonl [--require-ready]
 
-Truth: converts a redacted channel live proof wrapper into conservative
-same-run UI/device event rows. It does not synthesize replay, timeline,
+Truth: converts a redacted channel live proof artifact into conservative
+same-run UI/device event rows. It accepts the mission-spine Telegram wrapper
+and Phase24 trusted-inbound channel artifacts that already passed their own
+live listener. It does not synthesize replay, timeline,
 mobile/desktop/channel convergence, END-BAR, GO-LIVE, or adoption proof.`);
 }
 
@@ -69,6 +71,88 @@ function readJson(path, label) {
   }
 }
 
+function isObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function validateMissionSpineWrapper(proof) {
+  const failures = [];
+  if (proof.proof !== "mission_spine_channel_live_proof") failures.push("channel_live_proof_mismatch");
+  if (proof.status !== "passed") failures.push("channel_live_proof_not_passed");
+  if (proof.secret_policy?.artifact_contains_redacted_text_only !== true) {
+    failures.push("channel_live_proof_secret_policy_not_redacted");
+  }
+  const telegram = isObject(proof.telegram_live) ? proof.telegram_live : {};
+  const forgedRejected = telegram.forged_bearer_rejected === true || proof.forged_bearer_rejected === true;
+  const nonAllowlistedRejected = telegram.non_allowlisted_sender_rejected === true || proof.non_allowlisted_sender_rejected === true;
+  if (!forgedRejected || !nonAllowlistedRejected) {
+    failures.push("channel_live_proof_replay_controls_missing");
+  }
+  if (!String(proof.remaining_requirement || "").includes("UI/device consumption evidence")) {
+    failures.push("channel_live_proof_missing_ui_device_boundary");
+  }
+  return {
+    source: "mission_spine_channel_live_proof",
+    capturedAt: stringValue(proof.generated_at_utc),
+    truthLabel: "derived_from_redacted_channel_live_proof_not_final_ui_device_proof",
+    canEmitReplayBlocked: failures.length === 0,
+    failures,
+  };
+}
+
+function phase24ObservedEventKey(schemaVersion) {
+  if (schemaVersion === "friday.phase24b.discord_trusted_inbound_proof.v1") return "observedDiscordEvent";
+  if (schemaVersion === "friday.phase24c.telegram_trusted_inbound_proof.v1") return "observedTelegramEvent";
+  if (schemaVersion === "friday.phase24d.lark_feishu_trusted_inbound_proof.v1") return "observedLarkFeishuEvent";
+  return "";
+}
+
+function validatePhase24TrustedInbound(proof) {
+  const failures = [];
+  const observedEventKey = phase24ObservedEventKey(proof.schemaVersion);
+  if (!observedEventKey) failures.push("phase24_channel_schema_unsupported");
+  if (proof.status !== "passed") failures.push("phase24_channel_status_not_passed");
+  if (!Array.isArray(proof.failures) || proof.failures.length !== 0) failures.push("phase24_channel_failures_present");
+  if (proof.criteria?.artifactHasNoToken !== true) failures.push("phase24_channel_artifact_token_check_missing");
+  if (proof.criteria?.channelBoundaryConsumable !== true) failures.push("phase24_channel_boundary_not_consumable");
+  if (proof.criteria?.channelBoundaryNoLiveClaim !== true) failures.push("phase24_channel_boundary_live_claim_missing");
+  if (proof.criteria?.fullEvidenceSurfaceExported !== true) failures.push("phase24_channel_evidence_surface_not_exported");
+  if (observedEventKey && !isObject(proof[observedEventKey])) failures.push(`phase24_channel_observed_event_missing:${observedEventKey}`);
+  if (!isObject(proof.evidenceSurface)) failures.push("phase24_channel_evidence_surface_missing");
+  return {
+    source: proof.schemaVersion || "phase24_channel_trusted_inbound",
+    capturedAt: stringValue(proof.completedAt || proof.startedAt),
+    truthLabel: "derived_from_phase24_trusted_inbound_channel_proof_not_final_ui_device_proof",
+    canEmitReplayBlocked: false,
+    failures,
+  };
+}
+
+function validateChannelProof(proof) {
+  if (!isObject(proof)) {
+    return {
+      source: "unknown_channel_proof",
+      capturedAt: "",
+      truthLabel: "invalid_channel_proof_not_ui_device_proof",
+      canEmitReplayBlocked: false,
+      failures: ["channel_live_proof_not_object"],
+    };
+  }
+  if (proof.proof === "mission_spine_channel_live_proof") return validateMissionSpineWrapper(proof);
+  if (phase24ObservedEventKey(proof.schemaVersion)) return validatePhase24TrustedInbound(proof);
+  return {
+    source: stringValue(proof.schemaVersion || proof.proof || "unknown_channel_proof"),
+    capturedAt: "",
+    truthLabel: "unsupported_channel_proof_not_ui_device_proof",
+    canEmitReplayBlocked: false,
+    failures: ["channel_live_proof_unsupported_schema"],
+  };
+}
+
 if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
   block("mission_id_unexpected_shape", missionId || "<missing>");
 }
@@ -77,47 +161,37 @@ if (!outPath) block("missing_arg", "out");
 const channelLiveProof = requireFile("channel-live-proof", channelLiveProofPath);
 const channelCapture = requireFile("channel-capture", channelCapturePath);
 const proof = readJson(channelLiveProof, "channel-live-proof");
+const proofDecision = validateChannelProof(proof);
 
-if (proof) {
-  if (proof.proof !== "mission_spine_channel_live_proof") block("channel_live_proof_mismatch", String(proof.proof ?? ""));
-  if (proof.status !== "passed") block("channel_live_proof_not_passed", String(proof.status ?? ""));
-  if (proof.secret_policy?.artifact_contains_redacted_text_only !== true) {
-    block("channel_live_proof_secret_policy_not_redacted", "artifact_contains_redacted_text_only");
-  }
-  const telegram = proof.telegram_live && typeof proof.telegram_live === "object" ? proof.telegram_live : {};
-  const forgedRejected = telegram.forged_bearer_rejected === true || proof.forged_bearer_rejected === true;
-  const nonAllowlistedRejected = telegram.non_allowlisted_sender_rejected === true || proof.non_allowlisted_sender_rejected === true;
-  if (!forgedRejected || !nonAllowlistedRejected) {
-    block("channel_live_proof_replay_controls_missing", "forged_bearer_rejected_and_non_allowlisted_sender_rejected");
-  }
-  if (!String(proof.remaining_requirement || "").includes("UI/device consumption evidence")) {
-    block("channel_live_proof_missing_ui_device_boundary", "remaining_requirement");
-  }
+for (const failure of proofDecision.failures) {
+  const [code, detail = ""] = failure.split(":");
+  block(code, detail);
 }
 
-const capturedAt = typeof proof?.generated_at_utc === "string" && proof.generated_at_utc.trim()
-  ? proof.generated_at_utc.trim()
+const capturedAt = proofDecision.capturedAt.trim()
+  ? proofDecision.capturedAt.trim()
   : new Date(0).toISOString();
-const rows = blockers.length === 0 ? [
-  {
-    surface: "channel",
-    event: "same_mission_projection_visible",
-    mission_id: missionId,
-    evidence_ref: channelCapture,
-    truth_label: "derived_from_redacted_channel_live_proof_not_final_ui_device_proof",
-    source: "mission_spine_channel_live_proof",
-    captured_at: capturedAt,
-  },
+const rows = blockers.length === 0 ? [{
+  surface: "channel",
+  event: "same_mission_projection_visible",
+  mission_id: missionId,
+  evidence_ref: channelCapture,
+  truth_label: proofDecision.truthLabel,
+  source: proofDecision.source,
+  captured_at: capturedAt,
+}] : [];
+if (blockers.length === 0 && proofDecision.canEmitReplayBlocked) {
+  rows.push(
   {
     surface: "channel",
     event: "channel_replay_blocked_visible",
     mission_id: missionId,
     evidence_ref: channelCapture,
     truth_label: "derived_from_redacted_channel_live_proof_negative_controls_not_final_ui_device_proof",
-    source: "mission_spine_channel_live_proof",
+    source: proofDecision.source,
     captured_at: capturedAt,
-  },
-] : [];
+  });
+}
 
 if (blockers.length === 0 && outPath) {
   const out = abs(outPath);
@@ -135,7 +209,7 @@ const output = {
   outputRows: rows.length,
   emittedEvents: rows.map((row) => `${row.surface}:${row.event}`),
   blockers,
-  caveat: "Conservative channel event bridge only. Replay-blocked visibility is emitted only from passed redacted channel-wrapper negative controls; this does not claim timeline proof, mobile/desktop/channel convergence, END-BAR, or GO-LIVE.",
+  caveat: "Conservative channel event bridge only. Replay-blocked visibility is emitted only when the channel proof includes replay controls. Phase24 trusted-inbound artifacts prove user-origin channel consumption but do not emit replay-blocked visibility unless their own proof includes replay controls; this does not claim timeline proof, mobile/desktop/channel convergence, END-BAR, or GO-LIVE.",
 };
 
 console.log(JSON.stringify(output, null, 2));

--- a/scripts/ops/friday-ui-device-proof-gap-report.mjs
+++ b/scripts/ops/friday-ui-device-proof-gap-report.mjs
@@ -229,6 +229,31 @@ function supportingProof(label, path, validate) {
 }
 
 function supportingProofs() {
+  function channelProofFailures(value) {
+    const failures = [];
+    if (value.proof === "mission_spine_channel_live_proof") {
+      if (value.status !== "passed") failures.push("status_not_passed");
+      if (!String(value.remaining_requirement || "").includes("UI/device consumption")) failures.push("remaining_requirement_missing");
+      return failures;
+    }
+    const observedEventKeyBySchema = {
+      "friday.phase24b.discord_trusted_inbound_proof.v1": "observedDiscordEvent",
+      "friday.phase24c.telegram_trusted_inbound_proof.v1": "observedTelegramEvent",
+      "friday.phase24d.lark_feishu_trusted_inbound_proof.v1": "observedLarkFeishuEvent",
+    };
+    const observedEventKey = observedEventKeyBySchema[value.schemaVersion];
+    if (!observedEventKey) failures.push("proof_mismatch");
+    if (value.status !== "passed") failures.push("status_not_passed");
+    if (!Array.isArray(value.failures) || value.failures.length !== 0) failures.push("phase24_failures_present");
+    if (value.criteria?.artifactHasNoToken !== true) failures.push("phase24_artifact_token_check_missing");
+    if (value.criteria?.channelBoundaryConsumable !== true) failures.push("phase24_channel_boundary_not_consumable");
+    if (value.criteria?.channelBoundaryNoLiveClaim !== true) failures.push("phase24_channel_boundary_live_claim_missing");
+    if (value.criteria?.fullEvidenceSurfaceExported !== true) failures.push("phase24_evidence_surface_not_exported");
+    if (observedEventKey && (typeof value[observedEventKey] !== "object" || value[observedEventKey] === null)) {
+      failures.push(`phase24_observed_event_missing:${observedEventKey}`);
+    }
+    return failures;
+  }
   return [
     supportingProof("backendLiveProof", supportingProofArgs.backendLiveProof, (value) => {
       const failures = [];
@@ -238,11 +263,7 @@ function supportingProofs() {
       return failures;
     }),
     supportingProof("channelLiveProof", supportingProofArgs.channelLiveProof, (value) => {
-      const failures = [];
-      if (value.proof !== "mission_spine_channel_live_proof") failures.push("proof_mismatch");
-      if (value.status !== "passed") failures.push("status_not_passed");
-      if (!String(value.remaining_requirement || "").includes("UI/device consumption")) failures.push("remaining_requirement_missing");
-      return failures;
+      return channelProofFailures(value);
     }),
     supportingProof("objectiveCoverage", supportingProofArgs.objectiveCoverage, (value) => {
       const failures = [];

--- a/scripts/ops/friday-ui-device-proof-gap-report.mjs
+++ b/scripts/ops/friday-ui-device-proof-gap-report.mjs
@@ -385,10 +385,22 @@ if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId
 const evidence = Object.fromEntries(
   Object.entries(evidenceArgs).map(([role, path]) => [role, requireFile(role, path)]),
 );
-const knownEvidenceRefs = new Set(Object.values(evidence).filter(Boolean).map(evidenceKey));
 const eventFile = requireFile("events", eventsPath);
-const observations = parseJsonl(eventFile).map((raw, index) => normalizeEvent(raw, index, knownEvidenceRefs));
 const manifest = parseManifest(manifestPath);
+const manifestExtraEvidenceRefs = manifest && Array.isArray(manifest.extra_evidence_refs)
+  ? manifest.extra_evidence_refs.filter((ref) => typeof ref === "string" && ref.trim())
+  : [];
+const manifestNegativeEvidenceRefs = manifest && Array.isArray(manifest.negative_control_segments)
+  ? manifest.negative_control_segments.flatMap((segment) => Array.isArray(segment?.evidence_refs)
+      ? segment.evidence_refs.filter((ref) => typeof ref === "string" && ref.trim())
+      : [])
+  : [];
+const knownEvidenceRefs = new Set([
+  ...Object.values(evidence).filter(Boolean),
+  ...manifestExtraEvidenceRefs,
+  ...manifestNegativeEvidenceRefs,
+].map(evidenceKey));
+const observations = parseJsonl(eventFile).map((raw, index) => normalizeEvent(raw, index, knownEvidenceRefs));
 const negativeControlObservations = negativeControlObservationsFromManifest(manifest);
 const supportingProofRows = supportingProofs();
 

--- a/test/unit/qa/friday-channel-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-channel-proof-events-cli.test.ts
@@ -30,6 +30,41 @@ function writeChannelProof(path: string, overrides: Record<string, unknown> = {}
   }, null, 2));
 }
 
+function writePhase24DiscordProof(path: string, overrides: Record<string, unknown> = {}) {
+  writeFileSync(path, JSON.stringify({
+    schemaVersion: "friday.phase24b.discord_trusted_inbound_proof.v1",
+    phase: "phase24b",
+    scope: "Discord live trusted user inbound proof",
+    status: "passed",
+    startedAt: "2026-06-30T11:20:00.000Z",
+    completedAt: "2026-06-30T11:21:00.000Z",
+    reportPath: "/tmp/phase24b-discord-trusted-inbound-proof.json",
+    environment: {
+      commit_sha: "095811ada740d342e181f91ac38b5d8fac2ee768",
+    },
+    criteria: {
+      artifactHasNoToken: true,
+      channelBoundaryConsumable: true,
+      channelBoundaryNoLiveClaim: true,
+      fullEvidenceSurfaceExported: true,
+    },
+    diagnostics: {},
+    evidenceSurface: {
+      runEndpoint: "/v1/agent/runs/example",
+      auditEndpoint: "/v1/agent/runs/example/audit",
+    },
+    observedDiscordEvent: {
+      type: "MESSAGE_CREATE",
+      authorBotFalse: true,
+      senderMatched: true,
+      channelMatched: true,
+      nonceMatched: true,
+    },
+    failures: [],
+    ...overrides,
+  }, null, 2));
+}
+
 describe("friday-channel-proof-events", () => {
   it("emits conservative channel projection and replay-blocked events from a passed wrapper", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-channel-proof-events-"));
@@ -86,6 +121,50 @@ describe("friday-channel-proof-events", () => {
           captured_at: "2026-06-24T23:59:00.000Z",
         },
       ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits only channel projection for a passed Phase24 trusted-inbound artifact", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-channel-proof-events-phase24-"));
+    try {
+      const proof = join(tempDir, "phase24b-discord-trusted-inbound-proof.json");
+      const channelCapture = join(tempDir, "channel-capture.json");
+      const out = join(tempDir, "channel-events.jsonl");
+      writePhase24DiscordProof(proof);
+      writeFileSync(channelCapture, JSON.stringify({ truth: "redacted_channel_capture" }));
+
+      const stdout = execFileSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--channel-live-proof=${proof}`,
+        `--channel-capture=${channelCapture}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      const result = JSON.parse(stdout) as {
+        status?: string;
+        outputRows?: number;
+        emittedEvents?: string[];
+        caveat?: string;
+      };
+      const rows = readFileSync(out, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+
+      expect(result.status).toBe("ready");
+      expect(result.outputRows).toBe(1);
+      expect(result.emittedEvents).toEqual(["channel:same_mission_projection_visible"]);
+      expect(result.caveat).toContain("do not emit replay-blocked");
+      expect(rows[0]).toMatchObject({
+        surface: "channel",
+        event: "same_mission_projection_visible",
+        mission_id: missionId,
+        evidence_ref: channelCapture,
+        truth_label: "derived_from_phase24_trusted_inbound_channel_proof_not_final_ui_device_proof",
+        source: "friday.phase24b.discord_trusted_inbound_proof.v1",
+        captured_at: "2026-06-30T11:21:00.000Z",
+      });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -155,6 +234,40 @@ describe("friday-channel-proof-events", () => {
       const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
       expect(output.status).toBe("blocked");
       expect(output.blockers?.map((blocker) => blocker.code)).toContain("channel_live_proof_replay_controls_missing");
+      expect(() => readFileSync(out, "utf8")).toThrow();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when a Phase24 channel artifact is not passed", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-channel-proof-events-phase24-blocked-"));
+    try {
+      const proof = join(tempDir, "phase24b-discord-trusted-inbound-proof.json");
+      const channelCapture = join(tempDir, "channel-capture.json");
+      const out = join(tempDir, "channel-events.jsonl");
+      writePhase24DiscordProof(proof, {
+        status: "blocked",
+        failures: ["No trusted user-origin message arrived"],
+      });
+      writeFileSync(channelCapture, JSON.stringify({ truth: "redacted_channel_capture" }));
+
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--channel-live-proof=${proof}`,
+        `--channel-capture=${channelCapture}`,
+        `--out=${out}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("blocked");
+      expect(output.blockers?.map((blocker) => blocker.code)).toEqual(expect.arrayContaining([
+        "phase24_channel_status_not_passed",
+        "phase24_channel_failures_present",
+      ]));
       expect(() => readFileSync(out, "utf8")).toThrow();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });

--- a/test/unit/qa/friday-channel-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-channel-proof-events-cli.test.ts
@@ -40,7 +40,7 @@ function writePhase24DiscordProof(path: string, overrides: Record<string, unknow
     completedAt: "2026-06-30T11:21:00.000Z",
     reportPath: "/tmp/phase24b-discord-trusted-inbound-proof.json",
     environment: {
-      commit_sha: "095811ada740d342e181f91ac38b5d8fac2ee768",
+      commit_sha: "095811ada740d342e181f91ac38b5d8fac2ee768", // pragma: allowlist secret
     },
     criteria: {
       artifactHasNoToken: true,

--- a/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
@@ -123,7 +123,7 @@ function writePhase24ChannelProof(path: string) {
     completedAt: "2026-06-30T11:21:00.000Z",
     reportPath: "/tmp/phase24b-discord-trusted-inbound-proof.json",
     environment: {
-      commit_sha: "095811ada740d342e181f91ac38b5d8fac2ee768",
+      commit_sha: "095811ada740d342e181f91ac38b5d8fac2ee768", // pragma: allowlist secret
     },
     criteria: {
       artifactHasNoToken: true,
@@ -375,6 +375,38 @@ describe("friday-ui-device-proof-gap-report", () => {
       const rows = completeRows({ ...files, desktop: alias });
       const manifest = join(tempDir, "manifest.json");
       writeFileSync(manifest, JSON.stringify(completeManifest(), null, 2));
+
+      const result = run(tempDir, files, rows, [
+        `--manifest=${manifest}`,
+        "--require-complete",
+      ]);
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as { status?: string; blockers?: unknown[] };
+      expect(output.status).toBe("complete_inputs_observed");
+      expect(output.blockers).toEqual([]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts manifest-declared extra evidence refs as strict inputs", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-gap-report-manifest-extra-"));
+    try {
+      const files = evidenceFiles(tempDir);
+      const extraTrace = join(tempDir, "desktop-accessibility.trace");
+      writeFileSync(extraTrace, "real desktop accessibility trace captured during the same run\n");
+      const rows = completeRows(files).map((row) => {
+        const typed = row as { event?: string };
+        if (typed.event === "mission_workbench_visible") {
+          return { ...row, evidence_ref: extraTrace };
+        }
+        return row;
+      });
+      const manifest = join(tempDir, "manifest.json");
+      writeFileSync(manifest, JSON.stringify({
+        ...completeManifest(),
+        extra_evidence_refs: [extraTrace],
+      }, null, 2));
 
       const result = run(tempDir, files, rows, [
         `--manifest=${manifest}`,

--- a/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts
@@ -113,6 +113,40 @@ function writeSupportingProofs(tempDir: string) {
   return { backend, channel };
 }
 
+function writePhase24ChannelProof(path: string) {
+  writeFileSync(path, JSON.stringify({
+    schemaVersion: "friday.phase24b.discord_trusted_inbound_proof.v1",
+    phase: "phase24b",
+    scope: "Discord live trusted user inbound proof",
+    status: "passed",
+    startedAt: "2026-06-30T11:20:00.000Z",
+    completedAt: "2026-06-30T11:21:00.000Z",
+    reportPath: "/tmp/phase24b-discord-trusted-inbound-proof.json",
+    environment: {
+      commit_sha: "095811ada740d342e181f91ac38b5d8fac2ee768",
+    },
+    criteria: {
+      artifactHasNoToken: true,
+      channelBoundaryConsumable: true,
+      channelBoundaryNoLiveClaim: true,
+      fullEvidenceSurfaceExported: true,
+    },
+    diagnostics: {},
+    evidenceSurface: {
+      runEndpoint: "/v1/agent/runs/example",
+      auditEndpoint: "/v1/agent/runs/example/audit",
+    },
+    observedDiscordEvent: {
+      type: "MESSAGE_CREATE",
+      authorBotFalse: true,
+      senderMatched: true,
+      channelMatched: true,
+      nonceMatched: true,
+    },
+    failures: [],
+  }, null, 2));
+}
+
 function run(tempDir: string, files: ReturnType<typeof evidenceFiles>, rows: unknown[], extraArgs: string[] = []) {
   const events = join(tempDir, "events.jsonl");
   writeJsonl(events, rows);
@@ -212,6 +246,39 @@ describe("friday-ui-device-proof-gap-report", () => {
         countsTowardUiDeviceProof: false,
         failures: [],
       }));
+      expect(output.supportingProofs).toContainEqual(expect.objectContaining({
+        role: "channelLiveProof",
+        status: "usable_precondition_not_ui_device_evidence",
+        countsTowardUiDeviceProof: false,
+        failures: [],
+      }));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts Phase24 trusted-inbound channel proof as a supporting precondition only", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-gap-report-phase24-supporting-"));
+    try {
+      const files = evidenceFiles(tempDir);
+      const phase24 = join(tempDir, "phase24b-discord-trusted-inbound-proof.json");
+      writePhase24ChannelProof(phase24);
+      const result = run(tempDir, files, partialRows(files), [
+        `--channel-live-proof=${phase24}`,
+      ]);
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout) as {
+        status?: string;
+        supportingProofs?: Array<{
+          role?: string;
+          status?: string;
+          countsTowardUiDeviceProof?: boolean;
+          failures?: string[];
+        }>;
+        gaps?: { missingObservations?: unknown[] };
+      };
+      expect(output.status).toBe("gaps_present");
+      expect(output.gaps?.missingObservations?.length).toBeGreaterThan(0);
       expect(output.supportingProofs).toContainEqual(expect.objectContaining({
         role: "channelLiveProof",
         status: "usable_precondition_not_ui_device_evidence",


### PR DESCRIPTION
## Summary
- Allow the strict UI/device channel event bridge to accept passed Phase24 trusted-inbound channel artifacts in addition to the existing mission-spine Telegram wrapper.
- Keep truth boundaries strict: Phase24 artifacts emit only channel projection, while replay-blocked visibility is emitted only when the proof includes replay controls.
- Teach the UI/device gap report to classify Phase24 trusted-inbound channel artifacts as supporting preconditions, not as complete UI/device proof.
- Teach the gap report to honor manifest-declared `extra_evidence_refs` and negative-control evidence refs, so real auxiliary traces can count only when the manifest explicitly binds them.
- Add an ops-only Rust `mission_bound_channel_live_projection` bridge that validates a live channel proof, writes a governed Channel work item + ChannelInbound link through the Mission runtime path, and immediately proves the Mission Workbench projection exposes refs-only channel evidence.
- Fix detect-secrets false positives in the new channel fixture commit SHAs with inline allowlist comments.

## Verification
- `git diff --check`
- `node --check scripts/ops/friday-channel-proof-events.mjs`
- `node --check scripts/ops/friday-ui-device-proof-gap-report.mjs`
- `npm run test -- --run --project default test/unit/qa/friday-channel-proof-events-cli.test.ts test/unit/qa/friday-ui-device-proof-gap-report-cli.test.ts`
- `cargo check -p friday-hub --bin mission_bound_channel_live_projection`
- `detect-secrets-hook --baseline .secrets.baseline ...` using the CI exclude pattern
- Isolated DB-copy run of `mission_bound_channel_live_projection` against current-SHA Telegram proof: `status=ready`, `channelReceiptRefs=true`, `telegramTranscriptSurface=true`, `runtimeOutcome=recorded`.
- Strict evidence assembly replay after manifest regeneration: `gap-report.regenerated.json` reached `status=complete_inputs_observed` with no missing observations, no missing order events, and no missing checks.

## Live evidence notes
- Current-SHA Telegram live proof succeeded on run `28440250231` for `095811ada740d342e181f91ac38b5d8fac2ee768`.
- DB-copy replay proved the channel proof can be attached to the target Mission graph and projected as a Telegram/channel transcript surface.
- Merging the derived workbench channel events with the existing strict evidence cleared channel observations/order; live DB application remains a separate operator-visible step and must not be confused with release/adoption.
- This PR still does not claim END-BAR, release, adoption, or full product completion by itself.
