### PR TITLE
Tighten UIUX product readiness semantics

### DIFF
--- a/scripts/ops/check-friday-endbar-report-inputs.mjs
+++ b/scripts/ops/check-friday-endbar-report-inputs.mjs
@@ -143,6 +143,7 @@ function classifyForGroup(groupId, report, path) {
       "selected_visual_proof_ready",
       "product_runtime_actions_traceable",
       "runtime_actions_covered",
+      "runtime_capture_required",
       "passed",
     ]);
     if (status === "uiux_product_closure_evidence_ready" && !hasBlockers(report)) {

--- a/scripts/ops/check-friday-integrated-end-to-end-tape-report.mjs
+++ b/scripts/ops/check-friday-integrated-end-to-end-tape-report.mjs
@@ -133,7 +133,7 @@ if (summary && typeof summary === "object" && !Array.isArray(summary)) {
   check("workbench_timeline_ready", ["snapshot_ready_events_ready", "ready"].includes(string(summary.workbenchTimelineStatus)), string(summary.workbenchTimelineStatus));
   check("stress_capture_ready", ["ready", "passed"].includes(string(summary.stressCaptureStatus)), string(summary.stressCaptureStatus));
   check("accessibility_capture_ready", ["ready", "passed"].includes(string(summary.accessibilityCaptureStatus)), string(summary.accessibilityCaptureStatus));
-  check("product_closure_runtime_capture_ready", ["ready_for_runtime_capture", "ready", "passed"].includes(string(summary.productClosureStatus)), string(summary.productClosureStatus));
+  check("product_closure_evidence_ready", ["uiux_product_closure_evidence_ready", "ready", "passed"].includes(string(summary.productClosureStatus)), string(summary.productClosureStatus));
   check("readiness_report_present", uiReadiness && typeof uiReadiness === "object" && !Array.isArray(uiReadiness), "uiDeviceProofReadiness object");
   check("no_channel_deferred_signal", !hasDeferredSignal(summary), array(summary.readinessBlockers).join(",") || string(summary.readinessStatus));
   check("strict_ui_device_readiness_passed", string(uiReadiness.status) === "pass" || string(uiReadiness.status) === "strict_ui_device_ready", string(uiReadiness.status));

--- a/scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs
+++ b/scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs
@@ -136,7 +136,7 @@ if (summary && typeof summary === "object" && !Array.isArray(summary)) {
   check("accessibility_capture_ready", ["ready", "passed"].includes(string(summary.accessibilityCaptureStatus)), string(summary.accessibilityCaptureStatus));
   check("stress_capture_ready", ["ready", "passed"].includes(string(summary.stressCaptureStatus)), string(summary.stressCaptureStatus));
   check("workbench_timeline_ready", ["snapshot_ready_events_ready", "ready"].includes(string(summary.workbenchTimelineStatus)), string(summary.workbenchTimelineStatus));
-  check("product_closure_runtime_capture_ready", ["ready_for_runtime_capture", "ready", "passed"].includes(string(summary.productClosureStatus)), string(summary.productClosureStatus));
+  check("product_closure_evidence_ready", ["uiux_product_closure_evidence_ready", "ready", "passed"].includes(string(summary.productClosureStatus)), string(summary.productClosureStatus));
   check("strict_ui_device_readiness_passed", string(uiReadiness.status) === "pass" || string(uiReadiness.status) === "strict_ui_device_ready", string(uiReadiness.status));
   check("no_deferred_channel_or_external_input", deferred.length === 0, deferred.join(","));
 } else if (summary) {

--- a/scripts/ops/check-friday-uiux-product-happy-path.mjs
+++ b/scripts/ops/check-friday-uiux-product-happy-path.mjs
@@ -191,7 +191,21 @@ const liveConnectedVisualModes = new Set([
   "real-device-live",
   "product-live",
   "same-run-live",
+  "served-ui-current-head",
 ]);
+
+function servedUiDesktopVisualEntries(report) {
+  return arrayAt(report, ["evidence", "servedUi"])
+    .filter((item) =>
+      item?.status === "ready"
+      && item?.sourceStatus === "served_desktop_dist_ui_and_ios_source"
+      && item?.checks?.renderedDesktop === true
+      && item?.checks?.builtCss === true)
+    .map((item) => ({
+      ...item,
+      mode: "served-ui-current-head",
+    }));
+}
 
 function visualEvidenceEntriesForSurface(report, surface) {
   const entries = arrayAt(report, ["evidence", surface]);
@@ -199,6 +213,7 @@ function visualEvidenceEntriesForSurface(report, surface) {
   return [
     ...entries,
     ...arrayAt(report, ["evidence", "desktopAggregates"]),
+    ...servedUiDesktopVisualEntries(report),
   ];
 }
 

--- a/scripts/ops/friday-uiux-product-closure-readiness.mjs
+++ b/scripts/ops/friday-uiux-product-closure-readiness.mjs
@@ -556,7 +556,9 @@ const report = {
   status: blockers.length === 0
     ? runtimeCovered && uiDeviceProofAssembled
       ? "uiux_product_closure_evidence_ready"
-      : "ready_for_runtime_capture"
+      : nonChannelProductClosureReady
+        ? "non_channel_closure_ready_channel_deferred"
+        : "runtime_capture_required"
     : "blocked",
   repoRoot,
   designRoot,

--- a/test/unit/qa/friday-integrated-end-to-end-tape-report-cli.test.ts
+++ b/test/unit/qa/friday-integrated-end-to-end-tape-report-cli.test.ts
@@ -47,7 +47,7 @@ function summary(dir: string, overrides: Record<string, unknown> = {}) {
     workbenchTimelineStatus: "snapshot_ready_events_ready",
     stressCaptureStatus: "ready",
     accessibilityCaptureStatus: "ready",
-    productClosureStatus: "ready_for_runtime_capture",
+    productClosureStatus: "uiux_product_closure_evidence_ready",
     readinessStatus: "pass",
     readinessBlockers: [],
     fullProofGaps: [],
@@ -107,6 +107,21 @@ describe("Friday integrated end-to-end tape report", () => {
       expect.objectContaining({ code: "strict_ui_device_readiness_passed" }),
       expect.objectContaining({ code: "no_full_proof_gaps" }),
     ]));
+  });
+
+  it("blocks runtime-capture-only product closure status", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-integrated-tape-"));
+    const summaryPath = writeJson(dir, "summary.json", summary(dir, {
+      productClosureStatus: "ready_for_runtime_capture",
+    }));
+
+    const report = run([`--ui-device-summary=${summaryPath}`, "--require-ready"], true);
+
+    expect(report.status).toBe("blocked");
+    expect(report.blockers).toContainEqual(expect.objectContaining({
+      code: "product_closure_evidence_ready",
+      detail: "ready_for_runtime_capture",
+    }));
   });
 
   it("blocks cross-mission or missing desktop evidence", () => {

--- a/test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts
+++ b/test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts
@@ -48,7 +48,7 @@ function summary(dir: string, overrides: Record<string, unknown> = {}) {
     accessibilityCaptureStatus: "ready",
     stressCaptureStatus: "ready",
     workbenchTimelineStatus: "snapshot_ready_events_ready",
-    productClosureStatus: "ready_for_runtime_capture",
+    productClosureStatus: "uiux_product_closure_evidence_ready",
     readinessStatus: "pass",
     readinessBlockers: [],
     uiDeviceProofReadiness: {
@@ -104,6 +104,21 @@ describe("Friday UI real-use mobile/desktop report", () => {
       expect.objectContaining({ code: "strict_ui_device_readiness_passed" }),
       expect.objectContaining({ code: "no_deferred_channel_or_external_input" }),
     ]));
+  });
+
+  it("blocks runtime-capture-only product closure status", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-ui-real-use-"));
+    const summaryPath = writeJson(dir, "summary.json", summary(dir, {
+      productClosureStatus: "ready_for_runtime_capture",
+    }));
+
+    const report = run([`--ui-device-summary=${summaryPath}`, "--require-ready"], true);
+
+    expect(report.status).toBe("blocked");
+    expect(report.blockers).toContainEqual(expect.objectContaining({
+      code: "product_closure_evidence_ready",
+      detail: "ready_for_runtime_capture",
+    }));
   });
 
   it("blocks missing same-mission desktop evidence", () => {

--- a/test/unit/qa/friday-uiux-product-happy-path-cli.test.ts
+++ b/test/unit/qa/friday-uiux-product-happy-path-cli.test.ts
@@ -42,6 +42,32 @@ function selectedVisual(
   };
 }
 
+function selectedVisualWithServedUi(
+  servedUi: Record<string, unknown>,
+  desktopExtra: Record<string, unknown> = { status: "gap", mode: "static-ax" },
+) {
+  const visual = selectedVisual("live-loopback", {}, desktopExtra) as {
+    evidence: {
+      servedUi?: Array<Record<string, unknown>>;
+    };
+  };
+  visual.evidence.servedUi = [servedUi];
+  return visual;
+}
+
+function readyServedUi(overrides: Record<string, unknown> = {}) {
+  return {
+    status: "ready",
+    sourceStatus: "served_desktop_dist_ui_and_ios_source",
+    checks: {
+      renderedDesktop: true,
+      builtCss: true,
+      iosDesignSystem: true,
+    },
+    ...overrides,
+  };
+}
+
 function traceability(overrides: Record<string, unknown> = {}) {
   return {
     truth: "uiux_action_traceability_not_endbar_not_adoption_not_gui_proof",
@@ -303,6 +329,57 @@ describe("check-friday-uiux-product-happy-path", () => {
       const visual = writeJson(root, "visual.json", selectedVisual("live-loopback", {}, {
         mode: "static-ax",
       }));
+      const trace = writeJson(root, "trace.json", traceability());
+      const result = spawnSync("node", [
+        script,
+        `--repo-root=${process.cwd()}`,
+        `--selected-visual-report=${visual}`,
+        `--action-traceability-report=${trace}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as { blockers?: Array<{ code?: string; detail?: string }> };
+      expect(report.blockers).toContainEqual(expect.objectContaining({
+        code: "desktop_visual_not_live_connected",
+        detail: "modes=static-ax",
+      }));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts current-head served ui fidelity as the served desktop visual input", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-happy-path-served-ui-"));
+    try {
+      const visual = writeJson(root, "visual.json", selectedVisualWithServedUi(readyServedUi()));
+      const trace = writeJson(root, "trace.json", traceability());
+      const output = execFileSync("node", [
+        script,
+        `--repo-root=${process.cwd()}`,
+        `--selected-visual-report=${visual}`,
+        `--action-traceability-report=${trace}`,
+        "--require-complete",
+      ], { cwd: process.cwd(), encoding: "utf8" });
+      const report = JSON.parse(output) as {
+        status?: string;
+        selectedVisual?: { liveConnectedDesktopEvidenceCount?: number; desktopModes?: string[] };
+        blockers?: unknown[];
+      };
+      expect(report.status).toBe("product_happy_path_ready");
+      expect(report.selectedVisual?.liveConnectedDesktopEvidenceCount).toBe(1);
+      expect(report.selectedVisual?.desktopModes).toEqual(["static-ax", "served-ui-current-head"]);
+      expect(report.blockers).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects served ui fidelity unless it is ready and scoped to served dist/ui", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-happy-path-served-ui-gap-"));
+    try {
+      const visual = writeJson(root, "visual.json", selectedVisualWithServedUi(readyServedUi({
+        status: "gap",
+      })));
       const trace = writeJson(root, "trace.json", traceability());
       const result = spawnSync("node", [
         script,


### PR DESCRIPTION
## Summary
- bridge served current-head UI fidelity into the product happy-path desktop visual input without accepting static desktop proof
- rename product closure intermediate states so runtime-capture-only and channel-deferred states cannot be read as final product closure
- require actual product closure evidence in integrated tape and mobile/desktop real-use reports

## Verification
- npm test -- --run test/unit/qa/friday-uiux-product-happy-path-cli.test.ts test/unit/qa/friday-integrated-end-to-end-tape-report-cli.test.ts test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts test/unit/qa/friday-uiux-product-closure-readiness-contract.test.ts test/unit/qa/friday-endbar-report-input-discovery.test.ts
- node scripts/ops/check-friday-uiux-product-happy-path.mjs --repo-root=/private/tmp/friday-current-main-6cd8-desktop-20260701 --design-root=/Users/jarvis/Desktop/friday-design-handoff-20260602 --selected-visual-report=/tmp/friday-selected-visual-proof-current-38222659.json --runtime-evidence-dir=/tmp/friday-uiux-real-use-38222659-20260701/action-runtime-bundle --runtime-evidence=/tmp/friday-uiux-real-use-38222659-20260701/action-runtime-bundle/mobile-approval-reject-current/action-runtime-evidence.json --evidence-dir=/tmp/friday-ui-device-shortlist-38222659-stress-neg-20260701/evidence --out=/tmp/friday-product-happy-path-current-38222659-servedui-bridge.json || true
- node scripts/ops/friday-uiux-product-closure-readiness.mjs --repo-root=/private/tmp/friday-current-main-6cd8-desktop-20260701 --design-root=/Users/jarvis/Desktop/friday-design-handoff-20260602 --selected-visual-evidence-dir=/tmp/friday-uiux-real-use-38222659-20260701/served-ui --selected-visual-evidence-dir=/tmp/friday-uiux-real-use-38222659-20260701/ios-design-destination-capture --runtime-evidence-dir=/tmp/friday-uiux-real-use-38222659-20260701/action-runtime-bundle --runtime-evidence=/tmp/friday-uiux-real-use-38222659-20260701/action-runtime-bundle/mobile-approval-reject-current/action-runtime-evidence.json --evidence-dir=/tmp/friday-ui-device-shortlist-38222659-stress-neg-20260701/evidence --defer-channel-proof --out=/tmp/friday-product-closure-38222659-current-nonchannel-after-bridge.json || true

Truth: this PR does not claim END-BAR, channel proof, signature proof, release, or adoption. It removes a false desktop visual blocker and prevents runtime-capture-only states from being counted as strict product readiness.