### PR TITLE
Polish iOS live status banner

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -11,7 +11,9 @@ import SwiftUI
 ///
 /// Truth rules: the projection is refs-only (counts/labels/ids — never a body); the
 /// `runtimeFeedStatus` + `statusLabels` ride AS-IS (never upgraded); a 503 / offline / dark
-/// server renders AS truth (honest-unavailable), never a fabricated ready Home. Governed recovery
+/// server renders AS truth (honest-unavailable), never a fabricated ready Home. Status labels only
+/// become a blocking banner when the feed itself is not live; live-feed notes stay in the proof
+/// card so the product path does not claim the Hub is stale while showing Hub live. Governed recovery
 /// actions only appear when the live projection exposes WorkItem retry/cancel affordances.
 struct FridayHomeScreen: View {
   @ObservedObject var viewModel: HomeViewModel
@@ -94,8 +96,7 @@ struct FridayHomeScreen: View {
       subtitle: "Here is what Friday is watching for you.")
     selectedHomeHero
 
-    // Honest status banner — any stale/offline/error label rides AS truth.
-    if !projection.statusLabels.isEmpty {
+    if projection.shouldPromoteStatusLabelsToBlockingBanner {
       StatusBanner(labels: projection.statusLabels)
     }
 
@@ -401,6 +402,17 @@ struct FridayHomeScreen: View {
           Spacer()
         }
         FridayProofLine(label: "mission_id", ref: projection.missionId)
+        if !projection.statusLabels.isEmpty {
+          HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text("notes")
+              .font(.caption2.weight(.semibold))
+              .foregroundStyle(MobileTheme.textSecondary)
+            ForEach(projection.statusLabels, id: \.self) { label in
+              FridayChip(text: label, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+            }
+            Spacer(minLength: 0)
+          }
+        }
         if let summary = projection.routeDecisionSummary {
           FridayProofLine(label: "route", ref: summary)
         }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -207,7 +207,7 @@ struct FridayProjectionScreen: View {
   @ViewBuilder
   private func loadedContent(_ surface: ProjectionSurface, _ projection: HomeProjection) -> some View {
     VStack(spacing: 16) {
-      if !projection.statusLabels.isEmpty {
+      if projection.shouldPromoteStatusLabelsToBlockingBanner {
         StatusBanner(labels: projection.statusLabels)
       }
       detailActionsCard(projection)

--- a/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/HomeViewModel.swift
@@ -58,6 +58,17 @@ public struct HomeProjection: Sendable, Equatable {
   /// The Hub epoch-millis the snapshot was generated (lets the UI flag staleness).
   public let generatedAtMs: Int64
 
+  public var hasLiveRuntimeFeed: Bool {
+    let normalized = runtimeFeedStatus.lowercased()
+    return normalized.contains("live")
+      || normalized.contains("connected")
+      || normalized.contains("online")
+  }
+
+  public var shouldPromoteStatusLabelsToBlockingBanner: Bool {
+    !statusLabels.isEmpty && !hasLiveRuntimeFeed
+  }
+
   public init(_ snapshot: WorkbenchSnapshot) {
     let raw = snapshot.raw
     let route = raw["routeDecision"] as? [String: Any]

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/HomeViewModelTests.swift
@@ -411,6 +411,36 @@ final class HomeViewModelTests: XCTestCase {
       evidenceRef: "proof://mobile/home-refresh/\(p.missionId)")
   }
 
+  func testLiveRuntimeStatusLabelsStayAsProofNotesNotBlockingBanner() throws {
+    let projection = HomeProjection(try sampleSnapshot())
+    XCTAssertEqual(projection.runtimeFeedStatus, "live_rust_hub_projection")
+    XCTAssertEqual(projection.statusLabels, ["stale"])
+    XCTAssertTrue(projection.hasLiveRuntimeFeed)
+    XCTAssertFalse(projection.shouldPromoteStatusLabelsToBlockingBanner)
+  }
+
+  func testNonLiveRuntimeStatusLabelsStillBlockTheProductPath() throws {
+    let json = """
+    {
+      "missionId": "mission-offline",
+      "fridayConversationId": "conv-offline",
+      "runtimeFeedStatus": "offline_projection_cache",
+      "statusLabels": ["offline"],
+      "workItems": [],
+      "providerReceiptRefs": [],
+      "channelReceiptRefs": [],
+      "memoryCandidates": [],
+      "runOutcomeLearningCandidates": [],
+      "capabilityStates": [],
+      "transcriptSections": []
+    }
+    """
+    let snapshot = try WorkbenchSnapshot(projectionJSON: Data(json.utf8), generatedAtMs: 1_780_640_000_000)
+    let projection = HomeProjection(snapshot)
+    XCTAssertFalse(projection.hasLiveRuntimeFeed)
+    XCTAssertTrue(projection.shouldPromoteStatusLabelsToBlockingBanner)
+  }
+
   func testPreviewReadClientMatchesSelectedMobileDesignSample() async throws {
     let projection = HomeProjection(try await PreviewReadClient().fetchWorkbench())
     XCTAssertEqual(projection.runtimeFeedStatus, "preview_sample")


### PR DESCRIPTION
## Summary
- keep HomeProjection statusLabels as proof notes when the runtime feed is live
- only promote status labels to a blocking iOS banner when the feed itself is non-live
- apply the same behavior to projection detail surfaces so Hub-live product paths do not show a contradictory fresh-connection warning

## Verification
- swift test --package-path apps/friday-ios --filter HomeViewModelTests/testLiveRuntimeStatusLabelsStayAsProofNotesNotBlockingBanner --filter HomeViewModelTests/testNonLiveRuntimeStatusLabelsStillBlockTheProductPath
- FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS=8 bash scripts/ops/friday-ios-design-destination-capture.sh --out-dir /private/tmp/friday-ios-live-status-polish-20260630Tcurrent --mode live-loopback --destinations home
- ordinary simulator launch screenshot: /private/tmp/friday-ios-live-status-polish-ordinary-launch-20260630Tcurrent.png
- node scripts/ops/check-friday-served-ui-design-fidelity.mjs --out=/private/tmp/friday-served-ui-design-fidelity-live-status-polish-20260630.json

Truth: this is a UI/product-state polish PR only. It does not claim END-BAR, adoption, release, or operator signature completion.