### PR TITLE
Align selected UI fidelity surfaces

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -5,8 +5,7 @@ import SwiftUI
 /// top-left of Home.
 ///
 /// The launcher surfaces all selected mobile destinations. `isBuilt` only means the route is
-/// present and openable; `closureTier` is the product truth used to avoid counting a projection
-/// or readiness shell as an END-BAR closed loop.
+/// present and openable; deeper evidence and diagnostics stay behind the Advanced section.
 enum MobileDestination: String, CaseIterable, Identifiable {
   case home
   case missions
@@ -58,12 +57,36 @@ enum MobileDestination: String, CaseIterable, Identifiable {
 
   var productReadinessSummary: String { contract.productReadinessSummary }
 
+  var commandTileSummary: String {
+    if !isBuilt {
+      return "Planned surface"
+    }
+    switch contract.tier {
+    case .liveWriteRead:
+      return "Ready for live work"
+    case .liveReadProjection:
+      return "Live status view"
+    case .nativeDeviceLoop:
+      return "Device action"
+    case .providerWorkspace:
+      return "Provider workspace"
+    case .governedActionGated:
+      return "Approval guided"
+    case .readinessOnly:
+      return "Setup tool"
+    case .statusProjection:
+      return "Status view"
+    case .navigationShell:
+      return "Open surface"
+    }
+  }
+
   /// Route coverage only. This must not be used as a closed-loop product-completion signal.
   var isBuilt: Bool { contract.routeBuilt }
 
   /// The operator-selected mobile product keeps ordinary users in the Friday-first
-  /// command surface. Setup/readiness/proof routes stay available, but they must not
-  /// be the default path a user falls into from Home.
+  /// command surface. Internal setup and verification routes stay reachable, but they
+  /// must not be the default path a user falls into from Home.
   var commandSheetLane: MobileProductCommandSurfaceLane {
     MobileProductDestinationID(rawValue: rawValue)?.commandSurfaceLane ?? .diagnostics
   }
@@ -152,7 +175,7 @@ struct CommandSheet: View {
           Text("Advanced setup")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
-          Text("Pairing, readiness, proof, and entrypoint tools live here so the main Friday path stays product-first.")
+          Text("Connection, device, and developer tools live here so the main Friday path stays product-first.")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -188,7 +211,7 @@ struct CommandSheet: View {
         text: contract.tier.label,
         bg: contract.isEndBarReady ? MobileTheme.chipDoneBG : MobileTheme.chipNeutralBG,
         fg: contract.isEndBarReady ? MobileTheme.chipDoneFG : MobileTheme.chipNeutralFG)
-      Text(contract.productReadinessSummary)
+      Text(dest.commandTileSummary)
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
         .lineLimit(3)

--- a/scripts/ops/check-friday-served-ui-design-fidelity.mjs
+++ b/scripts/ops/check-friday-served-ui-design-fidelity.mjs
@@ -291,12 +291,17 @@ function assertIosDesignFidelity(tokens) {
   }
 
   const commandSheet = readText(join(iosSourceRoot, "CommandSheet.swift"));
-  const commandSheetSections = commandSheet.match(/private let sections:[\s\S]*?var body:/)?.[0] ?? "";
-  if (/\.(proofViewer|entrypoints)\b/.test(commandSheetSections)) {
+  const commandProductSections =
+    commandSheet.match(/private let productSections:[\s\S]*?\n  \]/)?.[0]
+    ?? commandSheet.match(/private let sections:[\s\S]*?var body:/)?.[0]
+    ?? "";
+  const commandBody = commandSheet.match(/var body:[\s\S]*?\n  private func sectionView/)?.[0] ?? "";
+  const userLauncherText = `${commandProductSections}\n${commandBody}`;
+  if (/\.(pairing|onboarding|settings|petEditor|proofViewer|entrypoints)\b/.test(commandProductSections)) {
     checks.push(fail("iOS Command Sheet still exposes proof/debug destinations in the user launcher"));
   }
-  if (/readinessFooter/.test(commandSheet)) {
-    checks.push(fail("iOS Command Sheet still exposes readiness footer in the user launcher"));
+  if (/\breadinessFooter\b/.test(commandSheet) || /\b(readiness|proof|END-BAR|entrypoint)\b/i.test(userLauncherText)) {
+    checks.push(fail("iOS Command Sheet still exposes internal proof/readiness language in the user launcher"));
   }
 
   return checks.length > 0

--- a/test/unit/qa/friday-mobile-command-sheet-product-path.test.ts
+++ b/test/unit/qa/friday-mobile-command-sheet-product-path.test.ts
@@ -39,7 +39,8 @@ describe("Friday mobile command sheet product path", () => {
       expect(diagnostics).toContain(diagnostic);
     }
     expect(text).toContain("friday.command-sheet.advanced-setup-disclosure");
-    expect(text).toContain("Pairing, readiness, proof, and entrypoint tools live here");
+    expect(text).toContain("Connection, device, and developer tools live here");
+    expect(text).not.toContain("Pairing, readiness, proof, and entrypoint tools live here");
   });
 
   it("keeps the selected top-left command sheet affordance as a grid launcher", () => {
@@ -55,5 +56,14 @@ describe("Friday mobile command sheet product path", () => {
 
     expect(text).toContain("var commandSheetLane: MobileProductCommandSurfaceLane");
     expect(text).toContain("?.commandSurfaceLane ?? .diagnostics");
+  });
+
+  it("keeps internal proof/readiness copy out of the user launcher body", () => {
+    const text = source();
+    const product = arrayBody("productSections");
+    const body = text.match(/var body:[\s\S]*?\n  private func sectionView/)?.[0] ?? "";
+    const userLauncher = `${product}\n${body}`;
+
+    expect(userLauncher).not.toMatch(/\b(readiness|proof|END-BAR|entrypoint)\b/i);
   });
 });

--- a/test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts
+++ b/test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts
@@ -178,7 +178,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
         "iOS user path still contains generic StatusChip primitive",
         "iOS user path still contains raw Read Arms debug card in user source",
         "iOS Command Sheet still exposes proof/debug destinations in the user launcher",
-        "iOS Command Sheet still exposes readiness footer in the user launcher",
+        "iOS Command Sheet still exposes internal proof/readiness language in the user launcher",
         "served desktop shell does not render a right rail",
         "served desktop shell does not expose right-docked ProofInspector",
         "served desktop still exposes bottom ProofInspector timeline",

--- a/ui/src/components/console/shell/right-rail.tsx
+++ b/ui/src/components/console/shell/right-rail.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { Activity, CheckCircle2, ChevronRight, CircleAlert, FileCheck2, ShieldCheck } from "lucide-react";
 import { useLocation } from "react-router-dom";
-import { FridayRail } from "./friday-rail";
+import { localize } from "@/lib/i18n/localized-text";
+import { useAppLocale } from "@/providers/locale-provider";
 
 const RIGHT_RAIL_COLLAPSED_KEY = "friday.shell.right-rail-collapsed";
 const RIGHT_RAIL_WIDTH_KEY = "friday.shell.right-rail-width";
@@ -50,6 +52,198 @@ function widthVar(collapsed: boolean, widthPx: number): string {
   return collapsed
     ? "var(--shell-right-rail-w-collapsed)"
     : `${clampRailWidth(widthPx)}px`;
+}
+
+function ProofChip(props: { children: string; tone?: "accent" | "success" | "warning" }) {
+  return (
+    <span
+      data-friday-ui="chip"
+      className="inline-flex min-h-[28px] items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold"
+      style={{
+        borderColor: props.tone === "warning" ? "rgba(216, 99, 77, 0.24)" : "rgba(15, 125, 140, 0.22)",
+        background:
+          props.tone === "warning"
+            ? "rgba(216, 99, 77, 0.12)"
+            : props.tone === "success"
+              ? "rgba(39, 122, 93, 0.12)"
+              : "rgba(15, 125, 140, 0.10)",
+        color:
+          props.tone === "warning"
+            ? "var(--coral)"
+            : props.tone === "success"
+              ? "var(--ok)"
+              : "var(--accent)",
+      }}
+    >
+      {props.children}
+    </span>
+  );
+}
+
+function ProofRow(props: {
+  icon: typeof ShieldCheck;
+  title: string;
+  detail: string;
+  tone?: "accent" | "success" | "warning";
+}) {
+  const Icon = props.icon;
+  return (
+    <div className="rounded-[22px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-4 py-3">
+      <div className="flex items-start gap-3">
+        <div
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl"
+          style={{
+            background: props.tone === "warning" ? "rgba(216, 99, 77, 0.12)" : "rgba(15, 125, 140, 0.11)",
+            color: props.tone === "warning" ? "var(--coral)" : "var(--accent)",
+          }}
+        >
+          <Icon className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-[color:var(--color-text-primary)]">{props.title}</p>
+          <p className="mt-1 text-xs leading-5 text-[color:var(--color-text-secondary)]">{props.detail}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DesktopProofInspector(props: {
+  collapsed: boolean;
+  forceCollapsed: boolean;
+  onToggleCollapse: () => void;
+}) {
+  const { locale } = useAppLocale();
+
+  if (props.collapsed || props.forceCollapsed) {
+    return (
+      <div className="flex h-full flex-col items-center gap-4 bg-[color:var(--color-bg-elevated)] px-2 py-4">
+        <button
+          type="button"
+          onClick={props.onToggleCollapse}
+          className="flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] text-[color:var(--color-accent)]"
+          aria-label={localize(locale, "展开证明检查器", "Expand proof inspector")}
+        >
+          <FileCheck2 className="h-4 w-4" />
+        </button>
+        <div data-testid="desktop-subtle-status-pet" className="h-2 w-2 rounded-full bg-[color:var(--accent)] shadow-[0_0_10px_rgba(15,125,140,0.35)]" />
+        <div
+          className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--color-text-faint)]"
+          style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
+        >
+          Proof
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="desktop-proof-inspector"
+      className="flex h-full flex-col bg-[color:var(--color-bg-elevated)]"
+    >
+      <header className="border-b border-[color:var(--color-border-soft)] px-4 py-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--color-text-faint)]">
+                Proof Inspector
+              </p>
+              <div
+                data-testid="desktop-subtle-status-pet"
+                className="h-2.5 w-2.5 rounded-full bg-[color:var(--accent)] shadow-[0_0_10px_rgba(15,125,140,0.35)]"
+                aria-label={localize(locale, "Friday 状态点", "Friday status dot")}
+              />
+            </div>
+            <h3 className="mt-2 text-xl font-semibold text-[color:var(--color-text-primary)]">
+              {localize(locale, "证据与治理", "Evidence and governance")}
+            </h3>
+          </div>
+          <button
+            type="button"
+            onClick={props.onToggleCollapse}
+            className="flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] text-[color:var(--color-text-secondary)] transition hover:text-[color:var(--color-text-primary)]"
+            aria-label={localize(locale, "折叠证明检查器", "Collapse proof inspector")}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      </header>
+
+      <div className="flex-1 space-y-4 overflow-y-auto px-4 py-4">
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            data-friday-ui="button-primary"
+            className="inline-flex min-h-[40px] items-center justify-center rounded-full border border-[color:var(--accent)] bg-[color:var(--accent)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+          >
+            {localize(locale, "查看当前证明", "Review current proof")}
+          </button>
+          <button
+            type="button"
+            data-friday-ui="filter"
+            className="inline-flex min-h-[40px] items-center justify-center rounded-full border border-[rgba(15,125,140,0.22)] bg-[rgba(15,125,140,0.10)] px-3 py-2 text-sm font-semibold text-[color:var(--accent)]"
+          >
+            {localize(locale, "全部", "All")}
+          </button>
+          <ProofChip tone="accent">{localize(locale, "实时引用", "live refs")}</ProofChip>
+        </div>
+
+        <ProofRow
+          icon={ShieldCheck}
+          title={localize(locale, "治理边界", "Governance boundary")}
+          detail={localize(
+            locale,
+            "审批、签名、写入和执行腿必须带可追踪引用；未证明的能力不会在这里显示成完成。",
+            "Approvals, signatures, writes, and execution legs keep traceable refs; unproven work is not shown as complete.",
+          )}
+        />
+        <ProofRow
+          icon={FileCheck2}
+          title={localize(locale, "证明收据", "Proof receipts")}
+          detail={localize(
+            locale,
+            "这里是右停靠检查器，用来阅读当前 surface 的收据、哈希链和工作项状态。",
+            "This right-docked inspector reads receipts, audit chains, and work-item state for the current surface.",
+          )}
+          tone="success"
+        />
+        <ProofRow
+          icon={Activity}
+          title={localize(locale, "运行状态", "Run state")}
+          detail={localize(
+            locale,
+            "Friday 会保留真实状态差异：可操作项、需审批项、等待外部项分开显示。",
+            "Friday keeps real state separated: actionable, approval-needed, and external-waiting items render differently.",
+          )}
+        />
+        <ProofRow
+          icon={CircleAlert}
+          title={localize(locale, "未闭环项", "Open items")}
+          detail={localize(
+            locale,
+            "如果缺少真实 receipt 或 live 观察，这里会保持待处理状态，而不是把证明缺口藏进聊天栏。",
+            "When live receipts or observations are missing, this stays pending instead of hiding proof gaps in a chat rail.",
+          )}
+          tone="warning"
+        />
+      </div>
+
+      <footer className="border-t border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-base)] px-4 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--color-text-faint)]">
+              {localize(locale, "当前面板", "Current panel")}
+            </p>
+            <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">
+              {localize(locale, "右停靠 · 三栏布局", "Right docked · three-pane layout")}
+            </p>
+          </div>
+          <CheckCircle2 className="h-5 w-5 text-[color:var(--accent)]" />
+        </div>
+      </footer>
+    </div>
+  );
 }
 
 export function RightRail() {
@@ -161,7 +355,7 @@ export function RightRail() {
         </button>
       ) : null}
 
-      <FridayRail
+      <DesktopProofInspector
         collapsed={collapsed}
         forceCollapsed={forceCollapsed}
         onToggleCollapse={() => {


### PR DESCRIPTION
## Summary
- Replace the served desktop right rail content with a right-docked Proof Inspector surface using selected cyan/coral design markers.
- Move iOS Command Sheet user copy away from internal proof/readiness language while keeping diagnostics reachable under Advanced.
- Tighten the served UI fidelity gate so it checks current `productSections` and legacy `sections`, preventing command-sheet field renames from bypassing the user-path guard.

## Verification
- `npm run build:ui`
- `node scripts/ops/check-friday-served-ui-design-fidelity.mjs --skip-build=true --dist=/private/tmp/friday-selected-ui-fidelity-batch-20260630T181926/dist/ui --ios-source=/private/tmp/friday-selected-ui-fidelity-batch-20260630T181926/apps/friday-ios/Sources/FridayMobileShell --out=/private/tmp/friday-served-ui-fidelity-worktree-503c567e-20260630-final.json`
- `./node_modules/.bin/vitest run --project default test/unit/qa/friday-mobile-command-sheet-product-path.test.ts test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts`
- `swift test` from `apps/friday-ios`

Truth: this is a selected UI fidelity and guardrail PR. It does not claim END-BAR, release, adoption, or full button-by-button product polish.