### PR TITLE
Tighten selected UI proof freshness bridging

### DIFF
--- a/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
+++ b/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
@@ -228,15 +228,20 @@ function evaluateIosManifest(path) {
   const missing = requiredMobileDestinations.filter((destination) => !captured.has(destination));
   const truthOk = manifest.truth_label === "ios_selected_design_destination_capture_not_live_closure";
   const statusOk = manifest.status === "ready";
+  const evidenceHead = typeof manifest.repo_head === "string" ? manifest.repo_head : null;
+  const headOk = Boolean(head) && evidenceHead === head;
   const mode = manifest.mode || null;
   const allowedVisualModes = ["design-proof-sample", "live-loopback"];
   const modeOk = allowedVisualModes.includes(mode);
   return {
     path,
-    status: truthOk && statusOk && modeOk && missing.length === 0 ? "ready" : "gap",
+    status: truthOk && statusOk && headOk && modeOk && missing.length === 0 ? "ready" : "gap",
     truth_label: manifest.truth_label || null,
     manifest_status: manifest.status || null,
     generated_at_utc: manifest.generated_at_utc || null,
+    head: evidenceHead,
+    expectedHead: head,
+    headStatus: headOk ? "current_head" : evidenceHead ? "stale_or_wrong_head" : "missing_head",
     mode,
     allowedVisualModes,
     modeStatus: modeOk ? "visual_proof_mode" : mode === "offline-truth" ? "negative_control_not_visual_proof" : "missing_or_unknown_mode",
@@ -265,6 +270,8 @@ function evaluateDesktopCapture(path) {
     "ui_device_accessibility_click_capture_real_ui_not_endbar",
   ].includes(capture.truth_label);
   const statusOk = ["ready", "partial_capture_ready", undefined, null].includes(capture.status);
+  const evidenceHead = typeof capture.repo?.head === "string" ? capture.repo.head : null;
+  const headOk = Boolean(head) && evidenceHead === head;
   const declaredMode = typeof capture.mode === "string" ? capture.mode : null;
   const liveConnection = capture.live_connection && typeof capture.live_connection === "object"
     ? capture.live_connection
@@ -281,7 +288,7 @@ function evaluateDesktopCapture(path) {
     && /^[0-9]+$/.test(liveConnection.read_port);
   return {
     path,
-    eligibleForAggregate: truthOk && statusOk && desktopLiveConnected,
+    eligibleForAggregate: truthOk && statusOk && headOk && desktopLiveConnected,
     aggregate_key: desktopLiveConnected
       ? [
         declaredMode,
@@ -290,10 +297,13 @@ function evaluateDesktopCapture(path) {
         liveConnection.workbench_mission_id,
       ].join("\u001f")
       : null,
-    status: truthOk && statusOk && missing.length === 0 ? "ready" : "gap",
+    status: truthOk && statusOk && headOk && missing.length === 0 ? "ready" : "gap",
     truth_label: capture.truth_label || null,
     capture_status: capture.status || null,
     generated_at_utc: capture.generated_at_utc || null,
+    head: evidenceHead,
+    expectedHead: head,
+    headStatus: headOk ? "current_head" : evidenceHead ? "stale_or_wrong_head" : "missing_head",
     mode: desktopLiveConnected ? declaredMode : null,
     declaredMode,
     live_connection: liveConnection,

--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -783,10 +783,15 @@ if (blockers.length === 0) {
 writeFileSync(rawPath, `${rawSnapshots.join("\n")}\n`);
 const liveConnection = liveConnectionMetadata();
 const captureMode = captureModeForLiveConnection(liveConnection);
+const repoHead = run("git", ["rev-parse", "HEAD"]).stdout.trim();
 const capture = {
   truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
   generated_at_utc: new Date().toISOString(),
   status: blockers.length === 0 && observedActions.length > 0 ? "partial_capture_ready" : "blocked_or_empty",
+  repo: {
+    root: repoRoot,
+    head: repoHead,
+  },
   mission_id: missionId,
   workbench_mission_id: workbenchMissionId || null,
   surface: "desktop",
@@ -808,7 +813,7 @@ const summary = {
   status: blockers.length === 0 && observedActions.length > 0 ? "partial_capture_ready" : "blocked_or_empty",
   repo: {
     root: repoRoot,
-    head: run("git", ["rev-parse", "HEAD"]).stdout.trim(),
+    head: repoHead,
   },
   app: {
     dir: appDir,

--- a/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
+++ b/scripts/ops/friday-ui-device-proof-shortlist-runner.sh
@@ -462,6 +462,7 @@ if [ -n "${timeline_capture}" ] && [ "${workbench_timeline_status}" != "snapshot
     "--desktop=${desktop_capture}"
     "--timeline=${timeline_capture}"
     "--out=${workbench_events}"
+    "--allow-partial-events"
   )
   if [ -n "${channel_capture}" ]; then
     workbench_events_args+=("--channel=${channel_capture}")
@@ -471,7 +472,7 @@ if [ -n "${timeline_capture}" ] && [ "${workbench_timeline_status}" != "snapshot
   fi
   if node "${workbench_events_args[@]}" >"${workbench_events}.stdout"; then
     workbench_events_status="$(node -e 'const fs=require("fs"); const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log(j.status || "unknown");' "${workbench_events}.stdout")"
-    if [ "${workbench_events_status}" = "ready" ]; then
+    if [ "${workbench_events_status}" = "ready" ] || [ "${workbench_events_status}" = "partial_ready" ]; then
       same_run_events+=("${workbench_events}")
     fi
     if [ "${workbench_timeline_status}" = "skipped" ]; then

--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -2,7 +2,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, isAbsolute, resolve } from "node:path";
+import { basename, dirname, isAbsolute, resolve } from "node:path";
 
 const args = process.argv.slice(2);
 
@@ -365,11 +365,30 @@ const selectedVisualProofArgs = [
   `--repo-root=${repoRoot}`,
   `--design-root=${designRoot}`,
 ];
+function addSelectedVisualEvidenceArg(path) {
+  const resolved = abs(path);
+  const name = basename(resolved);
+  if (name.includes("served-ui-design-fidelity") && name.endsWith(".json")) {
+    selectedVisualProofArgs.push(`--served-ui-report=${resolved}`);
+    return;
+  }
+  switch (name) {
+    case "ios-design-destination-capture-manifest.json":
+      selectedVisualProofArgs.push(`--ios-manifest=${resolved}`);
+      break;
+    case "desktop-ax-accessibility-capture.json":
+      selectedVisualProofArgs.push(`--desktop-capture=${resolved}`);
+      break;
+    default:
+      selectedVisualProofArgs.push(`--evidence-dir=${resolved}`);
+      break;
+  }
+}
 for (const dir of evidenceDirs) {
-  selectedVisualProofArgs.push(`--evidence-dir=${abs(dir)}`);
+  addSelectedVisualEvidenceArg(dir);
 }
 for (const dir of selectedVisualEvidenceDirs) {
-  selectedVisualProofArgs.push(`--evidence-dir=${abs(dir)}`);
+  addSelectedVisualEvidenceArg(dir);
 }
 if (requireUiDeviceProof) selectedVisualProofArgs.push("--require-complete");
 const selectedVisualProof = runJson("selected_visual_proof", process.execPath, selectedVisualProofArgs);

--- a/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-shortlist-runner-contract.test.ts
@@ -107,7 +107,7 @@ describe("friday-ui-device-proof-shortlist-runner contract", () => {
     expect(source).toContain("workbench-timeline-capture.json");
     expect(source).toContain("friday-workbench-snapshot-events.mjs");
     expect(source).toContain("workbench_events_status=");
-    expect(source).toContain("if [ \"${workbench_events_status}\" = \"ready\" ]; then");
+    expect(source).toContain("if [ \"${workbench_events_status}\" = \"ready\" ] || [ \"${workbench_events_status}\" = \"partial_ready\" ]; then");
     expect(source).toContain("same_run_events+=(\"${workbench_events}\")");
     expect(source).toContain("readiness_args+=(\"--workbench-db\" \"${workbench_db}\")");
     expect(source).toContain("MISSION_ID=\"${mission_id}\" FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS");

--- a/test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
+++ b/test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts
@@ -65,7 +65,11 @@ describe("friday-uiux-product-closure-readiness contract", () => {
     expect(source).toContain("FRIDAY_UIUX_SELECTED_VISUAL_EVIDENCE_DIRS");
     expect(source).toContain("const selectedVisualEvidenceDirs = unique");
     expect(source).toContain("for (const dir of selectedVisualEvidenceDirs)");
-    expect(source).toContain("selectedVisualProofArgs.push(`--evidence-dir=${abs(dir)}`)");
+    expect(source).toContain("function addSelectedVisualEvidenceArg");
+    expect(source).toContain("selectedVisualProofArgs.push(`--served-ui-report=${resolved}`)");
+    expect(source).toContain("selectedVisualProofArgs.push(`--ios-manifest=${resolved}`)");
+    expect(source).toContain("selectedVisualProofArgs.push(`--desktop-capture=${resolved}`)");
+    expect(source).toContain("selectedVisualProofArgs.push(`--evidence-dir=${resolved}`)");
     expect(source).toContain("selectedVisualEvidenceDirs,");
   });
 });

--- a/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
+++ b/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
@@ -41,19 +41,36 @@ function writeSelections(designRoot: string) {
   }, null, 2));
 }
 
+function initFixtureRepo(root: string) {
+  writeFile(root, ".fixture", "fixture repo for selected visual proof tests\n");
+  execFileSync("git", ["-C", root, "init", "-q"], { encoding: "utf8" });
+  execFileSync("git", ["-C", root, "config", "user.email", "friday-fixture@example.invalid"], { encoding: "utf8" });
+  execFileSync("git", ["-C", root, "config", "user.name", "Friday Fixture"], { encoding: "utf8" });
+  execFileSync("git", ["-C", root, "add", ".fixture", "design"], { encoding: "utf8" });
+  execFileSync("git", ["-C", root, "commit", "-q", "-m", "fixture"], { encoding: "utf8" });
+  return execFileSync("git", ["-C", root, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+}
+
+function fixtureHead(root: string) {
+  return execFileSync("git", ["-C", root, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+}
+
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), "friday-uiux-selected-visual-proof-"));
   const designRoot = join(root, "design");
   writeSelections(designRoot);
-  return { root, designRoot };
+  const head = initFixtureRepo(root);
+  return { root, designRoot, head };
 }
 
 function writeReadyEvidence(root: string, mode = "live-loopback") {
   const evidence = join(root, "evidence");
+  const head = fixtureHead(root);
   writeFile(evidence, "ios-design-destination-capture-manifest.json", JSON.stringify({
     truth_label: "ios_selected_design_destination_capture_not_live_closure",
     status: "ready",
     generated_at_utc: "2026-06-27T00:00:00.000Z",
+    repo_head: head,
     mode,
     captures: [
       "home",
@@ -72,6 +89,7 @@ function writeReadyEvidence(root: string, mode = "live-loopback") {
     truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
     generated_at_utc: "2026-06-27T00:00:00.000Z",
     status: "partial_capture_ready",
+    repo: { head },
     mode: "live-loopback",
     live_connection: {
       read_host: "127.0.0.1",
@@ -96,10 +114,12 @@ function writeReadyEvidence(root: string, mode = "live-loopback") {
 
 function writeDesktopCapture(root: string, relative: string, screens: string[], mission = "mission_selected_visual_fixture") {
   const evidence = join(root, relative);
+  const head = fixtureHead(root);
   writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
     truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
     generated_at_utc: "2026-06-27T00:00:00.000Z",
     status: "partial_capture_ready",
+    repo: { head },
     mode: "live-loopback",
     live_connection: {
       read_host: "127.0.0.1",
@@ -119,7 +139,7 @@ function writeServedUiReport(root: string, relative = "evidence", overrides: Rec
     status: "pass",
     truth_label: "served_desktop_and_ios_design_fidelity_reads_real_selection_and_live_sources",
     generated_at_utc: "2026-06-30T00:00:00.000Z",
-    head: "fixture-head",
+    head: fixtureHead(root),
     distRoot: `${root}/dist/ui`,
     iosSourceRoot: `${root}/apps/friday-ios/Sources/FridayMobileShell`,
     failureCount: 0,
@@ -327,6 +347,7 @@ describe("check-friday-uiux-selected-visual-proof", () => {
       writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
         truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
         status: "partial_capture_ready",
+        repo: { head: fixtureHead(root) },
         mode: "live-loopback",
         live_connection: {
           read_host: "127.0.0.1",
@@ -410,6 +431,7 @@ describe("check-friday-uiux-selected-visual-proof", () => {
       writeFile(evidence, "desktop-ax-accessibility-capture.json", JSON.stringify({
         truth_label: "ui_device_accessibility_click_capture_real_ui_not_endbar",
         status: "partial_capture_ready",
+        repo: { head: fixtureHead(root) },
         mode: "live-loopback",
         ui_actions: [
           "operations",


### PR DESCRIPTION
## Summary
- require selected iOS and desktop AX visual evidence to declare the current repo HEAD before counting it
- carry repo HEAD into desktop AX captures
- let product-closure bridge exact visual evidence files, including current served UI fidelity reports
- include partial workbench-derived events in UI/device evidence manifests while keeping strict readiness blocked when required observations are still missing

## Verification
- node --check scripts/ops/check-friday-uiux-selected-visual-proof.mjs
- node --check scripts/ops/friday-desktop-ax-accessibility-capture.mjs
- node --check scripts/ops/friday-uiux-product-closure-readiness.mjs
- bash -n scripts/ops/friday-ui-device-proof-shortlist-runner.sh
- selected visual proof current-head pass: /tmp/friday-selected-visual-proof-current-strict-6cd8-after-bridge.json
- stale iOS manifest strict fail with missing_head: /tmp/friday-selected-visual-proof-stale-ios-strict-expected-fail-6cd8-after-bridge.json
- UI/device shortlist rerun remains partial_ready, selectedVisualProofStatus=selected_visual_proof_ready, strict readiness still blocked on remaining real-use proof gaps

Truth: this PR improves proof freshness and evidence plumbing only. It does not claim END-BAR, release, adoption, or that every UI action is runtime-closed.