### PR TITLE
Fix desktop AX capture full-tree evidence

### DIFF
--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -696,7 +696,9 @@ if (blockers.length === 0) {
       });
     }
     await new Promise((resolveWait) => setTimeout(resolveWait, 350));
-    const raw = destinationReady.ready ? destinationReady.raw : captureTreeRaw();
+    // `waitForDestination` may return a minimal marker-only tree once the destination is ready.
+    // Capture a fresh full tree for evidence so status chips and proof refs are not dropped.
+    const raw = captureTreeRaw();
     rawSnapshots.push(`--- destination=${destination} nav=${navStatus} ---\n${raw}`);
     const elements = parseRawTree(raw);
     for (const [label, event] of [


### PR DESCRIPTION
## Summary
- Capture a fresh full Accessibility tree after desktop destination readiness instead of reusing the marker-only readiness tree.
- Keeps the existing destination-ready logic, but prevents status chips/proof refs from being dropped from evidence.

## Verification
- `node --check scripts/ops/friday-desktop-ax-accessibility-capture.mjs`
- Re-ran current-head desktop negative-control AX capture; observed `stale_label_visible`, `offline_label_visible`, and `error_label_visible` from real macOS Accessibility.
- Reassembled current strict UI/device evidence at `/private/tmp/friday-ui-device-current-channel-e8d3-20260701T014409Z/evidence-current-strict-full-20260701T0208`; gap report: `complete_inputs_observed`, blockers empty; readiness: `UI/DEVICE PROOF PASSED`.

Truth: this is proof tooling only; it does not claim END-BAR/adoption or change product behavior.