### PR TITLE
Thread strict evidence controls through UIUX proof wrappers

### DIFF
--- a/rust-core/scripts/mission-spine-channel-live-gate-self-test.sh
+++ b/rust-core/scripts/mission-spine-channel-live-gate-self-test.sh
@@ -45,6 +45,8 @@ jq -e '
   .proof == "mission_spine_channel_live_proof"
   and .status == "passed"
   and .capture_mode == "--wrap-existing"
+  and (.head | type == "string" and length >= 12)
+  and (.head_short | type == "string" and length == 12)
   and .telegram_live.proof == "telegram_inbound_through_rust_channels_pipeline"
   and .telegram_live.sender_allowlisted == true
   and .secret_policy.artifact_contains_redacted_text_only == true
@@ -92,6 +94,8 @@ jq -e '
   .proof == "mission_spine_channel_live_proof"
   and .status == "failed_timeout"
   and .capture_mode == "--wrap-existing"
+  and (.head | type == "string" and length >= 12)
+  and (.head_short | type == "string" and length == 12)
   and .telegram_live.status == "failed_timeout"
   and .telegram_live.bot_identity_verified == true
   and .secret_policy.artifact_contains_redacted_text_only == true

--- a/rust-core/scripts/mission-spine-channel-live-gate.sh
+++ b/rust-core/scripts/mission-spine-channel-live-gate.sh
@@ -28,6 +28,8 @@ EOF
 esac
 
 generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+git_head="$(git rev-parse HEAD 2>/dev/null || printf 'unknown')"
+git_head_short="${git_head:0:12}"
 channel_live_proof_out="${MISSION_SPINE_CHANNEL_LIVE_PROOF_OUT:-/tmp/friday-mission-spine-channel-live-proof.json}"
 
 export TELEGRAM_LISTEN_SECONDS="${TELEGRAM_LISTEN_SECONDS:-300}"
@@ -78,12 +80,24 @@ if jq -e '
   jq \
     --arg generated_at "$generated_at" \
     --arg worktree "$root" \
+    --arg git_head "$git_head" \
+    --arg git_head_short "$git_head_short" \
+    --arg github_sha "${GITHUB_SHA:-}" \
+    --arg github_run_id "${GITHUB_RUN_ID:-}" \
+    --arg github_ref_name "${GITHUB_REF_NAME:-}" \
     --arg raw_artifact "$TELEGRAM_PROOF_OUT" \
     --arg mode "$mode" \
     '{
     proof: "mission_spine_channel_live_proof",
     generated_at_utc: $generated_at,
     worktree: $worktree,
+    head: $git_head,
+    head_short: $git_head_short,
+    github: {
+      sha: (if ($github_sha | length) > 0 then $github_sha else null end),
+      run_id: (if ($github_run_id | length) > 0 then $github_run_id else null end),
+      ref_name: (if ($github_ref_name | length) > 0 then $github_ref_name else null end)
+    },
     status: "passed",
     capture_mode: $mode,
     scope: "real Telegram/channel inbound proof through Rust channel auth and redaction pipeline; not real UI/device consumption proof",
@@ -128,12 +142,24 @@ if jq -e '
   jq \
     --arg generated_at "$generated_at" \
     --arg worktree "$root" \
+    --arg git_head "$git_head" \
+    --arg git_head_short "$git_head_short" \
+    --arg github_sha "${GITHUB_SHA:-}" \
+    --arg github_run_id "${GITHUB_RUN_ID:-}" \
+    --arg github_ref_name "${GITHUB_REF_NAME:-}" \
     --arg raw_artifact "$TELEGRAM_PROOF_OUT" \
     --arg mode "$mode" \
     '{
       proof: "mission_spine_channel_live_proof",
       generated_at_utc: $generated_at,
       worktree: $worktree,
+      head: $git_head,
+      head_short: $git_head_short,
+      github: {
+        sha: (if ($github_sha | length) > 0 then $github_sha else null end),
+        run_id: (if ($github_run_id | length) > 0 then $github_run_id else null end),
+        ref_name: (if ($github_ref_name | length) > 0 then $github_ref_name else null end)
+      },
       status: "failed_timeout",
       capture_mode: $mode,
       scope: "diagnostic only: Telegram bot identity was verified but no trusted allowlisted text message arrived during the live proof window",

--- a/scripts/ops/friday-uiux-real-use-proof-driver.sh
+++ b/scripts/ops/friday-uiux-real-use-proof-driver.sh
@@ -22,6 +22,7 @@ usage:
     [--workbench-db /abs/rust-hub.sqlite]
     [--harvest-dir /abs/artifact-dir ...]
     [--same-run-events /abs/events.jsonl ...]
