### PR TITLE
Tighten selected UI detail fidelity

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -397,11 +397,11 @@ struct FridayHomeScreen: View {
           Image(systemName: "antenna.radiowaves.left.and.right")
             .foregroundStyle(MobileTheme.textSecondary).frame(width: 22)
           // The runtime feed status TRUTH label rides AS-IS — never upgraded.
-          Text("feed: \(projection.runtimeFeedStatus)")
+          Text("Live connection: \(projection.runtimeFeedStatus)")
             .font(.subheadline).foregroundStyle(MobileTheme.textPrimary)
           Spacer()
         }
-        FridayProofLine(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "mission", ref: projection.missionId)
         if !projection.statusLabels.isEmpty {
           HStack(alignment: .firstTextBaseline, spacing: 8) {
             Text("notes")
@@ -428,7 +428,7 @@ struct FridayHomeScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         HStack(alignment: .firstTextBaseline) {
-          Text("Evidence flow")
+          Text("Activity flow")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
@@ -482,8 +482,8 @@ struct FridayHomeScreen: View {
     .accessibilityElement(children: .combine)
     .accessibilityLabel(
       projection.timelinePages.isEmpty
-        ? "Evidence flow waiting for bounded mission timeline pages"
-        : "Evidence flow shows \(projection.timelinePages.count) bounded mission timeline pages")
+        ? "Activity flow waiting for bounded mission timeline pages"
+        : "Activity flow shows \(projection.timelinePages.count) bounded mission timeline pages")
     .accessibilityIdentifier("friday.home.evidence-flow")
   }
 
@@ -802,7 +802,7 @@ struct FridayHomeScreen: View {
           Text("refs only — open the Mission Workbench for detail")
             .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
           ForEach(projection.workItemIds, id: \.self) { id in
-            FridayProofLine(label: "workItemId", ref: id)
+            FridayProofLine(label: "work item", ref: id)
           }
         }
       }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
@@ -98,14 +98,14 @@ struct FridayNewSessionScreen: View {
           Text(summary)
             .font(.caption)
             .foregroundStyle(MobileTheme.textPrimary)
-          FridayProofLine(label: "mission_id", ref: missionId)
-          FridayProofLine(label: "work_item_id", ref: workItemId)
+          FridayProofLine(label: "mission", ref: missionId)
+          FridayProofLine(label: "work item", ref: workItemId)
           FridayProofLine(label: "surface", ref: surfaceThreadId)
           FridayChip(
-            text: createdOrReady ? "created_or_ready" : status,
+            text: createdOrReady ? "ready" : status,
             bg: MobileTheme.chipDoneBG,
             fg: MobileTheme.chipDoneFG)
-          Text("Refs-only receipt. Provider execution and readable results still require the governed live loop to finish.")
+          Text("Friday saved a governed receipt. Provider execution and readable results still require the governed live loop to finish.")
             .font(.caption2)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -297,7 +297,7 @@ struct FridayProjectionScreen: View {
             .disabled(viewModel.detailState.isLoading)
           }
         } else {
-          Text("Session detail arms require an agent session ref in the projection.")
+          Text("Session details appear after Friday receives a live session link.")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
@@ -361,15 +361,15 @@ struct FridayProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Mission", count: nil)
-        FridayProofLine(label: "mission_id", ref: projection.missionId)
-        FridayProofLine(label: "conversation_id", ref: projection.fridayConversationId)
+        FridayProofLine(label: "mission", ref: projection.missionId)
+        FridayProofLine(label: "conversation", ref: projection.fridayConversationId)
         if let route = projection.routeDecisionSummary {
           Text(route)
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
         if let selected = projection.routeSelected {
-          FridayProofLine(label: "selectedRoute", ref: selected)
+          FridayProofLine(label: "selected route", ref: selected)
         }
       }
     }
@@ -433,8 +433,8 @@ struct FridayProjectionScreen: View {
           .font(.caption)
           .foregroundStyle(MobileTheme.textPrimary)
           .accessibilityIdentifier("friday.missions.dispatch-ready")
-        FridayProofLine(label: "mission_id", ref: missionId)
-        FridayProofLine(label: "work_item_id", ref: workItemId)
+        FridayProofLine(label: "mission", ref: missionId)
+        FridayProofLine(label: "work item", ref: workItemId)
         FridayProofLine(label: "action", ref: "mobile/missions/dispatch")
         Button {
           onOpenFridayChat(context)
@@ -536,7 +536,7 @@ struct FridayProjectionScreen: View {
           Image(systemName: "antenna.radiowaves.left.and.right")
             .foregroundStyle(MobileTheme.textSecondary)
             .frame(width: 22)
-          Text("feed: \(projection.runtimeFeedStatus)")
+          Text("Live connection: \(projection.runtimeFeedStatus)")
             .font(.subheadline)
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
@@ -572,7 +572,7 @@ struct FridayProjectionScreen: View {
                 statusChip(capability.truthLabel)
               }
               if !capability.proofRef.isEmpty {
-                FridayProofLine(label: "proofRef", ref: capability.proofRef)
+                FridayProofLine(label: "receipt", ref: capability.proofRef)
               }
             }
             .padding(.vertical, 4)
@@ -604,7 +604,7 @@ struct FridayProjectionScreen: View {
                 .font(.caption)
                 .foregroundStyle(MobileTheme.textSecondary)
               HStack(spacing: 8) {
-                FridayProofLine(label: "activity_id", ref: event.id)
+                FridayProofLine(label: "activity", ref: event.id)
                 Spacer()
                 Button {
                   Task { await viewModel.markActivityDone(activityId: event.id) }
@@ -619,7 +619,7 @@ struct FridayProjectionScreen: View {
               }
               candidateDecisionStateView(doneState, pendingText: "Marking activity done...")
               if let proofRef = event.proofRef {
-                FridayProofLine(label: "proofRef", ref: proofRef)
+                FridayProofLine(label: "receipt", ref: proofRef)
               }
             }
             .padding(.vertical, 4)
@@ -639,7 +639,7 @@ struct FridayProjectionScreen: View {
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         if let selected = projection.routeSelected {
-          FridayProofLine(label: "selectedRoute", ref: selected)
+          FridayProofLine(label: "selected route", ref: selected)
         }
         if !projection.routeAlternatives.isEmpty {
           VStack(alignment: .leading, spacing: 6) {
@@ -728,7 +728,7 @@ struct FridayProjectionScreen: View {
           Label("Check Provider Auth", systemImage: "stethoscope")
         }
         .disabled(viewModel.detailState.isLoading)
-        FridayProofLine(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "mission", ref: projection.missionId)
       }
     }
   }
@@ -810,7 +810,7 @@ struct FridayProjectionScreen: View {
           value: projection.runtimeFeedStatus.isEmpty ? "not in projection" : projection.runtimeFeedStatus,
           healthy: false)
         FridayProofLine(label: "action", ref: "mobile/pet/state-mapping")
-        FridayProofLine(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "mission", ref: projection.missionId)
       }
     }
     .accessibilityIdentifier("friday.pet-editor.readiness")
@@ -982,7 +982,7 @@ struct FridayProjectionScreen: View {
         candidateDecisionStateView(recoveryState, pendingText: "Updating WorkItem...")
       }
       if let proofRef = item.proofRef {
-        FridayProofLine(label: "proofRef", ref: proofRef)
+        FridayProofLine(label: "receipt", ref: proofRef)
       }
     }
     .padding(.vertical, 4)
@@ -1027,7 +1027,7 @@ struct FridayProjectionScreen: View {
       }
       candidateDecisionStateView(decisionState, pendingText: "Applying memory decision...")
       if !candidate.evidenceRef.isEmpty {
-        FridayProofLine(label: "evidenceRef", ref: candidate.evidenceRef)
+        FridayProofLine(label: "evidence", ref: candidate.evidenceRef)
       }
     }
     .padding(.vertical, 4)
@@ -1070,13 +1070,13 @@ struct FridayProjectionScreen: View {
       }
       learningDecisionStateView(decisionState)
       if !candidate.runId.isEmpty {
-        FridayProofLine(label: "runId", ref: candidate.runId)
+        FridayProofLine(label: "run", ref: candidate.runId)
       }
       if !candidate.workItemId.isEmpty {
-        FridayProofLine(label: "workItemId", ref: candidate.workItemId)
+        FridayProofLine(label: "work item", ref: candidate.workItemId)
       }
       if !candidate.evidenceRef.isEmpty {
-        FridayProofLine(label: "evidenceRef", ref: candidate.evidenceRef)
+        FridayProofLine(label: "evidence", ref: candidate.evidenceRef)
       }
     }
     .padding(.vertical, 4)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
