### PR TITLE
Polish iOS product surface copy

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -233,7 +233,7 @@ struct FridayChatScreen: View {
                 .foregroundStyle(MobileTheme.textPrimary)
                 .lineLimit(4)
               if item.receiptRefs.isEmpty, let runId = item.runId {
-                FridayProofLine(label: "run_id", ref: short(runId))
+                FridayProofLine(label: "run", ref: short(runId))
               } else if !item.receiptRefs.isEmpty {
                 receiptRefs(item.receiptRefs, limit: 4)
               }
@@ -252,7 +252,7 @@ struct FridayChatScreen: View {
     case .composing:
       placeholder(
         "Ask Friday anything.",
-        "Answers are refs-only (a fingerprint + counts). "
+        "Answers include receipts and readable content when the owner-gated readback grants it. "
           + (runControlEnabled
             ? "A mutating action pauses for your approval."
             : "Read-only — approvals are not available yet."))
@@ -436,10 +436,10 @@ struct FridayChatScreen: View {
             .fixedSize(horizontal: false, vertical: true)
             .textSelection(.enabled)
           if let runId = r.answerBodyRunId {
-            FridayProofLine(label: "answer_body_run_id", ref: runId)
+            FridayProofLine(label: "answer run", ref: runId)
           }
         } else {
-          Text("Answer body is not available from the owner-gated readback yet.")
+          Text("Friday saved the answer receipt; readable text will appear after the owner-gated readback grants it.")
             .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
         }
         receiptRefs(r.receiptRefs)
@@ -467,10 +467,10 @@ struct FridayChatScreen: View {
           Text(summary).font(.callout).foregroundStyle(MobileTheme.textPrimary)
         }
         // PROOF (the digest the operator signs over) — never a body.
-        FridayProofLine(label: "action_digest", ref: short(card.actionDigest))
-        FridayProofLine(label: "approval_id", ref: card.approvalId)
+        FridayProofLine(label: "action seal", ref: short(card.actionDigest))
+        FridayProofLine(label: "approval", ref: card.approvalId)
         Text("Friday paused this mutating action. Approving asks the operator signer for a "
-          + "signature; the phone relays it but never signs (INV-1).")
+          + "signature; the phone relays it but never signs.")
           .font(.caption2).foregroundStyle(MobileTheme.textSecondary)
         HStack(spacing: 12) {
           Button {
@@ -549,7 +549,7 @@ struct FridayChatScreen: View {
         FridayProofLine(label: ref.label, ref: short(ref.ref))
       }
       if let limit, refs.count > limit {
-        FridayProofLine(label: "more_refs", ref: "+\(refs.count - limit)")
+        FridayProofLine(label: "more receipts", ref: "+\(refs.count - limit)")
       }
     }
     .accessibilityIdentifier("friday.chat.receipt-refs")

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
@@ -15,8 +15,8 @@ struct FridayContextPassportScreen: View {
           header(status: "connect", ready: false)
           UnavailableView(
             reason: reason,
-            title: "Connect Context Passport",
-            detail: "Friday needs the live Hub projection to show PairAck, trust grant, and passport readiness.",
+            title: "Connect Shared Context",
+            detail: "Friday needs the live Hub projection to show paired-device setup, approval grant, and shared-context readiness.",
             systemImage: "checklist.checked",
             identifier: "friday.context-passport.unavailable")
         case .loaded(let projection):
@@ -39,15 +39,15 @@ struct FridayContextPassportScreen: View {
       checklistCard(status)
       governedCeremoniesCard(status)
       sendCard(projection)
-      refsCard(status)
-      truthCard(status)
+      deviceCard(status)
+      setupDetailsCard(status)
     } else {
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
           Text("Waiting for provisioning")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
-          Text("PairAck, trust grant, and context passport status will appear after the Hub projection refreshes.")
+          Text("Device pairing, approval grant, and shared-context status will appear after the Hub projection refreshes.")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -64,10 +64,10 @@ struct FridayContextPassportScreen: View {
           .foregroundStyle(ready ? MobileTheme.cyan : MobileTheme.coral)
           .frame(width: 34, height: 34)
         VStack(alignment: .leading, spacing: 4) {
-          Text("Context Passport")
+          Text("Shared Context")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
-          Text("governed device and shared-context readiness")
+          Text("paired device and shared-context readiness")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
@@ -85,7 +85,7 @@ struct FridayContextPassportScreen: View {
     GlassPanel {
       HStack(spacing: 12) {
         ProgressView()
-        Text("Reading provisioning truth")
+          Text("Checking shared-context status")
           .font(.footnote)
           .foregroundStyle(MobileTheme.textSecondary)
       }
@@ -125,16 +125,16 @@ struct FridayContextPassportScreen: View {
     .accessibilityIdentifier("friday.context-passport.checklist")
   }
 
-  private func refsCard(_ status: HomeT3ProvisioningStatus) -> some View {
+  private func deviceCard(_ status: HomeT3ProvisioningStatus) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Device", count: nil)
         if let device = status.latestDevice {
-          FridayProofLine(label: "device_id", ref: device.deviceId)
+          FridayProofLine(label: "device", ref: device.deviceId)
           FridayProofLine(label: "label", ref: device.label)
-          FridayProofLine(label: "fingerprint", ref: device.pubkeyFingerprint)
+          FridayProofLine(label: "device key", ref: device.pubkeyFingerprint)
         } else {
-          Text("No trusted device ref is present in this projection.")
+          Text("No paired device is visible yet.")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -146,15 +146,15 @@ struct FridayContextPassportScreen: View {
   private func governedCeremoniesCard(_ status: HomeT3ProvisioningStatus) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-        cardHeader("Governed Ceremonies", count: nil)
+        cardHeader("Operator Setup", count: nil)
         ceremonyRow(
-          title: "Trust grant",
+          title: "Approval grant",
           value: "\(status.activeTrustGrantCount) active / \(status.trustGrantCount) total",
           satisfied: status.activeTrustGrantCount > 0,
           detail: "Authorizes scoped Friday work; mobile only reads the Hub projection.")
         ceremonyRow(
-          title: "Context passport",
-          value: "\(status.contextPassportCount) minted",
+          title: "Shared context",
+          value: status.contextPassportCount > 0 ? "\(status.contextPassportCount) ready" : "waiting",
           satisfied: status.contextPassportCount > 0,
           detail: "Shares non-sensitive mission context to the governed destination lane.")
         ceremonyRow(
@@ -162,7 +162,7 @@ struct FridayContextPassportScreen: View {
           value: "\(status.contextPassportItemCount) item(s)",
           satisfied: status.contextPassportItemCount > 0,
           detail: "Shares only scoped references created by the operator ceremony.")
-        Text("This screen never mints grants, passports, or signatures. It only renders operator-created Hub rows.")
+        Text("This screen only shows setup completed by the operator. It never creates approvals or signatures.")
           .font(.caption2)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -198,7 +198,7 @@ struct FridayContextPassportScreen: View {
   private func sendCard(_ projection: HomeProjection) -> some View {
     let status = projection.t3ProvisioningStatus
     let isReady = status?.isFullyProvisioned == true
-    let missing = status?.missingOperatorSteps.joined(separator: ", ") ?? "T3 projection"
+    let missing = userFacingProvisioningMissing(status?.missingOperatorSteps ?? [])
     return GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Send", count: 3)
@@ -242,20 +242,37 @@ struct FridayContextPassportScreen: View {
     }
   }
 
-  private func truthCard(_ status: HomeT3ProvisioningStatus) -> some View {
+  private func setupDetailsCard(_ status: HomeT3ProvisioningStatus) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-        cardHeader("Truth", count: nil)
+        cardHeader("Setup Details", count: nil)
         Text(status.homeSummary)
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
-        FridayProofLine(label: "truth", ref: status.truthLabel)
+        FridayProofLine(label: "status", ref: status.truthLabel)
         if !status.missingOperatorSteps.isEmpty {
-          FridayProofLine(label: "missing", ref: status.missingOperatorSteps.joined(separator: ", "))
+          FridayProofLine(label: "needed", ref: userFacingProvisioningMissing(status.missingOperatorSteps))
         }
       }
     }
+  }
+
+  private func userFacingProvisioningMissing(_ steps: [String]) -> String {
+    guard !steps.isEmpty else { return "setup" }
+    return steps.map { step in
+      switch step {
+      case "trusted_device", "device_identity", "active_trusted_device":
+        return "paired device"
+      case "trust_grant", "active_trust_grant":
+        return "approval grant"
+      case "context_passport", "context_passport_item":
+        return "shared context"
+      default:
+        return step.replacingOccurrences(of: "_", with: " ")
+      }
+    }
+    .joined(separator: ", ")
   }
 
   private func cardHeader(_ title: String, count: Int?) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -823,7 +823,7 @@ struct FridayHomeScreen: View {
     if attempt.mode != .idle {
       Divider().opacity(0.35)
       HStack {
-        Text("PairAck").font(.caption.weight(.semibold)).foregroundStyle(MobileTheme.textPrimary)
+        Text("Pairing receipt").font(.caption.weight(.semibold)).foregroundStyle(MobileTheme.textPrimary)
         Spacer()
         FridayChip(
           text: attempt.mode.rawValue,
@@ -835,16 +835,16 @@ struct FridayHomeScreen: View {
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
       if let hubId = attempt.hubId {
-        FridayProofLine(label: "ack_hub_id", ref: hubId)
+        FridayProofLine(label: "hub", ref: hubId)
       }
       if let pairingId = attempt.pairingId {
-        FridayProofLine(label: "ack_pairing_id", ref: pairingId)
+        FridayProofLine(label: "pairing", ref: pairingId)
       }
       if let deviceId = attempt.deviceId {
-        FridayProofLine(label: "ack_device_id", ref: deviceId)
+        FridayProofLine(label: "device", ref: deviceId)
       }
       if let errorCode = attempt.errorCode {
-        FridayProofLine(label: "ack_error", ref: errorCode)
+        FridayProofLine(label: "issue", ref: errorCode)
       }
     }
   }
@@ -853,7 +853,7 @@ struct FridayHomeScreen: View {
   private func hubProvisioningRows(_ status: HomeT3ProvisioningStatus?) -> some View {
     Divider().opacity(0.35)
     HStack {
-      Text("Hub provisioning").font(.caption.weight(.semibold)).foregroundStyle(MobileTheme.textPrimary)
+      Text("Hub setup").font(.caption.weight(.semibold)).foregroundStyle(MobileTheme.textPrimary)
       Spacer()
       if let status {
         FridayChip(
@@ -870,22 +870,22 @@ struct FridayHomeScreen: View {
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
       if !status.missingOperatorSteps.isEmpty {
-        FridayProofLine(label: "missing", ref: status.missingOperatorSteps.joined(separator: ", "))
+        FridayProofLine(label: "needed", ref: userFacingProvisioningMissing(status.missingOperatorSteps))
       }
       if let device = status.latestDevice {
-        FridayProofLine(label: "latest_device", ref: device.deviceId)
-        FridayProofLine(label: "device_fingerprint", ref: device.pubkeyFingerprint)
+        FridayProofLine(label: "device", ref: device.deviceId)
+        FridayProofLine(label: "device key", ref: device.pubkeyFingerprint)
       }
-      FridayProofLine(label: "device_identity_count", ref: String(status.deviceIdentityCount))
-      FridayProofLine(label: "trusted_device_count", ref: String(status.trustedDeviceCount))
-      FridayProofLine(label: "active_trusted_device_count", ref: String(status.activeTrustedDeviceCount))
-      FridayProofLine(label: "trust_grant_count", ref: String(status.trustGrantCount))
-      FridayProofLine(label: "active_trust_grant_count", ref: String(status.activeTrustGrantCount))
-      FridayProofLine(label: "context_passport_count", ref: String(status.contextPassportCount))
-      FridayProofLine(label: "context_passport_item_count", ref: String(status.contextPassportItemCount))
-      FridayProofLine(label: "truth", ref: status.truthLabel)
+      FridayProofLine(label: "device records", ref: String(status.deviceIdentityCount))
+      FridayProofLine(label: "trusted devices", ref: String(status.trustedDeviceCount))
+      FridayProofLine(label: "active devices", ref: String(status.activeTrustedDeviceCount))
+      FridayProofLine(label: "approval grants", ref: String(status.trustGrantCount))
+      FridayProofLine(label: "active grants", ref: String(status.activeTrustGrantCount))
+      FridayProofLine(label: "shared contexts", ref: String(status.contextPassportCount))
+      FridayProofLine(label: "shared items", ref: String(status.contextPassportItemCount))
+      FridayProofLine(label: "setup status", ref: status.truthLabel)
     } else {
-        Text("Connect to the live Hub to see PairAck, trust grant, and context passport status.")
+        Text("Connect to the live Hub to see pairing, approval grant, and shared-context status.")
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
@@ -943,6 +943,23 @@ struct FridayHomeScreen: View {
     .accessibilityElement(children: .combine)
     .accessibilityLabel("Work items, \(projection.workItemIds.count) references")
     .accessibilityIdentifier("friday.home.work-items-card")
+  }
+
+  private func userFacingProvisioningMissing(_ steps: [String]) -> String {
+    guard !steps.isEmpty else { return "setup" }
+    return steps.map { step in
+      switch step {
+      case "trusted_device", "device_identity", "active_trusted_device":
+        return "paired device"
+      case "trust_grant", "active_trust_grant":
+        return "approval grant"
+      case "context_passport", "context_passport_item":
+        return "shared context"
+      default:
+        return step.replacingOccurrences(of: "_", with: " ")
+      }
+    }
+    .joined(separator: ", ")
   }
 }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -72,8 +72,8 @@ private enum ProjectionSurface {
     case .onboarding: return "Onboarding"
     case .settings: return "Settings"
     case .petEditor: return "Pet Editor"
-    case .proofViewer: return "Proof Viewer"
-    case .entrypoints: return "iOS Entrypoints"
+    case .proofViewer: return "Receipts"
+    case .entrypoints: return "Launch Tools"
     }
   }
 
@@ -95,7 +95,7 @@ private enum ProjectionSurface {
 
   var statusLabel: String {
     switch self {
-    case .missions: return "mission truth"
+    case .missions: return "mission status"
     case .needsMe: return "operator attention"
     case .memory: return "candidate review"
     case .platform: return "runtime"
@@ -104,8 +104,8 @@ private enum ProjectionSurface {
     case .onboarding: return "local readiness"
     case .settings: return "read seam"
     case .petEditor: return "companion state"
-    case .proofViewer: return "receipt truth"
-    case .entrypoints: return "native launchers"
+    case .proofViewer: return "receipt review"
+    case .entrypoints: return "mobile launch tools"
     }
   }
 }
@@ -336,7 +336,7 @@ struct FridayProjectionScreen: View {
           Text(detail.summary)
             .font(.caption)
             .foregroundStyle(MobileTheme.textPrimary)
-          FridayProofLine(label: "generated", ref: generatedText(detail.generatedAtMs))
+          FridayProofLine(label: "updated", ref: generatedText(detail.generatedAtMs))
           if let providerReadiness = detail.providerReadiness {
             ProviderReadinessPanel(detail: providerReadiness)
           }
@@ -362,14 +362,14 @@ struct FridayProjectionScreen: View {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Mission", count: nil)
         FridayProofLine(label: "mission", ref: projection.missionId)
-        FridayProofLine(label: "conversation", ref: projection.fridayConversationId)
+        FridayProofLine(label: "thread", ref: projection.fridayConversationId)
         if let route = projection.routeDecisionSummary {
           Text(route)
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
         if let selected = projection.routeSelected {
-          FridayProofLine(label: "selected route", ref: selected)
+          FridayProofLine(label: "route", ref: selected)
         }
       }
     }
@@ -465,7 +465,7 @@ struct FridayProjectionScreen: View {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Work Items", count: projection.workItems.count)
         if projection.workItems.isEmpty {
-          emptyText("No work-item refs in this projection.")
+          emptyText("No active work items are visible right now.")
         } else {
           ForEach(projection.workItems) { item in
             workItemRow(item)
@@ -483,7 +483,7 @@ struct FridayProjectionScreen: View {
         if attentionItems.isEmpty && projection.memoryCandidates.isEmpty
           && projection.runOutcomeLearningCandidates.isEmpty
         {
-          emptyText("No projected operator-attention refs.")
+          emptyText("No approvals, memory reviews, or recovery items need your attention.")
         } else {
           ForEach(attentionItems) { item in
             workItemRow(item)
@@ -542,7 +542,7 @@ struct FridayProjectionScreen: View {
           Spacer()
         }
         FridayProofLine(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
-        FridayProofLine(label: "generated", ref: generatedText(projection.generatedAtMs))
+        FridayProofLine(label: "updated", ref: generatedText(projection.generatedAtMs))
       }
     }
   }
@@ -552,7 +552,7 @@ struct FridayProjectionScreen: View {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Capabilities", count: projection.capabilityStates.count)
         if projection.capabilityStates.isEmpty {
-          emptyText("No capability refs in this projection.")
+          emptyText("No capability updates are visible right now.")
         } else {
           ForEach(projection.capabilityStates) { capability in
             VStack(alignment: .leading, spacing: 6) {
@@ -588,19 +588,19 @@ struct FridayProjectionScreen: View {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Activity", count: projection.transcriptEvents.count)
         if projection.transcriptEvents.isEmpty {
-          emptyText("No transcript events in this projection.")
+          emptyText("No recent activity is visible right now.")
         } else {
           ForEach(projection.transcriptEvents.prefix(12)) { event in
             let doneState = viewModel.activityMarkDoneStates[event.id]
             VStack(alignment: .leading, spacing: 5) {
               HStack {
-                Text(event.sectionTitle)
+                Text(displayEventSection(event.sectionTitle))
                   .font(.system(size: 12, weight: .semibold))
                   .foregroundStyle(MobileTheme.textPrimary)
                 Spacer()
-                statusChip(event.status)
+                statusChip(displayStatus(event.status))
               }
-              Text(event.summary)
+              Text(displayEventSummary(event.summary))
                 .font(.caption)
                 .foregroundStyle(MobileTheme.textSecondary)
               HStack(spacing: 8) {
@@ -639,7 +639,7 @@ struct FridayProjectionScreen: View {
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         if let selected = projection.routeSelected {
-          FridayProofLine(label: "selected route", ref: selected)
+          FridayProofLine(label: "route", ref: selected)
         }
         if !projection.routeAlternatives.isEmpty {
           VStack(alignment: .leading, spacing: 6) {
@@ -647,7 +647,7 @@ struct FridayProjectionScreen: View {
               .font(.caption.weight(.semibold))
               .foregroundStyle(MobileTheme.textSecondary)
             ForEach(projection.routeAlternatives, id: \.self) { alternative in
-              FridayProofLine(label: "alternative", ref: alternative)
+              FridayProofLine(label: "option", ref: alternative)
             }
           }
         }
@@ -656,7 +656,7 @@ struct FridayProjectionScreen: View {
           FridayProofLine(label: "action", ref: "mobile/workflow/cancel")
         }
         if projection.workItems.isEmpty {
-          emptyText("No workflow work-item refs.")
+          emptyText("No workflow work items are visible right now.")
         } else {
           VStack(alignment: .leading, spacing: 8) {
             ForEach(projection.workItems) { item in
@@ -672,10 +672,10 @@ struct FridayProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader(
-          "Receipt Refs",
+          "Receipts",
           count: projection.providerReceiptRefs.count + projection.channelReceiptRefs.count)
         if projection.providerReceiptRefs.isEmpty && projection.channelReceiptRefs.isEmpty {
-          emptyText("No receipt refs in this projection.")
+          emptyText("No receipts are visible right now.")
         } else {
           ForEach(projection.providerReceiptRefs, id: \.self) {
             FridayProofLine(label: "provider", ref: $0)
@@ -737,26 +737,26 @@ struct FridayProjectionScreen: View {
   private func t3ProvisioningRows(_ status: HomeT3ProvisioningStatus?) -> some View {
     if let status {
       readinessRow(
-        title: "Trust grant",
-        value: status.activeTrustGrantCount > 0 ? "active grant present" : "operator grant not present",
+        title: "Approval grant",
+        value: status.activeTrustGrantCount > 0 ? "active" : "waiting for operator",
         healthy: status.activeTrustGrantCount > 0)
       readinessRow(
-        title: "Context passport",
-        value: status.contextPassportCount > 0 ? "\(status.contextPassportCount) passport(s)" : "not minted",
+        title: "Shared context",
+        value: status.contextPassportCount > 0 ? "\(status.contextPassportCount) ready" : "waiting for setup",
         healthy: status.contextPassportCount > 0 && status.contextPassportItemCount > 0)
       if let device = status.latestDevice {
-        FridayProofLine(label: "trusted_device", ref: device.deviceId)
-        FridayProofLine(label: "device_fingerprint", ref: device.pubkeyFingerprint)
+        FridayProofLine(label: "device", ref: device.deviceId)
+        FridayProofLine(label: "device key", ref: device.pubkeyFingerprint)
       }
-      FridayProofLine(label: "truth", ref: status.truthLabel)
+      FridayProofLine(label: "setup status", ref: status.truthLabel)
     } else {
       readinessRow(
-        title: "Trust grant",
-        value: "not in projection",
+        title: "Approval grant",
+        value: "waiting for Hub projection",
         healthy: false)
       readinessRow(
-        title: "Context passport",
-        value: "not in projection",
+        title: "Shared context",
+        value: "waiting for Hub projection",
         healthy: false)
     }
   }
@@ -769,7 +769,7 @@ struct FridayProjectionScreen: View {
         FridayProofLine(label: "mode", ref: "live-read projection")
         FridayProofLine(label: "protocol", ref: "v\(fridayCurrentSchemaVersion)")
         FridayProofLine(label: "feed", ref: projection.runtimeFeedStatus)
-        FridayProofLine(label: "generated", ref: generatedText(projection.generatedAtMs))
+        FridayProofLine(label: "updated", ref: generatedText(projection.generatedAtMs))
         Button {
           Task { await viewModel.loadDetail(.providersDoctor(probe: nil)) }
         } label: {
@@ -807,7 +807,7 @@ struct FridayProjectionScreen: View {
           healthy: true)
         readinessRow(
           title: "Live state mapping",
-          value: projection.runtimeFeedStatus.isEmpty ? "not in projection" : projection.runtimeFeedStatus,
+          value: projection.runtimeFeedStatus.isEmpty ? "waiting for Hub projection" : projection.runtimeFeedStatus,
           healthy: false)
         FridayProofLine(label: "action", ref: "mobile/pet/state-mapping")
         FridayProofLine(label: "mission", ref: projection.missionId)
@@ -820,14 +820,14 @@ struct FridayProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader(
-          "Proof Receipts",
+          "Receipts",
           count: projection.providerReceiptRefs.count + projection.channelReceiptRefs.count)
-        Text("Receipt refs appear here only after the live Hub reports them. Friday keeps the details private until a trusted session can open them.")
+        Text("Receipts appear here only after the live Hub reports them. Friday keeps details private until a trusted session can open them.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         if projection.providerReceiptRefs.isEmpty && projection.channelReceiptRefs.isEmpty {
-          emptyText("No proof receipt refs in this projection.")
+          emptyText("No receipts are visible right now.")
         } else {
           ForEach(projection.providerReceiptRefs, id: \.self) {
             FridayProofLine(label: "provider", ref: $0)
@@ -845,8 +845,8 @@ struct FridayProjectionScreen: View {
   private func entrypointsCard(_ projection: HomeProjection) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-        cardHeader("Native Entrypoints", count: nil)
-        Text("Widgets, controls, push entry, share intake, and deep links stay grouped here as internal launch diagnostics for the mobile app.")
+        cardHeader("Launch Tools", count: nil)
+        Text("Widgets, controls, push entry, share intake, and deep links stay grouped here for internal mobile diagnostics.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -855,7 +855,7 @@ struct FridayProjectionScreen: View {
         readinessRow(title: "Push entry", value: "local permission surface wired; APNs delivery still unproven", healthy: false)
         readinessRow(title: "Widget/control", value: "native launcher proof still required", healthy: false)
         FridayProofLine(label: "action", ref: "mobile/entrypoints/readiness")
-        FridayProofLine(label: "conversation", ref: projection.fridayConversationId)
+        FridayProofLine(label: "thread", ref: projection.fridayConversationId)
       }
     }
     .accessibilityIdentifier("friday.entrypoints.readiness")
@@ -931,7 +931,7 @@ struct FridayProjectionScreen: View {
     let recoveryState = viewModel.workItemStatusStates[item.id]
     return VStack(alignment: .leading, spacing: 6) {
       HStack {
-        Text(item.title)
+        Text(displayWorkItemTitle(item.title, fallback: item.id))
           .font(.system(size: 13, weight: .medium))
           .foregroundStyle(MobileTheme.textPrimary)
           .accessibilityIdentifier("friday.workflow.work-item.\(item.id)")
@@ -942,12 +942,12 @@ struct FridayProjectionScreen: View {
           fg: item.done ? MobileTheme.chipDoneFG : MobileTheme.chipNeutralFG)
       }
       HStack(spacing: 6) {
-        statusChip(item.state)
-        statusChip(item.owner)
-        statusChip(item.recoveryKind)
+        statusChip(displayStatus(item.state))
+        statusChip(displayOwner(item.owner))
+        statusChip(displayStatus(item.recoveryKind))
       }
       if !item.blockingReason.isEmpty {
-        Text(item.blockingReason)
+        Text(displaySentence(item.blockingReason))
           .font(.system(size: 11))
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -1158,5 +1158,86 @@ struct FridayProjectionScreen: View {
     guard generatedAtMs > 0 else { return "unknown" }
     let date = Date(timeIntervalSince1970: Double(generatedAtMs) / 1000.0)
     return date.formatted(date: .abbreviated, time: .shortened)
+  }
+
+  private func displayWorkItemTitle(_ raw: String, fallback: String) -> String {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalized = trimmed.lowercased()
+    if normalized.contains("refs-only") && normalized.contains("round-trip") {
+      return "Review live device round-trip"
+    }
+    if normalized.contains("bounded mission timeline") {
+      return "Mission timeline updated"
+    }
+    if normalized.contains("desktop surface") {
+      return "Desktop surface linked"
+    }
+    if normalized.hasPrefix("proof://") || normalized.hasPrefix("proof:/") {
+      return "Route decision"
+    }
+    return displayTitle(trimmed.isEmpty ? fallback : trimmed)
+  }
+
+  private func displayEventSection(_ raw: String) -> String {
+    let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    if normalized.contains("transcript") {
+      return "Activity"
+    }
+    return displayTitle(raw)
+  }
+
+  private func displayEventSummary(_ raw: String) -> String {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalized = trimmed.lowercased()
+    if normalized.contains("bounded mission timeline") {
+      return "Mission timeline updated"
+    }
+    if normalized.contains("desktop surface") {
+      return "Desktop surface linked"
+    }
+    if normalized.hasPrefix("proof://") || normalized.hasPrefix("proof:/") {
+      return "Route decision receipt"
+    }
+    return displayTitle(trimmed.isEmpty ? "Activity update" : trimmed)
+  }
+
+  private func displayOwner(_ raw: String) -> String {
+    let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    if normalized == "friday_owned" || normalized == "friday-owned" {
+      return "Friday"
+    }
+    return displayStatus(raw)
+  }
+
+  private func displayStatus(_ raw: String) -> String {
+    let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    switch normalized {
+    case "ready_to_dispatch", "ready for dispatch":
+      return "ready"
+    case "timeline_read":
+      return "timeline"
+    case "completed_with_proof":
+      return "complete"
+    case "":
+      return "status"
+    default:
+      return displaySentence(raw)
+    }
+  }
+
+  private func displayTitle(_ raw: String) -> String {
+    let clean = displaySentence(raw)
+    guard let first = clean.first else { return "Friday update" }
+    return first.uppercased() + clean.dropFirst()
+  }
+
+  private func displaySentence(_ raw: String) -> String {
+    raw
+      .replacingOccurrences(of: "refs-only", with: "receipt")
+      .replacingOccurrences(of: "Proof://", with: "")
+      .replacingOccurrences(of: "proof://", with: "")
+      .replacingOccurrences(of: "_", with: " ")
+      .replacingOccurrences(of: "-", with: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
@@ -33,7 +33,7 @@ struct FridayProviderAuthScreen: View {
           Text("Provider Workspace")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
-          Text("provider readiness, queues, sessions, and native-control truth")
+          Text("provider connections, queues, sessions, and controls")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
@@ -49,7 +49,7 @@ struct FridayProviderAuthScreen: View {
         Text("Provider Doctor")
           .font(.headline)
           .foregroundStyle(MobileTheme.textPrimary)
-        Text("Checks provider CLI/auth/route readiness through the Hub read arm. This surface never asks for, stores, or displays provider secrets.")
+        Text("Checks provider login, route, and session readiness from the live Hub. This surface never asks for, stores, or displays provider secrets.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -74,7 +74,7 @@ struct FridayProviderAuthScreen: View {
       GlassPanel {
         HStack(spacing: 12) {
           ProgressView()
-          Text("Reading Provider Workspace projection")
+          Text("Checking Provider Workspace")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
@@ -127,13 +127,13 @@ struct FridayProviderAuthScreen: View {
         metricPill("Running", "\(projection.workItems.filter { !$0.done }.count)")
         metricPill("Capabilities", "\(projection.capabilityStates.count)")
       }
-      Text("Provider Workspace Home: route, queue, session controls, and cost refs are surfaced from the live Hub projection.")
+      Text("Provider workspace shows route, queue, session controls, and cost receipts from the live Hub.")
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
       let providerItems = projection.providerWorkItems
       if providerItems.isEmpty {
-        Text("No provider-linked WorkItem refs in the current projection.")
+        Text("No provider-linked work items are visible right now.")
           .font(.caption2)
           .foregroundStyle(MobileTheme.textSecondary)
       } else {
@@ -155,11 +155,11 @@ struct FridayProviderAuthScreen: View {
           .foregroundStyle(item.needsAttention ? MobileTheme.coral : MobileTheme.textSecondary)
           .frame(width: 18)
         VStack(alignment: .leading, spacing: 2) {
-          Text(item.title)
+          Text(displayWorkItemTitle(item.title, fallback: item.id))
             .font(.caption.weight(.semibold))
             .foregroundStyle(MobileTheme.textPrimary)
             .lineLimit(1)
-          Text("\(item.owner) · \(item.state)")
+          Text("\(displayOwner(item.owner)) · \(displayStatus(item.state))")
             .font(.caption2)
             .foregroundStyle(MobileTheme.textSecondary)
             .lineLimit(1)
@@ -171,13 +171,13 @@ struct FridayProviderAuthScreen: View {
           fg: item.done ? MobileTheme.chipDoneFG : (item.needsAttention ? MobileTheme.chipWarnFG : MobileTheme.chipNeutralFG))
       }
       if !item.blockingReason.isEmpty {
-        Text(item.blockingReason)
+        Text(displaySentence(item.blockingReason))
           .font(.caption2)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
       }
       if let proofRef = item.proofRef, !proofRef.isEmpty {
-        FridayProofLine(label: "work_item_proof", ref: proofRef)
+        FridayProofLine(label: "work receipt", ref: proofRef)
       }
       if item.canRetry || item.canCancel {
         HStack(spacing: 8) {
@@ -211,7 +211,7 @@ struct FridayProviderAuthScreen: View {
           .fixedSize(horizontal: false, vertical: true)
       }
       if !projection.routeAlternatives.isEmpty {
-        Text("alternates: \(projection.routeAlternatives.joined(separator: ", "))")
+        Text("Other safe routes: \(projection.routeAlternatives.map(displayRoute).joined(separator: ", ")).")
           .font(.caption2)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -227,15 +227,15 @@ struct FridayProviderAuthScreen: View {
         .foregroundStyle(MobileTheme.textPrimary)
       controlRow(
         "Token ledger",
-        state: projection.tokenLedgerRunId == nil ? "needs run ref" : "run readback ready",
+        state: projection.tokenLedgerRunId == nil ? "waiting for usage" : "usage ready",
         healthy: projection.tokenLedgerRunId != nil)
       controlRow(
         "Provider receipts",
-        state: projection.providerReceiptRefs.isEmpty ? "none projected" : "\(projection.providerReceiptRefs.count) refs",
+        state: projection.providerReceiptRefs.isEmpty ? "waiting" : "\(projection.providerReceiptRefs.count) receipt(s)",
         healthy: !projection.providerReceiptRefs.isEmpty)
       controlRow(
         "Channel receipts",
-        state: projection.channelReceiptRefs.isEmpty ? "none projected" : "\(projection.channelReceiptRefs.count) refs",
+        state: projection.channelReceiptRefs.isEmpty ? "waiting" : "\(projection.channelReceiptRefs.count) receipt(s)",
         healthy: !projection.channelReceiptRefs.isEmpty)
       if let runId = projection.tokenLedgerRunId {
         Button {
@@ -260,7 +260,7 @@ struct FridayProviderAuthScreen: View {
       controlRow("Session list", state: "live read", healthy: true)
       controlRow(
         "Session open/link",
-        state: projection.agentSessionId == nil ? "needs session ref" : "live read",
+        state: projection.agentSessionId == nil ? "waiting for session" : "live read",
         healthy: projection.agentSessionId != nil)
       controlRow("Send / stop / steer / resume", state: "governed action gated", healthy: false)
       controlRow("Secrets / login custody", state: "never stored here", healthy: false)
@@ -300,7 +300,7 @@ struct FridayProviderAuthScreen: View {
   private func providerRefs(_ projection: HomeProjection) -> some View {
     VStack(alignment: .leading, spacing: 8) {
       if let route = projection.routeSelected {
-        FridayProofLine(label: "selected_route", ref: route)
+          FridayProofLine(label: "route", ref: route)
       }
       ForEach(projection.providerReceiptRefs.prefix(3), id: \.self) { ref in
         FridayProofLine(label: "provider receipt", ref: ref)
@@ -370,7 +370,7 @@ struct FridayProviderAuthScreen: View {
             .font(.caption)
             .foregroundStyle(MobileTheme.textPrimary)
             .fixedSize(horizontal: false, vertical: true)
-          FridayProofLine(label: "generated", ref: generatedText(detail.generatedAtMs))
+          FridayProofLine(label: "updated", ref: generatedText(detail.generatedAtMs))
           if let providerReadiness = detail.providerReadiness {
             ProviderReadinessPanel(detail: providerReadiness)
           } else {
@@ -406,13 +406,13 @@ struct FridayProviderAuthScreen: View {
   @ViewBuilder
   private func genericReadbackFacts(_ detail: HomeReadDetail) -> some View {
     if detail.facts.isEmpty {
-      Text("The latest read result returned no typed facts; refs below remain the only evidence.")
+          Text("The latest provider check returned receipts but no extra details yet.")
         .font(.caption)
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
     } else {
       VStack(alignment: .leading, spacing: 8) {
-        Text("Readback Facts")
+        Text("Provider Details")
           .font(.caption.weight(.semibold))
           .foregroundStyle(MobileTheme.textPrimary)
         ForEach(detail.facts) { fact in
@@ -427,11 +427,11 @@ struct FridayProviderAuthScreen: View {
   private func detailRefs(_ refs: [String]) -> some View {
     if !refs.isEmpty {
       VStack(alignment: .leading, spacing: 8) {
-        Text("Evidence Refs")
+        Text("Receipts")
           .font(.caption.weight(.semibold))
           .foregroundStyle(MobileTheme.textPrimary)
         ForEach(refs, id: \.self) { ref in
-          FridayProofLine(label: "proof", ref: ref)
+          FridayProofLine(label: "receipt", ref: ref)
         }
       }
     }
@@ -459,5 +459,75 @@ struct FridayProviderAuthScreen: View {
     guard generatedAtMs > 0 else { return "unknown" }
     let date = Date(timeIntervalSince1970: Double(generatedAtMs) / 1000.0)
     return date.formatted(date: .abbreviated, time: .shortened)
+  }
+
+  private func displayWorkItemTitle(_ raw: String, fallback: String) -> String {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalized = trimmed.lowercased()
+    if normalized.contains("refs-only") && normalized.contains("round-trip") {
+      return "Review live device round-trip"
+    }
+    if normalized.contains("bounded mission timeline") {
+      return "Mission timeline updated"
+    }
+    if normalized.contains("desktop surface") {
+      return "Desktop surface linked"
+    }
+    if normalized.hasPrefix("proof://") || normalized.hasPrefix("proof:/") {
+      return "Route decision"
+    }
+    return displayTitle(trimmed.isEmpty ? fallback : trimmed)
+  }
+
+  private func displayRoute(_ raw: String) -> String {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalized = trimmed.lowercased()
+    if normalized == "surface-local chat" || normalized == "surface_local_chat" {
+      return "local chat"
+    }
+    if normalized == "mission spine" || normalized == "mission_spine" {
+      return "Mission Spine"
+    }
+    return displayTitle(trimmed)
+  }
+
+  private func displayOwner(_ raw: String) -> String {
+    let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    if normalized == "friday_owned" || normalized == "friday-owned" {
+      return "Friday"
+    }
+    return displayStatus(raw)
+  }
+
+  private func displayStatus(_ raw: String) -> String {
+    let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    switch normalized {
+    case "ready_to_dispatch", "ready for dispatch":
+      return "ready"
+    case "timeline_read":
+      return "timeline"
+    case "completed_with_proof":
+      return "complete"
+    case "":
+      return "status"
+    default:
+      return displaySentence(raw)
+    }
+  }
+
+  private func displayTitle(_ raw: String) -> String {
+    let clean = displaySentence(raw)
+    guard let first = clean.first else { return "Friday update" }
+    return first.uppercased() + clean.dropFirst()
+  }
+
+  private func displaySentence(_ raw: String) -> String {
+    raw
+      .replacingOccurrences(of: "refs-only", with: "receipt")
+      .replacingOccurrences(of: "Proof://", with: "")
+      .replacingOccurrences(of: "proof://", with: "")
+      .replacingOccurrences(of: "_", with: " ")
+      .replacingOccurrences(of: "-", with: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -66,7 +66,7 @@ struct FridaySessionDetailScreen: View {
             Text("Session")
               .font(.headline)
               .foregroundStyle(MobileTheme.textPrimary)
-            Text("continuation truth")
+            Text("Transcript and controls")
               .font(.caption)
               .foregroundStyle(MobileTheme.textSecondary)
           }
@@ -79,12 +79,12 @@ struct FridaySessionDetailScreen: View {
         }
         FridayProofLine(label: "mission", ref: projection.missionId)
         if let agentSessionId = projection.agentSessionId {
-          FridayProofLine(label: "agent_session_id", ref: agentSessionId)
+          FridayProofLine(label: "session", ref: agentSessionId)
         }
         if let runId = firstRunId(projection) {
-          FridayProofLine(label: "run_id", ref: runId)
+          FridayProofLine(label: "run", ref: runId)
         }
-        FridayProofLine(label: "generated", ref: generatedText(projection.generatedAtMs))
+        FridayProofLine(label: "updated", ref: generatedText(projection.generatedAtMs))
       }
     }
   }
@@ -144,7 +144,7 @@ struct FridaySessionDetailScreen: View {
               Text("Approval Required")
                 .font(.headline)
                 .foregroundStyle(MobileTheme.textPrimary)
-              Text("operator-signed relay only")
+              Text("Approval relay")
                 .font(.caption)
                 .foregroundStyle(MobileTheme.textSecondary)
             }
@@ -161,9 +161,9 @@ struct FridaySessionDetailScreen: View {
               .foregroundStyle(MobileTheme.textPrimary)
               .fixedSize(horizontal: false, vertical: true)
           }
-          FridayProofLine(label: "run_id", ref: approval.runId)
-          FridayProofLine(label: "approval_id", ref: approval.approvalId)
-          FridayProofLine(label: "action_digest", ref: short(approval.actionDigest))
+          FridayProofLine(label: "run", ref: approval.runId)
+          FridayProofLine(label: "approval", ref: approval.approvalId)
+          FridayProofLine(label: "digest", ref: short(approval.actionDigest))
 
           VStack(alignment: .leading, spacing: 5) {
             approvalCapabilityRow("Resume", control: resume)
@@ -471,7 +471,7 @@ struct FridaySessionDetailScreen: View {
             }
           }
           if let generatedAtMs = section.generatedAtMs {
-            FridayProofLine(label: "generated", ref: generatedText(generatedAtMs))
+            FridayProofLine(label: "updated", ref: generatedText(generatedAtMs))
           }
           ForEach(section.refs, id: \.self) { ref in
             FridayProofLine(label: nil, ref: ref)
@@ -489,14 +489,14 @@ struct FridaySessionDetailScreen: View {
   private func proofRefsCard(_ refs: [String]) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-        cardHeader("Proof Refs", count: refs.count)
+        cardHeader("Receipts", count: refs.count)
         if refs.isEmpty {
-          Text("No proof refs were returned by the session read arms.")
+          Text("No receipts are attached to this session yet.")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         } else {
           ForEach(refs, id: \.self) { ref in
-            FridayProofLine(label: "proof", ref: ref)
+            FridayProofLine(label: "receipt", ref: ref)
           }
         }
       }
@@ -508,7 +508,7 @@ struct FridaySessionDetailScreen: View {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Learning", count: projection.runOutcomeLearningCandidates.count)
         if projection.runOutcomeLearningCandidates.isEmpty {
-          Text("No run-outcome learning candidates in this projection.")
+          Text("No learning suggestions need review right now.")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         } else {
@@ -632,10 +632,21 @@ struct FridaySessionDetailScreen: View {
     if control.isEnabled {
       return FridayChip(text: control.truthLabel, bg: MobileTheme.chipPendingBG, fg: MobileTheme.chipPendingFG)
     }
-    if control.truthLabel == "read arm" {
-      return FridayChip(text: control.truthLabel, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+    if isReadOnlyControlTruth(control.truthLabel) {
+      return FridayChip(text: "read only", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
     }
-    return FridayChip(text: control.truthLabel, bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+    return FridayChip(text: displayControlTruthLabel(control.truthLabel), bg: MobileTheme.chipWarnBG, fg: MobileTheme.chipWarnFG)
+  }
+
+  private func isReadOnlyControlTruth(_ raw: String) -> Bool {
+    raw == "read arm"
+  }
+
+  private func displayControlTruthLabel(_ raw: String) -> String {
+    raw
+      .replacingOccurrences(of: "_", with: " ")
+      .replacingOccurrences(of: "-", with: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   private func short(_ s: String) -> String {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
@@ -100,7 +100,7 @@ struct FridayShareIntakeScreen: View {
               Text("Friday Chat handoff is armed")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MobileTheme.textPrimary)
-              Text("The next tap carries these share refs into Chat as a prefilled governed turn. Provider results will appear when the live loop returns them.")
+              Text("The next tap carries this shared context into Chat as a prefilled governed turn. Provider results will appear when the live loop returns them.")
                 .font(.caption2)
                 .foregroundStyle(MobileTheme.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
@@ -31,7 +31,7 @@ struct FridayTokenLedgerScreen: View {
   @ViewBuilder
   private func loadedContent(_ projection: HomeProjection) -> some View {
     let runId = projection.tokenLedgerRunId
-    header(status: runId == nil ? "no run ref" : "readable", ready: runId != nil)
+    header(status: runId == nil ? "waiting" : "ready", ready: runId != nil)
 
     if let runId {
       runRefCard(runId: runId, projection: projection)
@@ -54,7 +54,7 @@ struct FridayTokenLedgerScreen: View {
           Text("Token Ledger")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
-          Text("provider usage readback")
+          Text("Usage and cost history")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
@@ -72,7 +72,7 @@ struct FridayTokenLedgerScreen: View {
     GlassPanel {
       HStack(spacing: 12) {
         ProgressView()
-        Text("Reading token ledger truth")
+        Text("Reading usage ledger")
           .font(.footnote)
           .foregroundStyle(MobileTheme.textSecondary)
       }
@@ -83,12 +83,12 @@ struct FridayTokenLedgerScreen: View {
   private func runRefCard(runId: String, projection: HomeProjection) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-        cardHeader("Selected Run", count: nil)
-        Text("Friday reads provider usage from the run reference projected by the Hub.")
+        cardHeader("Usage Source", count: nil)
+        Text("Friday reads provider usage from the live work item selected by the Hub.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
-        FridayProofLine(label: "run_id", ref: runId)
+        FridayProofLine(label: "run", ref: runId)
         FridayProofLine(label: "mission", ref: projection.missionId)
         Button {
           Task { await viewModel.loadDetail(.runReadback(runId: runId)) }
@@ -107,13 +107,13 @@ struct FridayTokenLedgerScreen: View {
   private func noRunRefCard(_ projection: HomeProjection) -> some View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-        cardHeader("No Run Ref", count: nil)
+        cardHeader("Waiting for Usage", count: nil)
         Text("Token totals will appear after the current work produces a completed run reference.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         FridayProofLine(label: "mission", ref: projection.missionId)
-        FridayProofLine(label: "feed", ref: projection.runtimeFeedStatus)
+        FridayProofLine(label: "live state", ref: projection.runtimeFeedStatus)
       }
     }
     .accessibilityIdentifier("friday.token-ledger.no-run-ref")
@@ -126,15 +126,15 @@ struct FridayTokenLedgerScreen: View {
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
           cardHeader("Projected Receipts", count: count)
-          Text("These are refs already projected by the Hub. They are evidence links only; Friday still needs a run ref before showing per-run token totals.")
+          Text("These receipts are already available from the Hub. Per-run token totals appear after a live run is selected.")
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
           ForEach(projection.providerReceiptRefs.prefix(5), id: \.self) { ref in
-            FridayProofLine(label: "provider receipt", ref: ref)
+            FridayProofLine(label: "provider", ref: ref)
           }
           ForEach(projection.channelReceiptRefs.prefix(5), id: \.self) { ref in
-            FridayProofLine(label: "channel receipt", ref: ref)
+            FridayProofLine(label: "channel", ref: ref)
           }
         }
       }
@@ -164,7 +164,7 @@ struct FridayTokenLedgerScreen: View {
             .font(.caption)
             .foregroundStyle(MobileTheme.textPrimary)
             .fixedSize(horizontal: false, vertical: true)
-          FridayProofLine(label: "generated", ref: generatedText(detail.generatedAtMs))
+          FridayProofLine(label: "updated", ref: generatedText(detail.generatedAtMs))
           if !detail.facts.isEmpty {
             VStack(spacing: 8) {
               ForEach(detail.facts) { fact in

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -93,7 +93,7 @@ struct FridayVoiceScreen: View {
           .foregroundStyle(MobileTheme.textPrimary)
           .fixedSize(horizontal: false, vertical: true)
           .accessibilityIdentifier("friday.voice.readiness-card")
-        Text("Readiness plus local voice-loop truth: capture and speech output run from Friday Chat when these gates are ready.")
+        Text("Capture and speech output run from Friday Chat when these gates are ready.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -227,7 +227,7 @@ struct FridayVoiceScreen: View {
       text: voiceTruthDisplayLabel(truthLabel),
       bg: enabled ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
       fg: enabled ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
-    .accessibilityLabel("Truth label \(truthLabel)")
+    .accessibilityLabel("Voice status \(voiceTruthDisplayLabel(truthLabel))")
   }
 
   private func voiceTruthDisplayLabel(_ truthLabel: String) -> String {

--- a/scripts/ops/check-friday-native-action-closure.mjs
+++ b/scripts/ops/check-friday-native-action-closure.mjs
@@ -221,8 +221,8 @@ const checks = [
       "requires a pending approval ref",
       "Add shared text or a URL before submitting.",
       "Share Intake is unavailable",
-      "Readiness plus local voice-loop truth",
-      "Friday reads provider usage from the run reference projected by the Hub.",
+      "Capture and speech output run from Friday Chat when these gates are ready.",
+      "Friday reads provider usage from the live work item selected by the Hub.",
     ]),
   ),
   check(

--- a/test/unit/qa/friday-product-facing-copy.test.ts
+++ b/test/unit/qa/friday-product-facing-copy.test.ts
@@ -15,6 +15,7 @@ const productSurfaceFiles = [
   "apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift",
   "apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift",
   "apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift",
+  "apps/friday-ios/Sources/FridayMobileShell/CommandSheet.swift",
   "apps/friday-ios/Sources/FridayMobileShell/HeroPet.swift",
   "apps/macos/FridayHubConsole/Sources/FridayHubConsole/CompanionPetView.swift",
   "apps/macos/FridayHubConsole/Sources/FridayHubConsole/DesktopChatScreen.swift",
@@ -54,6 +55,13 @@ const forbiddenVisibleCopy = [
   "not configured in this build",
   "proof only",
   "not proof only",
+  "Proof Refs",
+  "No proof refs",
+  "Proof Viewer",
+  "iOS Entrypoints",
+  "Native Entrypoints",
+  "Reading token ledger truth",
+  "continuation truth",
 ];
 
 const servedProductSurfaceFiles = [
@@ -168,6 +176,121 @@ describe("Friday product-facing unavailable copy", () => {
     const failures = rawQueuePatterns
       .filter((pattern) => pattern.test(source))
       .map((pattern) => String(pattern));
+
+    expect(failures).toEqual([]);
+  });
+
+  it("keeps raw projection wording out of iOS secondary product screens", () => {
+    const secondaryFiles = [
+      "apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift",
+      "apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift",
+    ];
+    const rawSecondaryPatterns = [
+      /No work-item refs in this projection\./,
+      /No projected operator-attention refs\./,
+      /No capability refs in this projection\./,
+      /No transcript events in this projection\./,
+      /No workflow work-item refs\./,
+      /No receipt refs in this projection\./,
+      /No provider-linked WorkItem refs in the current projection\./,
+      /Proof Receipts/,
+      /Receipt Refs/,
+      /No proof receipt refs/,
+      /Native Entrypoints/,
+      /iOS Entrypoints/,
+      /Proof Viewer/,
+      /FridayProofLine\(label:\s*"conversation"/,
+      /FridayProofLine\(label:\s*"selected route"/,
+      /FridayProofLine\(label:\s*"trusted_device"/,
+      /FridayProofLine\(label:\s*"device_fingerprint"/,
+      /FridayProofLine\(label:\s*"device_id"/,
+      /FridayProofLine\(label:\s*"ack_device_id"/,
+      /FridayProofLine\(label:\s*"ack_pairing_id"/,
+      /FridayProofLine\(label:\s*"ack_hub_id"/,
+      /FridayProofLine\(label:\s*"device_fingerprint"/,
+      /FridayProofLine\(label:\s*"latest_device"/,
+      /FridayProofLine\(label:\s*"device_identity_count"/,
+      /FridayProofLine\(label:\s*"trusted_device_count"/,
+      /FridayProofLine\(label:\s*"active_trusted_device_count"/,
+      /FridayProofLine\(label:\s*"trust_grant_count"/,
+      /FridayProofLine\(label:\s*"context_passport_count"/,
+      /FridayProofLine\(label:\s*"truth"/,
+      /FridayProofLine\(label:\s*"generated"/,
+      /PairAck/,
+      /not minted/,
+      /not in projection/,
+      /cardHeader\("Truth"/,
+      /Text\("Reading provisioning truth"/,
+      /No trusted device ref is present in this projection/,
+      /Text\("provider readiness, queues, sessions, and native-control truth"/,
+      /Hub read arm/,
+      /Reading Provider Workspace projection/,
+      /FridayProofLine\(label:\s*"work_item_proof"/,
+      /needs run ref/,
+      /run readback ready/,
+      /Text\("Evidence Refs"/,
+      /FridayProofLine\(label:\s*"proof"/,
+      /alternates:\s*\\\(/,
+      /Text\(item\.title\)/,
+      /Text\("\\\(item\.owner\)[^"]*\\\(item\.state\)/,
+      /Text\(item\.blockingReason\)/,
+      /Text\(event\.summary\)/,
+      /Text\(event\.sectionTitle\)/,
+      /statusChip\(event\.status\)/,
+    ];
+    const failures: string[] = [];
+    for (const relativePath of secondaryFiles) {
+      const source = readFileSync(join(repoRoot, relativePath), "utf8");
+      source.split("\n").forEach((line, index) => {
+        for (const pattern of rawSecondaryPatterns) {
+          if (pattern.test(line)) {
+            failures.push(`${relativePath}:${index + 1}: ${pattern}`);
+          }
+        }
+      });
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("keeps raw session and token-ledger labels out of iOS product screens", () => {
+    const focusedFiles = [
+      "apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift",
+      "apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift",
+    ];
+    const rawFocusedPatterns = [
+      /FridayProofLine\(label:\s*"run_id"/,
+      /FridayProofLine\(label:\s*"agent_session_id"/,
+      /FridayProofLine\(label:\s*"approval_id"/,
+      /FridayProofLine\(label:\s*"action_digest"/,
+      /FridayProofLine\(label:\s*"answer_body_run_id"/,
+      /FridayProofLine\(label:\s*"more_refs"/,
+      /Answers are refs-only/,
+      /Answer body is not available from the owner-gated readback yet/,
+      /Readiness plus local voice-loop truth/,
+      /Truth label/,
+      /share refs/,
+      /FridayProofLine\(label:\s*"feed"/,
+      /Text\("provider usage readback"/,
+      /Text\("continuation truth"/,
+      /Text\("Reading token ledger truth"/,
+      /cardHeader\("No Run Ref"/,
+      /cardHeader\("Proof Refs"/,
+      /No proof refs were returned by the session read arms\./,
+      /No run-outcome learning candidates in this projection\./,
+      /control\.truthLabel == "read arm"/,
+    ];
+    const failures: string[] = [];
+    for (const relativePath of focusedFiles) {
+      const source = readFileSync(join(repoRoot, relativePath), "utf8");
+      source.split("\n").forEach((line, index) => {
+        for (const pattern of rawFocusedPatterns) {
+          if (pattern.test(line)) {
+            failures.push(`${relativePath}:${index + 1}: ${pattern}`);
+          }
+        }
+      });
+    }
 
     expect(failures).toEqual([]);
   });


### PR DESCRIPTION
## Summary
- replace raw proof/projection labels on iOS Home, Chat, Provider Workspace, Shared Context, Voice, Share Intake, and projection surfaces with selected-product language
- keep receipt/proof traceability intact while moving engineering terms out of the ordinary product path
- expand product-facing copy guards so PairAck/device_id/truth/run_id-style labels do not regress into visible Swift UI constructors

## Verification
- npx vitest run --project default test/unit/qa/friday-product-facing-copy.test.ts
- swift test (apps/friday-ios)
- node scripts/ops/check-friday-served-ui-design-fidelity.mjs --out=/private/tmp/friday-ios-secondary-copy-fidelity-full-20260630-postrebase.json
- git diff --check origin/main...HEAD

## Truth
- This is UI/product-path realign work only: it does not claim END-BAR, GO-LIVE, adoption, release, or trusted-channel proof.
- It preserves fail-closed behavior and receipt traceability; internal truth labels remain available behind the product copy.