### PR TITLE
Tighten selected UI product surfaces

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -106,7 +106,7 @@ struct CommandSheet: View {
     ("Trust", [.contextPassport, .memory, .tokenLedger]),
   ]
   private let diagnosticsSections: [(String, [MobileDestination])] = [
-    ("Advanced", [.pairing, .onboarding, .settings, .petEditor, .proofViewer, .entrypoints]),
+    ("Device & Setup", [.pairing, .onboarding, .settings, .petEditor]),
   ]
 
   var body: some View {
@@ -172,10 +172,10 @@ struct CommandSheet: View {
           .font(.system(size: 18, weight: .semibold))
           .foregroundStyle(MobileTheme.cyan)
         VStack(alignment: .leading, spacing: 3) {
-          Text("Advanced setup")
+          Text("Device & setup")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
-          Text("Connection, device, and developer tools live here so the main Friday path stays product-first.")
+          Text("Connection, pairing, and companion settings live here so the main Friday path stays product-first.")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -24,6 +24,20 @@ struct FridayChatScreen: View {
   @State private var routePreference: MissionRoutePreference = .auto
   @State private var draft: String
 
+  private var routePreferenceTitles: [String] {
+    MissionRoutePreference.allCases.map(\.title)
+  }
+
+  private var routePreferenceTitle: Binding<String> {
+    Binding(
+      get: { routePreference.title },
+      set: { selectedTitle in
+        if let selected = MissionRoutePreference.allCases.first(where: { $0.title == selectedTitle }) {
+          routePreference = selected
+        }
+      })
+  }
+
   init(session: FridaySession, launchContext: ChatLaunchContext? = nil) {
     self.runControlEnabled = session.runControlEnabled
     _draft = State(initialValue: launchContext?.composerPrefill ?? "")
@@ -206,8 +220,7 @@ struct FridayChatScreen: View {
               .foregroundStyle(MobileTheme.textPrimary)
             Spacer()
             Button("Clear") { viewModel.clearHistory() }
-              .font(.caption)
-              .foregroundStyle(MobileTheme.cyan)
+              .buttonStyle(FridayButtonStyle(variant: .quiet))
               .accessibilityLabel("Clear Friday chat history")
           }
           ForEach(viewModel.history.suffix(8)) { item in
@@ -281,7 +294,7 @@ struct FridayChatScreen: View {
           }
           Text(userFacingChatReason(reason)).font(.caption2).foregroundStyle(MobileTheme.textSecondary)
           Button("Start over") { viewModel.newTurn() }
-            .font(.caption).foregroundStyle(MobileTheme.cyan)
+            .buttonStyle(FridayButtonStyle(variant: .secondary))
             .accessibilityLabel("Start a new Friday chat turn")
         }
       }
@@ -309,12 +322,7 @@ struct FridayChatScreen: View {
 
   private var composer: some View {
     VStack(alignment: .leading, spacing: 6) {
-      Picker("Route", selection: $routePreference) {
-        ForEach(MissionRoutePreference.allCases) { preference in
-          Text(preference.title).tag(preference)
-        }
-      }
-      .pickerStyle(.segmented)
+      FridaySegmentedControl(options: routePreferenceTitles, selection: routePreferenceTitle)
       .disabled(viewModel.phase.isBusy || viewModel.phase.isAwaitingApproval)
       .accessibilityLabel("Route preference")
       .accessibilityIdentifier("friday.chat.route-preference")
@@ -398,7 +406,8 @@ struct FridayChatScreen: View {
         HStack {
           FridayChip(text: r.status.uppercased(), bg: MobileTheme.chipDoneBG, fg: MobileTheme.chipDoneFG)
           Spacer()
-          Button("New") { viewModel.newTurn() }.font(.caption).foregroundStyle(MobileTheme.cyan)
+          Button("New") { viewModel.newTurn() }
+            .buttonStyle(FridayButtonStyle(variant: .quiet))
         }
         Text("Friday answered").font(.headline).foregroundStyle(MobileTheme.textPrimary)
         if let answer = readableAnswer(r.answerBody) {
@@ -498,7 +507,8 @@ struct FridayChatScreen: View {
             bg: r.accepted ? MobileTheme.chipDoneBG : MobileTheme.chipWarnBG,
             fg: r.accepted ? MobileTheme.chipDoneFG : MobileTheme.chipWarnFG)
           Spacer()
-          Button("New") { viewModel.newTurn() }.font(.caption).foregroundStyle(MobileTheme.cyan)
+          Button("New") { viewModel.newTurn() }
+            .buttonStyle(FridayButtonStyle(variant: .quiet))
         }
         Text(r.title)
           .font(.headline).foregroundStyle(MobileTheme.textPrimary)

--- a/scripts/ops/check-friday-served-ui-design-fidelity.mjs
+++ b/scripts/ops/check-friday-served-ui-design-fidelity.mjs
@@ -271,6 +271,10 @@ function assertIosDesignFidelity(tokens) {
       pattern: /\.buttonStyle\(\.bordered\)/,
     },
     {
+      name: "stock segmented picker",
+      pattern: /\.pickerStyle\(\.segmented\)/,
+    },
+    {
       name: "generic StatusChip primitive",
       pattern: /\bstruct\s+StatusChip\b/,
     },
@@ -295,10 +299,15 @@ function assertIosDesignFidelity(tokens) {
     commandSheet.match(/private let productSections:[\s\S]*?\n  \]/)?.[0]
     ?? commandSheet.match(/private let sections:[\s\S]*?var body:/)?.[0]
     ?? "";
+  const commandDiagnosticsSections =
+    commandSheet.match(/private let diagnosticsSections:[\s\S]*?(?:\n\s*var body|\n\s*private func|$)/)?.[0] ?? "";
   const commandBody = commandSheet.match(/var body:[\s\S]*?\n  private func sectionView/)?.[0] ?? "";
   const userLauncherText = `${commandProductSections}\n${commandBody}`;
   if (/\.(pairing|onboarding|settings|petEditor|proofViewer|entrypoints)\b/.test(commandProductSections)) {
     checks.push(fail("iOS Command Sheet still exposes proof/debug destinations in the user launcher"));
+  }
+  if (/\.(proofViewer|entrypoints)\b/.test(commandDiagnosticsSections)) {
+    checks.push(fail("iOS Command Sheet still exposes proof-harness destinations in the user launcher diagnostics drawer"));
   }
   if (/\breadinessFooter\b/.test(commandSheet) || /\b(readiness|proof|END-BAR|entrypoint)\b/i.test(userLauncherText)) {
     checks.push(fail("iOS Command Sheet still exposes internal proof/readiness language in the user launcher"));
@@ -451,10 +460,10 @@ async function assertRenderedStructure(tokens) {
       window.localStorage.setItem("friday.shell.rail-collapsed", "0");
     });
 
-    await page.goto(`${url}/home`, { waitUntil: "networkidle" });
-    await page.waitForSelector('[data-testid="app-shell-rail"]', { timeout: 10_000 });
-
-    const result = await page.evaluate((expected) => {
+    async function inspectRoute(pathname) {
+      await page.goto(`${url}${pathname}`, { waitUntil: "networkidle" });
+      await page.waitForSelector('[data-testid="app-shell-rail"]', { timeout: 10_000 });
+      return page.evaluate((expected) => {
       const rightRail = document.querySelector('[data-testid="app-shell-right-rail"]');
       const bottomDockText = [...document.querySelectorAll("section, aside, div")]
         .some((node) => /Proof inspector\s*[·-]\s*bottom timeline/i.test(node.textContent ?? ""));
@@ -485,20 +494,26 @@ async function assertRenderedStructure(tokens) {
         hasAccentApplied,
         expected,
       };
-    }, tokens);
+      }, tokens);
+    }
 
     const checks = [];
-    if (!result.rightRailPresent) checks.push(fail("served desktop shell does not render a right rail"));
-    if (!result.inspectorPresent) checks.push(fail("served desktop shell does not expose right-docked ProofInspector"));
-    if (result.bottomDockText) checks.push(fail("served desktop still exposes bottom ProofInspector timeline"));
-    if (result.heroPet) checks.push(fail("served desktop home still exposes hero/static pet instead of subtle status pet"));
-    if (!result.subtlePetPresent) checks.push(fail("served desktop subtle-status pet is missing"));
-    if (!result.primaryActionPresent) checks.push(fail("served desktop does not expose design-system primary button marker"));
-    if (!result.chipPresent) checks.push(fail("served desktop does not expose design-system chip marker"));
-    if (!result.filterPresent) checks.push(fail("served desktop does not expose design-system filter marker"));
-    if (!result.hasAccentApplied) checks.push(fail("served desktop rendered controls do not apply cyan/coral accent"));
+    const routeResults = [];
+    for (const pathname of ["/home", "/chat"]) {
+      const result = await inspectRoute(pathname);
+      routeResults.push({ pathname, ...result });
+      if (!result.rightRailPresent) checks.push(fail("served desktop shell does not render a right rail", { pathname }));
+      if (!result.inspectorPresent) checks.push(fail("served desktop shell does not expose right-docked ProofInspector", { pathname }));
+      if (result.bottomDockText) checks.push(fail("served desktop still exposes bottom ProofInspector timeline", { pathname }));
+      if (result.heroPet) checks.push(fail("served desktop home still exposes hero/static pet instead of subtle status pet", { pathname }));
+      if (!result.subtlePetPresent) checks.push(fail("served desktop subtle-status pet is missing", { pathname }));
+      if (!result.primaryActionPresent) checks.push(fail("served desktop does not expose design-system primary button marker", { pathname }));
+      if (!result.chipPresent) checks.push(fail("served desktop does not expose design-system chip marker", { pathname }));
+      if (!result.filterPresent) checks.push(fail("served desktop does not expose design-system filter marker", { pathname }));
+      if (!result.hasAccentApplied) checks.push(fail("served desktop rendered controls do not apply cyan/coral accent", { pathname }));
+    }
 
-    return checks.length > 0 ? checks : [pass("served desktop rendered structure matches selected design", result)];
+    return checks.length > 0 ? checks : [pass("served desktop rendered structure matches selected design", { routes: routeResults })];
   } finally {
     if (browser) await browser.close();
     await new Promise((resolveClose) => server.close(resolveClose));

--- a/test/unit/qa/friday-mobile-command-sheet-product-path.test.ts
+++ b/test/unit/qa/friday-mobile-command-sheet-product-path.test.ts
@@ -31,15 +31,19 @@ describe("Friday mobile command sheet product path", () => {
     expect(product).toContain(".contextPassport");
   });
 
-  it("keeps advanced diagnostics reachable through an explicit disclosure", () => {
+  it("keeps device setup reachable without exposing proof-harness destinations in the launcher", () => {
     const diagnostics = arrayBody("diagnosticsSections");
     const text = source();
 
-    for (const diagnostic of [".pairing", ".onboarding", ".settings", ".petEditor", ".proofViewer", ".entrypoints"]) {
+    for (const diagnostic of [".pairing", ".onboarding", ".settings", ".petEditor"]) {
       expect(diagnostics).toContain(diagnostic);
     }
+    for (const diagnostic of [".proofViewer", ".entrypoints"]) {
+      expect(diagnostics).not.toContain(diagnostic);
+    }
     expect(text).toContain("friday.command-sheet.advanced-setup-disclosure");
-    expect(text).toContain("Connection, device, and developer tools live here");
+    expect(text).toContain("Connection, pairing, and companion settings live here");
+    expect(text).not.toContain("Connection, device, and developer tools live here");
     expect(text).not.toContain("Pairing, readiness, proof, and entrypoint tools live here");
   });
 

--- a/test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts
+++ b/test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts
@@ -72,7 +72,8 @@ function writeGoodIos(root: string) {
   writeFile(iosRoot, "CommandSheet.swift", `
     struct CommandSheet: View {
       private let sections: [String] = ["home", "platform", "chat"]
-      var body: some View {}
+      private let diagnosticsSections: [String] = ["pairing", "settings"]
+      var body: some View { FridaySegmentedControl(options: ["Auto", "Codex"], selection: .constant("Auto")) }
     }
   `);
   return iosRoot;
@@ -90,7 +91,8 @@ function writeBadIos(root: string) {
   writeFile(iosRoot, "CommandSheet.swift", `
     struct CommandSheet: View {
       private let sections: [Destination] = [.home, .proofViewer, .entrypoints]
-      var body: some View { readinessFooter }
+      private let diagnosticsSections: [Destination] = [.pairing, .proofViewer, .entrypoints]
+      var body: some View { readinessFooter.pickerStyle(.segmented) }
     }
   `);
   return iosRoot;
@@ -102,7 +104,7 @@ function writeGoodDist(root: string) {
     :root { --accent: #0f7d8c; --coral: #d8634d; --app-bg: #f7f6f2; }
     body { background: #f7f6f2; color: #242424; }
   `);
-  writeFile(distRoot, "index.html", `
+  const html = `
     <!doctype html>
     <html>
       <head><link rel="stylesheet" href="/assets/app.css"></head>
@@ -117,7 +119,10 @@ function writeGoodDist(root: string) {
         </aside>
       </body>
     </html>
-  `);
+  `;
+  writeFile(distRoot, "index.html", html);
+  writeFile(distRoot, "home/index.html", html);
+  writeFile(distRoot, "chat/index.html", html);
   return distRoot;
 }
 
@@ -135,6 +140,15 @@ function writeBadDist(root: string) {
         <main data-testid="app-shell-rail">Console v2.0</main>
         <img alt="Friday status pet" />
         <section>Proof inspector - bottom timeline</section>
+      </body>
+    </html>
+  `);
+  writeFile(distRoot, "chat/index.html", `
+    <!doctype html>
+    <html>
+      <head><link rel="stylesheet" href="/assets/app.css"></head>
+      <body>
+        <main data-testid="app-shell-rail">Chat without proof rail</main>
       </body>
     </html>
   `);
@@ -175,9 +189,11 @@ describe("check-friday-served-ui-design-fidelity", () => {
       expect(failures).toEqual(expect.arrayContaining([
         "built css still carries old amber/jade token",
         "iOS user path still contains stock borderedProminent button",
+        "iOS user path still contains stock segmented picker",
         "iOS user path still contains generic StatusChip primitive",
         "iOS user path still contains raw Read Arms debug card in user source",
         "iOS Command Sheet still exposes proof/debug destinations in the user launcher",
+        "iOS Command Sheet still exposes proof-harness destinations in the user launcher diagnostics drawer",
         "iOS Command Sheet still exposes internal proof/readiness language in the user launcher",
         "served desktop shell does not render a right rail",
         "served desktop shell does not expose right-docked ProofInspector",

--- a/ui/src/components/console/shell/right-rail.tsx
+++ b/ui/src/components/console/shell/right-rail.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Activity, CheckCircle2, ChevronRight, CircleAlert, FileCheck2, ShieldCheck } from "lucide-react";
-import { useLocation } from "react-router-dom";
 import { localize } from "@/lib/i18n/localized-text";
 import { useAppLocale } from "@/providers/locale-provider";
 
@@ -247,8 +246,6 @@ function DesktopProofInspector(props: {
 }
 
 export function RightRail() {
-  const location = useLocation();
-  const isChatPage = location.pathname === "/chat";
   const [collapsed, setCollapsed] = useState<boolean>(() => readCollapsed());
   const [widthPx, setWidthPx] = useState<number>(() => readRailWidth());
   const forceCollapsed = false;
@@ -265,14 +262,14 @@ export function RightRail() {
   }, [widthPx]);
 
   useEffect(() => {
-    if (isChatPage || collapsed || forceCollapsed) {
+    if (collapsed || forceCollapsed) {
       return;
     }
     writeRailWidth(widthPx);
-  }, [collapsed, forceCollapsed, isChatPage, widthPx]);
+  }, [collapsed, forceCollapsed, widthPx]);
 
   useEffect(() => {
-    if (isChatPage || forceCollapsed) {
+    if (forceCollapsed) {
       return;
     }
 
@@ -305,11 +302,7 @@ export function RightRail() {
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
     };
-  }, [forceCollapsed, isChatPage]);
-
-  if (isChatPage) {
-    return null;
-  }
+  }, [forceCollapsed]);
 
   return (
     <aside


### PR DESCRIPTION
## Summary
- remove proof/entrypoints harness destinations from the iOS user command-sheet drawer while keeping device/setup routes reachable
- keep the selected desktop right-docked Proof Inspector present on both `/home` and `/chat`
- harden the served UI fidelity gate to check command-sheet diagnostics and both desktop routes

## Verification
- `./node_modules/.bin/vitest run --project default test/unit/qa/friday-mobile-command-sheet-product-path.test.ts test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts`
- `node scripts/ops/check-friday-served-ui-design-fidelity.mjs --out=/private/tmp/friday-served-ui-fidelity-6d326e71-final-fullbuild.json`
- `npm run typecheck:src`
- `swift test` in `apps/friday-ios`
- `git diff --check`

Truth: this tightens selected mobile/desktop UI fidelity and removes a user-path proof-harness leak. It does not claim END-BAR, release, adoption, or every-button mature UX.