### PR TITLE
Add unattended DeepSeek route proof wrapper

### DIFF
--- a/scripts/ops/friday-proof-of-life-keychain.sh
+++ b/scripts/ops/friday-proof-of-life-keychain.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Provisioned-passphrase wrapper for friday-proof-of-life.sh.
+#
+# This is the unattended DeepSeek route-proof path: a previously provisioned
+# macOS keychain item or owner-only passphrase file is streamed to the proof
+# script over stdin. The passphrase is never stored in an environment variable,
+# shell argv, or transcript.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly PROOF_SCRIPT="${SCRIPT_DIR}/friday-proof-of-life.sh"
+readonly KEYCHAIN_ACCOUNT="${FRIDAY_DEEPSEEK_PROOF_KEYCHAIN_ACCOUNT:-${FRIDAY_CODEX_MISSION_PROOF_KEYCHAIN_ACCOUNT:-friday}}"
+readonly KEYCHAIN_SERVICE="${FRIDAY_DEEPSEEK_PROOF_KEYCHAIN_SERVICE:-${FRIDAY_CODEX_MISSION_PROOF_KEYCHAIN_SERVICE:-friday-proof-passphrase}}"
+readonly PASSPHRASE_FILE="${FRIDAY_DEEPSEEK_PROOF_PASSPHRASE_FILE:-${FRIDAY_CODEX_MISSION_PROOF_PASSPHRASE_FILE:-${HOME}/.friday/friday-proof-passphrase}}"
+
+if [ ! -x "${PROOF_SCRIPT}" ]; then
+  echo "FATAL: proof script is not executable: ${PROOF_SCRIPT}" >&2
+  exit 3
+fi
+
+passphrase_file_ok() {
+  if [ ! -f "${PASSPHRASE_FILE}" ]; then
+    return 1
+  fi
+
+  local perms
+  local owner_uid
+  local self_uid
+  perms="$(stat -f '%Lp' "${PASSPHRASE_FILE}" 2>/dev/null || true)"
+  owner_uid="$(stat -f '%u' "${PASSPHRASE_FILE}" 2>/dev/null || true)"
+  self_uid="$(id -u)"
+
+  if [ "${owner_uid}" != "${self_uid}" ]; then
+    echo "FATAL: passphrase file must be owned by the current user: ${PASSPHRASE_FILE}" >&2
+    exit 4
+  fi
+  case "${perms}" in
+    400|600) ;;
+    *)
+      echo "FATAL: passphrase file must be mode 0600 or 0400; got ${perms:-unknown}: ${PASSPHRASE_FILE}" >&2
+      exit 4
+      ;;
+  esac
+  if [ ! -s "${PASSPHRASE_FILE}" ]; then
+    echo "FATAL: passphrase file is empty: ${PASSPHRASE_FILE}" >&2
+    exit 4
+  fi
+
+  return 0
+}
+
+read_provisioned_passphrase() {
+  if command -v security >/dev/null 2>&1 \
+    && security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w >/dev/null 2>&1; then
+    security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w
+    return 0
+  fi
+
+  if passphrase_file_ok; then
+    sed -n '1p' "${PASSPHRASE_FILE}"
+    return 0
+  fi
+
+  echo "FATAL: no provisioned proof passphrase found." >&2
+  echo "Checked keychain account='${KEYCHAIN_ACCOUNT}' service='${KEYCHAIN_SERVICE}' and file='${PASSPHRASE_FILE}'." >&2
+  echo "Provision it locally with hidden input or a 0600/0400 owner-only file; do not paste the passphrase into chat." >&2
+  exit 4
+}
+
+echo "Running DeepSeek route proof preflight (no passphrase, no traffic)..."
+FRIDAY_DEEPSEEK_PROOF_PREFLIGHT_ONLY=1 "${PROOF_SCRIPT}"
+echo
+
+PASSPHRASE="$(read_provisioned_passphrase)"
+trap 'unset PASSPHRASE' EXIT
+if [ -z "${PASSPHRASE}" ]; then
+  echo "FATAL: provisioned proof passphrase is empty." >&2
+  exit 4
+fi
+
+printf '%s\n' "${PASSPHRASE}" \
+  | FRIDAY_DEEPSEEK_PROOF_PASSPHRASE_STDIN=1 "${PROOF_SCRIPT}"