+    [--negative-control-events /abs/negative-events.jsonl ...]
     [--selected-visual-evidence-dir /abs/served-or-visual-evidence ...]
     [--runtime-evidence-dir /abs/evidence-dir ...]
     [--extra-action-runtime-evidence /abs/action-runtime-evidence.json ...]
@@ -69,6 +70,7 @@ skip_action_bundle=0
 accessibility_captures=()
 harvest_dirs=()
 same_run_events=()
+negative_control_events=()
 runtime_evidence_dirs=()
 selected_visual_evidence_dirs=()
 extra_action_runtime_evidence=()
@@ -231,6 +233,15 @@ while [ "$#" -gt 0 ]; do
       same_run_events+=("${1#--same-run-events=}")
       shift
       ;;
+    --negative-control-events)
+      [ "$#" -ge 2 ] || die "--negative-control-events requires a value"
+      negative_control_events+=("$2")
+      shift 2
+      ;;
+    --negative-control-events=*)
+      negative_control_events+=("${1#--negative-control-events=}")
+      shift
+      ;;
     --runtime-evidence-dir)
       [ "$#" -ge 2 ] || die "--runtime-evidence-dir requires a value"
       runtime_evidence_dirs+=("$2")
@@ -326,7 +337,7 @@ require_file_if_set() {
 }
 
 set +u
-for path in "${accessibility_captures[@]}" "${harvest_dirs[@]}" "${same_run_events[@]}" "${runtime_evidence_dirs[@]}" "${selected_visual_evidence_dirs[@]}" "${extra_action_runtime_evidence[@]}"; do
+for path in "${accessibility_captures[@]}" "${harvest_dirs[@]}" "${same_run_events[@]}" "${negative_control_events[@]}" "${runtime_evidence_dirs[@]}" "${selected_visual_evidence_dirs[@]}" "${extra_action_runtime_evidence[@]}"; do
   require_abs_if_set "input path" "${path}"
 done
 set -u
@@ -505,6 +516,10 @@ done
 for path in "${same_run_events[@]}"; do
   [ -n "${path}" ] || continue
   shortlist_args+=("--same-run-events" "${path}")
+done
+for path in "${negative_control_events[@]}"; do
+  [ -n "${path}" ] || continue
+  shortlist_args+=("--negative-control-events" "${path}")
 done
 for dir in "${runtime_evidence_dirs[@]}"; do
   [ -n "${dir}" ] || continue

--- a/test/unit/qa/friday-uiux-real-use-proof-driver-contract.test.ts
+++ b/test/unit/qa/friday-uiux-real-use-proof-driver-contract.test.ts
@@ -73,6 +73,9 @@ describe("friday-uiux-real-use-proof-driver contract", () => {
     expect(source).toContain("--defer-channel-proof");
     expect(source).toContain("defer_channel_proof=\"${FRIDAY_UI_DEVICE_DEFER_CHANNEL_PROOF:-0}\"");
     expect(source).toContain("shortlist_args+=(\"--defer-channel-proof\")");
+    expect(source).toContain("--negative-control-events");
+    expect(source).toContain("negative_control_events=()");
+    expect(source).toContain("shortlist_args+=(\"--negative-control-events\" \"${path}\")");
     expect(source).toContain("uiux_real_use_proof_driver_summary_not_endbar_not_adoption");
     expect(source).toContain("END-BAR requires strict UI/device readiness");
     expect(source).toContain("never fabricates accessibility clicks");


### PR DESCRIPTION
## Summary
- thread negative-control event inputs from the UI/UX real-use proof driver into the strict UI device shortlist runner
- add current git head metadata to mission-spine channel live proof wrappers so channel evidence can satisfy current-head proof consumers
- extend contract/self-tests for both paths

## Verification
- `bash -n rust-core/scripts/mission-spine-channel-live-gate.sh rust-core/scripts/mission-spine-channel-live-gate-self-test.sh scripts/ops/friday-uiux-real-use-proof-driver.sh`
- `bash rust-core/scripts/mission-spine-channel-live-gate-self-test.sh`
- `/Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default test/unit/qa/friday-uiux-real-use-proof-driver-contract.test.ts test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts test/unit/qa/friday-ui-device-observations-manifest-cli.test.ts`
- `git diff --check`

Truth: this does not claim END-BAR; it removes proof-plumbing gaps so real negative-control/channel evidence can be consumed by the strict UI/device chain.