### PR TITLE
Require live selected visual proof

### DIFF
--- a/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
+++ b/scripts/ops/check-friday-uiux-selected-visual-proof.mjs
@@ -231,7 +231,7 @@ function evaluateIosManifest(path) {
   const evidenceHead = typeof manifest.repo_head === "string" ? manifest.repo_head : null;
   const headOk = Boolean(head) && evidenceHead === head;
   const mode = manifest.mode || null;
-  const allowedVisualModes = ["design-proof-sample", "live-loopback"];
+  const allowedVisualModes = ["live-loopback", "real-device-live", "product-live", "same-run-live"];
   const modeOk = allowedVisualModes.includes(mode);
   return {
     path,
@@ -244,7 +244,13 @@ function evaluateIosManifest(path) {
     headStatus: headOk ? "current_head" : evidenceHead ? "stale_or_wrong_head" : "missing_head",
     mode,
     allowedVisualModes,
-    modeStatus: modeOk ? "visual_proof_mode" : mode === "offline-truth" ? "negative_control_not_visual_proof" : "missing_or_unknown_mode",
+    modeStatus: modeOk
+      ? "live_visual_proof_mode"
+      : mode === "design-proof-sample"
+        ? "design_sample_not_product_visual_proof"
+        : mode === "offline-truth"
+          ? "negative_control_not_visual_proof"
+          : "missing_or_unknown_mode",
     requiredMobileDestinations,
     capturedDestinations: [...captured],
     missingDestinations: missing,
@@ -424,7 +430,7 @@ const desktopReady = desktopVisualEvidence.some((item) => item.status === "ready
 if (!iosReady) {
   block(
     "mobile_selected_visual_proof_missing",
-    "Run proof:ios:design-destinations on current HEAD in design-proof-sample or live-loopback mode and pass its ios-design-destination-capture-manifest.json; offline-truth is a negative-control lane and is not selected visual proof",
+    "Run proof:ios:design-destinations on current HEAD in live-loopback, real-device-live, product-live, or same-run-live mode and pass its ios-design-destination-capture-manifest.json; design-proof-sample/offline-truth are not product visual proof",
   );
 }
 if (!desktopReady) {

--- a/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
+++ b/test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
@@ -211,20 +211,28 @@ describe("check-friday-uiux-selected-visual-proof", () => {
     }
   });
 
-  it("passes when current selected mobile visual evidence is a design-proof sample", () => {
+  it("rejects design-proof sample evidence as product visual proof", () => {
     const { root, designRoot } = fixture();
     try {
       const evidence = writeReadyEvidence(root, "design-proof-sample");
-      const output = execFileSync("node", [
+      const result = spawnSync("node", [
         script,
         `--repo-root=${root}`,
         `--design-root=${designRoot}`,
         `--evidence-dir=${evidence}`,
         "--require-complete",
       ], { cwd: process.cwd(), encoding: "utf8" });
-      const report = JSON.parse(output) as { status?: string; blockers?: unknown[] };
-      expect(report.status).toBe("selected_visual_proof_ready");
-      expect(report.blockers).toEqual([]);
+      expect(result.status).toBe(1);
+      const report = JSON.parse(result.stdout) as {
+        status?: string;
+        blockers?: Array<{ code?: string }>;
+        evidence?: { ios?: Array<{ modeStatus?: string }> };
+      };
+      expect(report.status).toBe("selected_visual_proof_gaps_present");
+      expect(report.blockers).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: "mobile_selected_visual_proof_missing" }),
+      ]));
+      expect(report.evidence?.ios?.[0]?.modeStatus).toBe("design_sample_not_product_visual_proof");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- tighten the selected UI visual proof gate so iOS `design-proof-sample` is not accepted as product visual proof
- accept only live/product modes (`live-loopback`, `real-device-live`, `product-live`, `same-run-live`) for selected visual proof
- add regression coverage showing design samples and offline truth remain useful negative/diagnostic lanes but cannot satisfy END-BAR visual proof

## Truth label
This is a gate-hardening PR only. It does not claim END-BAR, GO-LIVE, adoption, live device capture, or final selected-design completion. It prevents stale/design-sample evidence from being counted as the product visual proof.

## Verification
- npm test -- --run test/unit/qa/friday-uiux-selected-visual-proof-cli.test.ts
- git diff --check