@@ -303,9 +303,9 @@ struct FridayProviderAuthScreen: View {
         FridayProofLine(label: "selected_route", ref: route)
       }
       ForEach(projection.providerReceiptRefs.prefix(3), id: \.self) { ref in
-        FridayProofLine(label: "provider_receipt", ref: ref)
+        FridayProofLine(label: "provider receipt", ref: ref)
       }
-      FridayProofLine(label: "mission_id", ref: projection.missionId)
+      FridayProofLine(label: "mission", ref: projection.missionId)
     }
   }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -77,7 +77,7 @@ struct FridaySessionDetailScreen: View {
             bg: MobileTheme.chipPendingBG,
             fg: MobileTheme.chipPendingFG)
         }
-        FridayProofLine(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "mission", ref: projection.missionId)
         if let agentSessionId = projection.agentSessionId {
           FridayProofLine(label: "agent_session_id", ref: agentSessionId)
         }
@@ -557,13 +557,13 @@ struct FridaySessionDetailScreen: View {
       }
       learningDecisionStateView(decisionState)
       if !candidate.runId.isEmpty {
-        FridayProofLine(label: "runId", ref: candidate.runId)
+        FridayProofLine(label: "run", ref: candidate.runId)
       }
       if !candidate.workItemId.isEmpty {
-        FridayProofLine(label: "workItemId", ref: candidate.workItemId)
+        FridayProofLine(label: "work item", ref: candidate.workItemId)
       }
       if !candidate.evidenceRef.isEmpty {
-        FridayProofLine(label: "evidenceRef", ref: candidate.evidenceRef)
+        FridayProofLine(label: "evidence", ref: candidate.evidenceRef)
       }
     }
     .padding(.vertical, 4)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