--- a/scripts/ops/friday-proof-of-life.sh
+++ b/scripts/ops/friday-proof-of-life.sh
@@ -24,9 +24,11 @@
 #     side effect of any real run). It does NOT change config, flags, or state.
 #
 # SECRET HYGIENE
-#   - The passphrase is read silently (read -rs), never echoed, never written to
-#     disk, and never placed in a process argv (it is JSON-escaped via `jq -Rs`
-#     reading stdin and streamed to curl with `--data @-`).
+#   - The passphrase is read silently (read -rs) by default, or from stdin only
+#     when FRIDAY_DEEPSEEK_PROOF_PASSPHRASE_STDIN=1 is set by a local wrapper.
+#     It is never echoed, never written to disk, and never placed in a process
+#     argv (it is JSON-escaped via `jq -Rs` reading stdin and streamed to curl
+#     with `--data @-`).
 #   - The access token is held only in a shell variable and used only in an
 #     Authorization header. It is never printed.
 #   - All HTTP is to 127.0.0.1 only. The only external network call is the one
@@ -45,6 +47,8 @@ readonly TS_HUB="http://127.0.0.1:3141"
 readonly DEEPSEEK_PROVIDER_ID="fa15f1fe-a0b6-4f79-96c3-4ae8e1be28a4"
 readonly DEEPSEEK_MODEL="deepseek-v4-flash"
 readonly RUST_HUB_DB="${HOME}/Library/Application Support/Friday/state/rust-hub.sqlite"
+readonly PASSPHRASE_STDIN="${FRIDAY_DEEPSEEK_PROOF_PASSPHRASE_STDIN:-0}"
+readonly PREFLIGHT_ONLY="${FRIDAY_DEEPSEEK_PROOF_PREFLIGHT_ONLY:-0}"
 # The exact 4-tool read-only allowlist the qualifier predicate requires (clause 4).
 readonly PONG_TASK="Reply with exactly one JSON object and nothing else: {\"tool\":\"none\",\"answer\":\"PONG\"}"
 
@@ -128,10 +132,28 @@ curl_bearer_get() {
   } | curl --config - 2>/dev/null
 }
 
+if [ "${PREFLIGHT_ONLY}" = "1" ]; then
+  echo "DeepSeek route proof preflight OK."
+  echo "  tsHub: ${TS_HUB}"
+  echo "  rustDb: ${RUST_HUB_DB}"
+  echo "  deepseekProviderId: ${DEEPSEEK_PROVIDER_ID}"
+  echo "  deepseekModel: ${DEEPSEEK_MODEL}"
+  echo "  tokenLedgerRows: $(ledger_count)"
+  echo "Truth: preflight creates no traffic and proves only local readiness, not route proof / GO."
+  exit 0
+fi
+
 # ─── Step 1: login → access token (secret never hits argv/disk) ───
-printf 'Enter Friday local passphrase (input hidden): ' >&2
-read -rs PASSPHRASE
-printf '\n' >&2
+if [ "${PASSPHRASE_STDIN}" = "1" ]; then
+  if ! IFS= read -r PASSPHRASE; then
+    echo "FATAL: failed to read passphrase from stdin." >&2
+    exit 4
+  fi
+else
+  printf 'Enter Friday local passphrase (input hidden): ' >&2
+  read -rs PASSPHRASE
+  printf '\n' >&2
+fi
 if [ -z "${PASSPHRASE}" ]; then
   echo "FATAL: empty passphrase." >&2
   exit 4

--- a/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts
@@ -22,6 +22,10 @@ const routedProofScript = resolve(
   repoRoot,
   "scripts/ops/friday-proof-of-life.sh",
 );
