### PR TITLE
Tighten UI proof evidence readiness

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -959,9 +959,10 @@ fn run_session_reaper_tick(db: &friday_storage::Db, retention_on: bool, now_ms: 
         );
         if !r.is_empty() {
             eprintln!(
-                "hub_agent_run_server: retention sweep token_ledger={} surface_event={} mission={} work_item={} memory_item={} table_errors={}",
+                "hub_agent_run_server: retention sweep token_ledger={} surface_event={} provider_session_event={} mission={} work_item={} memory_item={} table_errors={}",
                 r.token_ledger_deleted,
                 r.surface_event_deleted,
+                r.provider_session_event_deleted,
                 r.mission_deleted,
                 r.work_item_deleted,
                 r.memory_item_deleted,

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -469,9 +469,11 @@ if [ -n "${timeline_capture}" ] && [ "${workbench_timeline_status}" != "snapshot
   if [ "${defer_channel_proof}" = "1" ]; then
     workbench_events_args+=("--defer-channel-proof")
   fi
-  if node "${workbench_events_args[@]}" --allow-partial-events >"${workbench_events}.stdout"; then
-    same_run_events+=("${workbench_events}")
+  if node "${workbench_events_args[@]}" >"${workbench_events}.stdout"; then
     workbench_events_status="$(node -e 'const fs=require("fs"); const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(j.status || "unknown");' "${workbench_events}.stdout")"
+    if [ "${workbench_events_status}" = "ready" ]; then
+      same_run_events+=("${workbench_events}")
+    fi
     if [ "${workbench_timeline_status}" = "skipped" ]; then
       workbench_timeline_status="events_${workbench_events_status}"
     else

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -94,8 +94,8 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("cargo run -p friday-hub --bin mission_workbench_projection");
     expect(source).toContain("workbench-timeline-capture.json");
     expect(source).toContain("friday-workbench-snapshot-events.mjs");
-    expect(source).toContain("--allow-partial-events");
     expect(source).toContain("workbench_events_status=");
+    expect(source).toContain("if [ \"${workbench_events_status}\" = \"ready\" ]; then");
     expect(source).toContain("same_run_events+=(\"${workbench_events}\")");
     expect(source).toContain("readiness_args+=(\"--workbench-db\" \"${workbench_db}\")");
     expect(source).toContain("MISSION_ID=\"${mission_id}\" FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS");


### PR DESCRIPTION
## Summary
- stop the UI/device shortlist runner from feeding partial workbench diagnostic rows into strict proof inputs
- keep workbench-derived rows only when the bridge reports `ready`, while still surfacing non-ready status for diagnosis
- include provider_session_event retention counts in the runtime retention sweep log

## Verification
- git diff --check
- cargo check -p friday-hub --bin hub_agent_run_server
- /Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts test/unit/qa/friday-workbench-snapshot-events-cli.test.ts test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts

Truth: this is a safety/readiness tightening PR. It does not claim END-BAR, release, adoption, or product completion.