### PR TITLE
Tighten iOS selected design runtime gate

### DIFF
--- a/scripts/ops/check-friday-ios-live-evidence-contract.mjs
+++ b/scripts/ops/check-friday-ios-live-evidence-contract.mjs
@@ -83,7 +83,7 @@ const checks = [
       ]),
       ...requireStrings(files.commandSheet, [
         "Command Sheet",
-        "Route coverage is not END-BAR",
+        "Route coverage only",
       ]),
       ...requireStrings(files.mobileProductContract, [
         "Device Pairing",
@@ -101,8 +101,8 @@ const checks = [
       ...requireStrings(files.home, [
         "showPairingProvisioning: Bool = false",
         "if showPairingProvisioning",
-        "Connect Friday to see approvals, memory candidates, and recovery items.",
-        "Connect Friday to see active work and provider progress.",
+        "friday.home.selected-design-intro",
+        "friday.home.selected-hero-pet",
       ]),
     ],
   },

--- a/scripts/ops/friday-ios-sim-xcui-observation.mjs
+++ b/scripts/ops/friday-ios-sim-xcui-observation.mjs
@@ -18,6 +18,7 @@ function usage() {
     [--interaction-scenarios=missions=missions-dispatch,shareIntake=share-submit]
     [--interaction-text='...'] [--interaction-url='https://...']
     [--normalize] [--require-observed] [--require-all-planned]
+    [--require-selected-design]
 
 Truth:
   Runs the checked-in Xcode UI-test bundle against an installed real iOS
@@ -67,6 +68,8 @@ const attachRunning = args.includes("--attach-running") || process.env.FRIDAY_IO
 const normalize = args.includes("--normalize");
 const requireObserved = args.includes("--require-observed");
 const requireAllPlanned = args.includes("--require-all-planned");
+const requireSelectedDesign = args.includes("--require-selected-design")
+  || process.env.FRIDAY_IOS_XCUI_REQUIRE_SELECTED_DESIGN === "1";
 const blockers = [];
 const warnings = [];
 
@@ -452,6 +455,53 @@ function observedRows(destination, targets, tree, treePath) {
   return { rows, missing };
 }
 
+function escapedRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function treeIncludesIdentifier(tree, id) {
+  return new RegExp(`identifier:\\s*['"]${escapedRegExp(id)}['"]`).test(tree);
+}
+
+function assertSelectedDesignTree(destination, tree) {
+  if (!requireSelectedDesign) return;
+
+  const requiredByDestination = {
+    home: [
+      "friday.mobile.toolbar.command-sheet",
+      "friday.mobile.toolbar.chat",
+      "friday.mobile.toolbar.refresh",
+      "friday.home.selected-design-intro",
+      "friday.home.selected-hero-pet",
+    ],
+  };
+  for (const id of requiredByDestination[destination] || []) {
+    if (!treeIncludesIdentifier(tree, id)) {
+      block("selected_design_required_id_missing", `${destination}:${id}`);
+    }
+  }
+
+  if (destination === "home") {
+    const forbiddenHomePatterns = [
+      ["legacy Friday Home title", /\bFriday Home\b/i],
+      ["offline landing state", /\bFriday is offline\b/i],
+      ["debug no-cache status copy", /No cached or fabricated status is shown/i],
+      ["home pairing setup panel", /\bDevice pairing\b/i],
+      ["home provisioning setup panel", /\bHub provisioning\b/i],
+      ["disabled setup badge", /\bdisabled\b/i],
+      ["not-loaded setup badge", /\bnot loaded\b/i],
+      ["read-off setup badge", /\bread off\b/i],
+      ["write-off setup badge", /\bwrite off\b/i],
+      ["home unavailable identifier", /identifier:\s*['"]friday\.home\.unavailable['"]/i],
+    ];
+    for (const [name, pattern] of forbiddenHomePatterns) {
+      if (pattern.test(tree)) {
+        block("selected_design_forbidden_home_state_visible", `${name}:${destination}`);
+      }
+    }
+  }
+}
+
 if (!missionId || !/^[A-Za-z0-9][A-Za-z0-9._:-]*$/.test(missionId) || !missionId.toLowerCase().includes("mission")) {
   block("mission_id_unexpected_shape", missionId || "<missing>");
 }
@@ -490,6 +540,7 @@ if (blockers.length === 0 && simulator) {
     const launchStdout = launchDestination(simulator, destination);
     if (blockers.length > 0) break;
     const runResult = runXcui(destination, scenario);
+    assertSelectedDesignTree(destination, runResult.tree);
     xcodeRuns.push({
       destination,
       interaction_scenario: scenario || null,
@@ -579,6 +630,7 @@ const summary = {
   bundle_id: bundleId,
   live_loopback_requested: liveLoopback,
   live_device_peer_requested: liveDevicePeer,
+  selected_design_required: requireSelectedDesign,
   data_container: dataContainer,
   target_count: allTargets.length,
   observed_count: observations.length,

--- a/test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts
+++ b/test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts
@@ -9,7 +9,7 @@ const script = "scripts/ops/friday-ios-sim-xcui-observation.mjs";
 const missionId = "mission_ios_sim_xcui_observation_contract";
 const fakeUdid = "11111111-2222-3333-4444-555555555555";
 
-async function writeFakeTools(binDir: string, mode: "pass" | "no-tree" | "missing-id" = "pass") {
+async function writeFakeTools(binDir: string, mode: "pass" | "no-tree" | "missing-id" | "selected-design" | "legacy-home" = "pass") {
   await mkdir(binDir, { recursive: true });
   const xcrun = join(binDir, "xcrun");
   writeFileSync(xcrun, `#!/usr/bin/env bash
@@ -38,10 +38,30 @@ exit 64
     ? ""
     : mode === "missing-id"
       ? "Application, identifier: 'friday.mobile.toolbar.command-sheet', label: 'Open Command Sheet'"
-      : [
-        "Application, 0x1, identifier: 'com.friday.shell'",
-        "  Button, 0x2, identifier: 'friday.mobile.toolbar.refresh', label: 'Refresh Hub status'",
-      ].join("\\n");
+      : mode === "selected-design"
+        ? [
+          "Application, 0x1, identifier: 'com.friday.shell'",
+          "  Button, 0x2, identifier: 'friday.mobile.toolbar.command-sheet', label: 'Open Command Sheet'",
+          "  Button, 0x3, identifier: 'friday.mobile.toolbar.refresh', label: 'Refresh Hub status'",
+          "  Button, 0x4, identifier: 'friday.mobile.toolbar.chat', label: 'Open Friday Chat'",
+          "  Other, 0x5, identifier: 'friday.home.selected-design-intro', label: 'Good morning. Here is what Friday is watching for you.'",
+          "  Other, 0x6, identifier: 'friday.home.selected-hero-pet', label: 'Friday companion'",
+        ].join("\\n")
+        : mode === "legacy-home"
+          ? [
+            "Application, 0x1, identifier: 'com.friday.shell'",
+            "  StaticText, 0x2, label: 'Friday Home'",
+            "  StaticText, 0x3, label: 'Friday is offline'",
+            "  StaticText, 0x4, label: 'No cached or fabricated status is shown.'",
+            "  StaticText, 0x5, label: 'Device pairing'",
+            "  StaticText, 0x6, label: 'disabled'",
+            "  StaticText, 0x7, label: 'Hub provisioning'",
+            "  Other, 0x8, identifier: 'friday.home.unavailable'",
+          ].join("\\n")
+          : [
+            "Application, 0x1, identifier: 'com.friday.shell'",
+            "  Button, 0x2, identifier: 'friday.mobile.toolbar.refresh', label: 'Refresh Hub status'",
+          ].join("\\n");
   writeFileSync(xcodebuild, `#!/usr/bin/env bash
 set -euo pipefail
 echo "Test Suite 'FridayIOSAXObserverUITests' started"
@@ -151,6 +171,59 @@ describe("friday-ios-sim-xcui-observation", () => {
       expect(result.status).toBe(2);
       const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
       expect(output.blockers?.map((blocker) => blocker.code)).toContain("planned_actions_missing");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes selected-design enforcement for the current product home identifiers", async () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ios-xcui-observation-selected-design-"));
+    try {
+      const binDir = join(root, "bin");
+      const outDir = join(root, "out");
+      await writeFakeTools(binDir, "selected-design");
+      const stdout = execFileSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        "--destinations=home",
+        "--require-selected-design",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      });
+      const output = JSON.parse(stdout) as { status?: string; selected_design_required?: boolean; blockers?: Array<{ code?: string }> };
+      expect(output.status).toBe("observation_ready");
+      expect(output.selected_design_required).toBe(true);
+      expect(output.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails selected-design enforcement for the old offline/debug home state", async () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ios-xcui-observation-legacy-home-"));
+    try {
+      const binDir = join(root, "bin");
+      const outDir = join(root, "out");
+      await writeFakeTools(binDir, "legacy-home");
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        "--destinations=home",
+        "--require-selected-design",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      const blockerCodes = output.blockers?.map((blocker) => blocker.code) ?? [];
+      expect(blockerCodes).toContain("selected_design_required_id_missing");
+      expect(blockerCodes).toContain("selected_design_forbidden_home_state_visible");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add an optional iOS XCUITest `--require-selected-design` runtime gate for the selected mobile Home design
- fail closed on the old offline/debug Home state and require selected-design identifiers from the product surface
- update the iOS live evidence contract guard to track the current selected-design Home copy/identifiers

## Truth labels
- This is a selected-design runtime guard plus static evidence-contract cleanup.
- It does not claim END-BAR, release GO, adoption, real device proof, or operator signing completion.
- The real simulator proof below used the existing OG9 organic mission so the Home projection was real, not a fake empty mission.

## Verification
- `git diff --check`
- `npm test -- test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts`
- `node scripts/ops/check-friday-ios-live-evidence-contract.mjs`
- `node scripts/ops/check-friday-served-ui-design-fidelity.mjs --out=/tmp/friday-served-ui-fidelity-after-rebase-20260701T043400Z.json`
- real iOS Simulator XCUITest selected-design gate:
  `/tmp/friday-ios-xcui-selected-design-live-og9-after-rebase-20260701T043417Z/ios-xcui-observation-summary.json`
