### PR TITLE
Guard NEW-32 CLI binary paths

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -246,7 +250,7 @@
         "filename": "src/providers/services/friday-provider-service.ts",
         "hashed_secret": "90c5d1358d128117989fc21f2897a25c99205e50",
         "is_verified": false,
-        "line_number": 96
+        "line_number": 97
       }
     ],
     "src/security/multi-tenant/api/friday-multi-tenant-security-api.types.ts": [
@@ -986,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-02T10:54:44Z"
+  "generated_at": "2026-07-02T22:20:21Z"
 }

--- a/src/providers/cli/friday-provider-cli-backend.ts
+++ b/src/providers/cli/friday-provider-cli-backend.ts
@@ -1,7 +1,8 @@
 import { execFile as execFileCb, spawn } from "node:child_process";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { mkdtemp, open, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 
 import { FridayDomainError } from "#errors";
@@ -15,6 +16,14 @@ import type {
 const execFile = promisify(execFileCb);
 const CLI_OUTPUT_MAX_BYTES = 1_048_576;
 const CLI_COMPLETION_TIMEOUT_MS = 300_000;
+const CLI_BINARY_ALLOWLIST_ENV = "FRIDAY_CLI_BINARY_ALLOWLIST";
+const DEFAULT_CLI_BINARY_ALLOWLIST_DIRS = [
+  "/usr/local/bin",
+  "/usr/bin",
+  "/bin",
+  "/opt/homebrew/bin",
+  "/opt/homebrew/sbin",
+] as const;
 
 interface FridayCliBackendSpec {
   id: FridayProviderCliBackendId;
@@ -207,9 +216,95 @@ function getCliBackendSpec(backendId: FridayProviderCliBackendId): FridayCliBack
   return CLI_BACKEND_SPECS[backendId];
 }
 
+function realpathOrResolve(path: string): string {
+  return existsSync(path) ? realpathSync.native(path) : resolve(path);
+}
+
+function isPathWithin(path: string, root: string): boolean {
+  const resolvedPath = realpathOrResolve(path);
+  const resolvedRoot = realpathOrResolve(root);
+  return resolvedPath === resolvedRoot || resolvedPath.startsWith(`${resolvedRoot}${sep}`);
+}
+
+function parseOperatorCliBinaryAllowlist(): readonly string[] {
+  const raw = process.env[CLI_BINARY_ALLOWLIST_ENV];
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(/[,:]/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && isAbsolute(entry))
+    .map(realpathOrResolve);
+}
+
+function listAllowedCliBinaryEntries(): readonly { path: string; kind: "dir" | "exact" }[] {
+  const defaults = DEFAULT_CLI_BINARY_ALLOWLIST_DIRS.map((entry) => ({
+    path: realpathOrResolve(entry),
+    kind: "dir" as const,
+  }));
+  const configured = parseOperatorCliBinaryAllowlist().map((entry) => {
+    if (existsSync(entry)) {
+      return {
+        path: entry,
+        kind: statSync(entry).isDirectory() ? "dir" as const : "exact" as const,
+      };
+    }
+    return { path: entry, kind: "exact" as const };
+  });
+  return [...defaults, ...configured];
+}
+
+function createCliBinaryPathValidationError(reason: string): FridayDomainError {
+  return new FridayDomainError(
+    "VALIDATION_ERROR",
+    `cliConfig.binaryPath is not in the allowed set: ${reason}`,
+    { httpStatus: 400 },
+  );
+}
+
+// Exported for focused NEW-32 tests and for provider-service write-time
+// validation. The spawn-time call remains load-bearing for persisted configs.
+export function assertAllowedCliBinaryPath(
+  binaryPath: string,
+  backendId: FridayProviderCliBackendId,
+): void {
+  const explicitPath = binaryPath.trim();
+  if (!isAbsolute(explicitPath)) {
+    throw createCliBinaryPathValidationError("explicit paths must be absolute");
+  }
+  if (explicitPath.split(/[\\/]+/).includes("..")) {
+    throw createCliBinaryPathValidationError("path traversal is not allowed");
+  }
+
+  const resolvedPath = realpathOrResolve(explicitPath);
+  if (isPathWithin(resolvedPath, tmpdir())) {
+    throw createCliBinaryPathValidationError("temporary directories are not allowed");
+  }
+  if (isPathWithin(resolvedPath, process.cwd())) {
+    throw createCliBinaryPathValidationError("the Friday workspace is not an allowed binary directory");
+  }
+
+  const spec = getCliBackendSpec(backendId);
+  const allowedEntries = listAllowedCliBinaryEntries();
+  if (allowedEntries.some((entry) => entry.kind === "exact" && entry.path === resolvedPath)) {
+    return;
+  }
+  if (
+    spec.binaryNames.includes(basename(resolvedPath)) &&
+    allowedEntries.some((entry) => entry.kind === "dir" && entry.path === dirname(resolvedPath))
+  ) {
+    return;
+  }
+
+  throw createCliBinaryPathValidationError("path must match an operator allowlisted file or directory");
+}
+
 function resolveBinaryPath(cliConfig: FridayProviderCliConfig): string {
   if (cliConfig.binaryPath && cliConfig.binaryPath.trim().length > 0) {
-    return cliConfig.binaryPath;
+    const binaryPath = cliConfig.binaryPath.trim();
+    assertAllowedCliBinaryPath(binaryPath, cliConfig.backendId);
+    return binaryPath;
   }
   const spec = getCliBackendSpec(cliConfig.backendId);
   return spec.binaryNames[0]!;
@@ -252,9 +347,10 @@ export async function probeFridayCliSession(input: {
 }): Promise<FridayCliSessionStatus> {
   const checkedAt = input.nowIso();
   const spec = getCliBackendSpec(input.cliConfig.backendId);
-  const binaryPath = resolveBinaryPath(input.cliConfig);
+  let binaryPath = input.cliConfig.binaryPath?.trim() || spec.binaryNames[0]!;
 
   try {
+    binaryPath = resolveBinaryPath(input.cliConfig);
     const versionResult = await runExecFile(
       binaryPath,
       spec.versionArgs,

--- a/src/providers/services/friday-provider-service.ts
+++ b/src/providers/services/friday-provider-service.ts
@@ -51,6 +51,7 @@ import { createFridayProviderProfileRepository } from "../persistence/friday-pro
 import { createFridaySecretRepository } from "../persistence/friday-secret-repository.js";
 import { createFridayProviderUsageRepository } from "../persistence/friday-provider-usage-repository.js";
 import {
+  assertAllowedCliBinaryPath,
   probeFridayCliSession,
   runFridayCliBackendTextCompletion,
 } from "../cli/friday-provider-cli-backend.js";
@@ -2187,6 +2188,9 @@ export function createFridayProviderService(
         "cliConfig is required when backendKind is 'cli'",
         { httpStatus: 400 },
       );
+    }
+    if (backendKind === "cli" && input.cliConfig?.binaryPath && input.cliConfig.binaryPath.trim().length > 0) {
+      assertAllowedCliBinaryPath(input.cliConfig.binaryPath, input.cliConfig.backendId);
     }
   }
 

--- a/test/unit/providers/cli/friday-provider-cli-backend.test.ts
+++ b/test/unit/providers/cli/friday-provider-cli-backend.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { runFridayCliBackendTextCompletion } from "#providers";
+import { probeFridayCliSession, runFridayCliBackendTextCompletion } from "#providers";
 import { parseCodexStatus } from "../../../../src/providers/cli/friday-provider-cli-backend.js";
 
 describe("friday-provider-cli-backend", () => {
@@ -13,6 +13,51 @@ describe("friday-provider-cli-backend", () => {
       rmSync(testDir, { recursive: true, force: true });
       testDir = undefined;
     }
+  });
+
+  it("rejects explicit tmpdir CLI binary paths before probing version", async () => {
+    const cliPath = writeMockCli(`
+      writeFileSync(${JSON.stringify(join(tmpdir(), "friday-new32-probe-pwned"))}, "executed");
+      process.stdout.write("codex 1.0.0\\n");
+    `, "codex");
+    const sentinelPath = join(testDir!, "PWNED");
+    writeFileSync(cliPath, `#!/usr/bin/env node\nimport { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(sentinelPath)}, "executed");\nprocess.stdout.write("codex 1.0.0\\n");\n`);
+    chmodSync(cliPath, 0o755);
+
+    const result = await probeFridayCliSession({
+      cliConfig: {
+        backendId: "codex-cli",
+        binaryPath: cliPath,
+      },
+      nowIso: () => "2026-07-02T00:00:00.000Z",
+    });
+
+    expect(existsSync(sentinelPath)).toBe(false);
+    expect(result.status).toBe("missing");
+    expect(result.message).toContain("cliConfig.binaryPath is not in the allowed set");
+  });
+
+  it("rejects explicit tmpdir CLI binary paths before text completion spawn", async () => {
+    const cliPath = writeMockCli(`
+      writeFileSync(${JSON.stringify(join(tmpdir(), "friday-new32-completion-pwned"))}, "executed");
+      process.stdout.write("unexpected completion\\n");
+    `, "codex");
+    const sentinelPath = join(testDir!, "PWNED");
+    writeFileSync(cliPath, `#!/usr/bin/env node\nimport { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(sentinelPath)}, "executed");\nprocess.stdout.write("unexpected completion\\n");\n`);
+    chmodSync(cliPath, 0o755);
+
+    await expect(runFridayCliBackendTextCompletion({
+      cliConfig: {
+        backendId: "codex-cli",
+        binaryPath: cliPath,
+      },
+      systemPrompt: "system",
+      conversation: "hello",
+    })).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      httpStatus: 400,
+    });
+    expect(existsSync(sentinelPath)).toBe(false);
   });
 
   it("bounds stdout captured from CLI text completions", async () => {
@@ -104,11 +149,11 @@ describe("friday-provider-cli-backend", () => {
     });
   });
 
-  function writeMockCli(source: string): string {
+  function writeMockCli(source: string, filename = "mock-cli.mjs"): string {
     testDir = join(tmpdir(), `friday-provider-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mkdirSync(testDir, { recursive: true });
-    const cliPath = join(testDir, "mock-cli.mjs");
-    writeFileSync(cliPath, `#!/usr/bin/env node\n${source}`);
+    const cliPath = join(testDir, filename);
+    writeFileSync(cliPath, `#!/usr/bin/env node\nimport { writeFileSync } from "node:fs";\n${source}`);
     chmodSync(cliPath, 0o755);
     return cliPath;
   }

--- a/test/unit/providers/cli/friday-provider-cli-backend.test.ts
+++ b/test/unit/providers/cli/friday-provider-cli-backend.test.ts
@@ -1,17 +1,29 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { chmodSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { probeFridayCliSession, runFridayCliBackendTextCompletion } from "#providers";
 import { parseCodexStatus } from "../../../../src/providers/cli/friday-provider-cli-backend.js";
 
 describe("friday-provider-cli-backend", () => {
   let testDir: string | undefined;
+  const originalCliBinaryAllowlist = process.env.FRIDAY_CLI_BINARY_ALLOWLIST;
+  const originalPath = process.env.PATH;
 
   afterEach(() => {
     if (testDir) {
       rmSync(testDir, { recursive: true, force: true });
       testDir = undefined;
+    }
+    if (originalCliBinaryAllowlist === undefined) {
+      delete process.env.FRIDAY_CLI_BINARY_ALLOWLIST;
+    } else {
+      process.env.FRIDAY_CLI_BINARY_ALLOWLIST = originalCliBinaryAllowlist;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
     }
   });
 
@@ -19,7 +31,7 @@ describe("friday-provider-cli-backend", () => {
     const cliPath = writeMockCli(`
       writeFileSync(${JSON.stringify(join(tmpdir(), "friday-new32-probe-pwned"))}, "executed");
       process.stdout.write("codex 1.0.0\\n");
-    `, "codex");
+    `, "codex", tmpdir());
     const sentinelPath = join(testDir!, "PWNED");
     writeFileSync(cliPath, `#!/usr/bin/env node\nimport { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(sentinelPath)}, "executed");\nprocess.stdout.write("codex 1.0.0\\n");\n`);
     chmodSync(cliPath, 0o755);
@@ -41,7 +53,7 @@ describe("friday-provider-cli-backend", () => {
     const cliPath = writeMockCli(`
       writeFileSync(${JSON.stringify(join(tmpdir(), "friday-new32-completion-pwned"))}, "executed");
       process.stdout.write("unexpected completion\\n");
-    `, "codex");
+    `, "codex", tmpdir());
     const sentinelPath = join(testDir!, "PWNED");
     writeFileSync(cliPath, `#!/usr/bin/env node\nimport { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(sentinelPath)}, "executed");\nprocess.stdout.write("unexpected completion\\n");\n`);
     chmodSync(cliPath, 0o755);
@@ -67,6 +79,7 @@ describe("friday-provider-cli-backend", () => {
         process.stdout.write("x".repeat(1100000));
       });
     `);
+    allowCliBinaryPath(cliPath);
 
     const result = await runFridayCliBackendTextCompletion({
       cliConfig: {
@@ -82,7 +95,8 @@ describe("friday-provider-cli-backend", () => {
   });
 
   it("maps missing CLI binaries to PROVIDER_UNREACHABLE for text completions", async () => {
-    const missingPath = join(tmpdir(), `friday-missing-cli-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const missingPath = `/usr/local/bin/friday-missing-cli-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    allowCliBinaryPath(missingPath);
 
     await expect(runFridayCliBackendTextCompletion({
       cliConfig: {
@@ -95,6 +109,23 @@ describe("friday-provider-cli-backend", () => {
       code: "PROVIDER_UNREACHABLE",
       httpStatus: 422,
       message: `CLI binary "${missingPath}" not found`,
+    });
+  });
+
+  it("keeps the default bare codex binary on PATH instead of applying explicit-path validation", async () => {
+    process.env.FRIDAY_CLI_BINARY_ALLOWLIST = "/definitely/not/codex";
+    process.env.PATH = "";
+
+    await expect(runFridayCliBackendTextCompletion({
+      cliConfig: {
+        backendId: "codex-cli",
+      },
+      systemPrompt: "system",
+      conversation: "hello",
+    })).rejects.toMatchObject({
+      code: "PROVIDER_UNREACHABLE",
+      httpStatus: 422,
+      message: "CLI binary \"codex\" not found",
     });
   });
 
@@ -149,8 +180,12 @@ describe("friday-provider-cli-backend", () => {
     });
   });
 
-  function writeMockCli(source: string, filename = "mock-cli.mjs"): string {
-    testDir = join(tmpdir(), `friday-provider-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  function allowCliBinaryPath(binaryPath: string): void {
+    process.env.FRIDAY_CLI_BINARY_ALLOWLIST = binaryPath;
+  }
+
+  function writeMockCli(source: string, filename = "mock-cli.mjs", rootDir = join(homedir(), ".friday-test-cli-binaries")): string {
+    testDir = join(rootDir, `friday-provider-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mkdirSync(testDir, { recursive: true });
     const cliPath = join(testDir, filename);
     writeFileSync(cliPath, `#!/usr/bin/env node\nimport { writeFileSync } from "node:fs";\n${source}`);


### PR DESCRIPTION
## Summary
- add a fail-closed allowlist validator for explicit provider CLI `cliConfig.binaryPath` values
- apply the validator before probe/completion execution and reuse it in provider-service CLI create/update compatibility validation
- preserve default bare `codex` PATH behavior plus operator-allowlisted exact file paths and ENOENT mapping

## Red-first evidence
- red commit: `5bfec660cd428abf2d5e07cdd8fa0f41a369155a` (`test(new32): expose cli binary path execution gap`)
- green commit: `0c36fce00837c435078baaad7bcee43cbcd74b5d` (`fix(new32): allowlist explicit cli binary paths`)
- evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new32-cli-binary-allowlist-redfirst-20260702T145902-0700`
- valid red: `red-focused-cli-backend-valid.log` and `red-focused-cli-backend-after-rebase.log` exit 1 with the two NEW-32 tests failing
- green/no-degrade: focused CLI backend 15/15, companion provider/agent/cli set 153/153, `npm run typecheck`, focused eslint exit 0 warnings only
- revert-red: `revert-red-focused-cli-backend-final.log` exits 1 after reverting final green, reproing the two tmpdir explicit-binary failures

## Independent review
- Reviewer K: `reviewer-k-new32-final-20260702`, PASS
- Reviewer L: `reviewer-l-new32-final-20260702`, PASS

## Boundaries
- NEW-32 is Med: auto-merge only after full PR-CI green, born-current clean state, no overlap, and main push-CI from #1454 has no true regression
- no `--admin`, no direct main/prod push
- deploy/rebuild/restart and production allowlist policy remain operator-gated
