### PR TITLE
Scope iOS proof screens as internal diagnostics

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift
@@ -78,6 +78,8 @@ enum MobileDestination: String, CaseIterable, Identifiable {
       return "Status view"
     case .navigationShell:
       return "Open surface"
+    case .internalDebug:
+      return "Internal diagnostic"
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayApp.swift
@@ -534,25 +534,35 @@ struct RootView: View {
   ) -> MobileDestination {
     let envValue = env["FRIDAY_MOBILE_INITIAL_DESTINATION"]?.trimmingCharacters(in: .whitespacesAndNewlines)
     if let envValue, let destination = MobileDestination(rawValue: envValue) {
-      return destination
+      return initialDestinationAllowed(destination, args: args, env: env) ? destination : .home
     }
 
     for (index, arg) in args.enumerated() {
       if arg.hasPrefix("--initial-destination=") {
         let rawValue = String(arg.dropFirst("--initial-destination=".count))
         if let destination = MobileDestination(rawValue: rawValue) {
-          return destination
+          return initialDestinationAllowed(destination, args: args, env: env) ? destination : .home
         }
       }
       if arg == "--initial-destination", args.indices.contains(index + 1) {
         let rawValue = args[index + 1]
         if let destination = MobileDestination(rawValue: rawValue) {
-          return destination
+          return initialDestinationAllowed(destination, args: args, env: env) ? destination : .home
         }
       }
     }
 
     return .home
+  }
+
+  private static func initialDestinationAllowed(
+    _ destination: MobileDestination,
+    args: [String],
+    env: [String: String]
+  ) -> Bool {
+    guard destination.closureTier == .internalDebug else { return true }
+    return env["FRIDAY_MOBILE_ALLOW_INTERNAL_DESTINATION"] == "1"
+      || args.contains("--allow-internal-destination")
   }
 
   private static func voiceChatLaunchContext(from projection: HomeProjection?) -> ChatLaunchContext {

--- a/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
+++ b/apps/friday-ios/Sources/FridayMobileShellCore/MobileProductReadinessContract.swift
@@ -9,6 +9,7 @@ public enum MobileProductLoopTier: String, CaseIterable, Sendable, Equatable {
   case readinessOnly
   case statusProjection
   case navigationShell
+  case internalDebug
 
   public var label: String {
     switch self {
@@ -20,6 +21,7 @@ public enum MobileProductLoopTier: String, CaseIterable, Sendable, Equatable {
     case .readinessOnly: return "readiness"
     case .statusProjection: return "projection"
     case .navigationShell: return "shell"
+    case .internalDebug: return "internal"
     }
   }
 
@@ -41,6 +43,8 @@ public enum MobileProductLoopTier: String, CaseIterable, Sendable, Equatable {
       return "Shows current status from projection refs; no product action is completed here."
     case .navigationShell:
       return "Route exists for selected UI coverage, but closed-loop product behavior is still pending."
+    case .internalDebug:
+      return "Internal proof/debug surface; it is not part of the user product END-BAR."
     }
   }
 }
@@ -314,16 +318,16 @@ public enum MobileProductDestinationID: String, CaseIterable, Sendable, Equatabl
       return contract(
         title: "Proof Viewer",
         systemImage: "doc.text.magnifyingglass",
-        tier: .liveReadProjection,
+        tier: .internalDebug,
         runtimeActionIds: ["mobile/proof/viewer-open"],
-        blockers: [.init(.needsRuntimeEvidence, label: "proof receipt open proof")])
+        blockers: [])
     case .entrypoints:
       return contract(
         title: "iOS Entrypoints",
         systemImage: "rectangle.stack.badge.plus",
-        tier: .readinessOnly,
+        tier: .internalDebug,
         runtimeActionIds: ["mobile/entrypoints/readiness"],
-        blockers: [.init(.needsRuntimeEvidence, label: "widget/control/app-intent proof")])
+        blockers: [])
     }
   }
 

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/MobileProductReadinessContractTests.swift
@@ -32,6 +32,19 @@ func mobileProductContractCoversOperatorSelectedDestinations() {
 }
 
 @Test