@@ -82,13 +82,13 @@ struct FridayShareIntakeScreen: View {
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
             .accessibilityIdentifier("friday.share.ready")
-          FridayProofLine(label: "mission_id", ref: receipt.missionId)
+          FridayProofLine(label: "mission", ref: receipt.missionId)
           if let workItemId = receipt.workItemId {
-            FridayProofLine(label: "work_item_id", ref: workItemId)
+            FridayProofLine(label: "work item", ref: workItemId)
           }
           FridayProofLine(label: "surface", ref: receipt.surfaceThreadId)
           FridayChip(
-            text: receipt.createdOrReady ? "created_or_ready" : receipt.status,
+            text: receipt.createdOrReady ? "ready" : receipt.status,
             bg: MobileTheme.chipDoneBG,
             fg: MobileTheme.chipDoneFG)
           Divider().opacity(0.5)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
@@ -54,7 +54,7 @@ struct FridayTokenLedgerScreen: View {
           Text("Token Ledger")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
-          Text("refs-only provider usage readback")
+          Text("provider usage readback")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
@@ -89,7 +89,7 @@ struct FridayTokenLedgerScreen: View {
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         FridayProofLine(label: "run_id", ref: runId)
-        FridayProofLine(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "mission", ref: projection.missionId)
         Button {
           Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
         } label: {
@@ -112,7 +112,7 @@ struct FridayTokenLedgerScreen: View {
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
-        FridayProofLine(label: "mission_id", ref: projection.missionId)
+        FridayProofLine(label: "mission", ref: projection.missionId)
         FridayProofLine(label: "feed", ref: projection.runtimeFeedStatus)
       }
     }
@@ -131,10 +131,10 @@ struct FridayTokenLedgerScreen: View {
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
           ForEach(projection.providerReceiptRefs.prefix(5), id: \.self) { ref in
-            FridayProofLine(label: "provider_receipt", ref: ref)
+            FridayProofLine(label: "provider receipt", ref: ref)
           }
           ForEach(projection.channelReceiptRefs.prefix(5), id: \.self) { ref in
-            FridayProofLine(label: "channel_receipt", ref: ref)
+            FridayProofLine(label: "channel receipt", ref: ref)
           }
         }
       }

--- a/scripts/ops/check-friday-served-ui-design-fidelity.mjs
+++ b/scripts/ops/check-friday-served-ui-design-fidelity.mjs
@@ -192,10 +192,21 @@ function assertBuiltCss(tokens) {
       checks.push(fail("built css still carries old amber/jade token", { banned: value }));
     }
   }
+  const bannedDetailPatterns = [
+    ["decorative radial-gradient background", /radial-gradient/i],
+    ["legacy decorative orb class", /agent-orb/i],
+    ["old warm-brown detail stroke", /rgba\(\s*122,\s*106,\s*88/i],
+    ["old espresso grid stroke", /rgba\(\s*51,\s*41,\s*34/i],
+  ];
+  for (const [name, pattern] of bannedDetailPatterns) {
+    if (pattern.test(css)) {
+      checks.push(fail(`built css still carries ${name}`));
+    }
+  }
 
   return checks.length > 0
     ? checks
-    : [pass("built css applies cyan/coral tokens and excludes amber/jade tokens", { cssFiles: cssFiles.length })];
+    : [pass("built css applies cyan/coral tokens and excludes stale decorative palette remnants", { cssFiles: cssFiles.length })];
 }
 
 function swiftFiles() {

--- a/test/unit/qa/friday-product-facing-copy.test.ts
+++ b/test/unit/qa/friday-product-facing-copy.test.ts
@@ -111,4 +111,36 @@ describe("Friday product-facing unavailable copy", () => {
 
     expect(failures).toEqual([]);
   });
+
+  it("keeps raw receipt field names out of visible iOS product labels", () => {
+    const rawLabelPatterns = [
+      /FridayProofLine\(label:\s*"mission_id"/,
+      /FridayProofLine\(label:\s*"work_item_id"/,
+      /FridayProofLine\(label:\s*"conversation_id"/,
+      /FridayProofLine\(label:\s*"selectedRoute"/,
+      /FridayProofLine\(label:\s*"provider_receipt"/,
+      /FridayProofLine\(label:\s*"channel_receipt"/,
+      /FridayProofLine\(label:\s*"proofRef"/,
+      /FridayProofLine\(label:\s*"evidenceRef"/,
+      /FridayProofLine\(label:\s*"runId"/,
+      /FridayProofLine\(label:\s*"workItemId"/,
+      /FridayProofLine\(label:\s*"activity_id"/,
+      /Text\("feed:/,
+      /"Refs-only receipt/,
+      /"created_or_ready"/,
+    ];
+    const failures: string[] = [];
+    for (const relativePath of productSurfaceFiles) {
+      const source = readFileSync(join(repoRoot, relativePath), "utf8");
+      source.split("\n").forEach((line, index) => {
+        for (const pattern of rawLabelPatterns) {
+          if (pattern.test(line)) {
+            failures.push(`${relativePath}:${index + 1}: ${pattern}`);
+          }
+        }
+      });
+    }
+
+    expect(failures).toEqual([]);
+  });
 });

--- a/test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts
+++ b/test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts
@@ -130,7 +130,9 @@ function writeBadDist(root: string) {
   const distRoot = join(root, "dist");
   writeFile(distRoot, "assets/app.css", `
     :root { --amber-500: #c77d2e; --jade-500: #4f7a5c; }
-    body { background: #fff8ef; color: #2f2115; }
+    body { background: radial-gradient(circle, #fff8ef, #ffffff); color: #2f2115; }
+    .agent-orb { background: rgba(122, 106, 88, 0.18); }
+    .canvas { background-image: linear-gradient(to right, rgba(51, 41, 34, 0.05), transparent); }
   `);
   writeFile(distRoot, "index.html", `
     <!doctype html>
@@ -188,6 +190,10 @@ describe("check-friday-served-ui-design-fidelity", () => {
       const failures = report.checks?.filter((check) => check.ok === false).map((check) => check.message) ?? [];
       expect(failures).toEqual(expect.arrayContaining([
         "built css still carries old amber/jade token",
+        "built css still carries decorative radial-gradient background",
+        "built css still carries legacy decorative orb class",
+        "built css still carries old warm-brown detail stroke",
+        "built css still carries old espresso grid stroke",
         "iOS user path still contains stock borderedProminent button",
         "iOS user path still contains stock segmented picker",
         "iOS user path still contains generic StatusChip primitive",

--- a/ui/src/components/console/shell/console-shell.tsx
+++ b/ui/src/components/console/shell/console-shell.tsx
@@ -179,16 +179,16 @@ export function ConsoleShell() {
               <div
                 className="absolute inset-x-0 bottom-0 max-h-[82vh] overflow-y-auto rounded-t-[22px] border px-4 pb-5 pt-2 shadow-[0_-12px_44px_rgba(0,0,0,0.22)]"
                 style={{
-                  borderColor: "rgba(122, 106, 88, 0.18)",
+                  borderColor: "var(--surface-border)",
                   background: "var(--surface-2)",
                 }}
               >
                 <div
                   aria-hidden="true"
                   className="mx-auto mb-3 h-1.5 w-11 rounded-full"
-                  style={{ background: "rgba(122, 106, 88, 0.22)" }}
+                  style={{ background: "rgba(15, 125, 140, 0.22)" }}
                 />
-              <div className="flex items-center justify-between gap-3 border-b pb-3" style={{ borderColor: "rgba(122, 106, 88, 0.18)" }}>
+              <div className="flex items-center justify-between gap-3 border-b pb-3" style={{ borderColor: "var(--surface-border)" }}>
                 <div>
                   <p className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--ink-300)" }}>
                     {localize(locale, "命令面板", "Command Sheet")}
@@ -210,7 +210,7 @@ export function ConsoleShell() {
                     onClick={() => setShowMobileMore(false)}
                     className="min-h-[88px] rounded-[var(--radius-md)] border px-3 py-3"
                     style={{
-                      borderColor: "rgba(122, 106, 88, 0.18)",
+                      borderColor: "var(--surface-border)",
                       background: "var(--surface-2)",
                     }}
                   >

--- a/ui/src/components/console/shell/provider-truth.tsx
+++ b/ui/src/components/console/shell/provider-truth.tsx
@@ -132,7 +132,7 @@ export function ProviderTruthCompact(props: {
         className,
       )}
       style={{
-        borderColor: "rgba(122, 106, 88, 0.22)",
+        borderColor: "rgba(15, 125, 140, 0.22)",
         background: "var(--surface-2)",
         color: "var(--ink-700)",
       }}
@@ -147,7 +147,7 @@ export function ProviderTruthCompact(props: {
         <span
           className="shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px]"
           style={{
-            borderColor: "rgba(122, 106, 88, 0.2)",
+            borderColor: "rgba(15, 125, 140, 0.20)",
             color: "var(--ink-300)",
             fontFamily: "var(--font-mono-jb)",
           }}

--- a/ui/src/components/console/shell/rail.tsx
+++ b/ui/src/components/console/shell/rail.tsx
@@ -96,7 +96,7 @@ export function Rail({ collapsed, onToggleCollapse }: RailProps) {
         style={{
           background: "var(--surface-1)",
           borderColor: "var(--ink-300)",
-          borderRightColor: "rgba(122, 106, 88, 0.15)",
+          borderRightColor: "rgba(18, 40, 45, 0.10)",
         }}
       >
         <div className={cn("flex items-center gap-2 px-1 pb-3", collapsed ? "justify-center" : "justify-between")}>
@@ -141,7 +141,7 @@ export function Rail({ collapsed, onToggleCollapse }: RailProps) {
 
         <div
           className="mt-4 border-t pt-3"
-          style={{ borderColor: "rgba(122, 106, 88, 0.18)" }}
+          style={{ borderColor: "var(--surface-border)" }}
           aria-label="Advanced surfaces"
         >
           <nav className="space-y-1">
@@ -153,7 +153,7 @@ export function Rail({ collapsed, onToggleCollapse }: RailProps) {
 
         <div
           className="mt-auto border-t pt-3"
-          style={{ borderColor: "rgba(122, 106, 88, 0.18)" }}
+          style={{ borderColor: "var(--surface-border)" }}
         >
           <RailNavItem
             item={{
@@ -230,7 +230,7 @@ export function MobileNav(props: { onOpenMore: () => void }) {
       className="fixed inset-x-0 bottom-0 z-30 border-t lg:hidden"
       style={{
         background: "var(--surface-1)",
-        borderColor: "rgba(122, 106, 88, 0.18)",
+        borderColor: "var(--surface-border)",
         height: "var(--shell-mobile-nav-h)",
       }}
     >

--- a/ui/src/components/console/shell/right-rail-slots/assistant.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/assistant.tsx
@@ -71,7 +71,7 @@ function ApprovalRow(props: {
     <li
       className="flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3"
       style={{
-        borderColor: "rgba(122, 106, 88, 0.18)",
+        borderColor: "var(--surface-border)",
         background: "var(--surface-2)",
       }}
     >

--- a/ui/src/components/console/shell/right-rail-slots/automations.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/automations.tsx
@@ -59,7 +59,7 @@ function Row(props: { to: string; Icon: typeof CalendarClock; title: string; hin
         to={props.to}
         className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
         style={{
-          borderColor: "rgba(122, 106, 88, 0.18)",
+          borderColor: "var(--surface-border)",
           background: "var(--surface-2)",
         }}
       >

--- a/ui/src/components/console/shell/right-rail-slots/channels.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/channels.tsx
@@ -37,7 +37,7 @@ export function ChannelsRightRailSlot() {
       <div
         className="flex items-center gap-2 rounded-[var(--radius-md)] border px-3 py-2 text-xs"
         style={{
-          borderColor: "rgba(122, 106, 88, 0.18)",
+          borderColor: "var(--surface-border)",
           background: "var(--surface-2)",
           color: badge.color,
         }}
@@ -97,7 +97,7 @@ function Row(props: { to: string; Icon: typeof Radio; title: string; hint: strin
         to={props.to}
         className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
         style={{
-          borderColor: "rgba(122, 106, 88, 0.18)",
+          borderColor: "var(--surface-border)",
           background: "var(--surface-2)",
         }}
       >

--- a/ui/src/components/console/shell/right-rail-slots/home.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/home.tsx
@@ -51,7 +51,7 @@ export function HomeRightRailSlot() {
               to={item.to}
               className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
               style={{
-                borderColor: "rgba(122, 106, 88, 0.18)",
+                borderColor: "var(--surface-border)",
                 background: "var(--surface-2)",
               }}
             >

--- a/ui/src/components/console/shell/right-rail-slots/packs.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/packs.tsx
@@ -63,7 +63,7 @@ function PackRow(props: {
         to={props.to}
         className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
         style={{
-          borderColor: "rgba(122, 106, 88, 0.18)",
+          borderColor: "var(--surface-border)",
           background: "var(--surface-2)",
         }}
       >

--- a/ui/src/components/console/shell/right-rail-slots/sessions.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/sessions.tsx
@@ -45,7 +45,7 @@ export function SessionsRightRailSlot() {
                 to="/sessions"
                 className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
                 style={{
-                  borderColor: "rgba(122, 106, 88, 0.18)",
+                  borderColor: "var(--surface-border)",
                   background: "var(--surface-2)",
                 }}
               >
@@ -79,7 +79,7 @@ function EmptyRow(props: { locale: "zh" | "en" }) {
     <div
       className="flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3"
       style={{
-        borderColor: "rgba(122, 106, 88, 0.18)",
+        borderColor: "var(--surface-border)",
         background: "var(--surface-2)",
       }}
     >

--- a/ui/src/components/console/shell/right-rail-slots/settings-providers.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/settings-providers.tsx
@@ -53,7 +53,7 @@ export function SettingsProvidersRightRailSlot() {
       <div
         className="flex items-center gap-3 rounded-[var(--radius-md)] border px-3 py-3"
         style={{
-          borderColor: "rgba(122, 106, 88, 0.18)",
+          borderColor: "var(--surface-border)",
           background: "var(--surface-2)",
         }}
       >

--- a/ui/src/components/console/shell/right-rail-slots/usage.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/usage.tsx
@@ -59,7 +59,7 @@ function Row(props: { to: string; Icon: typeof Gauge; title: string; hint: strin
         to={props.to}
         className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
         style={{
-          borderColor: "rgba(122, 106, 88, 0.18)",
+          borderColor: "var(--surface-border)",
           background: "var(--surface-2)",
         }}
       >

--- a/ui/src/components/console/shell/right-rail-slots/workflows.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/workflows.tsx
@@ -59,7 +59,7 @@ function Row(props: { to: string; Icon: typeof Workflow; title: string; hint: st
         to={props.to}
         className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
         style={{
-          borderColor: "rgba(122, 106, 88, 0.18)",
+          borderColor: "var(--surface-border)",
           background: "var(--surface-2)",
         }}
       >

--- a/ui/src/components/console/shell/right-rail.tsx
+++ b/ui/src/components/console/shell/right-rail.tsx
@@ -343,7 +343,7 @@ export function RightRail() {
         >
           <span
             className="h-20 w-[3px] rounded-full opacity-55 transition-opacity group-hover/right-rail:opacity-100"
-            style={{ background: "rgba(122, 106, 88, 0.28)" }}
+            style={{ background: "rgba(15, 125, 140, 0.20)" }}
           />
         </button>
       ) : null}

--- a/ui/src/components/console/shell/splash/shell.tsx
+++ b/ui/src/components/console/shell/splash/shell.tsx
@@ -119,7 +119,7 @@ export function SplashShell(props: SplashShellProps) {
                 : {
                     background: "transparent",
                     color: "var(--ink-700)",
-                    border: "1px solid rgba(122, 106, 88, 0.22)",
+                    border: "1px solid rgba(15, 125, 140, 0.22)",
                   };
               const className = "inline-flex min-h-[40px] items-center gap-2 rounded-[var(--radius-md)] px-4 text-sm font-medium transition-opacity hover:opacity-90";
               if (action.href) {

--- a/ui/src/components/console/shell/top-bar.tsx
+++ b/ui/src/components/console/shell/top-bar.tsx
@@ -52,7 +52,7 @@ export function TopBar(props: {
       style={{
         height: "var(--shell-topbar-h)",
         background: "var(--surface-1)",
-        borderColor: "rgba(122, 106, 88, 0.18)",
+        borderColor: "var(--surface-border)",
       }}
     >
       <div className="flex min-w-0 items-center">
@@ -78,7 +78,7 @@ export function TopBar(props: {
           aria-label={localize(locale, "打开命令面板", "Open command palette")}
           className="inline-flex min-h-[36px] items-center gap-2 rounded-[var(--radius-md)] border px-3 text-xs transition-colors hover:bg-[color:var(--accent-soft)]"
           style={{
-            borderColor: "rgba(122, 106, 88, 0.22)",
+            borderColor: "rgba(15, 125, 140, 0.22)",
             background: "var(--surface-2)",
             color: "var(--ink-500)",
           }}
@@ -88,7 +88,7 @@ export function TopBar(props: {
           <kbd
             className="rounded border px-1 py-0.5 font-mono text-[10px]"
             style={{
-              borderColor: "rgba(122, 106, 88, 0.2)",
+              borderColor: "rgba(15, 125, 140, 0.20)",
               color: "var(--ink-300)",
               fontFamily: "var(--font-mono-jb)",
             }}
@@ -109,7 +109,7 @@ function LiveIndicator(props: { color: string; label: string }) {
       style={{
         background: "var(--surface-2)",
         color: "var(--ink-700)",
-        border: "1px solid rgba(122, 106, 88, 0.18)",
+        border: "1px solid var(--surface-border)",
       }}
     >
       <span
@@ -141,7 +141,7 @@ export function MobileTopBar(props: {
       style={{
         height: "var(--shell-mobile-topbar-h)",
         background: "var(--surface-1)",
-        borderColor: "rgba(122, 106, 88, 0.18)",
+        borderColor: "var(--surface-border)",
       }}
     >
       <div className="flex min-w-0 items-center gap-3">
@@ -150,7 +150,7 @@ export function MobileTopBar(props: {
           onClick={onToggleMobileMore}
           className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[var(--radius-md)] border"
           style={{
-            borderColor: "rgba(122, 106, 88, 0.22)",
+            borderColor: "rgba(15, 125, 140, 0.22)",
             background: "var(--surface-2)",
             color: "var(--ink-700)",
           }}
@@ -189,7 +189,7 @@ export function MobileTopBar(props: {
           onClick={onToggleLocale}
           className="flex h-9 items-center gap-1.5 rounded-[var(--radius-md)] border px-2 text-xs"
           style={{
-            borderColor: "rgba(122, 106, 88, 0.22)",
+            borderColor: "rgba(15, 125, 140, 0.22)",
             background: "var(--surface-2)",
             color: "var(--ink-700)",
           }}

--- a/ui/src/components/core/primitives.tsx
+++ b/ui/src/components/core/primitives.tsx
@@ -33,7 +33,7 @@ export function StatusPill(props: {
   return (
     <span
       className={cn(
-        "inline-flex min-h-[32px] items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] transition-colors",
+        "inline-flex min-h-[30px] items-center rounded-[var(--radius-sm)] border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.08em] transition-colors",
         props.tone === "success" && "border-[color:var(--color-border-success)] bg-[color:var(--color-bg-success-subtle)] text-[color:var(--color-text-success)]",
         props.tone === "warning" && "border-[color:var(--color-border-warning)] bg-[color:var(--color-bg-warning-subtle)] text-[color:var(--color-text-warning)]",
         props.tone === "danger" && "border-[color:var(--color-border-danger)] bg-[color:var(--color-bg-danger-subtle)] text-[color:var(--color-text-danger)]",
@@ -58,7 +58,7 @@ export function ActionButton(
     <button
       type={type ?? "button"}
       className={cn(
-        "inline-flex min-h-[44px] items-center justify-center rounded-2xl border px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50",
+        "inline-flex min-h-[40px] items-center justify-center rounded-[var(--radius-md)] border px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50",
         tone === "danger" && "border-[color:var(--color-border-strong)] bg-[color:var(--color-bg-contrast)] text-[color:var(--color-text-primary)] hover:bg-[color:var(--color-accent-muted)]",
         tone === "secondary" && "border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] text-[color:var(--color-text-secondary)] hover:border-[color:var(--color-border-strong)] hover:bg-[color:var(--color-bg-surface-strong)] hover:text-[color:var(--color-text-primary)]",
         (!tone || tone === "primary") && "border-[color:var(--color-accent)] bg-[color:var(--color-accent)] text-[color:var(--color-bg-base)] hover:opacity-90",

--- a/ui/src/components/workflows/workflow-builder-workspace.tsx
+++ b/ui/src/components/workflows/workflow-builder-workspace.tsx
@@ -2589,8 +2589,8 @@ function WorkflowBuilderEditor() {
                 className="pointer-events-none absolute inset-0 opacity-70"
                 style={{
                   backgroundImage: `
-                    linear-gradient(to right, rgba(51, 41, 34, 0.05) 1px, transparent 1px),
-                    linear-gradient(to bottom, rgba(51, 41, 34, 0.05) 1px, transparent 1px)
+                    linear-gradient(to right, rgba(15, 125, 140, 0.045) 1px, transparent 1px),
+                    linear-gradient(to bottom, rgba(15, 125, 140, 0.045) 1px, transparent 1px)
                   `,
                   backgroundSize: `${CANVAS_GRID_SIZE}px ${CANVAS_GRID_SIZE}px`,
                 }}

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -573,7 +573,7 @@ export function HomePage() {
                 <span
                   className="inline-flex min-h-[36px] items-center gap-2 rounded-[var(--radius-md)] border px-3 py-1.5 text-xs"
                   style={{
-                    borderColor: "rgba(122, 106, 88, 0.22)",
+                    borderColor: "rgba(15, 125, 140, 0.22)",
                     background: "var(--surface-2)",
                     color: "var(--ink-700)",
                   }}
@@ -598,7 +598,7 @@ export function HomePage() {
                   onClick={() => requestCommandPaletteOpen()}
                   className="inline-flex min-h-[36px] items-center gap-2 rounded-[var(--radius-md)] border px-3 text-xs transition-colors hover:bg-[color:var(--accent-soft)]"
                   style={{
-                    borderColor: "rgba(122, 106, 88, 0.22)",
+                    borderColor: "rgba(15, 125, 140, 0.22)",
                     background: "var(--surface-2)",
                     color: "var(--ink-500)",
                   }}
@@ -608,7 +608,7 @@ export function HomePage() {
                   <kbd
                     className="rounded border px-1 py-0.5 font-mono text-[10px]"
                     style={{
-                      borderColor: "rgba(122, 106, 88, 0.2)",
+                      borderColor: "rgba(15, 125, 140, 0.20)",
                       color: "var(--ink-300)",
                       fontFamily: "var(--font-mono-jb)",
                     }}

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -3000,12 +3000,6 @@ export function SetupPage() {
 
   return (
     <div className="relative min-h-screen bg-[color:var(--color-bg-base)] text-[color:var(--color-text-primary)]">
-      {/* Subtle background orbs */}
-      <div className="pointer-events-none absolute inset-0">
-        <div className="agent-orb agent-orb-left" />
-        <div className="agent-orb agent-orb-right" />
-      </div>
-
       <div className="relative">
         {currentStep === 0 && renderStep0()}
         {currentStep === 1 && renderStep1()}

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -61,7 +61,7 @@
   --font-mono: "JetBrains Mono", "IBM Plex Mono", "SFMono-Regular", ui-monospace, monospace;
 
   --density-card-padding: 1.35rem;
-  --density-card-radius: 28px;
+  --density-card-radius: 16px;
   --density-section-gap: 1.25rem;
   --density-grid-gap: 1rem;
 
@@ -111,7 +111,7 @@
   --color-bg-chrome-strong: rgba(255, 255, 255, 0.78);
 
   --density-card-padding: 1.15rem;
-  --density-card-radius: 22px;
+  --density-card-radius: 14px;
   --density-section-gap: 1rem;
   --density-grid-gap: 0.85rem;
 
@@ -119,10 +119,7 @@
 }
 
 [data-locale="zh"] body {
-  background:
-    radial-gradient(circle at top left, rgba(15, 125, 140, 0.06), transparent 28%),
-    radial-gradient(circle at bottom right, rgba(216, 99, 77, 0.04), transparent 24%),
-    linear-gradient(180deg, #f7f6f2 0%, #ffffff 100%);
+  background: #f7f6f2;
 }
 
 [data-locale="zh"] .agent-eyebrow {
@@ -151,10 +148,7 @@
   body {
     min-height: 100vh;
     margin: 0;
-    background:
-      radial-gradient(circle at top left, var(--color-accent-muted), transparent 28%),
-      radial-gradient(circle at bottom right, rgba(51, 41, 34, 0.05), transparent 24%),
-      linear-gradient(180deg, var(--color-bg-base) 0%, var(--color-bg-elevated) 100%);
+    background: var(--color-bg-base);
     color: var(--color-text-primary);
     font-family: var(--font-display);
     font-feature-settings: "rlig" 1, "calt" 1;
@@ -179,31 +173,9 @@
 
 .agent-grid {
   background-image:
-    linear-gradient(rgba(51, 41, 34, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(51, 41, 34, 0.04) 1px, transparent 1px);
+    linear-gradient(rgba(15, 125, 140, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(15, 125, 140, 0.04) 1px, transparent 1px);
   background-size: 36px 36px;
-  mask-image: radial-gradient(circle at center, black 34%, transparent 84%);
-}
-
-.agent-orb {
-  position: absolute;
-  width: 30rem;
-  height: 30rem;
-  border-radius: 9999px;
-  filter: blur(72px);
-  opacity: 0.22;
-}
-
-.agent-orb-left {
-  left: -9rem;
-  top: -8rem;
-  background: var(--color-accent-strong);
-}
-
-.agent-orb-right {
-  right: -12rem;
-  bottom: -9rem;
-  background: rgba(51, 41, 34, 0.08);
 }
 
 .agent-card {
@@ -247,7 +219,7 @@
   font-family: var(--font-display);
   font-size: 1.25rem;
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
   color: var(--color-text-primary);
 }
 
@@ -506,10 +478,10 @@
   transition: background 0.3s;
 }
 .scrollbar-autohide.is-scrolling {
-  scrollbar-color: rgba(51, 41, 34, 0.15) transparent;
+  scrollbar-color: rgba(15, 125, 140, 0.18) transparent;
 }
 .scrollbar-autohide.is-scrolling::-webkit-scrollbar-thumb {
-  background: rgba(51, 41, 34, 0.15);
+  background: rgba(15, 125, 140, 0.18);
 }
 
 /* ── Mobile refinements ── */

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -38,10 +38,10 @@
   --rust-500: var(--danger);
 
   /* ── Radius ── */
-  --radius-sm: 11px;
-  --radius-md: 15px;
-  --radius-lg: 22px;
-  --radius-xl: 30px;
+  --radius-sm: 8px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 18px;
 
   /* ── Shell layout ── */
   --shell-rail-w: 240px;


### PR DESCRIPTION
## Summary
- remove stale decorative orbs, radial-gradient backgrounds, old warm-brown detail strokes, and over-rounded shared controls from selected served UI paths
- clean visible iOS product receipt labels so raw field names do not leak into the user path
- extend selected-design fidelity/product-copy gates to fail on stale decorative palette remnants and raw iOS receipt labels

## Verification
- `./node_modules/.bin/vitest run --project default test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts test/unit/qa/friday-product-facing-copy.test.ts`
- `npm run typecheck:src`
- `swift test` in `apps/friday-ios`
- `node scripts/ops/check-friday-served-ui-design-fidelity.mjs --out=/private/tmp/friday-served-ui-fidelity-detail-batch.json`
- `git diff --check`

Truth: this tightens selected UI detail fidelity for served desktop + iOS; it does not claim every product action is fully release-polished or END-BAR complete.