### PR TITLE
Polish product happy path unavailable copy

### DIFF
--- a/test/unit/ui/setup-provider-regressions.test.ts
+++ b/test/unit/ui/setup-provider-regressions.test.ts
@@ -106,7 +106,21 @@ describe("setup provider regressions", () => {
     expect(providerTruthSource).toContain("当前实际路由");
     expect(providerTruthSource).toContain("这不是 setup 输入回显");
     expect(providerTruthSource).toContain("Setup / 默认配置");
+    expect(providerTruthSource).toContain("Connect provider route");
+    expect(providerTruthSource).toContain("Choose model");
+    expect(providerTruthSource).not.toContain("Current route unavailable");
+    expect(providerTruthSource).not.toContain("Live provider truth is unavailable");
+    expect(providerTruthSource).not.toContain("No live route");
     expect(providerTruthHookSource).toContain("OpenAI Provider");
     expect(providerTruthHookSource).toContain("moonshot|kimi|月之暗面");
+  });
+
+  it("keeps mission workbench empty state user-facing instead of engineering-unavailable copy", () => {
+    const missionWorkbenchSource = readFileSync("ui/src/routes/mission-workbench-page.tsx", "utf8");
+
+    expect(missionWorkbenchSource).toContain("Connect the live mission projection");
+    expect(missionWorkbenchSource).toContain("placeholder work or fabricated evidence");
+    expect(missionWorkbenchSource).not.toContain("Hub projection unavailable");
+    expect(missionWorkbenchSource).not.toContain("Live Rust Hub projection is unavailable");
   });
 });

--- a/ui/src/components/console/shell/provider-truth.tsx
+++ b/ui/src/components/console/shell/provider-truth.tsx
@@ -16,13 +16,13 @@ function statusTone(status: ProviderTruthStatus): "success" | "warning" | "dange
 
 function statusLabel(status: ProviderTruthStatus, locale: AppLocale): string {
   if (status === "offline") {
-    return localize(locale, "离线", "Offline");
+    return localize(locale, "待连接", "Connect");
   }
   if (status === "unavailable") {
-    return localize(locale, "暂不可用", "Unavailable");
+    return localize(locale, "待设置", "Needs setup");
   }
   if (status === "degraded") {
-    return localize(locale, "降级", "Degraded");
+    return localize(locale, "需确认", "Review");
   }
   return localize(locale, "正常", "Healthy");
 }
@@ -72,7 +72,7 @@ function alertHeadline(
   if (alert.code === "route_adjusted") {
     return localize(locale, "真实路由已偏离默认配置", "Live route has moved off the configured default");
   }
-  return localize(locale, "真实 provider 状态不可用", "Live provider truth is unavailable");
+  return localize(locale, "需要连接 provider 路由", "Connect provider route");
 }
 
 function alertDetail(
@@ -104,8 +104,8 @@ function alertDetail(
     return alert.providerName;
   }
   return locale === "zh"
-    ? "Friday 当前无法完整确认 provider 真相。"
-    : "Friday could not fully confirm the provider truth right now.";
+    ? "Friday 需要先确认 provider 路由，才会把任务交给模型。"
+    : "Friday needs a confirmed provider route before handing work to a model.";
 }
 
 export function ProviderTruthCompact(props: {
@@ -120,9 +120,9 @@ export function ProviderTruthCompact(props: {
   const providerName = truth?.current?.providerName
     ?? (loading
       ? localize(locale, "读取 provider…", "Reading provider…")
-      : localize(locale, "未拿到路由", "No live route"));
+      : localize(locale, "连接路由", "Connect route"));
   const modelLabel = truth?.current?.model
-    ?? (loading ? localize(locale, "加载中", "Loading") : localize(locale, "不可用", "Unavailable"));
+    ?? (loading ? localize(locale, "加载中", "Loading") : localize(locale, "选择模型", "Choose model"));
 
   return (
     <span
@@ -187,7 +187,7 @@ export function ProviderTruthCard(props: {
     title: current?.providerName
       ?? (loading
         ? localize(locale, "正在读取当前 provider", "Reading current provider")
-        : localize(locale, "当前路由不可见", "Current route unavailable")),
+        : localize(locale, "连接 provider 路由", "Connect provider route")),
     model: current?.model ?? (loading ? localize(locale, "加载中", "Loading") : localize(locale, "未选择", "Not selected")),
     success: localize(
       locale,

--- a/ui/src/routes/mission-workbench-page.tsx
+++ b/ui/src/routes/mission-workbench-page.tsx
@@ -156,19 +156,19 @@ export function MissionWorkbenchPage() {
           </h1>
           <div className="mt-3 flex flex-wrap gap-2">
             {targetMissionId ? <StatusPill tone="neutral">selected mission</StatusPill> : null}
-            <StatusPill tone="warning">{isLoading ? "checking live connection" : "Hub projection unavailable"}</StatusPill>
+            <StatusPill tone="warning">{isLoading ? "checking live connection" : "connect mission projection"}</StatusPill>
           </div>
         </header>
         <div className="rounded-lg border border-[color:var(--color-border-warning)] bg-[color:var(--color-bg-warning-subtle)] p-4 text-sm text-[color:var(--color-text-primary)]">
           <p className="font-semibold">
-            {localize(locale, "真实 Rust Hub 投影不可用。", "Live Rust Hub projection is unavailable.")}
+            {localize(locale, "连接真实任务投影。", "Connect the live mission projection.")}
           </p>
           <p className="mt-1 text-[color:var(--color-text-secondary)]">
             {liveUnavailable
               ? localize(
                 locale,
-                "Friday 还没有拿到实时任务投影；连接恢复前不会显示占位任务或虚假证据。",
-                "Friday has not received the live mission projection yet. It will not show placeholder work or fabricated evidence while disconnected.",
+                "Friday 还没有拿到实时任务数据；连接恢复前不会显示占位任务或虚假证据。",
+                "Friday has not received live mission data yet. It will not show placeholder work or fabricated evidence before the connection is restored.",
               )
               : localize(
                 locale,


### PR DESCRIPTION
## Summary
- Replace engineering unavailable/offline copy in provider truth UI with user-facing setup/connection language while preserving warning status.
- Reword Mission Workbench empty state to explain live mission projection connection without fabricated work.
- Add regression assertions so those old product-path phrases do not return.

## Verification
- `pnpm vitest run test/unit/ui/setup-provider-regressions.test.ts test/unit/qa/friday-product-facing-copy.test.ts`
- `node scripts/ops/check-friday-served-ui-design-fidelity.mjs --repo-root=/private/tmp/friday-endbar-main-c037-20260701 --design-root=/Users/jarvis/Desktop/friday-design-handoff-20260602 --out=/private/tmp/friday-served-ui-design-fidelity-c037-user-copy-20260701T124203Z.json`

Truth: product copy polish only. This does not claim END-BAR, adoption, release, or strict product happy-path completion.