### PR TITLE
Polish desktop product path traceability

### DIFF
--- a/ui/src/routes/agent-page.tsx
+++ b/ui/src/routes/agent-page.tsx
@@ -65,6 +65,8 @@ import { ActionButton, ShellCard, StatusPill } from "@/components/core/primitive
 
 const OPERATOR_ID = "ui-operator";
 
+type SystemIntentResult = Awaited<ReturnType<typeof systemApi.executeIntent>>;
+
 const STARTER_SKILL_PROMPTS: Record<string, string> = {
   "repo-health-check": "Run the repo-health-check starter skill for this workspace and tell me the next useful action.",
   "workspace-change-risk-review": "Run the workspace-change-risk-review starter skill against the current workspace changes and summarize risk.",
@@ -322,6 +324,7 @@ export function AgentPage() {
   const [auditDrawerOpen, setAuditDrawerOpen] = useState(false);
   const [remoteLabel, setRemoteLabel] = useState("");
   const [remoteFingerprint, setRemoteFingerprint] = useState("");
+  const [lastSystemIntentResult, setLastSystemIntentResult] = useState<SystemIntentResult | null>(null);
   const passkeysSupported = typeof PublicKeyCredential !== "undefined";
   const operatorUserId = authStorage.getUser()?.id?.trim() || "anonymous";
   const commandCenterSessionKey = `ui:command-center:${operatorUserId}`;
@@ -570,6 +573,7 @@ export function AgentPage() {
         layout: input.layout,
       }),
     onSuccess: (result) => {
+      setLastSystemIntentResult(result);
       toast.success(result.message);
       void queryClient.invalidateQueries({ queryKey: systemKeys.state() });
       void queryClient.invalidateQueries({ queryKey: systemKeys.approvals() });
@@ -760,6 +764,20 @@ export function AgentPage() {
             </div>
           </form>
         </ShellCard>
+
+        {lastSystemIntentResult ? (
+          <ShellCard
+            eyebrow={locale === "zh" ? "最近系统操作" : "Last system action"}
+            title={lastSystemIntentResult.message}
+            aside={<StatusPill tone={systemIntentTone(lastSystemIntentResult.status)}>{lastSystemIntentResult.status}</StatusPill>}
+          >
+            <div className="grid gap-3 sm:grid-cols-3">
+              <Metric label="Action" value={lastSystemIntentResult.action.replaceAll("_", " ")} />
+              <Metric label="When" value={formatRelative(lastSystemIntentResult.performedAt)} />
+              <Metric label="Receipt" value={lastSystemIntentResult.id} mono />
+            </div>
+          </ShellCard>
+        ) : null}
 
         <ShellCard
           eyebrow={locale === "zh" ? "推荐技能" : "Recommended Skills"}
@@ -1393,6 +1411,10 @@ function Metric(props: {
       {props.tone ? <StatusPill tone={props.tone} className="mt-3">{props.tone}</StatusPill> : null}
     </div>
   );
+}
+
+function systemIntentTone(status: SystemIntentResult["status"]): "success" | "warning" | "danger" {
+  return status === "completed" ? "success" : status === "blocked" ? "danger" : "warning";
 }
 
 function RemoteDeviceCard(props: {

--- a/ui/src/routes/mission-workbench-page.tsx
+++ b/ui/src/routes/mission-workbench-page.tsx
@@ -63,6 +63,25 @@ function capabilityStateRenderKey(capability: MissionWorkbenchCapabilityState, i
   ].join(":");
 }
 
+function RefDetails(props: { label: string; refs: Array<[string, string | null | undefined]> }) {
+  const refs = props.refs.filter((entry): entry is [string, string] => typeof entry[1] === "string" && entry[1].trim().length > 0);
+  if (refs.length === 0) return null;
+
+  return (
+    <details className="mt-3 rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-base)] p-2 text-xs text-[color:var(--color-text-secondary)]">
+      <summary className="cursor-pointer select-none font-medium text-[color:var(--color-text-primary)]">{props.label}</summary>
+      <div className="mt-2 space-y-2">
+        {refs.map(([label, ref]) => (
+          <p key={`${label}:${ref}`} className="break-all">
+            <span className="font-medium text-[color:var(--color-text-tertiary)]">{label}: </span>
+            {ref}
+          </p>
+        ))}
+      </div>
+    </details>
+  );
+}
+
 export function MissionWorkbenchPage() {
   const { locale } = useAppLocale();
   const queryClient = useQueryClient();
@@ -136,8 +155,8 @@ export function MissionWorkbenchPage() {
             {localize(locale, "任务工作台", "Mission Workbench")}
           </h1>
           <div className="mt-3 flex flex-wrap gap-2">
-            {targetMissionId ? <StatusPill tone="neutral">capture target: {targetMissionId}</StatusPill> : null}
-            <StatusPill tone="warning">{isLoading ? "checking live Rust Hub" : "live Rust Hub unavailable"}</StatusPill>
+            {targetMissionId ? <StatusPill tone="neutral">selected mission</StatusPill> : null}
+            <StatusPill tone="warning">{isLoading ? "checking live connection" : "Hub projection unavailable"}</StatusPill>
           </div>
         </header>
         <div className="rounded-lg border border-[color:var(--color-border-warning)] bg-[color:var(--color-bg-warning-subtle)] p-4 text-sm text-[color:var(--color-text-primary)]">
@@ -148,13 +167,13 @@ export function MissionWorkbenchPage() {
             {liveUnavailable
               ? localize(
                 locale,
-                "此页面不会显示占位任务、工作项或证据行；请修复 /v1/mission-spine/workbench 后再捕获。",
-                "This page does not display placeholder Missions, WorkItems, or evidence rows; fix /v1/mission-spine/workbench before capture.",
+                "Friday 还没有拿到实时任务投影；连接恢复前不会显示占位任务或虚假证据。",
+                "Friday has not received the live mission projection yet. It will not show placeholder work or fabricated evidence while disconnected.",
               )
               : localize(
                 locale,
-                "正在检查 /v1/mission-spine/workbench；真实投影返回前不会渲染任务数据。",
-                "Checking /v1/mission-spine/workbench; Mission data is not rendered until a real projection returns.",
+                "正在连接任务投影；真实数据返回前不会渲染任务状态。",
+                "Connecting the mission projection. Mission status is not rendered until real data returns.",
               )}
           </p>
         </div>
@@ -171,8 +190,8 @@ export function MissionWorkbenchPage() {
             {localize(locale, "任务工作台", "Mission Workbench")}
           </h1>
           <div className="mt-3 flex flex-wrap gap-2">
-            <StatusPill tone="success">{snapshot.missionId}</StatusPill>
-            {targetMissionId ? <StatusPill tone={snapshot.missionId === targetMissionId ? "success" : "danger"}>capture target: {targetMissionId}</StatusPill> : null}
+            <StatusPill tone="success">{localize(locale, "任务已连接", "Mission connected")}</StatusPill>
+            {targetMissionId ? <StatusPill tone={snapshot.missionId === targetMissionId ? "success" : "danger"}>{snapshot.missionId === targetMissionId ? "selected mission" : "different mission"}</StatusPill> : null}
             <StatusPill tone="warning">{snapshot.runtimeFeedStatus.replaceAll("_", " ")}</StatusPill>
             {snapshot.statusLabels.map((label) => (
               <StatusPill key={label} tone={label === "error" ? "danger" : "warning"}>{label}</StatusPill>
@@ -184,7 +203,7 @@ export function MissionWorkbenchPage() {
         <div className="grid min-w-[280px] grid-cols-2 gap-2 text-sm">
           <div className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-3">
             <p className="text-xs text-[color:var(--color-text-secondary)]">Conversation</p>
-            <p className="mt-1 truncate font-medium text-[color:var(--color-text-primary)]">{snapshot.fridayConversationId}</p>
+            <p className="mt-1 font-medium text-[color:var(--color-text-primary)]">{localize(locale, "已绑定", "Bound")}</p>
           </div>
           <div className="rounded-lg border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] p-3">
             <p className="text-xs text-[color:var(--color-text-secondary)]">Duplicate preflight</p>
@@ -205,7 +224,7 @@ export function MissionWorkbenchPage() {
                   <div className="flex items-start justify-between gap-3">
                     <div>
                       <p className="text-sm font-semibold text-[color:var(--color-text-primary)]">{item.title}</p>
-                      <p className="mt-1 truncate text-xs text-[color:var(--color-text-secondary)]">{item.id}</p>
+                      <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">{item.done ? "completed with receipt" : "waiting for completion receipt"}</p>
                     </div>
                     <StatusPill tone={toneForState(item.state)}>{item.state}</StatusPill>
                   </div>
@@ -221,11 +240,7 @@ export function MissionWorkbenchPage() {
                   <p className="mt-3 text-xs leading-5 text-[color:var(--color-text-secondary)]">
                     {item.blockingReason}
                   </p>
-                  {item.proofRef ? (
-                    <p className="mt-3 break-all rounded-lg bg-[color:var(--color-bg-base)] p-2 text-xs text-[color:var(--color-text-secondary)]">
-                      {item.proofRef}
-                    </p>
-                  ) : null}
+                  <RefDetails label="Work receipt" refs={[["work item", item.id], ["proof", item.proofRef]]} />
                   {item.canRetry || item.canCancel ? (
                     <div className="mt-3 flex flex-wrap gap-2">
                       {item.canRetry ? (
@@ -450,7 +465,7 @@ export function MissionWorkbenchPage() {
                     <StatusPill tone="danger">authority: false</StatusPill>
                   </div>
                   <p className="mt-3 text-sm leading-6 text-[color:var(--color-text-secondary)]">{candidate.preview}</p>
-                  <p className="mt-3 break-all text-xs text-[color:var(--color-text-tertiary)]">{candidate.evidenceRef}</p>
+                  <RefDetails label="Memory evidence" refs={[["evidence", candidate.evidenceRef]]} />
                 </div>
               ))}
             </div>
@@ -463,7 +478,7 @@ export function MissionWorkbenchPage() {
                   <div className="flex items-start justify-between gap-3">
                     <div>
                       <p className="text-sm font-semibold text-[color:var(--color-text-primary)]">{capability.label}</p>
-                      <p className="mt-1 truncate text-xs text-[color:var(--color-text-secondary)]">{capability.id}</p>
+                      <p className="mt-1 text-xs text-[color:var(--color-text-secondary)]">{capability.dispatchAllowed ? "ready for governed dispatch" : "waiting for approval or guardrail"}</p>
                     </div>
                     <StatusPill tone="neutral">{capability.kind}</StatusPill>
                   </div>
@@ -475,7 +490,7 @@ export function MissionWorkbenchPage() {
                     </StatusPill>
                   </div>
                   <p className="mt-3 text-sm leading-6 text-[color:var(--color-text-secondary)]">{capability.summary}</p>
-                  <p className="mt-3 break-all text-xs text-[color:var(--color-text-tertiary)]">{capability.proofRef}</p>
+                  <RefDetails label="Capability receipt" refs={[["capability", capability.id], ["proof", capability.proofRef]]} />
                 </div>
               ))}
             </div>

--- a/ui/src/routes/workflows-page.tsx
+++ b/ui/src/routes/workflows-page.tsx
@@ -642,7 +642,7 @@ export function WorkflowsPage() {
           </div>
         </ShellCard>
 
-        <ShellCard eyebrow={locale === "zh" ? "引导路径" : "Guided path"} title={locale === "zh" ? "Friday 在展示原始图表前先显示下一步安全操作" : "Friday shows the next safe moves before raw graph detail"}>
+        <ShellCard eyebrow={locale === "zh" ? "引导路径" : "Guided path"} title={locale === "zh" ? "Friday 先显示下一步安全操作，再展示依赖地图" : "Friday shows the next safe moves before the dependency map"}>
           {guidedSteps.length ? (
             <div className="space-y-3">
               {guidedSteps.map((step, index) => (
@@ -837,8 +837,8 @@ export function WorkflowsPage() {
             <div className="space-y-4">
               <p className="text-sm text-[color:var(--color-text-secondary)]">
                 {locale === "zh"
-                  ? "Friday 将原始图表保留在此作为操作上下文。恢复、部署、重运行和导出在上方，使此页面保持点击优先。"
-                  : "Friday keeps the raw graph here as operator context. Recovery, deploy, rerun, and export stay above it so this page remains click-first for standard work."}
+                  ? "Friday 将依赖地图保留在此作为操作上下文。恢复、部署、重运行和导出在上方，使此页面保持点击优先。"
+                  : "Friday keeps the dependency map here as operator context. Recovery, deploy, rerun, and export stay above it so this page remains click-first for standard work."}
               </p>
               <div className="h-[420px] overflow-hidden rounded-xl border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)]">
                 <ReactFlow


### PR DESCRIPTION
## Summary
- hide raw Mission/WorkItem/proof identifiers from the primary Mission Workbench path behind explicit receipt details
- replace debug-first disconnected copy with user-facing live projection wording while preserving fail-closed truth
- add a durable last system action receipt card after desktop system intents

## Verification
- npm run typecheck
- npm run check:client-ship-gate
- git diff --check

## Truth label
Product-path UI polish only. This does not claim END-BAR, adoption, channel proof, or that every mobile/desktop control has completed live-device QA.