### PR TITLE
Protect NEW-31 macOS launchd canonical gate

### DIFF
--- a/scripts/ops/friday-service-run.sh
+++ b/scripts/ops/friday-service-run.sh
@@ -58,5 +58,6 @@ if [[ -n "${BUILD_REASON}" ]]; then
 fi
 
 export FRIDAY_SYSTEM_ENABLED="${FRIDAY_SYSTEM_ENABLED:-true}"
+export FRIDAY_CANONICAL_GATE="${FRIDAY_CANONICAL_GATE:-true}"
 
 exec "${NODE_BIN}" "${DIST_ENTRY}" start

--- a/scripts/ops/install-friday-launchagent.sh
+++ b/scripts/ops/install-friday-launchagent.sh
@@ -142,6 +142,8 @@ $(write_common_env)
     <string>false</string>
     <key>FRIDAY_CHANNEL_WAKE_UI</key>
     <string>false</string>
+    <key>FRIDAY_CANONICAL_GATE</key>
+    <string>true</string>
     <key>FRIDAY_SYSTEM_ENABLED</key>
     <string>true</string>
     <key>FRIDAY_SYSTEM_COMPANION_SERVER_MODE</key>

--- a/test/unit/ops/friday-autostart-scripts.test.ts
+++ b/test/unit/ops/friday-autostart-scripts.test.ts
@@ -50,6 +50,20 @@ describe("Friday autostart scripts", () => {
     expect(uiRunner).toContain('exec open "${BASE_URL%/}/"');
   });
 
+  it("NEW-31 red: launchd hub plist carries the canonical mutating-action gate marker", () => {
+    const installer = readFileSync("scripts/ops/install-friday-launchagent.sh", "utf8");
+
+    expect(installer).toContain("<key>FRIDAY_CANONICAL_GATE</key>\n    <string>true</string>");
+  });
+
+  it("NEW-31 red: service runner defaults canonical mutating-action gate to protected", () => {
+    const serviceRunner = readFileSync("scripts/ops/friday-service-run.sh", "utf8");
+
+    expect(serviceRunner).toContain('export FRIDAY_CANONICAL_GATE="${FRIDAY_CANONICAL_GATE:-true}"');
+    expect(serviceRunner.indexOf('export FRIDAY_CANONICAL_GATE="${FRIDAY_CANONICAL_GATE:-true}"'))
+      .toBeLessThan(serviceRunner.indexOf('exec "${NODE_BIN}" "${DIST_ENTRY}" start'));
+  });
+
   it("includes autostart scripts in the npm package file list", () => {
     const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as { files: string[] };
 


### PR DESCRIPTION
## Summary\n- add FRIDAY_CANONICAL_GATE=true to the macOS HUB LaunchAgent environment\n- default the service runner to FRIDAY_CANONICAL_GATE=true before exec while preserving explicit overrides\n- add red-first autostart tests for the launchd marker and runner default\n\n## Evidence\n- red commit: 18c6e8df (test-only)\n- green commit: bf37ea38 (implementation-only)\n- focused tests: npx vitest run test/unit/ops/friday-autostart-scripts.test.ts test/unit/hub/friday-hub-bootstrap-env.test.ts => 86/86 passed\n- typecheck: npm run typecheck passed\n- reviewers G/H: PASS\n- handoff evidence: /Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new31-launchd-canonical-gate-redfirst-20260702T1438-0700\n\n## Gates\nNEW-31 is Med. Deployment/restart is operator-gated: this PR does not run launchctl, rewrite the live installed plist, restart prod, or touch main/prod directly.