### PR TITLE
Accept assembled UI proof in runtime satisfaction

### DIFF
--- a/scripts/ops/build-friday-uiux-runtime-blocker-satisfaction.mjs
+++ b/scripts/ops/build-friday-uiux-runtime-blocker-satisfaction.mjs
@@ -101,7 +101,6 @@ function requireEvidenceDir(path) {
   const expected = [
     "gap-report.json",
     "observations-manifest.json",
-    "same-run-events.with-channel.jsonl",
     "mobile.json",
     "desktop.json",
     "timeline.json",
@@ -115,16 +114,33 @@ function requireEvidenceDir(path) {
     }
     refs.push(file);
   }
+  const eventFile = ["same-run-events.with-channel.jsonl", "same-run-events.normalized.jsonl"]
+    .map((relative) => resolve(dir, relative))
+    .find((file) => existsSync(file));
+  if (!eventFile) {
+    block("evidence_file_missing", `${resolve(dir, "same-run-events.with-channel.jsonl")} or ${resolve(dir, "same-run-events.normalized.jsonl")}`);
+  } else {
+    refs.push(eventFile);
+  }
   const gapReportPath = resolve(dir, "gap-report.json");
   if (existsSync(gapReportPath)) {
     const gapReport = readJson("ui-device-gap-report", gapReportPath);
     const gapBlockers = Array.isArray(gapReport?.blockers) ? gapReport.blockers : [];
     if (gapBlockers.length > 0) block("ui_device_gap_report_has_blockers", JSON.stringify(gapBlockers.slice(0, 10)));
-    if (gapReport?.status && !["pass", "ready", "gaps_present"].includes(String(gapReport.status))) {
+    if (gapReport?.status && !["pass", "ready", "gaps_present", "complete_inputs_observed"].includes(String(gapReport.status))) {
       block("ui_device_gap_report_status_unexpected", String(gapReport.status));
     }
   }
   return { dir, refs };
+}
+
+function hasStrictUiDeviceProof(value) {
+  if (value?.truth === "assembled_real_ui_device_proof" && value?.status === "pass") return true;
+  if (value?.proof !== "mission_spine_ui_device_consumption") return false;
+  if (!String(value?.mission_id || "").toLowerCase().includes("mission")) return false;
+  if (!Array.isArray(value?.observations) || value.observations.length < 1) return false;
+  if (!Array.isArray(value?.negative_control_segments) || value.negative_control_segments.length < 1) return false;
+  return true;
 }
 
 function arrayAt(value, path) {
@@ -217,8 +233,8 @@ if ((trace?.counts?.productActionsMissingRuntimeEvidence ?? 0) !== 0) {
 if ((trace?.counts?.runtimeEvidenceInputs ?? 0) <= 0) {
   block("runtime_evidence_inputs_missing", String(trace?.counts?.runtimeEvidenceInputs ?? 0));
 }
-if (uiDeviceProof?.truth !== "assembled_real_ui_device_proof" || uiDeviceProof?.status !== "pass") {
-  block("ui_device_proof_not_strict_pass", `${String(uiDeviceProof?.truth || "missing")}:${String(uiDeviceProof?.status || "missing")}`);
+if (!hasStrictUiDeviceProof(uiDeviceProof)) {
+  block("ui_device_proof_not_strict_pass", `${String(uiDeviceProof?.truth || uiDeviceProof?.proof || "missing")}:${String(uiDeviceProof?.status || "missing")}`);
 }
 
 const proofRef = uiDeviceProofPath ? abs(uiDeviceProofPath) : "";

--- a/test/unit/qa/friday-uiux-runtime-blocker-satisfaction-cli.test.ts
+++ b/test/unit/qa/friday-uiux-runtime-blocker-satisfaction-cli.test.ts
@@ -44,6 +44,27 @@ function writeEvidenceDir(root: string) {
   return dir;
 }
 
+function writeCompleteEvidenceDir(root: string) {
+  const dir = writeEvidenceDir(root);
+  writeJson(dir, "gap-report.json", {
+    status: "complete_inputs_observed",
+    blockers: [],
+    checks: {
+      pressureAskCountOk: true,
+      duplicateSurfaceCountOk: true,
+      timelinePageCountOk: true,
+    },
+  });
+  return dir;
+}
+
+function writeNormalizedOnlyEvidenceDir(root: string) {
+  const dir = writeCompleteEvidenceDir(root);
+  rmSync(join(dir, "same-run-events.with-channel.jsonl"), { force: true });
+  writeText(dir, "same-run-events.normalized.jsonl", "{\"event\":\"mission_workbench_visible\"}\n");
+  return dir;
+}
+
 function trace(overrides: Record<string, unknown> = {}) {
   return {
     truth: "uiux_action_traceability_not_endbar_not_adoption_not_gui_proof",
@@ -319,6 +340,75 @@ describe("build-friday-uiux-runtime-blocker-satisfaction", () => {
       expect(report.counts?.satisfactions).toBe(1);
       expect(report.satisfactions?.[0]?.id).toBe("tokenLedger");
       expect(report.satisfactions?.[0]?.evidenceRefs).toContain("proof://desktop-ax/token-ledger");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts the canonical assembled UI/device proof artifact shape", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-runtime-satisfaction-canonical-proof-"));
+    try {
+      const tracePath = writeJson(root, "trace.json", trace());
+      const proofPath = writeJson(root, "ui-device-proof.json", {
+        proof: "mission_spine_ui_device_consumption",
+        mission_id: "mission_ui_device_contract",
+        observations: [{ surface: "mobile" }, { surface: "desktop" }, { surface: "channel" }],
+        negative_control_segments: [{
+          mission_id: "mission_negative_status",
+          observations: [
+            { surface: "*", event: "stale_label_visible" },
+            { surface: "*", event: "offline_label_visible" },
+            { surface: "*", event: "error_label_visible" },
+          ],
+        }],
+      });
+      const evidenceDir = writeCompleteEvidenceDir(root);
+      const output = execFileSync("node", [
+        script,
+        `--head=${head}`,
+        `--action-traceability-report=${tracePath}`,
+        `--ui-device-proof=${proofPath}`,
+        `--ui-device-evidence-dir=${evidenceDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        blockers?: unknown[];
+        counts?: { satisfactions?: number };
+      };
+      expect(report.status).toBe("ready");
+      expect(report.blockers).toEqual([]);
+      expect(report.counts?.satisfactions).toBe(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts capture-dir evidence that uses the normalized same-run event filename", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-runtime-satisfaction-normalized-events-"));
+    try {
+      const tracePath = writeJson(root, "trace.json", trace());
+      const proofPath = writeJson(root, "ui-device-proof.json", {
+        truth: "assembled_real_ui_device_proof",
+        status: "pass",
+      });
+      const evidenceDir = writeNormalizedOnlyEvidenceDir(root);
+      const output = execFileSync("node", [
+        script,
+        `--head=${head}`,
+        `--action-traceability-report=${tracePath}`,
+        `--ui-device-proof=${proofPath}`,
+        `--ui-device-evidence-dir=${evidenceDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        blockers?: unknown[];
+        counts?: { satisfactions?: number };
+      };
+      expect(report.status).toBe("ready");
+      expect(report.blockers).toEqual([]);
+      expect(report.counts?.satisfactions).toBe(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Accept canonical `mission_spine_ui_device_consumption` UI/device proof artifacts in the runtime blocker satisfaction builder.
- Accept capture-dir evidence that emits `same-run-events.normalized.jsonl` instead of only `same-run-events.with-channel.jsonl`.
- Treat `complete_inputs_observed` gap reports as a complete, non-blocking UI/device gap status.

## Verification
- `vitest run --project default test/unit/qa/friday-uiux-runtime-blocker-satisfaction-cli.test.ts`
- current-head runtime satisfaction recheck with `/private/tmp/friday-mission-spine-ui-device-proof.json` and `/private/tmp/friday-strict-reassembled-with-ax-channel-neg-proper-20260630T125124Z/evidence`: `status=ready`, `satisfactions=12`, `blockers=[]`

Truth: tooling compatibility only; does not lower END-BAR, release, adoption, provider, signature, or UI/device proof gates.