### PR TITLE
[codex] Fix UI device readiness evidence handling

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -720,7 +720,7 @@ derive_workbench_events_if_possible() {
     bridge_status="$(jq -r '.status // "unknown"' "$stdout_out" 2>/dev/null || printf 'unknown')"
     if [ "$bridge_status" != "ready" ]; then
       notes+=("workbench_snapshot_events_bridge:${bridge_status}:${stdout_out}")
-      if [ "${MODE}" = "require-proof" ]; then
+      if [ "${MODE}" = "require-proof" ] && { [ -z "$existing_events" ] || [ -z "${OBSERVATIONS_MANIFEST:-}" ]; }; then
         blockers+=("workbench_snapshot_events_bridge:${bridge_status}")
       fi
       return 0
@@ -743,7 +743,7 @@ derive_workbench_events_if_possible() {
     bridge_status="$(jq -r '.status // "unknown"' "$stdout_out" 2>/dev/null || printf 'unknown')"
     if [ "$bridge_status" != "unknown" ]; then
       notes+=("workbench_snapshot_events_bridge:${bridge_status}:${stdout_out}")
-      if [ "${MODE}" = "require-proof" ]; then
+      if [ "${MODE}" = "require-proof" ] && { [ -z "$existing_events" ] || [ -z "${OBSERVATIONS_MANIFEST:-}" ]; }; then
         blockers+=("workbench_snapshot_events_bridge:${bridge_status}")
       fi
       return 0
@@ -1017,6 +1017,12 @@ run_note_step "ui_device_gate_self_test" env \
   -u TIMELINE_EVIDENCE \
   -u OBSERVATIONS_MANIFEST \
   -u MISSION_SPINE_UI_DEVICE_PROOF \
+  -u MOBILE_EXTRA_EVIDENCE \
+  -u DESKTOP_EXTRA_EVIDENCE \
+  -u CHANNEL_EXTRA_EVIDENCE \
+  -u TIMELINE_EXTRA_EVIDENCE \
+  -u SHARED_EXTRA_EVIDENCE \
+  -u NEGATIVE_CONTROL_EVIDENCE_FILES \
   bash "${RUST_SCRIPTS_DIR}/mission-spine-ui-device-proof-gate-self-test.sh"
 
 if [ "${RUN_LIVE_READINESS}" = "1" ]; then


### PR DESCRIPTION
## Summary

- Keeps the UI/device readiness self-test isolated from caller extra-evidence environment variables.
- Treats workbench snapshot event derivation as non-fatal when a real evidence-dir already supplies same-run events plus an observations manifest.
- Preserves the strict assembler/final gate: missing real evidence still blocks, and the final UI/device proof must still assemble and pass.

## Validation

- `bash -n scripts/ops/friday-ui-device-proof-readiness.sh`
- `bash rust-core/scripts/mission-spine-ui-device-proof-gate-self-test.sh`
- Strict OG9 UI/device proof readiness on current evidence dir: `UI/DEVICE PROOF PASSED`

## Evidence

- Fresh Telegram live proof run `28489918343` at `9bd6abf7d59d33cf6576a5d0d3876197ddf24a43`
- Evidence dir: `/private/tmp/friday-og9-strict-evidence-current-20260701T025304Z`
- Assembled proof: `/tmp/friday-mission-spine-ui-device-proof.json`