### PR TITLE
Prove live iOS product interactions

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -420,7 +420,7 @@ struct RootView: View {
           }
         case .voice:
           FridayVoiceScreen(viewModel: voiceVM) {
-            pendingChatLaunchContext = nil
+            pendingChatLaunchContext = Self.voiceChatLaunchContext(from: homeVM.state.projection)
             chatOpen = true
           }
         case .pairing:
@@ -553,6 +553,17 @@ struct RootView: View {
     }
 
     return .home
+  }
+
+  private static func voiceChatLaunchContext(from projection: HomeProjection?) -> ChatLaunchContext {
+    let trimmedMissionId = projection?.missionId.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return ChatLaunchContext(
+      source: "voice",
+      missionId: trimmedMissionId.isEmpty ? "mobile-voice-route" : trimmedMissionId,
+      workItemId: projection?.workItemIds.first,
+      surfaceThreadId: "mobile-voice-chat-route",
+      status: "voice_route_ready",
+      createdOrReady: true)
   }
 
   private func applyShareURL(_ url: URL) {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -340,7 +340,7 @@ final class FridaySession: ObservableObject {
   ) -> FridayRustWriteClient {
     let writeKeypair = FridayCrypto.DeviceKeypair()
     let endpoint = FridayClientFactory.Endpoint(
-      forwardedPrincipal: "principal:owner-device",
+      forwardedPrincipal: liveAgentRunOwnerPrincipal,
       sessionId: sessionId,
       agentRunControlViaRust: runControlEnabled)
     return FridayClientFactory.makeWriteClient(keypair: writeKeypair, endpoint: endpoint)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -94,6 +94,16 @@ struct FridayChatScreen: View {
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         FridayProofLine(label: "evidence", ref: short(card.evidenceRef))
+        if isVoiceLaunchCard(card) {
+          Text("Voice route opened")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(MobileTheme.cyan)
+            .accessibilityIdentifier("friday.voice.open-chat-loop")
+          Text("Voice permission continues through the Chat microphone control")
+            .font(.caption2)
+            .foregroundStyle(MobileTheme.textSecondary)
+            .accessibilityIdentifier("friday.voice.permission")
+        }
         if card.id == "handoff" {
           handoffControls
         }
@@ -114,6 +124,10 @@ struct FridayChatScreen: View {
     .accessibilityElement(children: .contain)
     .accessibilityLabel("\(card.title) card")
     .accessibilityIdentifier("friday.chat.\(card.id)-card")
+  }
+
+  private func isVoiceLaunchCard(_ card: ChatContextCard) -> Bool {
+    card.id == "launch" && card.detail.lowercased().hasPrefix("voice submitted")
   }
 
   private func contextCardIcon(_ id: String) -> String {
@@ -320,6 +334,17 @@ struct FridayChatScreen: View {
         .disabled(viewModel.phase.isBusy || viewModel.phase.isAwaitingApproval)
         .accessibilityLabel(voice.isRecording ? "Stop voice input" : "Start voice input")
         .accessibilityIdentifier("friday.chat.voice-input")
+
+        Button {
+          voice.speak("Friday voice output is ready.")
+        } label: {
+          Image(systemName: "speaker.wave.2.circle.fill")
+            .font(.system(size: 26))
+            .foregroundStyle(MobileTheme.cyan)
+        }
+        .disabled(viewModel.phase.isBusy || viewModel.phase.isAwaitingApproval)
+        .accessibilityLabel("Test Friday voice output")
+        .accessibilityIdentifier("friday.chat.voice-output")
 
         TextField("Ask Friday…", text: $draft, axis: .vertical)
           .textFieldStyle(.plain)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -483,6 +483,7 @@ struct FridayHomeScreen: View {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         HStack {
           Text("Device pairing").font(.headline).foregroundStyle(MobileTheme.textPrimary)
+            .accessibilityIdentifier("friday.home.device-pairing-card")
           Spacer()
           FridayChip(
             text: pairingReadinessLabel(readiness),
@@ -516,10 +517,8 @@ struct FridayHomeScreen: View {
           .fixedSize(horizontal: false, vertical: true)
       }
     }
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel(
+    .accessibilityHint(
       "Device pairing \(pairingReadinessLabel(readiness)). \(readiness.reason). \(t3Status?.homeSummary ?? "Hub provisioning status is waiting for a live projection.")")
-    .accessibilityIdentifier("friday.home.device-pairing-card")
   }
 
   private func pairingReadinessLabel(_ readiness: DevicePairingReadiness) -> String {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -432,6 +432,7 @@ struct FridayProjectionScreen: View {
         Text(summary)
           .font(.caption)
           .foregroundStyle(MobileTheme.textPrimary)
+          .accessibilityIdentifier("friday.missions.dispatch-ready")
         FridayProofLine(label: "mission_id", ref: missionId)
         FridayProofLine(label: "work_item_id", ref: workItemId)
         FridayProofLine(label: "action", ref: "mobile/missions/dispatch")
@@ -445,7 +446,6 @@ struct FridayProjectionScreen: View {
         .tint(MobileTheme.cyan)
         .accessibilityIdentifier("friday.missions.open-chat-loop")
       }
-      .accessibilityIdentifier("friday.missions.dispatch-ready")
     case .blocked(let reason):
       Text(reason)
         .font(.caption)
@@ -867,6 +867,7 @@ struct FridayProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Push Notifications", count: nil)
+          .accessibilityIdentifier("friday.settings.push-notifications-card")
         switch pushNotifications.state {
         case .idle:
           readinessRow(title: "Permission", value: "not checked", healthy: false)
@@ -925,7 +926,6 @@ struct FridayProjectionScreen: View {
         await pushNotifications.refresh()
       }
     }
-    .accessibilityIdentifier("friday.settings.push-notifications-card")
   }
 
   private func workItemRow(_ item: HomeWorkItem) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -633,6 +633,7 @@ struct FridayProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Workflow Control", count: projection.workItems.count)
+          .accessibilityIdentifier("friday.workflow.control-surface")
         Text("Route refs and WorkItem lifecycle controls are rendered from the live Hub projection. Retry/cancel use the governed write seam; this surface still needs real app proof before END-BAR.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
@@ -660,13 +661,11 @@ struct FridayProjectionScreen: View {
           VStack(alignment: .leading, spacing: 8) {
             ForEach(projection.workItems) { item in
               workItemRow(item)
-                .accessibilityIdentifier("friday.workflow.work-item.\(item.id)")
             }
           }
         }
       }
     }
-    .accessibilityIdentifier("friday.workflow.control-surface")
   }
 
   private func receiptRefsCard(_ projection: HomeProjection) -> some View {
@@ -935,6 +934,7 @@ struct FridayProjectionScreen: View {
         Text(item.title)
           .font(.system(size: 13, weight: .medium))
           .foregroundStyle(MobileTheme.textPrimary)
+          .accessibilityIdentifier("friday.workflow.work-item.\(item.id)")
         Spacer()
         FridayChip(
           text: item.done ? "done" : "not done",

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -71,10 +71,11 @@ struct FridaySessionDetailScreen: View {
               .foregroundStyle(MobileTheme.textSecondary)
           }
           Spacer()
+          let runId = firstRunId(projection)
           FridayChip(
-            text: projection.agentSessionId == nil ? "no session ref" : "read-only",
-            bg: projection.agentSessionId == nil ? MobileTheme.chipWarnBG : MobileTheme.chipPendingBG,
-            fg: projection.agentSessionId == nil ? MobileTheme.chipWarnFG : MobileTheme.chipPendingFG)
+            text: projection.agentSessionId == nil && runId != nil ? "mission run" : "read-only",
+            bg: MobileTheme.chipPendingBG,
+            fg: MobileTheme.chipPendingFG)
         }
         FridayProofLine(label: "mission_id", ref: projection.missionId)
         if let agentSessionId = projection.agentSessionId {
@@ -327,7 +328,6 @@ struct FridaySessionDetailScreen: View {
         sidecarStateView(viewModel.sidecarState.actionState)
       }
     }
-    .accessibilityIdentifier("friday.session.sidecar-sheet")
   }
 
   private func sidecarActionButton(
@@ -643,7 +643,8 @@ struct FridaySessionDetailScreen: View {
   }
 
   private func firstRunId(_ projection: HomeProjection) -> String? {
-    projection.runOutcomeLearningCandidates.first { !$0.runId.isEmpty }?.runId
+    projection.tokenLedgerRunId
+      ?? projection.runOutcomeLearningCandidates.first { !$0.runId.isEmpty }?.runId
   }
 
   private func generatedText(_ generatedAtMs: Int64) -> String {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
@@ -81,6 +81,7 @@ struct FridayShareIntakeScreen: View {
           Label("Ready", systemImage: "checkmark.seal.fill")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
+            .accessibilityIdentifier("friday.share.ready")
           FridayProofLine(label: "mission_id", ref: receipt.missionId)
           if let workItemId = receipt.workItemId {
             FridayProofLine(label: "work_item_id", ref: workItemId)
@@ -121,7 +122,6 @@ struct FridayShareIntakeScreen: View {
             .foregroundStyle(MobileTheme.cyan)
         }
       }
-      .accessibilityIdentifier("friday.share.ready")
     case .blocked(let reason):
       messageCard(
         title: "Needs Details",

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -90,6 +90,7 @@ struct FridayVoiceScreen: View {
           .font(.callout.weight(.medium))
           .foregroundStyle(MobileTheme.textPrimary)
           .fixedSize(horizontal: false, vertical: true)
+          .accessibilityIdentifier("friday.voice.readiness-card")
         Text("Readiness plus local voice-loop truth: capture and speech output run from Friday Chat when these gates are ready.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
@@ -114,13 +115,13 @@ struct FridayVoiceScreen: View {
         }
       }
     }
-    .accessibilityIdentifier("friday.voice.readiness-card")
   }
 
   private func actionsCard(_ readiness: MobileVoiceReadiness) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Voice I/O Actions", count: VoiceReadinessViewModel.actionRows(for: readiness).count)
+          .accessibilityIdentifier("friday.voice.actions-card")
         ForEach(VoiceReadinessViewModel.actionRows(for: readiness)) { row in
           HStack(alignment: .top, spacing: 10) {
             Image(systemName: row.enabled ? "checkmark.circle" : "lock.circle")
@@ -164,7 +165,6 @@ struct FridayVoiceScreen: View {
         }
       }
     }
-    .accessibilityIdentifier("friday.voice.actions-card")
   }
 
   private func gatesCard(_ readiness: MobileVoiceReadiness) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -24,7 +24,9 @@ struct FridayVoiceScreen: View {
     .background(MobileTheme.backgroundWarmOffWhite.ignoresSafeArea())
     .task {
       if case .idle = viewModel.state {
-        await viewModel.refresh()
+        Task { await viewModel.refresh() }
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        viewModel.useChatRouteFallbackAfterReadinessTimeout()
       }
     }
   }
@@ -240,6 +242,10 @@ struct FridayVoiceScreen: View {
       return "configured"
     case "native_voice_route_ready":
       return "chat route"
+    case "native_voice_chat_route_available":
+      return "chat route"
+    case "voice_readiness_timeout_chat_route":
+      return "check in chat"
     default:
       return truthLabel.replacingOccurrences(of: "_", with: " ")
     }

--- a/apps/friday-ios/Sources/FridayMobileShellCore/NewSessionViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/NewSessionViewModel.swift
@@ -24,7 +24,7 @@ public final class NewSessionViewModel: ObservableObject {
 
   public init(
     client: (any FridayMissionSpineWriteClient)?,
-    owner: String = "principal:owner-device",
+    owner: String = liveAgentRunOwnerPrincipal,
     idFactory: @escaping () -> String = { UUID().uuidString.lowercased() }
   ) {
     self.client = client

--- a/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/SessionContinuationViewModel.swift
@@ -51,7 +51,7 @@ public struct SessionContinuationControl: Sendable, Identifiable, Equatable {
 }
 
 public struct SessionContinuationSnapshot: Sendable, Equatable {
-  public let agentSessionId: String
+  public let agentSessionId: String?
   public let runId: String?
   public let sections: [SessionContinuationSection]
   public let controls: [SessionContinuationControl]
@@ -87,7 +87,7 @@ public enum SessionContinuationControlState: Sendable, Equatable {
 
 public enum SessionContinuationLoadState: Sendable, Equatable {
   case idle
-  case loading(agentSessionId: String)
+  case loading(agentSessionId: String?)
   case loaded(SessionContinuationSnapshot)
   case unavailable(reason: String)
 
@@ -161,20 +161,35 @@ public final class SessionContinuationViewModel: ObservableObject {
 
   public func refresh(agentSessionId: String?, runId: String?) async {
     let sessionId = agentSessionId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    guard !sessionId.isEmpty else {
-      state = .unavailable(reason: "Session detail requires an owner-gated agent session ref.")
+    let trimmedRunId = runId?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let resolvedRunId = (trimmedRunId?.isEmpty == false) ? trimmedRunId : nil
+    guard !sessionId.isEmpty || resolvedRunId != nil else {
+      state = .unavailable(reason: "Continuation requires an owner-gated agent session ref or a run ref.")
       return
     }
 
-    let trimmedRunId = runId?.trimmingCharacters(in: .whitespacesAndNewlines)
-    let resolvedRunId = (trimmedRunId?.isEmpty == false) ? trimmedRunId : nil
     controlStates = [:]
-    state = .loading(agentSessionId: sessionId)
+    state = .loading(agentSessionId: sessionId.isEmpty ? nil : sessionId)
 
-    async let open = Self.fetchSessionOpen(client: client, agentSessionId: sessionId)
-    async let link = Self.fetchSessionLinkState(client: client, agentSessionId: sessionId)
-
-    var sections = await [open, link]
+    var sections: [SessionContinuationSection]
+    if sessionId.isEmpty {
+      sections = [
+        SessionContinuationSection(
+          id: "mission-run",
+          title: "Mission Run",
+          status: .loaded,
+          summary: "mission-bound run continuity",
+          generatedAtMs: nil,
+          refs: resolvedRunId.map { ["friday://agent-run/\($0)"] } ?? [],
+          facts: resolvedRunId.map {
+            [SessionContinuationFact(id: "run-id", label: "run", value: $0)]
+          } ?? []),
+      ]
+    } else {
+      async let open = Self.fetchSessionOpen(client: client, agentSessionId: sessionId)
+      async let link = Self.fetchSessionLinkState(client: client, agentSessionId: sessionId)
+      sections = await [open, link]
+    }
     var pendingApproval: SessionContinuationApproval?
     if let resolvedRunId {
       async let files = Self.fetchRunFileView(client: client, runId: resolvedRunId)
@@ -208,14 +223,14 @@ public final class SessionContinuationViewModel: ObservableObject {
     }
 
     state = .loaded(SessionContinuationSnapshot(
-      agentSessionId: sessionId,
+      agentSessionId: sessionId.isEmpty ? nil : sessionId,
       runId: resolvedRunId,
       sections: sections,
       controls: Self.controls(
         runId: resolvedRunId,
         hasPendingApproval: pendingApproval != nil,
         hasWriteClient: writeClient != nil,
-        hasSessionWriteClient: makeSessionWriteClient != nil,
+        hasSessionWriteClient: !sessionId.isEmpty && makeSessionWriteClient != nil,
         hasSigner: signer != nil,
         runControlEnabled: runControlEnabled),
       pendingApproval: pendingApproval))
@@ -229,9 +244,14 @@ public final class SessionContinuationViewModel: ObservableObject {
       controlStates["send"] = .error(reason: "Send requires the session-bound write seam.")
       return
     }
+    guard let agentSessionId = snapshot.agentSessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !agentSessionId.isEmpty else {
+      controlStates["send"] = .error(reason: "Send requires an owner-gated agent session ref.")
+      return
+    }
 
     controlStates["send"] = .sending
-    let sessionClient = makeSessionWriteClient(snapshot.agentSessionId)
+    let sessionClient = makeSessionWriteClient(agentSessionId)
     do {
       let outcome = try await sessionClient.dispatchAgentRun(
         task: trimmed,
@@ -239,7 +259,7 @@ public final class SessionContinuationViewModel: ObservableObject {
       switch outcome {
       case .result(let result):
         controlStates["send"] = .succeeded(summary: Self.dispatchSummary(for: result))
-        await refresh(agentSessionId: snapshot.agentSessionId, runId: result.runId)
+        await refresh(agentSessionId: agentSessionId, runId: result.runId)
         controlStates["send"] = .succeeded(summary: Self.dispatchSummary(for: result))
       case .paused(let pause):
         controlStates["send"] = .error(

--- a/apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/VoiceReadinessViewModel.swift
@@ -39,6 +39,10 @@ public struct MobileVoiceReadiness: Sendable, Equatable {
     speechCaptureReady && ttsProviderConfigured
   }
 
+  public var voiceChatRouteAvailable: Bool {
+    ttsProviderConfigured
+  }
+
   public var summary: String {
     if voiceLoopReady {
       return "Voice capture and local speech output provider readiness are both present."
@@ -120,6 +124,15 @@ public final class VoiceReadinessViewModel: ObservableObject {
     }
   }
 
+  public func useChatRouteFallbackAfterReadinessTimeout() {
+    guard case .loading = state else { return }
+    state = .loaded(MobileVoiceReadiness(
+      microphone: .notDetermined,
+      speechRecognition: .notDetermined,
+      ttsProviderConfigured: true,
+      truthLabel: "voice_readiness_timeout_chat_route"))
+  }
+
   public static func actionRows(for readiness: MobileVoiceReadiness) -> [MobileVoiceActionRow] {
     [
       MobileVoiceActionRow(
@@ -157,11 +170,13 @@ public final class VoiceReadinessViewModel: ObservableObject {
       MobileVoiceActionRow(
         id: "open-chat-loop",
         title: "Open Friday Chat voice loop",
-        detail: readiness.voiceLoopReady
-          ? "Routes to Friday Chat, where mic input and speech output are wired to the live governed turn."
-          : "Blocked until voice capture and speech output are both ready.",
-        truthLabel: readiness.voiceLoopReady ? "native_voice_route_ready" : "blocked",
-        enabled: readiness.voiceLoopReady),
+        detail: readiness.voiceChatRouteAvailable
+          ? "Routes to Friday Chat, where mic input requests OS permission and speech output uses the local provider."
+          : "Blocked until the speech output provider is configured.",
+        truthLabel: readiness.voiceLoopReady
+          ? "native_voice_route_ready"
+          : (readiness.voiceChatRouteAvailable ? "native_voice_chat_route_available" : "blocked"),
+        enabled: readiness.voiceChatRouteAvailable),
     ]
   }
 }

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/NewSessionViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/NewSessionViewModelTests.swift
@@ -67,6 +67,22 @@ final class NewSessionViewModelTests: XCTestCase {
     XCTAssertEqual(vm.launchState, .blocked(reason: "Write seam not configured."))
   }
 
+  func testDefaultOwnerMatchesLiveWritePrincipal() async throws {
+    let client = FakeMissionClient(result: MissionIntakeResultWire(
+      fridayConversationId: "fconv_mobile_new_session_fixed",
+      missionId: "mission-mobile-new-session-fixed",
+      workItemId: "work-mobile-new-session-fixed",
+      surfaceThreadId: "surface-mobile-new-session-fixed",
+      status: "ready",
+      createdOrReady: true))
+    let vm = NewSessionViewModel(client: client, idFactory: { "fixed" })
+
+    await vm.launch(intent: "Dispatch through the live mobile owner gate.")
+
+    let request = try XCTUnwrap(client.requests.first)
+    XCTAssertEqual(request.ownerPrincipal, liveAgentRunOwnerPrincipal)
+  }
+
   func testLaunchSubmitsGovernedMissionIntake() async throws {
     let client = FakeMissionClient(result: MissionIntakeResultWire(
       fridayConversationId: "fconv_mobile_new_session_fixed",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/SessionContinuationViewModelTests.swift
@@ -760,16 +760,37 @@ final class SessionContinuationViewModelTests: XCTestCase {
     })
   }
 
-  func testRefreshWithoutSessionRefFailsClosedWithoutReading() async {
+  func testRefreshWithRunOnlyLoadsMissionRunContinuationWithoutSessionReads() async {
     let client = FakeSessionReadClient()
     let vm = SessionContinuationViewModel(client: client)
 
     await vm.refresh(agentSessionId: nil, runId: "run-1")
 
+    guard case .loaded(let snapshot) = vm.state else {
+      return XCTFail("expected loaded run-only continuation, got \(vm.state)")
+    }
+    XCTAssertNil(snapshot.agentSessionId)
+    XCTAssertEqual(snapshot.runId, "run-1")
+    XCTAssertEqual(Set(client.requests), [
+      "run-readback:run-1",
+      "run-files:run-1",
+      "needs-me:run-1",
+    ])
+    XCTAssertEqual(snapshot.sections.map(\.id), ["mission-run", "run-files", "run-readback", "needs-me"])
+    XCTAssertEqual(snapshot.sections.first?.refs, ["friday://agent-run/run-1"])
+    XCTAssertEqual(snapshot.controls.first { $0.id == "send" }?.truthLabel, "NO-GO")
+  }
+
+  func testRefreshWithoutSessionOrRunRefFailsClosedWithoutReading() async {
+    let client = FakeSessionReadClient()
+    let vm = SessionContinuationViewModel(client: client)
+
+    await vm.refresh(agentSessionId: nil, runId: nil)
+
     guard case .unavailable(let reason) = vm.state else {
       return XCTFail("expected unavailable, got \(vm.state)")
     }
-    XCTAssertTrue(reason.contains("agent session ref"))
+    XCTAssertTrue(reason.contains("session ref or a run ref"))
     XCTAssertTrue(client.requests.isEmpty)
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/VoiceReadinessViewModelTests.swift
@@ -105,6 +105,25 @@ final class VoiceReadinessViewModelTests: XCTestCase {
     XCTAssertEqual(initialRows.first { $0.id == "open-chat-loop" }?.truthLabel, "blocked")
     XCTAssertEqual(initialRows.first { $0.id == "open-chat-loop" }?.enabled, false)
 
+    let routeOnly = MobileVoiceReadiness(
+      microphone: .notDetermined,
+      speechRecognition: .notDetermined,
+      ttsProviderConfigured: true,
+      truthLabel: "voice_readiness_timeout_chat_route")
+    let routeRows = VoiceReadinessViewModel.actionRows(for: routeOnly)
+    XCTAssertEqual(routeRows.first { $0.id == "realtime-loop" }?.truthLabel, "blocked")
+    XCTAssertEqual(routeRows.first { $0.id == "realtime-loop" }?.enabled, false)
+    XCTAssertEqual(routeRows.first { $0.id == "open-chat-loop" }?.truthLabel, "native_voice_chat_route_available")
+    XCTAssertEqual(routeRows.first { $0.id == "open-chat-loop" }?.enabled, true)
+
+    let disabledRoute = MobileVoiceReadiness(
+      microphone: .notDetermined,
+      speechRecognition: .notDetermined,
+      ttsProviderConfigured: false)
+    let disabledRouteRows = VoiceReadinessViewModel.actionRows(for: disabledRoute)
+    XCTAssertEqual(disabledRouteRows.first { $0.id == "open-chat-loop" }?.truthLabel, "blocked")
+    XCTAssertEqual(disabledRouteRows.first { $0.id == "open-chat-loop" }?.enabled, false)
+
     let captureOnly = MobileVoiceReadiness(
       microphone: .authorized,
       speechRecognition: .authorized,

--- a/apps/friday-ios/UITests/FridayIOSAXObserverUITests.swift
+++ b/apps/friday-ios/UITests/FridayIOSAXObserverUITests.swift
@@ -99,7 +99,9 @@ final class FridayIOSAXObserverUITests: XCTestCase {
       if permission.exists {
         permission.tap()
       }
-      try waitFor(app, identifier: "friday.voice.open-chat-loop", timeout: 10)
+      try tap(app, identifier: "friday.voice.open-chat-loop")
+      try waitFor(app, identifier: "friday.chat.voice-input", timeout: 10)
+      try tap(app, identifier: "friday.chat.voice-output")
     case "settings-push-permission":
       try tap(app, identifier: "friday.settings.push-permission")
       try waitFor(app, identifier: "friday.settings.push-notifications-card", timeout: 10)

--- a/apps/friday-ios/UITests/FridayIOSAXObserverUITests.swift
+++ b/apps/friday-ios/UITests/FridayIOSAXObserverUITests.swift
@@ -111,6 +111,9 @@ final class FridayIOSAXObserverUITests: XCTestCase {
       try type(text, into: app, identifier: "friday.home.pairing-qr-input")
       try tap(app, identifier: "friday.home.pair-button")
       try waitFor(app, identifier: "friday.home.pairing-cancel-button", timeout: 10)
+    case "session-sidecar-open":
+      try tap(app, identifier: "friday.session.sidecar-open")
+      try waitFor(app, identifier: "friday.session.sidecar-close", timeout: 10)
     default:
       XCTFail("Unsupported Friday iOS AX interaction scenario: \(scenario)")
     }

--- a/apps/friday-ios/UITests/FridayIOSAXObserverUITests.swift
+++ b/apps/friday-ios/UITests/FridayIOSAXObserverUITests.swift
@@ -1,10 +1,28 @@
 import XCTest
 
 final class FridayIOSAXObserverUITests: XCTestCase {
+  private struct InteractionRequest: Decodable {
+    let scenario: String?
+    let text: String?
+    let url: String?
+    let appLaunchArgs: [String]?
+    let appLaunchEnv: [String: String]?
+    let masterKeyFile: String?
+  }
+
   func testDumpFridayAccessibilityTree() throws {
     let app = XCUIApplication(bundleIdentifier: "com.friday.shell")
-    app.activate()
+    let request = try interactionRequest()
+    if request?.appLaunchArgs?.isEmpty != false,
+      ProcessInfo.processInfo.environment["FRIDAY_IOS_AX_ATTACH_RUNNING_APP"] == "1" {
+      app.activate()
+    } else {
+      configureAppLaunch(app, request: request)
+      app.launch()
+    }
     XCTAssertTrue(app.wait(for: .runningForeground, timeout: 10), "Friday iOS shell did not become foreground for AX observation")
+
+    try performRequestedInteraction(in: app, request: request)
 
     let tree = app.debugDescription
     XCTAssertFalse(tree.isEmpty, "Friday iOS shell AX tree was empty")
@@ -12,5 +30,126 @@ final class FridayIOSAXObserverUITests: XCTestCase {
     print("FRIDAY_AX_DESC_BEGIN")
     print(tree)
     print("FRIDAY_AX_DESC_END")
+  }
+
+  private func configureAppLaunch(_ app: XCUIApplication, request: InteractionRequest?) {
+    let env = ProcessInfo.processInfo.environment
+    if let appLaunchArgs = request?.appLaunchArgs {
+      app.launchArguments = appLaunchArgs
+    } else if let rawArgs = env["FRIDAY_IOS_AX_APP_LAUNCH_ARGS_JSON"],
+      let data = rawArgs.data(using: .utf8),
+      let decoded = try? JSONDecoder().decode([String].self, from: data) {
+      app.launchArguments = decoded
+    } else if let rawArgs = env["FRIDAY_IOS_AX_APP_LAUNCH_ARGS"] {
+      app.launchArguments = rawArgs
+        .split(separator: "\u{1f}")
+        .map(String.init)
+        .filter { !$0.isEmpty }
+    }
+
+    if let appLaunchEnv = request?.appLaunchEnv {
+      app.launchEnvironment = appLaunchEnv
+    } else if let rawEnv = env["FRIDAY_IOS_AX_APP_ENV_JSON"],
+      let data = rawEnv.data(using: .utf8),
+      let decoded = try? JSONDecoder().decode([String: String].self, from: data) {
+      app.launchEnvironment = decoded
+    }
+
+    if let masterKey = env["FRIDAY_MASTER_KEY"], !masterKey.isEmpty {
+      app.launchEnvironment["FRIDAY_MASTER_KEY"] = masterKey
+    } else if let masterKeyFile = request?.masterKeyFile,
+      let masterKey = try? String(contentsOfFile: masterKeyFile, encoding: .utf8)
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+      !masterKey.isEmpty {
+      app.launchEnvironment["FRIDAY_MASTER_KEY"] = masterKey
+    }
+    let hasInitialDestination = app.launchArguments.contains { $0.hasPrefix("--initial-destination") }
+    print(
+      "FRIDAY_AX_LAUNCH_CONFIG scenario=\(request?.scenario ?? "<nil>") "
+        + "args=\(app.launchArguments.count) initialDestination=\(hasInitialDestination) "
+        + "envKeys=\(app.launchEnvironment.keys.sorted().joined(separator: ","))")
+  }
+
+  private func performRequestedInteraction(in app: XCUIApplication, request: InteractionRequest?) throws {
+    let env = ProcessInfo.processInfo.environment
+    let scenario = request == nil
+      ? (env["FRIDAY_IOS_AX_INTERACTION_SCENARIO"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "")
+      : (request?.scenario?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "")
+    guard !scenario.isEmpty else { return }
+
+    let text = request?.text ?? env["FRIDAY_IOS_AX_INTERACTION_TEXT"] ?? "Friday UI live interaction proof"
+    let url = request?.url ?? env["FRIDAY_IOS_AX_INTERACTION_URL"] ?? "https://example.com/friday-ui-proof"
+
+    switch scenario {
+    case "missions-dispatch":
+      try type(text, into: app, identifier: "friday.missions.dispatch-input")
+      try tap(app, identifier: "friday.missions.dispatch-button")
+      try waitFor(app, identifier: "friday.missions.open-chat-loop", timeout: 30)
+    case "share-submit":
+      try type(url, into: app, identifier: "friday.share.url")
+      try type(text, into: app, identifier: "friday.share.text")
+      try tap(app, identifier: "friday.share.submit")
+      try waitFor(app, identifier: "friday.share.open-chat-loop", timeout: 30)
+    case "new-session-launch":
+      try type(text, into: app, identifier: "friday.new-session.intent-input")
+      try tap(app, identifier: "friday.new-session.launch-button")
+      try waitFor(app, identifier: "friday.new-session.open-chat-loop", timeout: 30)
+    case "voice-open-chat":
+      let permission = firstExistingElement(in: app, identifier: "friday.voice.permission", timeout: 3)
+      if permission.exists {
+        permission.tap()
+      }
+      try waitFor(app, identifier: "friday.voice.open-chat-loop", timeout: 10)
+    case "settings-push-permission":
+      try tap(app, identifier: "friday.settings.push-permission")
+      try waitFor(app, identifier: "friday.settings.push-notifications-card", timeout: 10)
+    default:
+      XCTFail("Unsupported Friday iOS AX interaction scenario: \(scenario)")
+    }
+  }
+
+  private func interactionRequest() throws -> InteractionRequest? {
+    let env = ProcessInfo.processInfo.environment
+    let path = env["FRIDAY_IOS_AX_INTERACTION_FILE"] ?? "/tmp/friday-ios-ax-interaction-current.json"
+    guard FileManager.default.fileExists(atPath: path) else { return nil }
+    let data = try Data(contentsOf: URL(fileURLWithPath: path))
+    return try JSONDecoder().decode(InteractionRequest.self, from: data)
+  }
+
+  private func type(_ text: String, into app: XCUIApplication, identifier: String) throws {
+    let field = firstExistingElement(in: app, identifier: identifier, timeout: 10)
+    XCTAssertTrue(field.exists, "Missing field \(identifier)")
+    field.tap()
+    field.typeText(text)
+  }
+
+  private func tap(_ app: XCUIApplication, identifier: String) throws {
+    let element = firstExistingElement(in: app, identifier: identifier, timeout: 10)
+    XCTAssertTrue(element.exists, "Missing tappable element \(identifier)")
+    XCTAssertTrue(element.isEnabled, "Tappable element \(identifier) is disabled")
+    element.tap()
+  }
+
+  private func waitFor(_ app: XCUIApplication, identifier: String, timeout: TimeInterval) throws {
+    let element = firstExistingElement(in: app, identifier: identifier, timeout: timeout)
+    XCTAssertTrue(element.exists, "Timed out waiting for \(identifier)")
+  }
+
+  private func firstExistingElement(in app: XCUIApplication, identifier: String, timeout: TimeInterval) -> XCUIElement {
+    let candidates = [
+      app.buttons.matching(identifier: identifier).firstMatch,
+      app.textFields.matching(identifier: identifier).firstMatch,
+      app.textViews.matching(identifier: identifier).firstMatch,
+      app.staticTexts.matching(identifier: identifier).firstMatch,
+      app.otherElements.matching(identifier: identifier).firstMatch,
+    ]
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if let found = candidates.first(where: { $0.exists }) {
+        return found
+      }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+    }
+    return candidates[0]
   }
 }

--- a/apps/friday-ios/UITests/FridayIOSAXObserverUITests.swift
+++ b/apps/friday-ios/UITests/FridayIOSAXObserverUITests.swift
@@ -103,6 +103,14 @@ final class FridayIOSAXObserverUITests: XCTestCase {
     case "settings-push-permission":
       try tap(app, identifier: "friday.settings.push-permission")
       try waitFor(app, identifier: "friday.settings.push-notifications-card", timeout: 10)
+    case "pairing-retry":
+      try type(text, into: app, identifier: "friday.home.pairing-qr-input")
+      try tap(app, identifier: "friday.home.pair-button")
+      try waitFor(app, identifier: "friday.home.pairing-retry-button", timeout: 10)
+    case "pairing-cancel":
+      try type(text, into: app, identifier: "friday.home.pairing-qr-input")
+      try tap(app, identifier: "friday.home.pair-button")
+      try waitFor(app, identifier: "friday.home.pairing-cancel-button", timeout: 10)
     default:
       XCTFail("Unsupported Friday iOS AX interaction scenario: \(scenario)")
     }

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -991,6 +991,7 @@ struct DesktopProjectionScreen: View {
                 }
                 if item.canCancel {
                   StatusChip(text: "cancel available", bg: HubTheme.chipNeutralBG, fg: HubTheme.chipNeutralFG)
+                    .accessibilityIdentifier("friday.desktop.recovery.cancel-available")
                 }
               }
               if let proofRef = item.proofRef {

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -580,6 +580,7 @@ struct DesktopProjectionScreen: View {
           }
         }
       }
+      .accessibilityIdentifier("friday.desktop.provider-route-decision-card")
       refsCard(
         title: "Receipt Parity",
         refs: snapshot.providerReceiptRefs + snapshot.channelReceiptRefs)

--- a/scripts/ops/friday-ios-sim-xcui-observation.mjs
+++ b/scripts/ops/friday-ios-sim-xcui-observation.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -14,15 +14,20 @@ function usage() {
     [--repo-root=/abs/repo] [--bundle-id=com.friday.shell]
     [--xcode-destination='platform=iOS Simulator,name=iPhone 17 Pro']
     [--destinations=home,fridayChat,...] [--timeout-seconds=90]
+    [--live-loopback] [--live-device-peer]
+    [--interaction-scenarios=missions=missions-dispatch,shareIntake=share-submit]
+    [--interaction-text='...'] [--interaction-url='https://...']
     [--normalize] [--require-observed] [--require-all-planned]
 
 Truth:
   Runs the checked-in Xcode UI-test bundle against an installed real iOS
   Simulator Friday app, captures XCUIApplication.debugDescription, and converts
   only observed accessibility identifiers into the real observation JSON consumed
-  by friday-ios-sim-accessibility-capture.mjs. It does not infer truth from
-  screenshots or static Swift source, does not click governed actions, and is
-  not END-BAR/adoption proof.`);
+  by friday-ios-sim-accessibility-capture.mjs. By default it only observes. When
+  --interaction-scenarios is supplied, it performs only the named explicit UI
+  interactions and waits for the resulting receipt identifiers. It does not infer
+  truth from screenshots or static Swift source, does not click unknown governed
+  actions, and is not END-BAR/adoption proof.`);
 }
 
 function arg(name) {
@@ -50,6 +55,15 @@ const destinations = (arg("destinations") || process.env.FRIDAY_IOS_XCUI_OBSERVA
   .map((value) => value.trim())
   .filter(Boolean);
 const timeoutSeconds = Number(arg("timeout-seconds") || process.env.FRIDAY_IOS_XCUI_OBSERVATION_TIMEOUT_SECONDS || "90");
+const liveLoopback = args.includes("--live-loopback") || process.env.FRIDAY_IOS_XCUI_LIVE_LOOPBACK === "1";
+const liveDevicePeer = args.includes("--live-device-peer") || process.env.FRIDAY_IOS_XCUI_LIVE_DEVICE_PEER === "1";
+const interactionScenarioCsv = arg("interaction-scenarios") || process.env.FRIDAY_IOS_XCUI_INTERACTION_SCENARIOS || "";
+const interactionText = arg("interaction-text") || process.env.FRIDAY_IOS_XCUI_INTERACTION_TEXT || "Friday UI live interaction proof";
+const interactionUrl = arg("interaction-url") || process.env.FRIDAY_IOS_XCUI_INTERACTION_URL || "https://example.com/friday-ui-proof";
+const interactionFilePath = arg("interaction-file")
+  || process.env.FRIDAY_IOS_AX_INTERACTION_FILE
+  || (outDir ? resolve(outDir, "ios-xcui-interaction-request.json") : "/tmp/friday-ios-ax-interaction-current.json");
+const attachRunning = args.includes("--attach-running") || process.env.FRIDAY_IOS_XCUI_ATTACH_RUNNING_APP === "1";
 const normalize = args.includes("--normalize");
 const requireObserved = args.includes("--require-observed");
 const requireAllPlanned = args.includes("--require-all-planned");
@@ -66,6 +80,29 @@ function run(command, commandArgs, options = {}) {
     encoding: "utf8",
     ...options,
   });
+}
+
+function parseInteractionScenarios(value) {
+  const map = new Map();
+  for (const raw of String(value || "").split(",")) {
+    const item = raw.trim();
+    if (!item) continue;
+    const [destination, scenario] = item.split("=").map((part) => part?.trim() || "");
+    if (!destination || !scenario) {
+      block("interaction_scenario_invalid", item);
+      continue;
+    }
+    if (!/^[A-Za-z][A-Za-z0-9]*$/.test(destination)) {
+      block("interaction_destination_invalid", destination);
+      continue;
+    }
+    if (!/^[a-z][a-z0-9-]*$/.test(scenario)) {
+      block("interaction_scenario_name_invalid", scenario);
+      continue;
+    }
+    map.set(destination, scenario);
+  }
+  return map;
 }
 
 function jsonOut(path, value) {
@@ -165,15 +202,109 @@ function readPlan(destination) {
   return Array.isArray(summary?.targets) ? summary.targets : [];
 }
 
+function mobileLaunchEnv() {
+  const env = {};
+  if (!liveLoopback) return env;
+  env.SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ = "1";
+  env.SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE = "1";
+  env.SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_PAIRING = "1";
+  if (!liveDevicePeer) {
+    env.SIMCTL_CHILD_FRIDAY_MOBILE_DISABLE_PRODUCT_LIVE_LOOPBACK = "1";
+  }
+  if (liveDevicePeer) {
+    env.SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR = "1";
+    env.SIMCTL_CHILD_FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR = "1";
+  }
+  if (process.env.FRIDAY_MOBILE_LIVE_READ_HOST) env.SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ_HOST = process.env.FRIDAY_MOBILE_LIVE_READ_HOST;
+  if (process.env.FRIDAY_MOBILE_LIVE_READ_PORT) env.SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_READ_PORT = process.env.FRIDAY_MOBILE_LIVE_READ_PORT;
+  if (process.env.FRIDAY_MOBILE_LIVE_WRITE_HOST) env.SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_HOST = process.env.FRIDAY_MOBILE_LIVE_WRITE_HOST;
+  if (process.env.FRIDAY_MOBILE_LIVE_WRITE_PORT) env.SIMCTL_CHILD_FRIDAY_MOBILE_LIVE_WRITE_PORT = process.env.FRIDAY_MOBILE_LIVE_WRITE_PORT;
+  if (process.env.FRIDAY_MASTER_KEY) env.SIMCTL_CHILD_FRIDAY_MASTER_KEY = process.env.FRIDAY_MASTER_KEY;
+  if (missionId) env.SIMCTL_CHILD_FRIDAY_MOBILE_MISSION_ID = missionId;
+  return env;
+}
+
+function appLaunchEnv() {
+  const env = {};
+  if (!liveLoopback) return env;
+  env.FRIDAY_MOBILE_LIVE_READ = "1";
+  env.FRIDAY_MOBILE_LIVE_WRITE = "1";
+  env.FRIDAY_MOBILE_LIVE_PAIRING = "1";
+  if (!liveDevicePeer) {
+    env.FRIDAY_MOBILE_DISABLE_PRODUCT_LIVE_LOOPBACK = "1";
+  }
+  if (liveDevicePeer) {
+    env.FRIDAY_MOBILE_LIVE_DEVICE_KEYPAIR = "1";
+    env.FRIDAY_MOBILE_SIMULATOR_FILE_DEVICE_KEYPAIR = "1";
+  }
+  if (process.env.FRIDAY_MOBILE_LIVE_READ_HOST) env.FRIDAY_MOBILE_LIVE_READ_HOST = process.env.FRIDAY_MOBILE_LIVE_READ_HOST;
+  if (process.env.FRIDAY_MOBILE_LIVE_READ_PORT) env.FRIDAY_MOBILE_LIVE_READ_PORT = process.env.FRIDAY_MOBILE_LIVE_READ_PORT;
+  if (process.env.FRIDAY_MOBILE_LIVE_WRITE_HOST) env.FRIDAY_MOBILE_LIVE_WRITE_HOST = process.env.FRIDAY_MOBILE_LIVE_WRITE_HOST;
+  if (process.env.FRIDAY_MOBILE_LIVE_WRITE_PORT) env.FRIDAY_MOBILE_LIVE_WRITE_PORT = process.env.FRIDAY_MOBILE_LIVE_WRITE_PORT;
+  if (process.env.FRIDAY_MASTER_KEY) env.FRIDAY_MASTER_KEY = process.env.FRIDAY_MASTER_KEY;
+  if (missionId) env.FRIDAY_MOBILE_MISSION_ID = missionId;
+  return env;
+}
+
+function appLaunchEnvForRequestFile() {
+  const env = appLaunchEnv();
+  delete env.FRIDAY_MASTER_KEY;
+  return env;
+}
+
+function appLaunchArgs(destination) {
+  const launchArgs = [];
+  if (liveLoopback) {
+    launchArgs.push(
+      "--live-read",
+      "--live-write",
+      "--live-pairing",
+      `--mission-id=${missionId}`,
+    );
+    if (!liveDevicePeer) {
+      launchArgs.push("--disable-product-live-loopback");
+    }
+    if (liveDevicePeer) {
+      launchArgs.push("--live-device-keypair", "--simulator-file-device-keypair");
+    }
+    if (process.env.FRIDAY_MOBILE_LIVE_READ_HOST) launchArgs.push("--live-read-host", process.env.FRIDAY_MOBILE_LIVE_READ_HOST);
+    if (process.env.FRIDAY_MOBILE_LIVE_READ_PORT) launchArgs.push("--live-read-port", process.env.FRIDAY_MOBILE_LIVE_READ_PORT);
+    if (process.env.FRIDAY_MOBILE_LIVE_WRITE_HOST) launchArgs.push("--live-write-host", process.env.FRIDAY_MOBILE_LIVE_WRITE_HOST);
+    if (process.env.FRIDAY_MOBILE_LIVE_WRITE_PORT) launchArgs.push("--live-write-port", process.env.FRIDAY_MOBILE_LIVE_WRITE_PORT);
+  }
+  launchArgs.push(`--initial-destination=${destination}`);
+  return launchArgs;
+}
+
+function writeMasterKeyFile() {
+  const value = process.env.FRIDAY_MASTER_KEY || "";
+  if (!liveLoopback || !value.trim() || !outDir) return null;
+  const file = resolve(outDir, "ios-xcui-master-key.env");
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `${value.trim()}\n`, { encoding: "utf8", mode: 0o600 });
+  chmodSync(file, 0o600);
+  return file;
+}
+
 function launchDestination(simulator, destination) {
+  if (!attachRunning) {
+    run("xcrun", ["simctl", "terminate", simulator.udid, bundleId]);
+    return `xctest-launch:${destination}`;
+  }
   const launch = run("xcrun", [
     "simctl",
     "launch",
     "--terminate-running-process",
     simulator.udid,
     bundleId,
-    `--initial-destination=${destination}`,
-  ]);
+    ...appLaunchArgs(destination),
+  ], {
+    env: {
+      ...process.env,
+      ...mobileLaunchEnv(),
+      SIMCTL_CHILD_FRIDAY_MOBILE_INITIAL_DESTINATION: destination,
+    },
+  });
   if (launch.status !== 0) {
     block("app_launch_failed", launch.stderr.trim() || launch.stdout.trim() || `${bundleId}:${destination}`);
     return null;
@@ -186,7 +317,33 @@ function extractAxTree(log) {
   return match?.[1] || "";
 }
 
-function runXcui(destination) {
+function writeInteractionFile(destination, scenario) {
+  const path = interactionFilePath;
+  if (!scenario && !liveLoopback) {
+    rmSync(path, { force: true });
+    return "";
+  }
+  const payload = {
+    destination,
+    scenario: scenario || null,
+    text: interactionText,
+    url: interactionUrl,
+    appLaunchArgs: appLaunchArgs(destination),
+    appLaunchEnv: appLaunchEnvForRequestFile(),
+    masterKeyFile: writeMasterKeyFile(),
+    generated_at_utc: new Date().toISOString(),
+    truth: "ios_xcui_explicit_interaction_request_not_proof",
+  };
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
+  if (path !== "/tmp/friday-ios-ax-interaction-current.json") {
+    writeFileSync("/tmp/friday-ios-ax-interaction-current.json", `${JSON.stringify(payload, null, 2)}\n`);
+  }
+  return path;
+}
+
+function runXcui(destination, scenario) {
+  const interactionFile = writeInteractionFile(destination, scenario);
   const project = resolve(repoRoot, "apps/friday-ios/UITests/FridayIOSAXObserver.xcodeproj");
   const result = run("xcodebuild", [
     "-project",
@@ -199,6 +356,19 @@ function runXcui(destination) {
     "-skipMacroValidation",
     "test",
   ], {
+    env: {
+      ...process.env,
+      ...(scenario ? {
+        FRIDAY_IOS_AX_INTERACTION_SCENARIO: scenario,
+        FRIDAY_IOS_AX_INTERACTION_TEXT: interactionText,
+        FRIDAY_IOS_AX_INTERACTION_URL: interactionUrl,
+        FRIDAY_IOS_AX_INTERACTION_FILE: interactionFile || interactionFilePath,
+      } : {}),
+      FRIDAY_IOS_AX_APP_LAUNCH_ARGS_JSON: JSON.stringify(appLaunchArgs(destination)),
+      FRIDAY_IOS_AX_APP_ENV_JSON: JSON.stringify(appLaunchEnv()),
+      FRIDAY_IOS_AX_INTERACTION_FILE: interactionFile || interactionFilePath,
+      ...(attachRunning ? { FRIDAY_IOS_AX_ATTACH_RUNNING_APP: "1" } : {}),
+    },
     timeout: Math.max(timeoutSeconds * 1000, 30_000),
   });
   const log = `${result.stdout || ""}${result.stderr || ""}`;
@@ -209,7 +379,7 @@ function runXcui(destination) {
   if (result.status !== 0) block("xcodebuild_ui_test_failed", `${destination}:${result.status}:${logPath}`);
   if (!tree.trim()) block("accessibility_tree_missing", `${destination}:${logPath}`);
   if (tree.trim()) writeFileSync(treePath, `${tree}\n`);
-  return { logPath, treePath, tree, status: result.status };
+  return { logPath, treePath, tree, status: result.status, interactionFile };
 }
 
 function observedRows(destination, targets, tree, treePath) {
@@ -252,6 +422,7 @@ const allTargets = [];
 const observations = [];
 const missingByDestination = {};
 const xcodeRuns = [];
+const interactionScenarios = parseInteractionScenarios(interactionScenarioCsv);
 
 if (blockers.length === 0) {
   mkdirSync(outDir, { recursive: true });
@@ -270,9 +441,12 @@ if (blockers.length === 0 && simulator) {
     if (blockers.length > 0) break;
     const launchStdout = launchDestination(simulator, destination);
     if (blockers.length > 0) break;
-    const runResult = runXcui(destination);
+    const scenario = interactionScenarios.get(destination) || "";
+    const runResult = runXcui(destination, scenario);
     xcodeRuns.push({
       destination,
+      interaction_scenario: scenario || null,
+      interaction_file: runResult.interactionFile || null,
       launch_stdout: launchStdout,
       status: runResult.status,
       log_path: runResult.logPath,
@@ -356,6 +530,8 @@ const summary = {
   missionId: missionId || null,
   simulator,
   bundle_id: bundleId,
+  live_loopback_requested: liveLoopback,
+  live_device_peer_requested: liveDevicePeer,
   data_container: dataContainer,
   target_count: allTargets.length,
   observed_count: observations.length,
@@ -371,8 +547,9 @@ const summary = {
   blockers,
   caveats: [
     "This is real XCUITest accessibility observation against an installed Simulator app, not a screenshot or static source proof.",
+    "When interaction_scenario is non-null, the checked-in UI test typed/tapped only that explicit scenario and waited for the resulting receipt identifier.",
     "It only proves identifiers visible on the launched destinations; product END-BAR still needs the broader same-run mobile+desktop proof bundle.",
-    "The UI test does not click governed actions or provide operator signatures.",
+    "The UI test never provides operator signatures.",
   ],
 };
 if (outDir && isAbsolute(outDir)) jsonOut(resolve(outDir, "ios-xcui-observation-summary.json"), summary);

--- a/test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts
+++ b/test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts
@@ -45,7 +45,13 @@ exit 64
   writeFileSync(xcodebuild, `#!/usr/bin/env bash
 set -euo pipefail
 echo "Test Suite 'FridayIOSAXObserverUITests' started"
-${tree ? `echo "FRIDAY_AX_DESC_BEGIN"\nprintf '%b\\n' "${tree.replace(/"/g, "\\\"")}"\necho "FRIDAY_AX_DESC_END"` : "echo 'no tree emitted'"}
+if [ "\${FRIDAY_IOS_AX_INTERACTION_SCENARIO:-}" = "missions-dispatch" ]; then
+  echo "FRIDAY_AX_DESC_BEGIN"
+  printf '%b\\n' "Application, 0x1, identifier: 'com.friday.shell'\\n  TextField, 0x2, identifier: 'friday.missions.dispatch-input', label: 'What should Friday do next?'\\n  Button, 0x3, identifier: 'friday.missions.open-chat-loop', label: 'Continue in Friday Chat'"
+  echo "FRIDAY_AX_DESC_END"
+else
+  ${tree ? `echo "FRIDAY_AX_DESC_BEGIN"\nprintf '%b\\n' "${tree.replace(/"/g, "\\\"")}"\necho "FRIDAY_AX_DESC_END"` : "echo 'no tree emitted'"}
+fi
 echo "Test Suite 'FridayIOSAXObserverUITests' passed"
 `);
   chmodSync(xcodebuild, 0o755);
@@ -145,6 +151,47 @@ describe("friday-ios-sim-xcui-observation", () => {
       expect(result.status).toBe(2);
       const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
       expect(output.blockers?.map((blocker) => blocker.code)).toContain("planned_actions_missing");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes explicit interaction scenario env through and captures the resulting receipt identifier", async () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ios-xcui-observation-interaction-"));
+    try {
+      const binDir = join(root, "bin");
+      const outDir = join(root, "out");
+      await writeFakeTools(binDir);
+      const stdout = execFileSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        "--destinations=missions",
+        "--interaction-scenarios=missions=missions-dispatch",
+        "--interaction-text=prove mission dispatch",
+        "--live-loopback",
+        "--normalize",
+        "--require-observed",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      });
+      const output = JSON.parse(stdout) as {
+        live_loopback_requested?: boolean;
+        xcode_runs?: Array<{ interaction_scenario?: string | null }>;
+        outputs?: { observation?: string; normalized?: string };
+      };
+      expect(output.live_loopback_requested).toBe(true);
+      expect(output.xcode_runs?.[0]?.interaction_scenario).toBe("missions-dispatch");
+
+      const observation = JSON.parse(readFileSync(output.outputs?.observation || "", "utf8")) as {
+        observations?: Array<{ runtimeActionId?: string; accessibility_id?: string }>;
+      };
+      expect(observation.observations).toContainEqual(expect.objectContaining({
+        runtimeActionId: "mobile/missions/open-chat-loop",
+        accessibility_id: "friday.missions.open-chat-loop",
+      }));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- make the iOS XCUITest observer launch the current app with explicit per-destination interaction requests instead of relying on a stale already-running simulator app
- prove live-loopback iOS product interactions for Missions, Share Intake, New Session, and Settings through real XCUITest taps and current-head accessibility trees
- align default mobile mission-intake owner with the live write principal so current iOS dispatch reaches the Hub instead of failing owner auth
- move several SwiftUI accessibility identifiers from broad containers to specific labels/buttons so proof runners and real assistive tech can see the actionable controls
- add a desktop provider route-decision card accessibility id used by the parity proof

## Proof
- `node --check scripts/ops/friday-ios-sim-xcui-observation.mjs`
- `npx vitest run test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts`
- `swift test --package-path apps/friday-ios --filter NewSessionViewModelTests`
- `swift test --package-path apps/macos/FridayHubConsole --filter DesktopProductReadinessContractTests`
- iOS Missions live proof: `/private/tmp/friday-ios-xcui-c6c-live-missions-interaction-axfix-currentapp-20260630T1330/ios-xcui-observation-summary.json`
- iOS Share/New Session live proof: `/private/tmp/friday-ios-xcui-c6c-live-share-newsession-axfix-20260630T1330/ios-xcui-observation-summary.json`
- iOS Settings live proof: `/private/tmp/friday-ios-xcui-c6c-live-settings-serial-20260630T1330/ios-xcui-observation-summary.json`
- Accumulated product happy-path gate: `/private/tmp/friday-product-happy-path-c6c-accumulated-mobile-live-proof-20260630T1330.json`

## Truth / Residuals
- This is not END-BAR and not public adoption.
- Accumulated product happy-path remains `product_happy_path_not_ready` with 8 residual blockers: mobile Session signature/runtime, mobile Token Ledger, mobile Voice, mobile Pairing, mobile Needs Me signature, mobile Workflows, desktop Recovery.
- Voice was intentionally not counted as satisfied: after the proof runner tapped permission, the app remained in `Checking voice readiness`; no fake voice/microphone proof was minted.
- No operator signing key or secret artifact is committed.
