### PR TITLE
[codex] Polish iOS selected product path

### DIFF
--- a/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayChatScreen.swift
@@ -201,7 +201,7 @@ struct FridayChatScreen: View {
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
     case .error(let reason):
-      Text(reason)
+      Text(userFacingChatReason(reason))
         .font(.caption2)
         .foregroundStyle(MobileTheme.chipWarnFG)
         .fixedSize(horizontal: false, vertical: true)

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayContextPassportScreen.swift
@@ -14,7 +14,7 @@ struct FridayContextPassportScreen: View {
         case .unavailable(let reason):
           header(status: "connect", ready: false)
           UnavailableView(
-            reason: reason,
+            reason: userFacingReason(reason),
             title: "Connect Shared Context",
             detail: "Friday needs the live Hub projection to show paired-device setup, approval grant, and shared-context readiness.",
             systemImage: "checklist.checked",
@@ -32,7 +32,7 @@ struct FridayContextPassportScreen: View {
   private func loadedContent(_ projection: HomeProjection) -> some View {
     let status = projection.t3ProvisioningStatus
     header(
-      status: status?.homeStatusLabel ?? "waiting",
+      status: userFacingStatus(status?.homeStatusLabel ?? "setup needed"),
       ready: status?.isFullyProvisioned == true)
 
     if let status {
@@ -44,7 +44,7 @@ struct FridayContextPassportScreen: View {
     } else {
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
-          Text("Waiting for provisioning")
+          Text("Setup Needed")
             .font(.headline)
             .foregroundStyle(MobileTheme.textPrimary)
           Text("Device pairing, approval grant, and shared-context status will appear after the Hub projection refreshes.")
@@ -154,7 +154,7 @@ struct FridayContextPassportScreen: View {
           detail: "Authorizes scoped Friday work; mobile only reads the Hub projection.")
         ceremonyRow(
           title: "Shared context",
-          value: status.contextPassportCount > 0 ? "\(status.contextPassportCount) ready" : "waiting",
+          value: status.contextPassportCount > 0 ? "\(status.contextPassportCount) ready" : "setup needed",
           satisfied: status.contextPassportCount > 0,
           detail: "Shares non-sensitive mission context to the governed destination lane.")
         ceremonyRow(
@@ -235,7 +235,7 @@ struct FridayContextPassportScreen: View {
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
     case .error(let reason):
-      Text(reason)
+      Text(userFacingReason(reason))
         .font(.caption2)
         .foregroundStyle(MobileTheme.chipWarnFG)
         .fixedSize(horizontal: false, vertical: true)
@@ -273,6 +273,32 @@ struct FridayContextPassportScreen: View {
       }
     }
     .joined(separator: ", ")
+  }
+
+  private func userFacingStatus(_ status: String) -> String {
+    switch status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "waiting", "pending", "queued":
+      return "setup needed"
+    case "blocked":
+      return "needs attention"
+    case "off", "disabled":
+      return "needs setup"
+    default:
+      return status
+    }
+  }
+
+  private func userFacingReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("transport")
+      || normalized.contains("connection") || normalized.contains("server dark")
+    {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then try again."
+    }
+    if normalized.contains("approval") || normalized.contains("operator") {
+      return "Approval is needed before shared context can continue."
+    }
+    return "Shared context appears after the paired device and approval grant are visible in the Hub projection."
   }
 
   private func cardHeader(_ title: String, count: Int?) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayHomeScreen.swift
@@ -184,8 +184,8 @@ struct FridayHomeScreen: View {
         id: "learning-\(candidate.id)",
         icon: "brain.head.profile",
         iconBg: MobileTheme.cyanSoft,
-        title: productLearningTitle(candidate.summary),
-        subtitle: productLearningSubtitle(kind: candidate.kind, state: candidate.state),
+        title: productLearningTitle(kind: candidate.kind),
+        subtitle: productLearningSubtitle(candidate),
         chip: "confirm",
         urgent: false,
         workItem: nil)
@@ -276,12 +276,31 @@ struct FridayHomeScreen: View {
     return "Owner: \(productReadableSentence(owner))."
   }
 
-  private func productLearningTitle(_ summary: String) -> String {
-    productReadableTitle(summary.isEmpty ? "Review learning candidate" : summary)
+  private func productLearningTitle(kind: String) -> String {
+    let label = productChipLabel(kind)
+    if label.contains("preference") {
+      return "Review preference"
+    }
+    if label.contains("world") || label.contains("model") {
+      return "Review world model"
+    }
+    if label.contains("memory") {
+      return "Review memory learning"
+    }
+    return "Review learning"
   }
 
-  private func productLearningSubtitle(kind: String, state: String) -> String {
-    "Candidate: \(productChipLabel(kind)) · \(productChipLabel(state))."
+  private func productLearningSubtitle(_ candidate: HomeRunOutcomeLearningCandidate) -> String {
+    let summary = candidate.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalized = summary.lowercased()
+    if !summary.isEmpty
+      && !normalized.contains("kind=")
+      && !normalized.contains("state=")
+      && !normalized.contains(";")
+    {
+      return productReadableSentence(summary)
+    }
+    return "\(productChipLabel(candidate.kind)) candidate is \(productChipLabel(candidate.state))."
   }
 
   private func productRouteTitle(_ rawRoute: String) -> String {
@@ -343,6 +362,12 @@ struct FridayHomeScreen: View {
       return "timeline"
     case "completed_with_proof":
       return "complete"
+    case "waiting", "queued", "pending":
+      return "in queue"
+    case "blocked":
+      return "needs attention"
+    case "off", "disabled":
+      return "needs setup"
     case "friday_owned":
       return "Friday"
     case "":
@@ -507,7 +532,7 @@ struct FridayHomeScreen: View {
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
     case .error(let reason):
-      Text(reason)
+      Text(userFacingDecisionReason(reason))
         .font(.caption2)
         .foregroundStyle(MobileTheme.coral)
     case nil:
@@ -566,7 +591,7 @@ struct FridayHomeScreen: View {
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
           FridayChip(
-            text: projection.timelinePages.isEmpty ? "waiting" : "\(projection.timelinePages.count) pages",
+            text: projection.timelinePages.isEmpty ? "ready soon" : "\(projection.timelinePages.count) pages",
             bg: projection.timelinePages.isEmpty ? MobileTheme.chipNeutralBG : MobileTheme.chipPendingBG,
             fg: projection.timelinePages.isEmpty ? MobileTheme.chipNeutralFG : MobileTheme.chipPendingFG)
         }
@@ -589,7 +614,7 @@ struct FridayHomeScreen: View {
                   .foregroundStyle(MobileTheme.textPrimary)
                   .lineLimit(1)
                 Spacer(minLength: 8)
-                FridayChip(text: page.statusText, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+                FridayChip(text: productChipLabel(page.statusText), bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
               }
               if !page.summary.isEmpty {
                 Text(page.summary)
@@ -889,7 +914,7 @@ struct FridayHomeScreen: View {
           bg: status.isFullyProvisioned ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
           fg: status.isFullyProvisioned ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
       } else {
-        FridayChip(text: "waiting", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+        FridayChip(text: "setup needed", bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
       }
     }
     if let status {
@@ -988,6 +1013,19 @@ struct FridayHomeScreen: View {
       }
     }
     .joined(separator: ", ")
+  }
+
+  private func userFacingDecisionReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("transport")
+      || normalized.contains("connection") || normalized.contains("server dark")
+    {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then try again."
+    }
+    if normalized.contains("approval") || normalized.contains("operator") {
+      return "Approval is needed before Friday can continue."
+    }
+    return "Friday paused safely and needs a fresh live confirmation before continuing."
   }
 }
 

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayNewSessionScreen.swift
@@ -141,7 +141,7 @@ struct FridayNewSessionScreen: View {
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
           cardHeader("Needs Connection", count: nil)
-          Text(reason)
+          Text(userFacingReason(reason))
             .font(.caption)
             .foregroundStyle(MobileTheme.coral)
             .fixedSize(horizontal: false, vertical: true)
@@ -154,6 +154,19 @@ struct FridayNewSessionScreen: View {
   private var launchInFlight: Bool {
     if case .launching = viewModel.launchState { return true }
     return false
+  }
+
+  private func userFacingReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("transport")
+      || normalized.contains("connection") || normalized.contains("server dark")
+    {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then try again."
+    }
+    if normalized.contains("approval") || normalized.contains("operator") {
+      return "Approval is needed before Friday can continue."
+    }
+    return "Friday needs a fresh live Hub connection before this session can start."
   }
 
   private func cardHeader(_ title: String, count: Int?) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProjectionScreens.swift
@@ -162,7 +162,7 @@ struct FridayProjectionScreen: View {
       loadedContent(surface, projection)
     case .unavailable(let reason):
       UnavailableView(
-        reason: reason,
+        reason: displayReason(reason),
         title: "Connect \(surface.title)",
         detail: "Friday needs the live Hub projection before this destination can show current state.",
         systemImage: surface.icon,
@@ -351,7 +351,7 @@ struct FridayProjectionScreen: View {
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
           cardHeader(title, count: nil)
-          Text(reason)
+          Text(displayReason(reason))
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
         }
@@ -449,7 +449,7 @@ struct FridayProjectionScreen: View {
         .accessibilityIdentifier("friday.missions.open-chat-loop")
       }
     case .blocked(let reason):
-      Text(reason)
+      Text(displayReason(reason))
         .font(.caption)
         .foregroundStyle(MobileTheme.coral)
         .fixedSize(horizontal: false, vertical: true)
@@ -740,11 +740,11 @@ struct FridayProjectionScreen: View {
     if let status {
       readinessRow(
         title: "Approval grant",
-        value: status.activeTrustGrantCount > 0 ? "active" : "waiting for operator",
+        value: status.activeTrustGrantCount > 0 ? "active" : "approval needed",
         healthy: status.activeTrustGrantCount > 0)
       readinessRow(
         title: "Shared context",
-        value: status.contextPassportCount > 0 ? "\(status.contextPassportCount) ready" : "waiting for setup",
+        value: status.contextPassportCount > 0 ? "\(status.contextPassportCount) ready" : "setup needed",
         healthy: status.contextPassportCount > 0 && status.contextPassportItemCount > 0)
       if let device = status.latestDevice {
         FridayProofLine(label: "device", ref: device.deviceId)
@@ -754,11 +754,11 @@ struct FridayProjectionScreen: View {
     } else {
       readinessRow(
         title: "Approval grant",
-        value: "waiting for Hub projection",
+        value: "connect Hub projection",
         healthy: false)
       readinessRow(
         title: "Shared context",
-        value: "waiting for Hub projection",
+        value: "connect Hub projection",
         healthy: false)
     }
   }
@@ -809,7 +809,7 @@ struct FridayProjectionScreen: View {
           healthy: true)
         readinessRow(
           title: "Live state mapping",
-          value: projection.runtimeFeedStatus.isEmpty ? "waiting for Hub projection" : projection.runtimeFeedStatus,
+          value: projection.runtimeFeedStatus.isEmpty ? "connect Hub projection" : displayStatus(projection.runtimeFeedStatus),
           healthy: false)
         FridayProofLine(label: "action", ref: "mobile/pet/state-mapping")
         FridayProofLine(label: "mission", ref: projection.missionId)
@@ -848,14 +848,14 @@ struct FridayProjectionScreen: View {
     GlassPanel {
       VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
         cardHeader("Launch Tools", count: nil)
-        Text("Widgets, controls, push entry, share intake, and deep links stay grouped here for internal mobile diagnostics.")
+        Text("Widgets, controls, push entry, share intake, and deep links stay grouped here as Friday launch surfaces.")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         readinessRow(title: "Share intake", value: "friday://share deep link wired", healthy: true)
         readinessRow(title: "Command sheet", value: "top-left launcher routes selected surfaces", healthy: true)
-        readinessRow(title: "Push entry", value: "local permission surface wired; APNs delivery still unproven", healthy: false)
-        readinessRow(title: "Widget/control", value: "native launcher proof still required", healthy: false)
+        readinessRow(title: "Push entry", value: "local permission ready; remote delivery setup next", healthy: false)
+        readinessRow(title: "Widget/control", value: "native launcher setup next", healthy: false)
         FridayProofLine(label: "action", ref: "mobile/entrypoints/readiness")
         FridayProofLine(label: "thread", ref: projection.fridayConversationId)
       }
@@ -890,15 +890,15 @@ struct FridayProjectionScreen: View {
             healthy: readiness.localNotificationUsable)
           readinessRow(
             title: "Remote APNs",
-            value: readiness.remoteDeliveryConfigured ? "configured" : "waiting for remote delivery setup",
+            value: readiness.remoteDeliveryConfigured ? "configured" : "set up remote delivery",
             healthy: readiness.remoteDeliveryConfigured)
           HStack(spacing: 6) {
-            statusChip(readiness.settings.alertSettingEnabled ? "alerts on" : "alerts off")
-            statusChip(readiness.settings.badgeSettingEnabled ? "badges on" : "badges off")
-            statusChip(readiness.settings.soundSettingEnabled ? "sounds on" : "sounds off")
+            statusChip(readiness.settings.alertSettingEnabled ? "alerts on" : "alerts muted")
+            statusChip(readiness.settings.badgeSettingEnabled ? "badges on" : "badges muted")
+            statusChip(readiness.settings.soundSettingEnabled ? "sounds on" : "sounds muted")
           }
         case let .unavailable(reason):
-          readinessRow(title: "Permission", value: reason, healthy: false)
+          readinessRow(title: "Permission", value: displayReason(reason), healthy: false)
         }
         HStack(spacing: 8) {
           Button {
@@ -1043,9 +1043,15 @@ struct FridayProjectionScreen: View {
     let decisionState = viewModel.runOutcomeLearningDecisionStates[candidate.id]
     return VStack(alignment: .leading, spacing: 6) {
       HStack(alignment: .top, spacing: 8) {
-        Text(candidate.summary)
+        VStack(alignment: .leading, spacing: 3) {
+          Text(displayLearningTitle(kind: candidate.kind))
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text(displayLearningSubtitle(candidate))
+            .font(.caption2)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
           .font(.system(size: 13, weight: .medium))
-          .foregroundStyle(MobileTheme.textPrimary)
           .frame(maxWidth: .infinity, alignment: .leading)
         HStack(spacing: 6) {
           Button {
@@ -1071,8 +1077,8 @@ struct FridayProjectionScreen: View {
         }
       }
       HStack(spacing: 6) {
-        statusChip(candidate.kind)
-        statusChip(candidate.state)
+        statusChip(displayStatus(candidate.kind))
+        statusChip(displayStatus(candidate.state))
       }
       learningDecisionStateView(decisionState)
       if !candidate.runId.isEmpty {
@@ -1114,7 +1120,7 @@ struct FridayProjectionScreen: View {
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
     case .error(let reason):
-      Text(reason)
+      Text(displayReason(reason))
         .font(.caption2)
         .foregroundStyle(MobileTheme.coral)
     case nil:
@@ -1224,11 +1230,67 @@ struct FridayProjectionScreen: View {
       return "timeline"
     case "completed_with_proof":
       return "complete"
+    case "waiting", "queued", "pending":
+      return "in queue"
+    case "blocked":
+      return "needs attention"
+    case "off", "disabled":
+      return "needs setup"
     case "":
       return "status"
     default:
       return displaySentence(raw)
     }
+  }
+
+  private func displayReason(_ raw: String) -> String {
+    let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    if normalized.isEmpty {
+      return "Friday needs a live Hub connection before this action can continue."
+    }
+    if normalized.contains("server dark") || normalized.contains("transport")
+      || normalized.contains("connection") || normalized.contains("offline")
+    {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then try again."
+    }
+    if normalized.contains("api_key_missing") {
+      return "Connect this provider account before Friday can route work there."
+    }
+    if normalized.contains("route_disabled") || normalized.contains("route_validation_not_ok") {
+      return "Enable and recheck this route before Friday can use it."
+    }
+    if normalized.contains("approval") || normalized.contains("operator") {
+      return "Approval is needed before Friday can continue."
+    }
+    return displaySentence(raw)
+  }
+
+  private func displayLearningTitle(kind: String) -> String {
+    let label = displayStatus(kind)
+    if label.contains("preference") {
+      return "Review preference"
+    }
+    if label.contains("world") || label.contains("model") {
+      return "Review world model"
+    }
+    if label.contains("memory") {
+      return "Review memory learning"
+    }
+    return "Review learning"
+  }
+
+  private func displayLearningSubtitle(_ candidate: HomeRunOutcomeLearningCandidate) -> String {
+    let summary = candidate.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalized = summary.lowercased()
+    if !summary.isEmpty
+      && !normalized.contains("candidate_kind=")
+      && !normalized.contains("kind=")
+      && !normalized.contains("state=")
+      && !normalized.contains(";")
+    {
+      return displaySentence(summary)
+    }
+    return "\(displayStatus(candidate.kind)) candidate is \(displayStatus(candidate.state))."
   }
 
   private func displayTitle(_ raw: String) -> String {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayProviderAuthScreen.swift
@@ -231,11 +231,11 @@ struct FridayProviderAuthScreen: View {
         healthy: projection.tokenLedgerRunId != nil)
       controlRow(
         "Provider receipts",
-        state: projection.providerReceiptRefs.isEmpty ? "waiting" : "\(projection.providerReceiptRefs.count) receipt(s)",
+        state: projection.providerReceiptRefs.isEmpty ? "receipts pending" : "\(projection.providerReceiptRefs.count) receipt(s)",
         healthy: !projection.providerReceiptRefs.isEmpty)
       controlRow(
         "Channel receipts",
-        state: projection.channelReceiptRefs.isEmpty ? "waiting" : "\(projection.channelReceiptRefs.count) receipt(s)",
+        state: projection.channelReceiptRefs.isEmpty ? "receipts pending" : "\(projection.channelReceiptRefs.count) receipt(s)",
         healthy: !projection.channelReceiptRefs.isEmpty)
       if let runId = projection.tokenLedgerRunId {
         Button {

--- a/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridaySessionDetailScreen.swift
@@ -198,7 +198,7 @@ struct FridaySessionDetailScreen: View {
         fg: control?.isEnabled == true ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
     }
     if let reason = control?.reason {
-      Text(reason)
+      Text(userFacingReason(reason))
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
@@ -366,7 +366,7 @@ struct FridaySessionDetailScreen: View {
         .foregroundStyle(MobileTheme.textSecondary)
         .fixedSize(horizontal: false, vertical: true)
     case .blocked(let reason):
-      Text(reason)
+      Text(userFacingReason(reason))
         .font(.caption2)
         .foregroundStyle(MobileTheme.coral)
         .fixedSize(horizontal: false, vertical: true)
@@ -421,7 +421,7 @@ struct FridaySessionDetailScreen: View {
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
     case .error(let reason):
-      Text(reason)
+      Text(userFacingReason(reason))
         .font(.caption2)
         .foregroundStyle(MobileTheme.coral)
     case .idle, nil:
@@ -477,7 +477,7 @@ struct FridaySessionDetailScreen: View {
             FridayProofLine(label: nil, ref: ref)
           }
         case .unavailable(let reason), .notRequested(let reason):
-          Text(reason)
+          Text(userFacingReason(reason))
             .font(.caption2)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -524,9 +524,15 @@ struct FridaySessionDetailScreen: View {
     let decisionState = homeViewModel.runOutcomeLearningDecisionStates[candidate.id]
     return VStack(alignment: .leading, spacing: 6) {
       HStack(alignment: .top, spacing: 8) {
-        Text(candidate.summary)
+        VStack(alignment: .leading, spacing: 3) {
+          Text(learningTitle(kind: candidate.kind))
+            .font(.system(size: 13, weight: .medium))
+            .foregroundStyle(MobileTheme.textPrimary)
+          Text(learningSubtitle(candidate))
+            .font(.caption2)
+            .foregroundStyle(MobileTheme.textSecondary)
+        }
           .font(.system(size: 13, weight: .medium))
-          .foregroundStyle(MobileTheme.textPrimary)
           .frame(maxWidth: .infinity, alignment: .leading)
         HStack(spacing: 6) {
           Button {
@@ -552,8 +558,8 @@ struct FridaySessionDetailScreen: View {
         }
       }
       HStack(spacing: 6) {
-        statusChip(candidate.kind)
-        statusChip(candidate.state)
+        statusChip(readableStatus(candidate.kind))
+        statusChip(readableStatus(candidate.state))
       }
       learningDecisionStateView(decisionState)
       if !candidate.runId.isEmpty {
@@ -593,6 +599,56 @@ struct FridaySessionDetailScreen: View {
     return "Friday needs a fresh live session view before this screen can continue."
   }
 
+  private func learningTitle(kind: String) -> String {
+    let label = readableStatus(kind)
+    if label.contains("preference") {
+      return "Review preference"
+    }
+    if label.contains("world") || label.contains("model") {
+      return "Review world model"
+    }
+    if label.contains("memory") {
+      return "Review memory learning"
+    }
+    return "Review learning"
+  }
+
+  private func learningSubtitle(_ candidate: HomeRunOutcomeLearningCandidate) -> String {
+    let summary = candidate.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalized = summary.lowercased()
+    if !summary.isEmpty
+      && !normalized.contains("candidate_kind=")
+      && !normalized.contains("kind=")
+      && !normalized.contains("state=")
+      && !normalized.contains(";")
+    {
+      return readableSentence(summary)
+    }
+    return "\(readableStatus(candidate.kind)) candidate is \(readableStatus(candidate.state))."
+  }
+
+  private func readableStatus(_ raw: String) -> String {
+    switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "waiting", "queued", "pending":
+      return "in queue"
+    case "blocked":
+      return "needs attention"
+    case "off", "disabled":
+      return "needs setup"
+    case "":
+      return "status"
+    default:
+      return readableSentence(raw)
+    }
+  }
+
+  private func readableSentence(_ raw: String) -> String {
+    raw
+      .replacingOccurrences(of: "_", with: " ")
+      .replacingOccurrences(of: "-", with: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
   @ViewBuilder
   private func learningDecisionStateView(_ state: HomeLearningDecisionState?) -> some View {
     switch state {
@@ -605,7 +661,7 @@ struct FridaySessionDetailScreen: View {
         .font(.caption2)
         .foregroundStyle(MobileTheme.textSecondary)
     case .error(let reason):
-      Text(reason)
+      Text(userFacingReason(reason))
         .font(.caption2)
         .foregroundStyle(MobileTheme.coral)
     case nil:

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayShareIntakeScreen.swift
@@ -126,7 +126,7 @@ struct FridayShareIntakeScreen: View {
       messageCard(
         title: "Needs Details",
         systemImage: "questionmark.circle",
-        reason: reason,
+        reason: userFacingReason(reason),
         tint: MobileTheme.coral,
         identifier: "friday.share.blocked")
     case .unavailable(let reason):

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayTokenLedgerScreen.swift
@@ -14,7 +14,7 @@ struct FridayTokenLedgerScreen: View {
         case .unavailable(let reason):
           header(status: "connect", ready: false)
           UnavailableView(
-            reason: reason,
+            reason: userFacingReason(reason),
             title: "Connect Token Ledger",
             detail: "Friday needs a live run reference before it can show provider usage on this device.",
             systemImage: "chart.bar.doc.horizontal",
@@ -31,7 +31,7 @@ struct FridayTokenLedgerScreen: View {
   @ViewBuilder
   private func loadedContent(_ projection: HomeProjection) -> some View {
     let runId = projection.tokenLedgerRunId
-    header(status: runId == nil ? "waiting" : "ready", ready: runId != nil)
+    header(status: runId == nil ? "run needed" : "ready", ready: runId != nil)
 
     if let runId {
       runRefCard(runId: runId, projection: projection)
@@ -183,7 +183,7 @@ struct FridayTokenLedgerScreen: View {
       GlassPanel {
         VStack(alignment: .leading, spacing: MobileTheme.rowSpacing) {
           cardHeader(title, count: nil)
-          Text(reason)
+          Text(userFacingReason(reason))
             .font(.caption)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -226,5 +226,15 @@ struct FridayTokenLedgerScreen: View {
     guard generatedAtMs > 0 else { return "unknown" }
     let date = Date(timeIntervalSince1970: Double(generatedAtMs) / 1000.0)
     return date.formatted(date: .abbreviated, time: .shortened)
+  }
+
+  private func userFacingReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("transport")
+      || normalized.contains("connection") || normalized.contains("server dark")
+    {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then try again."
+    }
+    return "Usage appears after Friday has a live run reference for this mission."
   }
 }

--- a/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/FridayVoiceScreen.swift
@@ -66,7 +66,7 @@ struct FridayVoiceScreen: View {
       }
     case let .unavailable(reason):
       UnavailableView(
-        reason: reason,
+        reason: userFacingReason(reason),
         title: "Set Up Voice",
         detail: "Friday needs microphone, speech, and playback readiness before voice can start.",
         systemImage: "waveform",
@@ -76,6 +76,19 @@ struct FridayVoiceScreen: View {
       actionsCard(readiness)
       gatesCard(readiness)
     }
+  }
+
+  private func userFacingReason(_ reason: String) -> String {
+    let normalized = reason.lowercased()
+    if normalized.contains("offline") || normalized.contains("transport")
+      || normalized.contains("connection") || normalized.contains("server dark")
+    {
+      return "Friday cannot reach the live Hub from this device. Check the connection, then try again."
+    }
+    if normalized.contains("permission") || normalized.contains("microphone") || normalized.contains("speech") {
+      return "Enable microphone and speech access, then refresh Voice."
+    }
+    return "Voice starts after this device can confirm microphone, speech, playback, and Friday Chat handoff."
   }
 
   private func readinessCard(_ readiness: MobileVoiceReadiness) -> some View {

--- a/apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift
+++ b/apps/friday-ios/Sources/FridayMobileShell/ProviderReadinessPanel.swift
@@ -15,32 +15,32 @@ struct ProviderReadinessPanel: View {
           fg: detail.ok ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
       }
       HStack(spacing: 6) {
-        statusChip(detail.anyAuthenticated ? "some auth" : "none auth")
-        statusChip(detail.allAuthenticated ? "all auth" : "partial auth")
+        statusChip(detail.anyAuthenticated ? "connected" : "connect accounts")
+        statusChip(detail.allAuthenticated ? "all ready" : "some need setup")
       }
       if !detail.readyProviders.isEmpty {
-        Text("ready: \(detail.readyProviders.joined(separator: ", "))")
+        Text("Ready providers: \(detail.readyProviders.map(productProviderName).joined(separator: ", "))")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
       }
       if let suggestedTextRoute = detail.suggestedTextRoute {
-        Text("text route: \(suggestedTextRoute)")
+        Text("Text route: \(productProviderName(suggestedTextRoute))")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
       }
       if let suggestedStrongRoute = detail.suggestedStrongRoute {
-        Text("strong route: \(suggestedStrongRoute)")
+        Text("Strong route: \(productProviderName(suggestedStrongRoute))")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
       }
       if let keyValidationProbed = detail.keyValidationProbed {
-        statusChip(keyValidationProbed ? "keys probed" : "keys not probed")
+        statusChip(keyValidationProbed ? "keys checked" : "check keys")
       }
       if !detail.confirmedValidKeys.isEmpty {
-        Text("confirmed keys: \(detail.confirmedValidKeys.joined(separator: ", "))")
+        Text("Confirmed keys: \(detail.confirmedValidKeys.map(productProviderName).joined(separator: ", "))")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
@@ -56,22 +56,22 @@ struct ProviderReadinessPanel: View {
     ForEach(detail.detected) { provider in
       VStack(alignment: .leading, spacing: 5) {
         HStack {
-          Text(provider.provider)
+          Text(productProviderName(provider.provider))
             .font(.system(size: 13, weight: .medium))
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
           FridayChip(
-            text: provider.authenticated ? "authenticated" : "not authenticated",
+            text: provider.authenticated ? "connected" : "connect",
             bg: provider.authenticated ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
             fg: provider.authenticated ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
         }
-        Text(provider.detail)
+        Text(productProviderDetail(provider.detail))
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         HStack(spacing: 6) {
-          statusChip(provider.installed ? "installed" : "not installed")
-          statusChip(provider.truthLabel)
+          statusChip(provider.installed ? "installed" : "install needed")
+          statusChip(productTruthLabel(provider.truthLabel))
         }
       }
       .padding(.vertical, 3)
@@ -82,21 +82,21 @@ struct ProviderReadinessPanel: View {
     ForEach(detail.routes) { route in
       VStack(alignment: .leading, spacing: 5) {
         HStack {
-          Text(route.providerId)
+          Text(productProviderName(route.providerId))
             .font(.system(size: 13, weight: .medium))
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
           FridayChip(
-            text: route.dispatchable ? "dispatchable" : "blocked",
+            text: route.dispatchable ? "ready" : "needs setup",
             bg: route.dispatchable ? MobileTheme.chipPendingBG : MobileTheme.chipWarnBG,
             fg: route.dispatchable ? MobileTheme.chipPendingFG : MobileTheme.chipWarnFG)
         }
-        Text("\(route.model) - \(route.modelSize) - \(route.strength)")
+        Text("\(productProviderName(route.model)) - \(productProviderName(route.modelSize)) - \(productProviderName(route.strength))")
           .font(.caption)
           .foregroundStyle(MobileTheme.textSecondary)
           .fixedSize(horizontal: false, vertical: true)
         if !route.blockers.isEmpty {
-          Text("blockers: \(route.blockers.joined(separator: ", "))")
+          Text("Needs setup: \(route.blockers.map(productBlockerLabel).joined(separator: ", "))")
             .font(.caption2)
             .foregroundStyle(MobileTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -115,14 +115,14 @@ struct ProviderReadinessPanel: View {
             .foregroundStyle(MobileTheme.textPrimary)
           Spacer()
           FridayChip(
-            text: failover.flagEnabled ? "armed" : "off",
+            text: failover.flagEnabled ? "armed" : "not armed",
             bg: failover.flagEnabled ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
             fg: failover.flagEnabled ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
         }
         HStack(spacing: 6) {
-          statusChip(failover.canEnable ? "can enable" : "blocked")
+          statusChip(failover.canEnable ? "can enable" : "needs setup")
           if !failover.blockers.isEmpty {
-            statusChip("blockers \(failover.blockers.count)")
+            statusChip("setup \(failover.blockers.count)")
           }
         }
       }
@@ -133,12 +133,12 @@ struct ProviderReadinessPanel: View {
   private var keyRows: some View {
     ForEach(detail.keyValidations) { key in
       HStack(spacing: 8) {
-        Text(key.provider)
+        Text(productProviderName(key.provider))
           .font(.system(size: 13, weight: .medium))
           .foregroundStyle(MobileTheme.textPrimary)
         Spacer()
         FridayChip(
-          text: key.label,
+          text: productBlockerLabel(key.label),
           bg: key.isConfirmedValid ? MobileTheme.chipPendingBG : MobileTheme.chipNeutralBG,
           fg: key.isConfirmedValid ? MobileTheme.chipPendingFG : MobileTheme.chipNeutralFG)
       }
@@ -148,5 +148,65 @@ struct ProviderReadinessPanel: View {
 
   private func statusChip(_ text: String) -> some View {
     FridayChip(text: text, bg: MobileTheme.chipNeutralBG, fg: MobileTheme.chipNeutralFG)
+  }
+
+  private func productProviderName(_ raw: String) -> String {
+    let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    switch normalized.lowercased() {
+    case "codex": return "Codex"
+    case "claude", "anthropic": return "Claude"
+    case "deepseek": return "DeepSeek"
+    case "deepseek_pro", "deepseek-pro": return "DeepSeek Pro"
+    case "gpt-5.5", "gpt-5", "openai": return normalized.uppercased()
+    case "text", "small": return "fast"
+    case "strong", "large": return "strong"
+    case "route_validation_not_ok": return "route check needed"
+    case "api_key_missing": return "login needed"
+    default:
+      return productReadable(normalized)
+    }
+  }
+
+  private func productProviderDetail(_ raw: String) -> String {
+    let normalized = raw.lowercased()
+    if normalized.contains("api_key_missing") {
+      return "Connect this provider before Friday routes work there."
+    }
+    if normalized.contains("route_disabled") || normalized.contains("route_validation_not_ok") {
+      return "This route needs to be enabled and checked before Friday can use it."
+    }
+    if normalized.contains("authenticated") {
+      return "Provider login is available for governed work."
+    }
+    return productReadable(raw)
+  }
+
+  private func productTruthLabel(_ raw: String) -> String {
+    let normalized = raw.lowercased()
+    if normalized.contains("live") { return "live" }
+    if normalized.contains("doctor") { return "checked" }
+    if normalized.contains("proof") { return "receipt" }
+    return productReadable(raw)
+  }
+
+  private func productBlockerLabel(_ raw: String) -> String {
+    let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    switch normalized {
+    case "api_key_missing": return "login needed"
+    case "route_validation_not_ok": return "route check needed"
+    case "friday_claude_route_disabled": return "enable Claude route"
+    case "friday_codex_route_disabled": return "enable Codex route"
+    case "friday_deepseek_pro_route_disabled": return "enable DeepSeek Pro route"
+    case "blocked": return "needs setup"
+    case "off": return "not armed"
+    default: return productReadable(raw)
+    }
+  }
+
+  private func productReadable(_ raw: String) -> String {
+    raw
+      .replacingOccurrences(of: "_", with: " ")
+      .replacingOccurrences(of: "-", with: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 }

--- a/scripts/ops/friday-ios-sim-xcui-observation.mjs
+++ b/scripts/ops/friday-ios-sim-xcui-observation.mjs
@@ -466,6 +466,22 @@ function treeIncludesIdentifier(tree, id) {
 function assertSelectedDesignTree(destination, tree) {
   if (!requireSelectedDesign) return;
 
+  const forbiddenRawProductPatterns = [
+    ["provider auth machine code", /\bapi_key_missing\b/i],
+    ["route validation machine code", /\broute_validation_not_ok\b/i],
+    ["route disabled machine code", /\bfriday_[a-z0-9_]+_route_disabled\b/i],
+    ["raw blockers label", /\bblockers:\s/i],
+    ["learning candidate machine summary", /\bcandidate_kind=/i],
+    ["transport debug copy", /server dark\?/i],
+    ["internal diagnostics copy", /\binternal mobile diagnostics\b/i],
+    ["honest-unavailable product copy", /\bhonest[-_ ]unavailable\b/i],
+  ];
+  for (const [name, pattern] of forbiddenRawProductPatterns) {
+    if (pattern.test(tree)) {
+      block("selected_design_raw_product_copy_visible", `${name}:${destination}`);
+    }
+  }
+
   const requiredByDestination = {
     home: [
       "friday.mobile.toolbar.command-sheet",

--- a/test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts
+++ b/test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts
@@ -9,7 +9,10 @@ const script = "scripts/ops/friday-ios-sim-xcui-observation.mjs";
 const missionId = "mission_ios_sim_xcui_observation_contract";
 const fakeUdid = "11111111-2222-3333-4444-555555555555";
 
-async function writeFakeTools(binDir: string, mode: "pass" | "no-tree" | "missing-id" | "selected-design" | "legacy-home" = "pass") {
+async function writeFakeTools(
+  binDir: string,
+  mode: "pass" | "no-tree" | "missing-id" | "selected-design" | "legacy-home" | "raw-provider-copy" = "pass",
+) {
   await mkdir(binDir, { recursive: true });
   const xcrun = join(binDir, "xcrun");
   writeFileSync(xcrun, `#!/usr/bin/env bash
@@ -58,6 +61,13 @@ exit 64
             "  StaticText, 0x7, label: 'Hub provisioning'",
             "  Other, 0x8, identifier: 'friday.home.unavailable'",
           ].join("\\n")
+          : mode === "raw-provider-copy"
+            ? [
+              "Application, 0x1, identifier: 'com.friday.shell'",
+              "  Other, 0x2, identifier: 'friday.provider-auth.detail'",
+              "  StaticText, 0x3, label: 'blockers: api_key_missing, friday_claude_route_disabled'",
+              "  StaticText, 0x4, label: 'candidate_kind=preference; consumer=recall-preference'",
+            ].join("\\n")
           : [
             "Application, 0x1, identifier: 'com.friday.shell'",
             "  Button, 0x2, identifier: 'friday.mobile.toolbar.refresh', label: 'Refresh Hub status'",
@@ -224,6 +234,31 @@ describe("friday-ios-sim-xcui-observation", () => {
       const blockerCodes = output.blockers?.map((blocker) => blocker.code) ?? [];
       expect(blockerCodes).toContain("selected_design_required_id_missing");
       expect(blockerCodes).toContain("selected_design_forbidden_home_state_visible");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails selected-design enforcement when a product path exposes provider machine codes", async () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-ios-xcui-observation-raw-provider-copy-"));
+    try {
+      const binDir = join(root, "bin");
+      const outDir = join(root, "out");
+      await writeFakeTools(binDir, "raw-provider-copy");
+      const result = spawnSync("node", [
+        script,
+        `--mission-id=${missionId}`,
+        `--out-dir=${outDir}`,
+        "--destinations=providerAuth",
+        "--require-selected-design",
+      ], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      });
+      expect(result.status).toBe(2);
+      const output = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string }> };
+      expect(output.blockers?.map((blocker) => blocker.code)).toContain("selected_design_raw_product_copy_visible");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What changed

- Reworked iOS selected-design user-path copy so normal product screens no longer surface raw debug/provider/internal machine labels such as `api_key_missing`, `route_disabled`, `blockers:`, `candidate_kind=...`, old offline setup panels, or `server dark?` transport text.
- Kept the underlying fail-closed / proof semantics intact: proof refs and governed states still render, but user-facing cards now explain setup, approval, connection, provider, and learning states in product language.
- Cleaned Home, projection/detail screens, provider readiness, shared context, token ledger, voice, share/new session, chat/session decision errors, and learning candidate rows.
- Extended the iOS XCU selected-design gate to fail red when product paths expose raw provider machine codes, learning candidate machine summaries, transport debug copy, internal diagnostics copy, or honest-unavailable product copy.

## Why

The selected mobile design was installed on current HEAD, but the live Simulator still exposed several engineering-state strings inside normal product paths. That made the app look like a debug shell even though the selected-design structure was present. This PR fixes that UX regression without weakening truth labels or fabricating readiness.

## Validation

- `npm test -- test/unit/qa/friday-ios-sim-xcui-observation-cli.test.ts test/unit/qa/friday-product-facing-copy.test.ts`
  - 13 tests passed, including red tests for old offline/debug home and raw provider/learning machine-code exposure.
- `swift test --package-path apps/friday-ios`
  - 94 XCTest tests passed + 63 Swift Testing checks passed.
- Installed current HEAD into iPhone 17 Pro Simulator with live-loopback mode:
  - `/tmp/friday-current-ui-live-loopback-final-74d5-20260701T055453Z.png`
- Full selected-design XCU observation against installed Simulator app:
  - `/tmp/friday-ios-xcui-userpath-final-74d5-20260701T055519Z/ios-xcui-observation-summary.json`
  - status `observation_ready`, blockers `[]`, target_count `22`, observed_count `15`.
- Explicit live-loopback interaction XCU run:
  - `/tmp/friday-ios-xcui-interactions-final-74d5-20260701T055649Z/ios-xcui-observation-summary.json`
  - status `observation_ready`, blockers `[]`, target_count `9`, observed_count `9`, no missing interactions.
- Raw-copy grep over final XCU output found no old offline template, provider machine codes, `candidate_kind=`, or transport-debug product copy.

## Caveats

- This is real iOS Simulator XCU/product-path evidence, not END-BAR/adoption proof by itself.
- Device-peer write remains correctly separate from the master-peer live-loopback proof; the real device write authority should remain governed by the existing trusted-device/write seam work, not bypassed in this UI polish PR.