### PR TITLE
Accept current served UI fidelity in visual proof gate

### DIFF
--- a/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
+++ b/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
@@ -317,8 +317,12 @@ function evaluateServedUiReport(path) {
   const checkMessages = checks
     .filter((check) => check?.ok === true && typeof check.message === "string")
     .map((check) => check.message);
+  const hasCheckMessage = (predicate) => checkMessages.some(predicate);
   const hasRenderedDesktop = checkMessages.includes("served desktop rendered structure matches selected design");
-  const hasBuiltCss = checkMessages.includes("built css applies cyan/coral tokens and excludes amber/jade tokens");
+  const hasBuiltCss = hasCheckMessage((message) =>
+    message === "built css applies cyan/coral tokens and excludes amber/jade tokens"
+    || message === "built css applies cyan/coral tokens and excludes stale decorative palette remnants"
+  );
   const hasIosDesignSystem = checkMessages.includes("iOS source applies selected mobile design system and keeps debug/readiness surfaces out of the user path");
   const truthOk = report.truth_label === "served_desktop_and_ios_design_fidelity_reads_real_selection_and_live_sources";
   const statusOk = report.status === "pass" && Number(report.failureCount || 0) === 0;

--- a/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
+++ b/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
@@ -127,7 +127,7 @@ function writeServedUiReport(root: string, relative = "evidence", overrides: Rec
       { ok: true, message: "operator-confirmed selections loaded", details: {} },
       { ok: true, message: "iOS source applies selected mobile design system and keeps debug/readiness surfaces out of the user path", details: {} },
       { ok: true, message: "served ui build completed", details: {} },
-      { ok: true, message: "built css applies cyan/coral tokens and excludes amber/jade tokens", details: {} },
+      { ok: true, message: "built css applies cyan/coral tokens and excludes stale decorative palette remnants", details: {} },
       { ok: true, message: "served desktop rendered structure matches selected design", details: {} },
     ],
     ...overrides,


### PR DESCRIPTION
## Summary
- Teach the selected visual proof gate to accept the current served UI fidelity report wording for the built CSS check.
- Keep the gate strict about source scope, same HEAD, rendered desktop structure, and iOS design-system checks.
- Update the fixture test so the current `stale decorative palette remnants` report wording stays covered.

## Verification
- `node scripts/ops/check-friday-served-ui-design-fidelity.mjs --design-root=/Users/jarvis/Desktop/friday-design-handoff-20260602 --out=/private/tmp/friday-served-ui-design-fidelity-current.json`
- `FRIDAY_IOS_DESIGN_CAPTURE_OUT=/private/tmp/friday-ios-design-destination-capture-20260630 npm run proof:ios:design-destinations`
- `node scripts/ops/check-friday-uiux-selected-visual-proof.mjs --design-root=/Users/jarvis/Desktop/friday-design-handoff-20260602 --served-ui-report=/private/tmp/friday-served-ui-design-fidelity-current.json --ios-manifest=/private/tmp/friday-ios-design-destination-capture-20260630/ios-design-destination-capture-manifest.json --require-complete`
- `/Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts`
- `/Users/jarvis/Projects/Friday/node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `git diff --check`

## Truth Labels
- The selected visual proof report reached `selected_visual_proof_ready` with current served desktop UI evidence plus current iOS simulator destination screenshots.
- This does not claim END-BAR, release, adoption, or live action closure.