### PR TITLE
Require current-head channel proof in strict UI evidence

### DIFF
--- a/rust-core/scripts/mission-spine-closure-audit-gate.sh
+++ b/rust-core/scripts/mission-spine-closure-audit-gate.sh
@@ -65,14 +65,17 @@ uiux_runtime_evidence_inputs_json="null"
 uiux_runtime_evidence_action_rows_json="null"
 uiux_residual_destinations_with_blockers_json="null"
 uiux_residual_destinations_all_runtime_actions_covered_json="null"
+current_head="$(git -C "$root" rev-parse HEAD)"
+channel_live_proof_head=""
 
 channel_wrapper_passes_strict_schema() {
   local artifact="$1"
   [[ -s "$artifact" ]] || return 1
-  jq -e '
+  jq -e --arg current_head "$current_head" '
     .proof == "mission_spine_channel_live_proof"
     and .status == "passed"
     and .capture_mode == "--live"
+    and ((.head // .git_sha // .github.sha // .github.head_sha // "") == $current_head)
     and .telegram_live.status == "passed"
     and .telegram_live.proof == "telegram_inbound_through_rust_channels_pipeline"
     and .telegram_live.bot_identity_verified == true
@@ -225,11 +228,17 @@ fi
 
 if [[ -s "$channel_live_proof_out" ]] \
   && jq -e '.proof == "mission_spine_channel_live_proof" and .status == "passed"' "$channel_live_proof_out" >/dev/null; then
-  channel_live_proof_available="true"
-  channel_live_proof_status="passed"
   channel_live_proof_generated_at="$(jq -r '.generated_at_utc // ""' "$channel_live_proof_out")"
-  if [[ "$ui_device_channel_proof_satisfies_telegram" == "true" ]]; then
-    channel_live_proof_source="ui_device_proof_channel_evidence"
+  channel_live_proof_head="$(jq -r '.head // .git_sha // .github.sha // .github.head_sha // ""' "$channel_live_proof_out")"
+  if channel_wrapper_passes_strict_schema "$channel_live_proof_out"; then
+    channel_live_proof_available="true"
+    channel_live_proof_status="passed"
+    if [[ "$ui_device_channel_proof_satisfies_telegram" == "true" ]]; then
+      channel_live_proof_source="ui_device_proof_channel_evidence"
+    fi
+  else
+    channel_live_proof_available="false"
+    channel_live_proof_status="blocked_wrapper_not_current_head_or_strict_schema"
   fi
 elif [[ -s "$telegram_raw_proof_out" ]] \
   && jq -e '
@@ -304,6 +313,8 @@ cat > "$report_out" <<EOF
     "artifact": "$channel_live_proof_artifact",
     "source": "$channel_live_proof_source",
     "ui_device_channel_proof_artifact": "$ui_device_channel_proof_artifact",
+    "current_head": "$current_head",
+    "proof_head": "$channel_live_proof_head",
     "generated_at_utc": "$channel_live_proof_generated_at",
     "scope": "machine-readable redacted wrapper artifact written by scripts/mission-spine-channel-live-gate.sh after real Telegram/channel proof passes; legacy raw artifacts are not accepted because they can contain provider/channel identifiers"
   },

--- a/scripts/ops/friday-channel-live-artifact-ingest.mjs
+++ b/scripts/ops/friday-channel-live-artifact-ingest.mjs
@@ -11,6 +11,7 @@ function usage() {
     [--artifact-dir=/abs/downloaded-artifact-dir | --channel-live-proof=/abs/mission_spine_channel_live_proof.json] \\
     [--raw-telegram-proof=/abs/telegram_live_proof.json] \\
     [--out=/abs/report.json] [--require-compatible]
+    [--require-current-head] [--current-head=<git-sha>]
 
 Truth: validates a downloaded GitHub Telegram live-proof artifact against the
 current mission_spine_channel_live_proof wrapper schema. It does not download
@@ -38,6 +39,8 @@ const channelLiveProofArg = arg("channel-live-proof");
 const rawTelegramProofArg = arg("raw-telegram-proof");
 const outPath = arg("out");
 const requireCompatible = args.includes("--require-compatible");
+const requireCurrentHead = args.includes("--require-current-head");
+const currentHead = arg("current-head") || process.env.FRIDAY_CURRENT_HEAD || "";
 const blockers = [];
 const notes = [];
 
@@ -109,6 +112,18 @@ function expectTrue(value, code) {
   if (value !== true) block(code, String(value));
 }
 
+function stringValue(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function wrapperHead(value) {
+  return stringValue(value?.head)
+    || stringValue(value?.git_sha)
+    || stringValue(value?.github?.sha)
+    || stringValue(value?.github?.head_sha)
+    || stringValue(value?.environment?.commit_sha);
+}
+
 if (artifactDir && (channelLiveProofArg || rawTelegramProofArg)) {
   notes.push("artifact_dir_with_explicit_paths:explicit_paths_take_precedence");
 }
@@ -130,6 +145,18 @@ if (wrapper && typeof wrapper === "object" && !Array.isArray(wrapper)) {
   if (wrapper.status !== "passed") block("wrapper_status_not_passed", String(wrapper.status ?? ""));
   if (!String(wrapper.remaining_requirement || "").includes("UI/device consumption evidence")) {
     block("wrapper_missing_ui_device_boundary", "remaining_requirement");
+  }
+  if (requireCurrentHead) {
+    if (!currentHead) {
+      block("current_head_missing", "--current-head or FRIDAY_CURRENT_HEAD");
+    } else {
+      const head = wrapperHead(wrapper);
+      if (!head) {
+        block("wrapper_head_missing", "head/github.sha");
+      } else if (head !== currentHead) {
+        block("wrapper_head_mismatch", head);
+      }
+    }
   }
   const telegram = wrapper.telegram_live && typeof wrapper.telegram_live === "object" ? wrapper.telegram_live : {};
   if (telegram.status !== "passed") block("telegram_status_not_passed", String(telegram.status ?? ""));
@@ -181,6 +208,9 @@ const report = {
   channelLiveProof: channelLiveProofPath || null,
   rawTelegramProof: rawTelegramProofPath || null,
   captureMode: wrapper?.capture_mode || null,
+  currentHeadRequired: requireCurrentHead,
+  currentHead: currentHead || null,
+  wrapperHead: wrapperHead(wrapper) || null,
   generatedAt: wrapper?.generated_at_utc || null,
   blockers,
   notes,

--- a/scripts/ops/friday-channel-proof-events.mjs
+++ b/scripts/ops/friday-channel-proof-events.mjs
@@ -12,6 +12,7 @@ function usage() {
     --channel-live-proof=/abs/channel-live-proof.json \\
     --channel-capture=/abs/channel-capture.json \\
     --out=/abs/channel-events.jsonl [--require-ready]
+    [--require-current-head] [--current-head=<git-sha>]
 
 Truth: converts a redacted channel live proof artifact into conservative
 same-run UI/device event rows. It accepts the mission-spine Telegram wrapper
@@ -31,10 +32,12 @@ if (args.includes("--help") || args.includes("-h")) {
 }
 
 const requireReady = args.includes("--require-ready");
+const requireCurrentHead = args.includes("--require-current-head");
 const missionId = arg("mission-id");
 const channelLiveProofPath = arg("channel-live-proof");
 const channelCapturePath = arg("channel-capture");
 const outPath = arg("out");
+const currentHead = arg("current-head") || process.env.FRIDAY_CURRENT_HEAD || "";
 const blockers = [];
 
 function block(code, detail) {
@@ -79,6 +82,30 @@ function stringValue(value) {
   return typeof value === "string" ? value : "";
 }
 
+function proofHead(proof) {
+  return stringValue(proof.head)
+    || stringValue(proof.git_sha)
+    || stringValue(proof.github?.sha)
+    || stringValue(proof.github?.head_sha)
+    || stringValue(proof.environment?.commit_sha);
+}
+
+function validateCurrentHead(proof, label) {
+  if (!requireCurrentHead) return [];
+  const failures = [];
+  if (!currentHead) {
+    failures.push("channel_live_proof_current_head_missing");
+    return failures;
+  }
+  const head = proofHead(proof);
+  if (!head) {
+    failures.push("channel_live_proof_head_missing");
+  } else if (head !== currentHead) {
+    failures.push(`channel_live_proof_head_mismatch:${label}:${head}`);
+  }
+  return failures;
+}
+
 function validateMissionSpineWrapper(proof) {
   const failures = [];
   if (proof.proof !== "mission_spine_channel_live_proof") failures.push("channel_live_proof_mismatch");
@@ -95,6 +122,7 @@ function validateMissionSpineWrapper(proof) {
   if (!String(proof.remaining_requirement || "").includes("UI/device consumption evidence")) {
     failures.push("channel_live_proof_missing_ui_device_boundary");
   }
+  failures.push(...validateCurrentHead(proof, "mission_spine"));
   return {
     source: "mission_spine_channel_live_proof",
     capturedAt: stringValue(proof.generated_at_utc),
@@ -123,6 +151,7 @@ function validatePhase24TrustedInbound(proof) {
   if (proof.criteria?.fullEvidenceSurfaceExported !== true) failures.push("phase24_channel_evidence_surface_not_exported");
   if (observedEventKey && !isObject(proof[observedEventKey])) failures.push(`phase24_channel_observed_event_missing:${observedEventKey}`);
   if (!isObject(proof.evidenceSurface)) failures.push("phase24_channel_evidence_surface_missing");
+  failures.push(...validateCurrentHead(proof, "phase24"));
   return {
     source: proof.schemaVersion || "phase24_channel_trusted_inbound",
     capturedAt: stringValue(proof.completedAt || proof.startedAt),
@@ -208,6 +237,9 @@ const output = {
   out: outPath ? abs(outPath) : null,
   outputRows: rows.length,
   emittedEvents: rows.map((row) => `${row.surface}:${row.event}`),
+  currentHeadRequired: requireCurrentHead,
+  currentHead: currentHead || null,
+  proofHead: proof && isObject(proof) ? proofHead(proof) || null : null,
   blockers,
   caveat: "Conservative channel event bridge only. Replay-blocked visibility is emitted only when the channel proof includes replay controls. Phase24 trusted-inbound artifacts prove user-origin channel consumption but do not emit replay-blocked visibility unless their own proof includes replay controls; this does not claim timeline proof, mobile/desktop/channel convergence, END-BAR, or GO-LIVE.",
 };

--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -772,11 +772,15 @@ derive_channel_events_if_possible() {
   mkdir -p "$(dirname "$derived_out")"
   existing_events="${SAME_RUN_EVENTS:-}"
 
+  local current_head
+  current_head="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
   if node "${REPO_ROOT}/scripts/ops/friday-channel-proof-events.mjs" \
     "--mission-id=${MISSION_ID}" \
     "--channel-live-proof=${CHANNEL_LIVE_PROOF}" \
     "--channel-capture=${CHANNEL_EVIDENCE}" \
-    "--out=${derived_out}" >"$stdout_out"; then
+    "--out=${derived_out}" \
+    "--current-head=${current_head}" \
+    --require-current-head >"$stdout_out"; then
     if [ ! -s "$derived_out" ]; then
       notes+=("channel_proof_events_bridge:no_events")
       return 0

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -491,12 +491,15 @@ channel_events=""
 if [ -n "${channel_live_proof}" ] || [ -n "${channel_capture}" ]; then
   [ -n "${channel_live_proof}" ] || die "--channel-live-proof is required with --channel-capture"
   [ -n "${channel_capture}" ] || die "--channel-capture is required with --channel-live-proof"
+  current_head="$(git -C "${repo_root}" rev-parse HEAD)"
   channel_events="${out_dir}/channel-events.jsonl"
   node "${repo_root}/scripts/ops/friday-channel-proof-events.mjs" \
     "--mission-id=${mission_id}" \
     "--channel-live-proof=${channel_live_proof}" \
     "--channel-capture=${channel_capture}" \
     "--out=${channel_events}" \
+    "--current-head=${current_head}" \
+    --require-current-head \
     --require-ready
   event_inputs+=("${channel_events}")
 fi

--- a/test/unit/qa/friday-channel-live-artifact-ingest-cli.test.ts
+++ b/test/unit/qa/friday-channel-live-artifact-ingest-cli.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const script = "scripts/ops/friday-channel-live-artifact-ingest.mjs";
+const currentHead = "095811ada740d342e181f91ac38b5d8fac2ee768";
 
 function writeRaw(path: string) {
   writeFileSync(path, JSON.stringify({
@@ -26,6 +27,7 @@ function writeRaw(path: string) {
 function writeWrapper(path: string, overrides: Record<string, unknown> = {}) {
   writeFileSync(path, JSON.stringify({
     proof: "mission_spine_channel_live_proof",
+    head: currentHead,
     generated_at_utc: "2026-06-26T17:35:00Z",
     status: "passed",
     capture_mode: "--live",
@@ -97,6 +99,35 @@ describe("friday-channel-live-artifact-ingest", () => {
       const output = JSON.parse(result.stdout) as { status?: string; blockers?: Array<{ code?: string }> };
       expect(output.status).toBe("blocked");
       expect(output.blockers?.map((blocker) => blocker.code)).toContain("channel_live_proof_missing");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when strict current-head validation sees a stale wrapper", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-channel-artifact-stale-head-"));
+    try {
+      const wrapper = join(root, "mission_spine_channel_live_proof.json");
+      writeWrapper(wrapper, { head: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+
+      const result = spawnSync("node", [
+        script,
+        `--channel-live-proof=${wrapper}`,
+        "--require-compatible",
+        "--require-current-head",
+        `--current-head=${currentHead}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as {
+        status?: string;
+        currentHeadRequired?: boolean;
+        wrapperHead?: string;
+        blockers?: Array<{ code?: string }>;
+      };
+      expect(output.status).toBe("blocked");
+      expect(output.currentHeadRequired).toBe(true);
+      expect(output.wrapperHead).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("wrapper_head_mismatch");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-channel-live-artifact-ingest-cli.test.ts
+++ b/test/unit/qa/friday-channel-live-artifact-ingest-cli.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const script = "scripts/ops/friday-channel-live-artifact-ingest.mjs";
-const currentHead = "095811ada740d342e181f91ac38b5d8fac2ee768";
+const currentHead = "test-current-head";
 
 function writeRaw(path: string) {
   writeFileSync(path, JSON.stringify({
@@ -108,7 +108,7 @@ describe("friday-channel-live-artifact-ingest", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-channel-artifact-stale-head-"));
     try {
       const wrapper = join(root, "mission_spine_channel_live_proof.json");
-      writeWrapper(wrapper, { head: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+      writeWrapper(wrapper, { head: "test-stale-head" });
 
       const result = spawnSync("node", [
         script,
@@ -126,7 +126,7 @@ describe("friday-channel-live-artifact-ingest", () => {
       };
       expect(output.status).toBe("blocked");
       expect(output.currentHeadRequired).toBe(true);
-      expect(output.wrapperHead).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+      expect(output.wrapperHead).toBe("test-stale-head");
       expect(output.blockers?.map((blocker) => blocker.code)).toContain("wrapper_head_mismatch");
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/test/unit/qa/friday-channel-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-channel-proof-events-cli.test.ts
@@ -6,10 +6,12 @@ import { describe, expect, it } from "vitest";
 
 const script = "scripts/ops/friday-channel-proof-events.mjs";
 const missionId = "mission_cli_channel_proof_events";
+const currentHead = "095811ada740d342e181f91ac38b5d8fac2ee768";
 
 function writeChannelProof(path: string, overrides: Record<string, unknown> = {}) {
   writeFileSync(path, JSON.stringify({
     proof: "mission_spine_channel_live_proof",
+    head: currentHead,
     generated_at_utc: "2026-06-24T23:59:00.000Z",
     status: "passed",
     scope: "real Telegram/channel inbound proof through Rust channel auth and redaction pipeline; not real UI/device consumption proof",
@@ -121,6 +123,43 @@ describe("friday-channel-proof-events", () => {
           captured_at: "2026-06-24T23:59:00.000Z",
         },
       ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed in strict mode when the channel wrapper is from a different head", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-channel-proof-events-head-"));
+    try {
+      const proof = join(tempDir, "channel-live-proof.json");
+      const channelCapture = join(tempDir, "channel-capture.json");
+      const out = join(tempDir, "channel-events.jsonl");
+      writeChannelProof(proof, { head: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+      writeFileSync(channelCapture, JSON.stringify({ truth: "redacted_channel_capture" }));
+
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--channel-live-proof=${proof}`,
+        `--channel-capture=${channelCapture}`,
+        `--out=${out}`,
+        "--require-ready",
+        "--require-current-head",
+        `--current-head=${currentHead}`,
+      ], { cwd: process.cwd(), encoding: "utf8" });
+
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as {
+        status?: string;
+        currentHeadRequired?: boolean;
+        proofHead?: string;
+        blockers?: Array<{ code?: string }>;
+      };
+      expect(output.status).toBe("blocked");
+      expect(output.currentHeadRequired).toBe(true);
+      expect(output.proofHead).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("channel_live_proof_head_mismatch");
+      expect(() => readFileSync(out, "utf8")).toThrow();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/unit/qa/friday-channel-proof-events-cli.test.ts
+++ b/test/unit/qa/friday-channel-proof-events-cli.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 
 const script = "scripts/ops/friday-channel-proof-events.mjs";
 const missionId = "mission_cli_channel_proof_events";
-const currentHead = "095811ada740d342e181f91ac38b5d8fac2ee768";
+const currentHead = "test-current-head";
 
 function writeChannelProof(path: string, overrides: Record<string, unknown> = {}) {
   writeFileSync(path, JSON.stringify({
@@ -134,7 +134,7 @@ describe("friday-channel-proof-events", () => {
       const proof = join(tempDir, "channel-live-proof.json");
       const channelCapture = join(tempDir, "channel-capture.json");
       const out = join(tempDir, "channel-events.jsonl");
-      writeChannelProof(proof, { head: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+      writeChannelProof(proof, { head: "test-stale-head" });
       writeFileSync(channelCapture, JSON.stringify({ truth: "redacted_channel_capture" }));
 
       const result = spawnSync("node", [
@@ -157,7 +157,7 @@ describe("friday-channel-proof-events", () => {
       };
       expect(output.status).toBe("blocked");
       expect(output.currentHeadRequired).toBe(true);
-      expect(output.proofHead).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+      expect(output.proofHead).toBe("test-stale-head");
       expect(output.blockers?.map((blocker) => blocker.code)).toContain("channel_live_proof_head_mismatch");
       expect(() => readFileSync(out, "utf8")).toThrow();
     } finally {

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -6,6 +6,10 @@ import { describe, expect, it } from "vitest";
 
 const missionId = "mission_cli_ui_device_readiness";
 
+function currentGitHead() {
+  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: process.cwd(), encoding: "utf8" }).trim();
+}
+
 function writeEvidenceDir(tempDir: string) {
   const files = {
     mobile: join(tempDir, "mobile.json"),
@@ -139,6 +143,7 @@ function writeRedactedChannelProof(tempDir: string) {
   const proof = join(tempDir, "channel-live-proof.json");
   writeFileSync(proof, JSON.stringify({
     proof: "mission_spine_channel_live_proof",
+    head: currentGitHead(),
     status: "passed",
     generated_at_utc: "2026-06-05T06:10:00Z",
     telegram_live: {

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -35,6 +35,18 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("real channel, timeline, stress, and negative-control evidence");
   });
 
+  it("requires current-head channel proof when deriving strict channel events", () => {
+    const runner = readFileSync("scripts/ops/friday-ui-device-proof-shortlist-runner.sh", "utf8");
+    const readiness = readFileSync("scripts/ops/friday-ui-device-proof-readiness.sh", "utf8");
+
+    expect(runner).toContain("current_head=\"$(git -C \"${repo_root}\" rev-parse HEAD)\"");
+    expect(runner).toContain("--current-head=${current_head}");
+    expect(runner).toContain("--require-current-head");
+    expect(readiness).toContain("current_head=\"$(git -C \"${REPO_ROOT}\" rev-parse HEAD)\"");
+    expect(readiness).toContain("--current-head=${current_head}");
+    expect(readiness).toContain("--require-current-head");
+  });
+
   it("can bind the runner to an exact existing Mission instead of only creating a shared-id Mission", () => {
     const source = readFileSync("scripts/ops/friday-ui-device-proof-shortlist-runner.sh", "utf8");
 

--- a/test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts
+++ b/test/unit/qa/mission-spine-closure-audit-gate-contract.test.ts
@@ -25,4 +25,13 @@ describe("mission-spine closure audit gate contract", () => {
     expect(script).toContain("\"uiux_non_channel_report_never_satisfies_strict_ui_device_proof\": true");
     expect(script).toContain("&& \"$ui_device_status\" == \"passed\"");
   });
+
+  it("requires channel live proof wrappers to match the current HEAD", () => {
+    expect(script).toContain("current_head=\"$(git -C \"$root\" rev-parse HEAD)\"");
+    expect(script).toContain("jq -e --arg current_head \"$current_head\"");
+    expect(script).toContain("(.head // .git_sha // .github.sha // .github.head_sha // \"\") == $current_head");
+    expect(script).toContain("channel_live_proof_status=\"blocked_wrapper_not_current_head_or_strict_schema\"");
+    expect(script).toContain("\"current_head\": \"$current_head\"");
+    expect(script).toContain("\"proof_head\": \"$channel_live_proof_head\"");
+  });
 });


### PR DESCRIPTION
## Summary
- add optional current-head validation to channel live artifact ingest and channel event derivation
- require current-head channel proof in strict UI/device readiness and shortlist paths
- cover stale-head fail-closed behavior in CLI/contract tests

## Validation
- `bash -n scripts/ops/friday-ui-device-proof-shortlist-runner.sh scripts/ops/friday-ui-device-proof-readiness.sh rust-core/scripts/mission-spine-channel-live-gate.sh`
- `ln -s /Users/jarvis/Projects/Friday/node_modules node_modules && /Users/jarvis/Projects/Friday/node_modules/.bin/vitest run --project default test/unit/qa/friday-channel-proof-events-cli.test.ts test/unit/qa/friday-channel-live-artifact-ingest-cli.test.ts test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts; rc=$?; rm node_modules; exit $rc`
- `git diff --check`

Truth: this does not claim channel proof done. It prevents stale/missing-head channel artifacts from satisfying strict UI/device evidence paths.