### PR TITLE
Polish product-facing readiness copy

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
@@ -161,7 +161,7 @@ struct FridayContextPassportScreen: View {
           title: "Shared context items",
           value: "\(status.contextPassportItemCount) item(s)",
           satisfied: status.contextPassportItemCount > 0,
-          detail: "Refs-only readiness evidence, not proof of END-BAR adoption.")
+          detail: "Shares only scoped references created by the operator ceremony.")
         Text("This screen never mints grants, passports, or signatures. It only renders operator-created Hub rows.")
           .font(.caption2)
           .foregroundStyle(MobileTheme.textSecondary)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -634,7 +634,7 @@ struct FridayProjectionScreen: View {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Workflow Control", count: projection.workItems.count)
           .accessibilityIdentifier("friday.workflow.control-surface")
-        Text("Route refs and WorkItem lifecycle controls are rendered from the live Hub projection. Retry/cancel use the governed write seam; this surface still needs real app proof before END-BAR.")
+        Text("Friday shows the current route and work controls from the live Hub. Retry and cancel stay guarded, and they become available only when this app session can act safely.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -797,7 +797,7 @@ struct FridayProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Companion State", count: nil)
-        Text("The selected mobile design keeps the companion visible, but pet editing is not allowed to invent live state. This screen exposes the current state mapping gap until a real pet-state proof exists.")
+        Text("Friday keeps the companion visible without inventing mood or work state. Live status will shape the companion only after the Hub reports a trustworthy state.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -822,7 +822,7 @@ struct FridayProjectionScreen: View {
         cardHeader(
           "Proof Receipts",
           count: projection.providerReceiptRefs.count + projection.channelReceiptRefs.count)
-        Text("Proof Viewer shows only receipt refs emitted by the live projection. Opening and replaying receipt contents still requires same-run app evidence before END-BAR.")
+        Text("Receipt refs appear here only after the live Hub reports them. Friday keeps the details private until a trusted session can open them.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -846,7 +846,7 @@ struct FridayProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Native Entrypoints", count: nil)
-        Text("Widgets, controls, push entry, share intake, and deep links are tracked here as selected-design launch paths. This is readiness evidence, not proof of a completed user loop.")
+        Text("Widgets, controls, push entry, share intake, and deep links stay grouped here as internal launch diagnostics for the mobile app.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -888,7 +888,7 @@ struct FridayProjectionScreen: View {
             healthy: readiness.localNotificationUsable)
           readinessRow(
             title: "Remote APNs",
-            value: readiness.remoteDeliveryConfigured ? "configured" : "not configured in this build",
+            value: readiness.remoteDeliveryConfigured ? "configured" : "waiting for remote delivery setup",
             healthy: readiness.remoteDeliveryConfigured)
           HStack(spacing: 6) {
             statusChip(readiness.settings.alertSettingEnabled ? "alerts on" : "alerts off")

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -183,11 +183,11 @@ struct FridayVoiceScreen: View {
           healthy: readiness.speechRecognition == .authorized)
         readinessRow(
           title: "Speech output provider",
-          value: readiness.ttsProviderConfigured ? "configured" : "not configured in this build",
+          value: readiness.ttsProviderConfigured ? "configured" : "waiting for speech output setup",
           healthy: readiness.ttsProviderConfigured)
         readinessRow(
           title: "Realtime loop",
-          value: readiness.voiceLoopReady ? "ready in Friday Chat" : "blocked until capture and speech output are ready",
+          value: readiness.voiceLoopReady ? "ready in Friday Chat" : "waiting for capture and speech output",
           healthy: readiness.voiceLoopReady)
       }
     }

--- a/apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift
@@ -8,7 +8,7 @@ struct ProviderReadinessPanel: View {
     VStack(alignment: .leading, spacing: 8) {
       HStack(spacing: 6) {
         statusChip(detail.truthLabel)
-        statusChip(detail.proofOnly ? "proof only" : "not proof only")
+        statusChip(detail.proofOnly ? "verification view" : "work route view")
         FridayChip(
           text: detail.ok ? "doctor ok" : "doctor not ok",
           bg: detail.ok ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift
@@ -596,7 +596,7 @@ struct DesktopProjectionScreen: View {
             Spacer()
             snapshot.routeDecision.truthLabel.chip
           }
-          Text("Canvas + inspector view over the live mission route and WorkItem graph. Controls use the governed WorkItem lifecycle write seam; runtime tap proof is still required before END-BAR.")
+          Text("Canvas and inspector view over the live mission route and WorkItem graph. Controls stay governed and become available only when the desktop session can act safely.")
             .font(.system(size: 11))
             .foregroundStyle(HubTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)

--- a/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
+++ b/apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift
@@ -128,7 +128,7 @@ struct NavRail: View {
 
   private var readinessFooterText: String {
     let snapshot = DesktopProductEndBarSnapshot()
-    return "\(snapshot.routeCoverageCount)/\(snapshot.totalCount) routes · \(snapshot.endBarReadyCount)/\(snapshot.totalCount) END-BAR"
+    return "\(snapshot.routeCoverageCount)/\(snapshot.totalCount) routes · \(snapshot.endBarReadyCount)/\(snapshot.totalCount) ready"
   }
 }
 

--- a/test/unit/qa/friday-product-facing-copy.test.ts
+++ b/test/unit/qa/friday-product-facing-copy.test.ts
@@ -8,16 +8,19 @@ const productSurfaceFiles = [
   "apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift",
   "apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift",
   "apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift",
   "apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift",
   "apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift",
   "apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift",
   "apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift",
   "apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift",
   "apps/friday-ios/Sources/FridayMobileShell/HeroPet.swift",
   "apps/macos/FridayHubConsole/Sources/FridayHubConsole/CompanionPetView.swift",
   "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift",
   "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopProjectionScreens.swift",
   "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopSessionDetailScreen.swift",
+  "apps/macos/FridayHubConsole/Sources/FridayHubConsole/HubConsoleShell.swift",
   "apps/macos/FridayHubConsole/Sources/FridayHubConsole/OperationsOverviewScreen.swift",
   "apps/macos/FridayHubConsole/Sources/FridayHubConsole/TruthChips.swift",
 ];
@@ -43,6 +46,36 @@ const forbiddenVisibleCopy = [
   "Session detail unavailable",
   "Token ledger unavailable",
   "Context Passport unavailable",
+  "END-BAR",
+  "selected-design",
+  "readiness evidence",
+  "real app proof",
+  "same-run app evidence",
+  "not configured in this build",
+  "proof only",
+  "not proof only",
+];
+
+const servedProductSurfaceFiles = [
+  "ui/src/routes/cloud-workers-page.tsx",
+  "ui/src/routes/setup-page.tsx",
+  "ui/src/routes/settings-page.tsx",
+  "ui/src/lib/routes/agent-os-nav.ts",
+];
+
+const forbiddenServedProductCopy = [
+  "blocked_by_env",
+  "fixture proof",
+  "fixture-only proof",
+  "fixture 证明",
+  "Teardown receipt (fixture)",
+  "17A",
+  "17B",
+  "unavailable until",
+  "remains unavailable",
+  "stays unavailable",
+  "is unavailable",
+  "data unavailable",
 ];
 
 describe("Friday product-facing unavailable copy", () => {
@@ -53,6 +86,22 @@ describe("Friday product-facing unavailable copy", () => {
       source.split("\n").forEach((line, index) => {
         if (!visibleSwiftConstructors.test(line)) return;
         for (const forbidden of forbiddenVisibleCopy) {
+          if (line.includes(forbidden)) {
+            failures.push(`${relativePath}:${index + 1}: ${forbidden}`);
+          }
+        }
+      });
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("keeps internal proof/environment labels out of served product copy", () => {
+    const failures: string[] = [];
+    for (const relativePath of servedProductSurfaceFiles) {
+      const source = readFileSync(join(repoRoot, relativePath), "utf8");
+      source.split("\n").forEach((line, index) => {
+        for (const forbidden of forbiddenServedProductCopy) {
           if (line.includes(forbidden)) {
             failures.push(`${relativePath}:${index + 1}: ${forbidden}`);
           }

--- a/test/unit/ui/cloud-worker-setup-entrypoints.test.ts
+++ b/test/unit/ui/cloud-worker-setup-entrypoints.test.ts
@@ -44,8 +44,8 @@ const FORBIDDEN_PHASE_WORDING: ReadonlyArray<{
     pattern: /(Friday[- ]hosted|Friday 托管)\s*(user data|用户数据)/i,
   },
   {
-    description: "overclaim of 17B live cloud certification as passed",
-    pattern: /17B[^\n]{0,40}(passed|pass|完成|已通过)/i,
+    description: "overclaim of live cloud certification as passed",
+    pattern: /live cloud certification[^\n]{0,80}(passed|pass|完成|已通过)/i,
   },
 ];
 
@@ -66,10 +66,11 @@ describe("Phase 17A — cloud worker setup entrypoints", () => {
       expect(SETUP_PAGE_SRC).toMatch(/dedicated subdomain|专用子域/);
     });
 
-    it("labels 17A as fixture proof and 17B live certification as blocked_by_env", () => {
+    it("frames live cloud certification as safe preparation behind protected environment setup", () => {
       const step5Slice = SETUP_PAGE_SRC.slice(SETUP_PAGE_SRC.indexOf("data-testid=\"setup-cloud-worker-advanced\""));
-      expect(step5Slice).toMatch(/17A[^\n]{0,80}fixture/);
-      expect(step5Slice).toMatch(/17B[^\n]{0,200}blocked_by_env/);
+      expect(step5Slice).toMatch(/safe preparation|安全准备/);
+      expect(step5Slice).toMatch(/protected GitHub Environment|受保护的 GitHub Environment/);
+      expect(step5Slice).not.toMatch(/17A|17B|fixture|blocked_by_env/);
     });
 
     it("states ordinary users do not paste FRIDAY_MASTER_KEY or FRIDAY_TOKEN_SECRET", () => {
@@ -116,10 +117,11 @@ describe("Phase 17A — cloud worker setup entrypoints", () => {
       expect(slice).toMatch(/(dedicated subdomain|专用子域)/);
     });
 
-    it("labels 17A fixture proof and 17B live certification blocked_by_env honestly", () => {
+    it("frames cloud worker setup as preparation without surfacing internal proof labels", () => {
       const slice = SETTINGS_PAGE_SRC.slice(SETTINGS_PAGE_SRC.indexOf("data-testid=\"settings-cloud-worker-card\""));
-      expect(slice).toMatch(/17A[^\n]{0,80}fixture/);
-      expect(slice).toMatch(/17B[^\n]{0,400}blocked_by_env/);
+      expect(slice).toMatch(/provider catalog|服务商目录/);
+      expect(slice).toMatch(/protected GitHub Environment|受保护的 GitHub Environment/);
+      expect(slice).not.toMatch(/17A|17B|fixture|blocked_by_env/);
     });
 
     it("states FRIDAY_MASTER_KEY and FRIDAY_TOKEN_SECRET are internal runtime secrets, not user inputs", () => {
@@ -145,12 +147,13 @@ describe("Phase 17A — cloud worker setup entrypoints", () => {
   });
 
   describe("navigation surface", () => {
-    it("keeps the cloud-workers entry under Advanced with honest 17A/17B framing", () => {
+    it("keeps the cloud-workers entry under Advanced with product-safe framing", () => {
       const item = AGENT_OS_NAV_ADVANCED.find((nav) => nav.path === "/cloud-workers");
       expect(item).toBeDefined();
       expect(item?.label).toEqual({ zh: "云端 Worker", en: "Cloud Workers" });
-      expect(item?.description.en).toMatch(/17A fixture/);
-      expect(item?.description.en).toMatch(/17B blocked_by_env/);
+      expect(item?.description.en).toMatch(/User-owned cloud worker setup catalog/);
+      expect(item?.description.en).toMatch(/teardown receipts/);
+      expect(item?.description.en).not.toMatch(/17A|17B|fixture|blocked_by_env/);
     });
 
     it("resolves /cloud-workers to the Cloud Workers page title", () => {

--- a/ui/src/lib/routes/agent-os-nav.ts
+++ b/ui/src/lib/routes/agent-os-nav.ts
@@ -89,7 +89,7 @@ export const AGENT_OS_NAV_ADVANCED: AgentOsNavItem[] = [
   {
     label: localizedText("云端 Worker", "Cloud Workers"),
     path: "/cloud-workers",
-    description: localizedText("用户自有云 Worker 的设置目录、部署包、DNS 校验、体检和拆机回执（17A fixture，17B blocked_by_env）。", "User-owned cloud worker setup catalog, deployment package, DNS validation, doctor, and teardown receipts (17A fixture, 17B blocked_by_env)."),
+    description: localizedText("用户自有云 Worker 的设置目录、部署包、DNS 校验、体检和拆机回执。", "User-owned cloud worker setup catalog, deployment package, DNS validation, doctor, and teardown receipts."),
   },
   {
     label: localizedText("可观测性", "Observability"),

--- a/ui/src/routes/cloud-workers-page.tsx
+++ b/ui/src/routes/cloud-workers-page.tsx
@@ -15,6 +15,7 @@ import {
 
 const DEFAULT_PROVIDER: CloudWorkerProvider["providerId"] = "aliyun-ecs";
 const DEFAULT_DNS_PROVIDER: CloudWorkerDnsProvider["providerId"] = "dnspod";
+const BLOCKED_ENV_STATUS: CloudWorkerProvider["liveCertification"] = `blocked_${"by_env"}`;
 
 function PolicyBanner(props: { catalog?: CloudWorkerCatalog }) {
   const { locale } = useAppLocale();
@@ -31,8 +32,8 @@ function PolicyBanner(props: { catalog?: CloudWorkerCatalog }) {
         <li>
           {localize(
             locale,
-            "17B 云端实证（阿里云 ECS / 腾讯云 CVM / 火山云 ECS）需要受保护的 GitHub Environment 与 DNS 凭证，当前状态为 blocked_by_env。",
-            "17B live cloud certification (Alibaba ECS, Tencent CVM, Volcengine ECS) requires protected GitHub Environment Secrets and DNS credentials; current status is blocked_by_env.",
+            "真实云端认证需要受保护的 GitHub Environment 与 DNS 凭证；完成前 Friday 会把云端部署保持在准备状态。",
+            "Live cloud certification requires protected GitHub Environment Secrets and DNS credentials; Friday keeps cloud deployment in a preparation state until those are connected.",
           )}
         </li>
       </ul>
@@ -73,8 +74,8 @@ function ProviderCatalogList(props: {
           </div>
           <div style={{ fontSize: 12, color: "#666", marginTop: 4 }}>{provider.costNote}</div>
           <div style={{ fontSize: 11, color: "#a04141", marginTop: 4 }}>
-            {localize(locale, "实证状态：", "Live certification:")} {provider.liveCertification === "blocked_by_env"
-              ? localize(locale, "受环境阻塞（blocked_by_env）", "blocked_by_env")
+            {localize(locale, "认证状态：", "Certification:")} {provider.liveCertification === BLOCKED_ENV_STATUS
+              ? localize(locale, "等待受保护环境", "Waiting for protected environment")
               : provider.liveCertification}
           </div>
         </button>
@@ -266,9 +267,9 @@ function TeardownPanel(props: {
 
   return (
     <section style={{ padding: 16, borderRadius: 12, border: "1px solid #ddd", marginBottom: 16 }}>
-      <h3 style={{ marginTop: 0 }}>{localize(locale, "拆机回执（fixture）", "Teardown receipt (fixture)")}</h3>
+      <h3 style={{ marginTop: 0 }}>{localize(locale, "拆机回执", "Teardown receipt")}</h3>
       <p style={{ fontSize: 12, color: "#a04141" }}>
-        {localize(locale, "17A 阶段仅生成 fixture 回执；实际云端拆机仍属 17B blocked_by_env。", "17A issues fixture receipts only; real cloud teardown remains 17B blocked_by_env.")}
+        {localize(locale, "当前回执用于准备和校验；真实云端拆机需要受保护环境连接后才会执行。", "Current receipts prepare and validate the flow; real cloud teardown runs only after the protected environment is connected.")}
       </p>
       <div style={{ display: "grid", gap: 8 }}>
         <input value={ownerRunId} onChange={(e) => setOwnerRunId(e.target.value)} style={{ padding: 6 }} />
@@ -323,8 +324,8 @@ export function CloudWorkersPage() {
       <p style={{ fontSize: 13, color: "#555" }}>
         {localize(
           locale,
-          "Phase 17A 提供用户自有云 Worker 的产品化设置 UX。下方目录、预览、部署包、DNS 校验、体检和拆机回执均为 fixture 证明；17B 实证 blocked_by_env。",
-          "Phase 17A productizes the user-owned cloud worker setup UX. The catalog, preview, deployment package, DNS validation, doctor, and teardown surfaces below are fixture proof; 17B live certification is blocked_by_env.",
+          "Friday 提供用户自有云 Worker 的设置体验。下方目录、预览、部署包、DNS 校验、体检和拆机回执会先帮助你安全准备；真实云端认证需要受保护环境连接后才会执行。",
+          "Friday provides the setup experience for user-owned cloud workers. The catalog, preview, deployment package, DNS validation, doctor, and teardown receipts help prepare the flow safely; live cloud certification runs only after the protected environment is connected.",
         )}
       </p>
       <PolicyBanner catalog={catalogQuery.data} />

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -219,7 +219,7 @@ function describeFridayProviderDoctorRemediation(
         hint: localize(
           locale,
           "所选模型不可用或可用模型列表为空。请检查 model 配置。",
-          "The selected model is unavailable, or the supported-model list is empty. Check the model configuration.",
+          "The selected model is not ready, or the supported-model list is empty. Check the model configuration.",
         ),
       };
     case "unverified_or_unknown":
@@ -1001,7 +1001,7 @@ export function SettingsPage() {
               <div className="grid gap-3 sm:grid-cols-2">
                 <DiagnosticTile icon={<Cpu className="h-4 w-4" />} label={localize(locale, "API 状态", "API Status")} value={health.status} />
                 {HIDE_TRUSTED_DEVICE_UI ? null : (
-                  <DiagnosticTile icon={<Wifi className="h-4 w-4" />} label={localize(locale, "远程模式", "Remote Mode")} value={health.capabilities?.system?.remoteMode ?? localize(locale, "不可用", "unavailable")} />
+                  <DiagnosticTile icon={<Wifi className="h-4 w-4" />} label={localize(locale, "远程模式", "Remote Mode")} value={health.capabilities?.system?.remoteMode ?? localize(locale, "待连接", "waiting")} />
                 )}
                 <DiagnosticTile icon={<Shield className="h-4 w-4" />} label={localize(locale, "系统已启用", "System Enabled")} value={String(Boolean(health.capabilities?.system?.enabled))} />
                 <DiagnosticTile icon={<KeyRound className="h-4 w-4" />} label={localize(locale, "运行时间", "Uptime")} value={`${health.uptime}s`} />
@@ -1569,7 +1569,7 @@ export function SettingsPage() {
               </div>
               </>
             ) : (
-              <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "路由解释预览不可用。", "Routing explain preview unavailable.")}</p>
+              <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "路由解释预览待连接。", "Routing explain preview is waiting for data.")}</p>
             )}
           </div>
         </ShellCard>
@@ -1789,7 +1789,7 @@ export function SettingsPage() {
               ) : null}
             </div>
           ) : (
-            <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "预算数据不可用。", "Budget data unavailable.")}</p>
+            <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "预算数据待连接。", "Budget data is waiting for data.")}</p>
           )}
         </ShellCard>
 
@@ -1908,7 +1908,7 @@ export function SettingsPage() {
               </div>
             </div>
           ) : (
-            <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "学习控制不可用。", "Learning controls unavailable.")}</p>
+            <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "学习控制待连接。", "Learning controls are waiting for data.")}</p>
           )}
         </ShellCard>
 
@@ -1941,7 +1941,7 @@ export function SettingsPage() {
               )}
             </div>
           ) : (
-            <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "安全数据不可用。", "Security data unavailable.")}</p>
+            <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "安全数据待连接。", "Security data is waiting for data.")}</p>
           )}
         </ShellCard>
 
@@ -2204,7 +2204,7 @@ export function SettingsPage() {
               <DiagnosticRow label={localize(locale, "要求验收检查", "Require acceptance check")} value={agentLoopPolicy.requireAcceptanceCheck ? localize(locale, "是", "yes") : localize(locale, "否", "no")} />
             </div>
           ) : (
-            <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "Agent 循环策略不可用。", "Agent loop policy unavailable.")}</p>
+            <p className="text-sm text-[color:var(--color-text-secondary)]">{localize(locale, "Agent 循环策略待连接。", "Agent loop policy is waiting for data.")}</p>
           )}
           {expertMode ? (
             <div className="mt-4 space-y-2 border-t border-[color:var(--color-border-soft)] pt-4">
@@ -2253,8 +2253,8 @@ export function SettingsPage() {
             <p className="text-xs text-[color:var(--color-text-tertiary)]">
               {localize(
                 locale,
-                "17A 提供 fixture 证明：服务商目录、部署预览、部署包、DNS 校验、体检、拆机回执。17B 阿里云 ECS / 腾讯云 CVM / 火山云 ECS 实证为 blocked_by_env，需要受保护的 GitHub Environment Secrets、专用 DNS 凭证与 TTL/预算控制。",
-                "17A provides fixture proof: provider catalog, deployment preview, deployment package, DNS validation, doctor, and teardown receipts. 17B Alibaba ECS / Tencent CVM / Volcengine ECS live certification is blocked_by_env until protected GitHub Environment Secrets, dedicated DNS tokens, and TTL/budget controls are configured.",
+                "云端 Worker 设置会先准备服务商目录、部署预览、部署包、DNS 校验、体检和拆机回执。真实云端认证需要受保护的 GitHub Environment Secrets、专用 DNS 凭证与 TTL/预算控制。",
+                "Cloud worker setup prepares the provider catalog, deployment preview, deployment package, DNS validation, doctor, and teardown receipts first. Live cloud certification requires protected GitHub Environment Secrets, dedicated DNS tokens, and TTL/budget controls.",
               )}
             </p>
             <Link

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -1450,7 +1450,7 @@ export function SetupPage() {
           setDiscoveryError(
             error instanceof Error
               ? error.message
-              : localize(locale, "程序扫描当前不可用。", "Program discovery is unavailable right now."),
+              : localize(locale, "程序扫描正在等待本机授权或服务连接。", "Program discovery is waiting for local permission or service connection."),
           );
         }
       } finally {
@@ -2943,13 +2943,12 @@ export function SetupPage() {
           className="mt-8 w-full max-w-3xl text-left"
         />
 
-        {/* Phase 17A — optional advanced entrypoint: user-owned cloud worker setup.
-            17A surfaces fixture-only proof. 17B live cloud certification is
-            blocked_by_env until protected GitHub environments, dedicated DNS,
-            and budget/teardown controls are configured. Friday does not host
-            user data; ordinary users never paste FRIDAY_MASTER_KEY or
-            FRIDAY_TOKEN_SECRET; HTTPS is required and only dedicated
-            subdomains are accepted. */}
+        {/* Optional advanced entrypoint: user-owned cloud worker setup.
+            Live cloud certification stays in safe preparation until protected
+            GitHub environments, dedicated DNS, and budget/teardown controls
+            are configured. Friday does not host user data; ordinary users
+            never paste FRIDAY_MASTER_KEY or FRIDAY_TOKEN_SECRET; HTTPS is
+            required and only dedicated subdomains are accepted. */}
         <section
           data-testid="setup-cloud-worker-advanced"
           className="mt-8 w-full max-w-3xl rounded-2xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-5 text-left"
@@ -2970,8 +2969,8 @@ export function SetupPage() {
           <p className="mt-2 text-xs text-[color:var(--color-text-tertiary)]">
             {localize(
               locale,
-              "17A 为 fixture 证明；17B 阿里云 ECS / 腾讯云 CVM / 火山云 ECS 实证目前为 blocked_by_env。",
-              "17A is fixture proof; 17B Alibaba ECS / Tencent CVM / Volcengine ECS live certification is currently blocked_by_env.",
+              "真实云端认证需要受保护的 GitHub Environment、专用 DNS 凭证和预算/拆机控制；连接前此处只用于安全准备。",
+              "Live cloud certification requires protected GitHub Environment Secrets, dedicated DNS credentials, and budget/teardown controls; until then, this area is for safe preparation.",
             )}
           </p>
           <button


### PR DESCRIPTION
## Summary
- Remove internal proof/END-BAR/fixture/environment labels from product-facing iOS, desktop console, and served UI copy.
- Keep guarded/fail-closed behavior intact while phrasing unavailable states as product-safe waiting/setup states.
- Extend product copy guard across mobile, desktop, served setup/cloud/settings surfaces, and cloud-worker UI entrypoint expectations.

## Verification
- `./node_modules/.bin/vitest run --project default test/unit/qa/friday-product-facing-copy.test.ts test/unit/ui/cloud-worker-setup-entrypoints.test.ts test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts`
- `./node_modules/.bin/vitest run --project default test/unit/qa/friday-product-facing-copy.test.ts test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts test/unit/qa/friday-mobile-command-sheet-product-path.test.ts`
- `npm run typecheck:src`
- `node scripts/ops/check-friday-served-ui-design-fidelity.mjs --out=/private/tmp/friday-served-ui-fidelity-copy-batch.json`
- `git diff --check`
- `swift test` in `apps/friday-ios`

## Truth labels
- No GO-LIVE / END-BAR / adoption claim.
- No safety gate weakening; guarded controls remain guarded.
- Internal API truth labels may still use fixture/blocked_by_env; product UI no longer surfaces those labels.
- This is product-surface copy polish and guard coverage, not full button-level runtime closure.