+const routedProofKeychainWrapper = resolve(
+  repoRoot,
+  "scripts/ops/friday-proof-of-life-keychain.sh",
+);
 const proofMacosWrapper = resolve(
   repoRoot,
   "scripts/ops/friday-codex-mission-proof-of-life-macos-prompt.sh",
@@ -922,6 +926,10 @@ describe("Codex mission proof gates", () => {
   it("single proof and D8 soak keep partial evidence out of strong success by default", () => {
     const proofSource = readFileSync(proofScript, "utf8");
     const routedProofSource = readFileSync(routedProofScript, "utf8");
+    const routedProofKeychainWrapperSource = readFileSync(
+      routedProofKeychainWrapper,
+      "utf8",
+    );
     const proofMacosWrapperSource = readFileSync(proofMacosWrapper, "utf8");
     const proofKeychainWrapperSource = readFileSync(
       proofKeychainWrapper,
@@ -1004,6 +1012,55 @@ describe("Codex mission proof gates", () => {
       expect(source).not.toContain("-H 'Authorization: Bearer");
       expect(source).not.toContain("Authorization: Bearer ${TOKEN}");
     }
+    expect(
+      spawnSync("bash", ["-n", routedProofKeychainWrapper], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      }).status,
+    ).toBe(0);
+    expect(routedProofSource).toContain(
+      'readonly PASSPHRASE_STDIN="${FRIDAY_DEEPSEEK_PROOF_PASSPHRASE_STDIN:-0}"',
+    );
+    expect(routedProofSource).toContain(
+      'readonly PREFLIGHT_ONLY="${FRIDAY_DEEPSEEK_PROOF_PREFLIGHT_ONLY:-0}"',
+    );
+    expect(routedProofSource).toContain("DeepSeek route proof preflight OK.");
+    expect(
+      routedProofSource.indexOf('if [ "${PREFLIGHT_ONLY}" = "1" ]; then'),
+    ).toBeLessThan(
+      routedProofSource.indexOf('if [ "${PASSPHRASE_STDIN}" = "1" ]; then'),
+    );
+    expect(routedProofKeychainWrapperSource).toContain(
+      'readonly KEYCHAIN_SERVICE="${FRIDAY_DEEPSEEK_PROOF_KEYCHAIN_SERVICE:-${FRIDAY_CODEX_MISSION_PROOF_KEYCHAIN_SERVICE:-friday-proof-passphrase}}"',
+    );
+    expect(routedProofKeychainWrapperSource).toContain(
+      'readonly PASSPHRASE_FILE="${FRIDAY_DEEPSEEK_PROOF_PASSPHRASE_FILE:-${FRIDAY_CODEX_MISSION_PROOF_PASSPHRASE_FILE:-${HOME}/.friday/friday-proof-passphrase}}"',
+    );
+    expect(routedProofKeychainWrapperSource).toContain("passphrase_file_ok()");
+    expect(routedProofKeychainWrapperSource).toContain(
+      "read_provisioned_passphrase()",
+    );
+    expect(routedProofKeychainWrapperSource).toContain("stat -f '%Lp'");
+    expect(routedProofKeychainWrapperSource).toContain("stat -f '%u'");
+    expect(routedProofKeychainWrapperSource).toContain("400|600) ;;");
+    expect(routedProofKeychainWrapperSource).toContain(
+      "FRIDAY_DEEPSEEK_PROOF_PREFLIGHT_ONLY=1",
+    );
+    expect(
+      routedProofKeychainWrapperSource.indexOf(
+        "FRIDAY_DEEPSEEK_PROOF_PREFLIGHT_ONLY=1",
+      ),
+    ).toBeLessThan(
+      routedProofKeychainWrapperSource.indexOf(
+        'PASSPHRASE="$(read_provisioned_passphrase)"',
+      ),
+    );
+    expect(routedProofKeychainWrapperSource).toContain(
+      "trap 'unset PASSPHRASE' EXIT",
+    );
+    expect(routedProofKeychainWrapperSource).toContain(
+      'FRIDAY_DEEPSEEK_PROOF_PASSPHRASE_STDIN=1 "${PROOF_SCRIPT}"',
+    );
     expect(proofSource).toContain(
       'readonly EXPECTED_CODEX_CLI_VERSION="${FRIDAY_CODEX_MISSION_PROOF_CODEX_VERSION:-codex-cli 0.140.0}"',
     );


### PR DESCRIPTION
## Summary
- add a keychain/file-backed wrapper for running the DeepSeek proof-of-life route without exposing the passphrase in argv/env/transcript
- add stdin/preflight gates to the underlying proof script so unattended runs can verify readiness before spending traffic
- cover the wrapper and new gates in the Codex mission proof gate tests

## Verification
- bash -n scripts/ops/friday-proof-of-life.sh
- bash -n scripts/ops/friday-proof-of-life-keychain.sh
- /Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default test/unit/scripts/ops/friday-codex-mission-proof-gates.test.ts

Truth: this is proof automation and a real DeepSeek route proof helper; it does not claim END-BAR, release, adoption, or user-origin organic product completion.