### PR TITLE
Align mobile approval proof action ids

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalApproveIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalApproveIntegrationTests.swift
@@ -120,7 +120,7 @@ private func writeMobileApprovalApproveProofIfRequested(
       [
         "surface": "mobile",
         "screen": "approval",
-        "action_id": "mobile/approval/check",
+        "action_id": "check",
         "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
         "status": "pass",
         "evidence_ref": "proof://mobile/approval-approve/\(result.runId)",
@@ -259,7 +259,7 @@ private func appendMobileFridayChatApproveEvidenceIfRequested(
   actions.append([
     "surface": "mobile",
     "screen": "fridayChat",
-    "action_id": "mobile/approval/check",
+    "action_id": "check",
     "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
     "status": "pass",
     "evidence_ref": "proof://mobile/fridaychat-approval-approve/\(result.runId)",

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalRejectIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalRejectIntegrationTests.swift
@@ -109,7 +109,7 @@ private func writeMobileApprovalRejectProofIfRequested(
       [
         "surface": "mobile",
         "screen": "approval",
-        "action_id": "mobile/approval/reject",
+        "action_id": "act",
         "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
         "status": "pass",
         "evidence_ref": "proof://mobile/approval-reject/\(result.runId)",
@@ -246,7 +246,7 @@ private func appendMobileFridayChatRejectEvidenceIfRequested(
   actions.append([
     "surface": "mobile",
     "screen": "fridayChat",
-    "action_id": "mobile/approval/reject",
+    "action_id": "act",
     "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
     "status": "pass",
     "evidence_ref": "proof://mobile/fridaychat-approval-reject/\(result.runId)",

--- a/test/unit/qa/friday-mobile-approval-approve-proof-cli.test.ts
+++ b/test/unit/qa/friday-mobile-approval-approve-proof-cli.test.ts
@@ -22,6 +22,7 @@ function contractBody() {
 | Surface | Screen [state] | action_id | Label | capability_id | reg | reg_status | truth_status | result/target | Rust/Hub owner gate test expectation |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | mobile | approval | check | Approve with proof | security_approval_bound_principal_gate_cat10_netnew | x | wired | wired_registry | result:confirmed | Runtime proof required. |
+| mobile | fridayChat | check | Approve | security_approval_bound_principal_gate_cat10_netnew | x | wired | wired_registry | result:confirmed | Runtime proof required. |
 `;
 }
 
@@ -53,6 +54,14 @@ cat > "${swiftProof}" <<'JSON'
   "run_id": "run-paused-1",
   "approval_id": "approval-1",
   "ui_actions": [
+    {
+      "surface": "mobile",
+      "screen": "fridayChat",
+      "action_id": "check",
+      "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
+      "status": "pass",
+      "evidence_ref": "proof://mobile/fridaychat-approval-approve/run-paused-1"
+    },
     {
       "surface": "mobile",
       "screen": "approval",
@@ -92,6 +101,12 @@ exit 0
         actions?: Array<{ surface?: string; screen?: string; action_id?: string; status?: string }>;
       };
       expect(actionEvidence.actions).toEqual([
+        expect.objectContaining({
+          surface: "mobile",
+          screen: "fridayChat",
+          action_id: "check",
+          status: "pass",
+        }),
         expect.objectContaining({
           surface: "mobile",
           screen: "approval",

--- a/test/unit/qa/friday-mobile-approval-reject-proof-cli.test.ts
+++ b/test/unit/qa/friday-mobile-approval-reject-proof-cli.test.ts
@@ -23,6 +23,7 @@ function contractBody() {
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | mobile | approval | act | Reject | security_approval_bound_principal_gate_cat10_netnew | x | wired | wired_registry | result:rejected | Runtime proof required. |
 | mobile | approval | check | Approve with proof | security_approval_bound_principal_gate_cat10_netnew | x | wired | wired_registry | result:confirmed | Runtime proof required. |
+| mobile | fridayChat | act | Reject | security_approval_bound_principal_gate_cat10_netnew | x | wired | wired_registry | result:rejected | Runtime proof required. |
 `;
 }
 
@@ -58,6 +59,14 @@ describe("friday-mobile-approval-reject-proof", () => {
             status: "pass",
             evidence_ref: "proof://mobile/approval-reject/run-paused-1",
           },
+          {
+            surface: "mobile",
+            screen: "fridayChat",
+            action_id: "act",
+            capability_id: "security_approval_bound_principal_gate_cat10_netnew",
+            status: "pass",
+            evidence_ref: "proof://mobile/fridaychat-approval-reject/run-paused-1",
+          },
         ],
       }, null, 2));
       const swift = writeFile(root, "swift", "#!/usr/bin/env bash\nexit 0\n");
@@ -89,6 +98,12 @@ describe("friday-mobile-approval-reject-proof", () => {
         expect.objectContaining({
           surface: "mobile",
           screen: "approval",
+          action_id: "act",
+          status: "pass",
+        }),
+        expect.objectContaining({
+          surface: "mobile",
+          screen: "fridayChat",
           action_id: "act",
           status: "pass",
         }),


### PR DESCRIPTION
## Summary
- Align mobile approval approve/reject live proof rows with the operator-selected ACTION-CONTRACT action ids.
- Cover both approval screen and fridayChat approval-card evidence rows for design runtime checks.
- Extend QA contract tests so real proof evidence is not missed by the END-BAR runtime gap checker.

## Verification
- npm test -- --run test/unit/qa/friday-mobile-approval-approve-proof-cli.test.ts test/unit/qa/friday-mobile-approval-reject-proof-cli.test.ts
- swift test --package-path apps/friday-ios --filter LiveApproval
- FRIDAY_MOBILE_APPROVAL_REJECT_LIVE=1 FRIDAY_MOBILE_APPROVAL_REJECT_STEP=both scripts/ops/friday-mobile-approval-reject-proof.sh (artifact dir: /tmp/friday-uiux-real-use-93a9-20260701/action-runtime-bundle/mobile-approval-reject-current-fixed)
- check-friday-design-action-runtime-evidence with all current runtime evidence + fixed reject now leaves only mobile approve signed-path rows