### PR TITLE
Require current-head UI device proof for blocker satisfaction

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -467,7 +467,7 @@ struct FridayChatScreen: View {
           Text(summary).font(.callout).foregroundStyle(MobileTheme.textPrimary)
         }
         // PROOF (the digest the operator signs over) — never a body.
-        FridayProofLine(label: "action seal", ref: short(card.actionDigest))
+        FridayProofLine(label: "action_digest", ref: short(card.actionDigest))
         FridayProofLine(label: "approval", ref: card.approvalId)
         Text("Friday paused this mutating action. Approving asks the operator signer for a "
           + "signature; the phone relays it but never signs.")

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -97,6 +97,7 @@ struct FridayVoiceScreen: View {
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
+          .accessibilityHint("Readiness plus local voice-loop truth: microphone capture, speech recognition, speech output, and Friday Chat handoff are checked on this device.")
         if readiness.canRequestPermission {
           Button {
             Task { await viewModel.requestPermission() }

--- a/rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root"
+current_head="$(git -C "$root" rev-parse HEAD 2>/dev/null || true)"
 
 usage() {
   cat >&2 <<'EOF'
@@ -255,6 +256,7 @@ mkdir -p "$(dirname "$out")"
 jq -n \
   --arg proof "mission_spine_ui_device_consumption" \
   --arg proof_source "real_ui_device_consumption" \
+  --arg head "$current_head" \
   --arg captured_at "$captured_at" \
   --arg capture_run_id "$capture_run_id" \
   --arg mission_id "$MISSION_ID" \
@@ -285,6 +287,7 @@ jq -n \
     {
       proof: $proof,
       proof_source: $proof_source,
+      head: $head,
       captured_at_utc: $captured_at,
       capture_run_id: $capture_run_id,
       mission_id: $mission_id,

--- a/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
@@ -72,6 +72,7 @@ write_proof() {
 {
   "proof": "mission_spine_ui_device_consumption",
   "proof_source": "$source",
+  "head": "ui-proof-gate-self-test-head",
   "fixture": $fixture,
   "captured_at_utc": "2026-06-04T21:00:00Z",
   "capture_run_id": "ui-proof-gate-self-test-run",

--- a/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-gate.sh
@@ -231,6 +231,7 @@ jq -e '
     and evidence_ref_known_any($root; .stress.evidence_ref);
   .proof == "mission_spine_ui_device_consumption"
   and .proof_source == "real_ui_device_consumption"
+  and (.head | nonempty_string)
   and (.captured_at_utc | nonempty_string)
   and (.capture_run_id | nonempty_string)
   and (.mission_id | nonempty_string)

--- a/scripts/ops/build-friday-uiux-runtime-blocker-satisfaction.mjs
+++ b/scripts/ops/build-friday-uiux-runtime-blocker-satisfaction.mjs
@@ -143,6 +143,37 @@ function hasStrictUiDeviceProof(value) {
   return true;
 }
 
+function containsHead(value, expectedHead) {
+  if (!expectedHead) return false;
+  const full = String(expectedHead);
+  const short = full.slice(0, 8);
+  const stack = [value];
+  const seen = new Set();
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current == null) continue;
+    if (typeof current === "string" || typeof current === "number" || typeof current === "boolean") {
+      const text = String(current);
+      if (text.includes(full) || (short.length >= 8 && text.includes(short))) return true;
+      continue;
+    }
+    if (typeof current !== "object" || seen.has(current)) continue;
+    seen.add(current);
+    if (Array.isArray(current)) {
+      for (const item of current) stack.push(item);
+      continue;
+    }
+    for (const [key, child] of Object.entries(current)) {
+      if (/^(head|gitHead|sourceHead|mainHead|commit|commitSha|sha)$/i.test(key)) {
+        const text = String(child || "");
+        if (text.includes(full) || (short.length >= 8 && text.includes(short))) return true;
+      }
+      stack.push(child);
+    }
+  }
+  return false;
+}
+
 function arrayAt(value, path) {
   let current = value;
   for (const key of path) current = current?.[key];
@@ -235,6 +266,9 @@ if ((trace?.counts?.runtimeEvidenceInputs ?? 0) <= 0) {
 }
 if (!hasStrictUiDeviceProof(uiDeviceProof)) {
   block("ui_device_proof_not_strict_pass", `${String(uiDeviceProof?.truth || uiDeviceProof?.proof || "missing")}:${String(uiDeviceProof?.status || "missing")}`);
+}
+if (head && !containsHead(uiDeviceProof, head)) {
+  block("ui_device_proof_head_mismatch", `expected current head ${head} in strict UI/device proof`);
 }
 
 const proofRef = uiDeviceProofPath ? abs(uiDeviceProofPath) : "";

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -580,10 +580,11 @@ if [ -n "${timeline_capture}" ] && { [ -n "${channel_capture}" ] || [ "${defer_c
   for path in "${event_inputs[@]}"; do
     capture_dir_args+=("--events=${path}")
   done
+  set +u
   for path in "${negative_control_events[@]}"; do
+    [ -n "${path}" ] || continue
     capture_dir_args+=("--negative-control-events=${path}")
   done
-  set +u
   for path in "${shared_extra_evidence[@]}"; do
     [ -n "${path}" ] || continue
     capture_dir_args+=("--shared-extra-evidence=${path}")

--- a/test/unit/qa/friday-uiux-runtime-blocker-satisfaction-cli.test.ts
+++ b/test/unit/qa/friday-uiux-runtime-blocker-satisfaction-cli.test.ts
@@ -102,6 +102,7 @@ describe("build-friday-uiux-runtime-blocker-satisfaction", () => {
       const proofPath = writeJson(root, "ui-device-proof.json", {
         truth: "assembled_real_ui_device_proof",
         status: "pass",
+        head,
       });
       const evidenceDir = writeEvidenceDir(root);
       const output = execFileSync("node", [
@@ -163,6 +164,7 @@ describe("build-friday-uiux-runtime-blocker-satisfaction", () => {
       const proofPath = writeJson(root, "ui-device-proof.json", {
         truth: "assembled_real_ui_device_proof",
         status: "pass",
+        head,
       });
       const evidenceDir = writeEvidenceDir(root);
       const result = spawnSync("node", [
@@ -211,6 +213,7 @@ describe("build-friday-uiux-runtime-blocker-satisfaction", () => {
       const proofPath = writeJson(root, "ui-device-proof.json", {
         truth: "assembled_real_ui_device_proof",
         status: "pass",
+        head,
       });
       const evidenceDir = writeEvidenceDir(root);
       const result = spawnSync("node", [
@@ -258,6 +261,7 @@ describe("build-friday-uiux-runtime-blocker-satisfaction", () => {
       const proofPath = writeJson(root, "ui-device-proof.json", {
         truth: "assembled_real_ui_device_proof",
         status: "pass",
+        head,
       });
       const evidenceDir = writeEvidenceDir(root);
       const result = spawnSync("node", [
@@ -321,6 +325,7 @@ describe("build-friday-uiux-runtime-blocker-satisfaction", () => {
       const proofPath = writeJson(root, "ui-device-proof.json", {
         truth: "assembled_real_ui_device_proof",
         status: "pass",
+        head,
       });
       const evidenceDir = writeEvidenceDir(root);
       const output = execFileSync("node", [
@@ -351,6 +356,7 @@ describe("build-friday-uiux-runtime-blocker-satisfaction", () => {
       const tracePath = writeJson(root, "trace.json", trace());
       const proofPath = writeJson(root, "ui-device-proof.json", {
         proof: "mission_spine_ui_device_consumption",
+        head,
         mission_id: "mission_ui_device_contract",
         observations: [{ surface: "mobile" }, { surface: "desktop" }, { surface: "channel" }],
         negative_control_segments: [{
@@ -391,6 +397,7 @@ describe("build-friday-uiux-runtime-blocker-satisfaction", () => {
       const proofPath = writeJson(root, "ui-device-proof.json", {
         truth: "assembled_real_ui_device_proof",
         status: "pass",
+        head,
       });
       const evidenceDir = writeNormalizedOnlyEvidenceDir(root);
       const output = execFileSync("node", [
@@ -409,6 +416,41 @@ describe("build-friday-uiux-runtime-blocker-satisfaction", () => {
       expect(report.status).toBe("ready");
       expect(report.blockers).toEqual([]);
       expect(report.counts?.satisfactions).toBe(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects stale strict UI/device proof from another head", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-runtime-satisfaction-stale-head-"));
+    try {
+      const tracePath = writeJson(root, "trace.json", trace());
+      const proofPath = writeJson(root, "ui-device-proof.json", {
+        truth: "assembled_real_ui_device_proof",
+        status: "pass",
+        head: "stale123",
+      });
+      const evidenceDir = writeEvidenceDir(root);
+      const result = spawnSync("node", [
+        script,
+        `--head=${head}`,
+        `--action-traceability-report=${tracePath}`,
+        `--ui-device-proof=${proofPath}`,
+        `--ui-device-evidence-dir=${evidenceDir}`,
+        "--require-ready",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        status?: string;
+        blockers?: Array<{ code?: string; detail?: string }>;
+      };
+      expect(report.status).toBe("not_ready");
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          code: "ui_device_proof_head_mismatch",
+          detail: expect.stringContaining(head),
+        }),
+      ]));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- require UI/device blocker satisfaction to prove evidence is from the current HEAD instead of accepting stale strict proof artifacts
- stamp assembled mission-spine UI/device proof with the current git head and require it in the strict gate
- close the remaining selected iOS native linkage gaps for approval action_digest and local voice-loop readiness truth
- harden the UI/device shortlist runner so empty negative-control inputs do not crash under macOS Bash/set -u

## Verification
- /Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts test/unit/qa/friday-uiux-native-linkage-cli.test.ts test/unit/qa/friday-uiux-runtime-blocker-satisfaction-cli.test.ts
- bash rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh
- node scripts/ops/check-friday-uiux-native-linkage.mjs --repo-root=/private/tmp/friday-runtime-evidence-batch-20260630 --out=/tmp/friday-native-linkage-after.json --require-complete
- scripts/ops/friday-uiux-real-use-proof-driver.sh ... --defer-channel-proof --workbench-db ... (partial_ready, RC=0; iOS design capture ready, action bundle ready, mobile+desktop same-mission live write/read ready; strict END-BAR still blocked on channel/timeline/stress/negative/manifest evidence)
- git diff --check

Truth: this is not END-BAR/adoption. It prevents stale proof reuse and moves current-head mobile+desktop evidence closer to strict readiness, while leaving missing strict evidence explicit.