+func mobileProductContractExcludesInternalProofHarnessFromUserEndBarScope() {
+  let snapshot = MobileProductEndBarSnapshot()
+  let userFacing = snapshot.contracts.filter { $0.tier != .internalDebug }
+  let internalOnly = snapshot.contracts.filter { $0.tier == .internalDebug }
+
+  #expect(snapshot.totalCount == 20)
+  #expect(userFacing.count == 18)
+  #expect(internalOnly.map(\.id).sorted() == ["entrypoints", "proofViewer"])
+  #expect(internalOnly.allSatisfy { $0.blockers.isEmpty })
+  #expect(!internalOnly.contains { $0.isEndBarReady })
+}
+
+@Test
 func mobileProductContractDoesNotTreatRouteCoverageAsEndBar() {
   let snapshot = MobileProductEndBarSnapshot()
 
@@ -189,14 +202,14 @@ func mobileProductContractTracksSelectedDesignCompanionProofAndEntrypoints() {
   #expect(petEditor.blockers.contains { $0.label == "pet state mapping proof" })
 
   #expect(proofViewer.title == "Proof Viewer")
-  #expect(proofViewer.tier == .liveReadProjection)
+  #expect(proofViewer.tier == .internalDebug)
   #expect(proofViewer.runtimeActionIds == ["mobile/proof/viewer-open"])
-  #expect(proofViewer.blockers.contains { $0.label == "proof receipt open proof" })
+  #expect(proofViewer.blockers.isEmpty)
 
   #expect(entrypoints.title == "iOS Entrypoints")
-  #expect(entrypoints.tier == .readinessOnly)
+  #expect(entrypoints.tier == .internalDebug)
   #expect(entrypoints.runtimeActionIds == ["mobile/entrypoints/readiness"])
-  #expect(entrypoints.blockers.contains { $0.label == "widget/control/app-intent proof" })
+  #expect(entrypoints.blockers.isEmpty)
 
   #expect(!petEditor.isEndBarReady)
   #expect(!proofViewer.isEndBarReady)

--- a/scripts/ops/check-friday-ios-design-destination-capture-contract.mjs
+++ b/scripts/ops/check-friday-ios-design-destination-capture-contract.mjs
@@ -16,7 +16,7 @@ function readText(repoRoot, relativePath) {
 const repoRoot = resolveRepoRoot();
 const scriptPath = "scripts/ops/friday-ios-design-destination-capture.sh";
 const pkgPath = "package.json";
-const requiredDestinations = [
+const requiredProductDestinations = [
   "home",
   "missions",
   "session",
@@ -34,6 +34,8 @@ const requiredDestinations = [
   "onboarding",
   "settings",
   "petEditor",
+];
+const internalDebugDestinations = [
   "proofViewer",
   "entrypoints",
 ];
@@ -54,12 +56,28 @@ pushCheck("iOS selected destination capture runner exists", scriptPath, scriptEx
 
 if (scriptExists) {
   const source = readText(repoRoot, scriptPath);
-  const missingDestinations = requiredDestinations.filter((destination) => !source.includes(destination));
+  const defaultDestinations = source.match(/destinations_csv="([^"]+)"/)?.[1]?.split(",") ?? [];
+  const internalDestinations = source.match(/internal_debug_destinations_csv="([^"]+)"/)?.[1]?.split(",") ?? [];
+  const missingDestinations = requiredProductDestinations.filter((destination) => !defaultDestinations.includes(destination));
+  const leakedInternalDestinations = internalDebugDestinations.filter((destination) => defaultDestinations.includes(destination));
+  const missingInternalDestinations = internalDebugDestinations.filter((destination) => !internalDestinations.includes(destination));
   pushCheck(
-    "iOS capture runner enumerates selected mobile destinations",
+    "iOS capture runner enumerates selected user-product mobile destinations",
     scriptPath,
     missingDestinations.length === 0,
     missingDestinations,
+  );
+  pushCheck(
+    "iOS capture runner excludes internal proof/debug destinations from the default user-product capture",
+    scriptPath,
+    leakedInternalDestinations.length === 0,
+    leakedInternalDestinations,
+  );
+  pushCheck(
+    "iOS capture runner keeps internal proof/debug destinations available for explicit diagnostics",
+    scriptPath,
+    missingInternalDestinations.length === 0,
+    missingInternalDestinations,
   );
   const requiredTruthStrings = [
     "ios_selected_design_destination_capture_not_live_closure",
@@ -96,7 +114,8 @@ const report = {
   repoRoot,
   truthLabel: "ios_design_destination_capture_contract_static_guard_not_runtime_pass",
   status: failed.length === 0 ? "passed" : "failed",
-  requiredDestinations,
+  requiredProductDestinations,
+  internalDebugDestinations,
   checks,
   caveat: "This proves the selected-design capture runner and package hook remain present and that offline-truth is not the selected visual proof lane; it does not claim screenshots were captured, END-BAR, GO-LIVE, adoption, or live action closure.",
 };

--- a/scripts/ops/check-friday-uiux-action-traceability.mjs
+++ b/scripts/ops/check-friday-uiux-action-traceability.mjs
@@ -379,7 +379,9 @@ const desktopDestinations = parseProductContract(
   resolve(repoRoot, "apps/macos/FridayHubConsole/Sources/FridayHubConsoleCore/DesktopProductReadinessContract.swift"),
   "desktop",
 );
-const productDestinations = [...mobileDestinations, ...desktopDestinations];
+const allDestinations = [...mobileDestinations, ...desktopDestinations];
+const internalDebugDestinations = allDestinations.filter((destination) => destination.tier === "internalDebug");
+const productDestinations = allDestinations.filter((destination) => destination.tier !== "internalDebug");
 const runtimeEvidencePaths = unique([
   ...runtimeEvidenceArgs.map((value) => resolve(value)),
   ...evidenceDirs.flatMap((dir) => runtimeEvidenceFromDir(dir)),
@@ -480,6 +482,7 @@ const report = {
     actionableContractRows: actionableContractRows.length,
     uniqueActionableContractRows: uniqueActionableIdentities.length,
     productDestinations: tracedDestinations.length,
+    internalDebugDestinations: internalDebugDestinations.length,
     productRuntimeActionIds: productActions.length,
     runtimeEvidenceInputs: runtimeEvidencePaths.length,
     runtimeEvidenceActionRows: evidenceActions.length,
@@ -498,6 +501,14 @@ const report = {
     counts: designActionRuntimeReport?.counts || null,
     runtimeEvidenceInputs: designActionRuntimeReport?.runtimeEvidenceInputs || runtimeEvidencePaths,
   },
+  internalDebugDestinations: internalDebugDestinations.map(({ surface, id, title, tier, runtimeActionIds }) => ({
+    surface,
+    id,
+    title,
+    tier,
+    runtimeActionIds,
+    caveat: "Internal proof/debug destination retained for diagnostics; excluded from user END-BAR product destination counts.",
+  })),
   bySurface: Object.fromEntries(["mobile", "desktop"].map((surface) => {
     const destinations = tracedDestinations.filter((destination) => destination.surface === surface);
     return [surface, {

--- a/scripts/ops/friday-ios-design-destination-capture.sh
+++ b/scripts/ops/friday-ios-design-destination-capture.sh
@@ -31,7 +31,8 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 out_dir=""
 mode="live-loopback"
 skip_initial_build=0
-destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,voice,pairing,needsMe,memory,platform,providerAuth,activity,workflows,onboarding,settings,petEditor,proofViewer,entrypoints"
+destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,voice,pairing,needsMe,memory,platform,providerAuth,activity,workflows,onboarding,settings,petEditor"
+internal_debug_destinations_csv="proofViewer,entrypoints"
 settle_seconds="${FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS:-6}"
 mission_id="${FRIDAY_MOBILE_MISSION_ID:-}"
 

--- a/test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts
+++ b/test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts
@@ -20,7 +20,8 @@ function createFixtureRepo(extraScriptSource = "") {
     },
   }, null, 2));
   writeFileWithParents(root, "scripts/ops/friday-ios-design-destination-capture.sh", `#!/usr/bin/env bash
-destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,voice,pairing,needsMe,memory,platform,providerAuth,activity,workflows,onboarding,settings,petEditor,proofViewer,entrypoints"
+destinations_csv="home,missions,session,contextPassport,tokenLedger,shareIntake,voice,pairing,needsMe,memory,platform,providerAuth,activity,workflows,onboarding,settings,petEditor"
+internal_debug_destinations_csv="proofViewer,entrypoints"
 truth_label="ios_selected_design_destination_capture_not_live_closure"
 design_source="friday-design-handoff-20260602/saved/mobile-selection.json"
 repo_head="$(git -C "$repo_root" rev-parse HEAD)"
@@ -43,14 +44,16 @@ describe("friday-ios-design-destination-capture-contract", () => {
       const report = JSON.parse(stdout) as {
         status?: string;
         truthLabel?: string;
-        requiredDestinations?: string[];
+        requiredProductDestinations?: string[];
+        internalDebugDestinations?: string[];
       };
       expect(report.status).toBe("passed");
       expect(report.truthLabel).toBe("ios_design_destination_capture_contract_static_guard_not_runtime_pass");
-      expect(report.requiredDestinations).toContain("providerAuth");
-      expect(report.requiredDestinations).toContain("petEditor");
-      expect(report.requiredDestinations).toContain("proofViewer");
-      expect(report.requiredDestinations).toContain("entrypoints");
+      expect(report.requiredProductDestinations).toContain("providerAuth");
+      expect(report.requiredProductDestinations).toContain("petEditor");
+      expect(report.requiredProductDestinations).not.toContain("proofViewer");
+      expect(report.requiredProductDestinations).not.toContain("entrypoints");
+      expect(report.internalDebugDestinations).toEqual(["proofViewer", "entrypoints"]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-mobile-command-sheet-product-path.test.ts
+++ b/test/unit/qa/friday-mobile-command-sheet-product-path.test.ts
@@ -70,4 +70,13 @@ describe("Friday mobile command sheet product path", () => {
 
     expect(userLauncher).not.toMatch(/\b(readiness|proof|END-BAR|entrypoint)\b/i);
   });
+
+  it("requires an explicit internal flag before initial launch can open proof harness routes", () => {
+    const text = readFileSync(appShell, "utf8");
+
+    expect(text).toContain("initialDestinationAllowed(destination, args: args, env: env)");
+    expect(text).toContain("destination.closureTier == .internalDebug");
+    expect(text).toContain('FRIDAY_MOBILE_ALLOW_INTERNAL_DESTINATION');
+    expect(text).toContain('--allow-internal-destination');
+  });
 });


### PR DESCRIPTION
## Summary
- reclassify iOS `proofViewer` and `entrypoints` as internal diagnostics instead of user END-BAR product destinations
- keep those proof/debug routes available for explicit diagnostics while excluding them from the default selected-design destination capture
- guard iOS initial-destination launch so internal proof harness routes require an explicit internal flag
- teach the UI/UX action traceability report to separate product destinations from internal debug destinations

## Verification
- `swift test` in `apps/friday-ios`
- `bash apps/friday-ios/build-sim.sh --mode design-proof-sample --shot=/private/tmp/friday-ios-1425-internal-guard-build.png`
- `FRIDAY_IOS_DESIGN_CAPTURE_SETTLE_SECONDS=1 bash scripts/ops/friday-ios-design-destination-capture.sh --mode design-proof-sample --out-dir /private/tmp/friday-ios-design-capture-1425-current`
- `node scripts/ops/check-friday-served-ui-design-fidelity.mjs --out=/private/tmp/friday-served-ui-fidelity-1425-current.json`
- `node scripts/ops/check-friday-uiux-selected-visual-proof.mjs --evidence-dir=/private/tmp/friday-ios-design-capture-1425-current --served-ui-report=/private/tmp/friday-served-ui-fidelity-1425-current.json --out=/private/tmp/friday-selected-visual-proof-1425-current-fresh.json` => `selected_visual_proof_ready`
- `./node_modules/.bin/vitest run --project default test/unit/qa/friday-ios-design-destination-capture-contract-cli.test.ts test/unit/qa/friday-uiux-action-traceability-cli.test.ts test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts test/unit/qa/friday-mobile-command-sheet-product-path.test.ts`
- `npm run typecheck:src`
- `node scripts/ops/check-friday-ios-design-destination-capture-contract.mjs`
- `node scripts/ops/check-friday-uiux-action-traceability.mjs --compact --out=/private/tmp/friday-uiux-action-traceability-5c39a93d-internal-debug-final.json`

## Truth labels
- Internal proof/debug screens are retained; this does not delete diagnostics.
- Selected visual proof is current-head visual evidence only; it does not claim runtime action closure.
- This does not claim END-BAR, GO-LIVE, release, adoption, or real user runtime closure.
- Product traceability still reports runtime evidence gaps separately.
