### PR TITLE
Guard NEW-33 browser navigation against SSRF

### DIFF
--- a/src/agent/tools/friday-agent-browser-tool.ts
+++ b/src/agent/tools/friday-agent-browser-tool.ts
@@ -18,6 +18,11 @@ import type {
 } from "../../browser/friday-browser-manager.js";
 import { browserArtifactDir, validateUrl } from "../../browser/friday-browser-manager.js";
 import { resolveBrowserTarget } from "../../browser/friday-browser-target-id.js";
+import {
+  createFridayAgentSsrfGuard,
+  type FridayAgentSsrfGuard,
+  FridaySsrfBlockedError,
+} from "../security/friday-agent-ssrf-guard.js";
 import type {
   FridayDomDocumentLike,
   FridayDomElementLike,
@@ -27,6 +32,7 @@ import type {
 
 export interface CreateFridayAgentBrowserToolOptions {
   browserManager: FridayBrowserManager;
+  ssrfGuard?: FridayAgentSsrfGuard;
 }
 
 type BrowserAction =
@@ -137,6 +143,21 @@ export function createFridayAgentBrowserTool(
   options: CreateFridayAgentBrowserToolOptions,
 ): FridayAgentToolDefinition {
   const { browserManager } = options;
+  const ssrfGuard = options.ssrfGuard ?? createFridayAgentSsrfGuard();
+
+  function validateBrowserNavigationUrl(url: string): string | undefined {
+    const urlError = validateUrl(url, browserManager.options.allowedOrigins);
+    if (urlError) return urlError;
+    try {
+      ssrfGuard.validate(url);
+      return undefined;
+    } catch (err) {
+      if (err instanceof FridaySsrfBlockedError) {
+        return err.message;
+      }
+      throw err;
+    }
+  }
 
   return {
     name: "browser",
@@ -504,7 +525,7 @@ export function createFridayAgentBrowserTool(
     const executionContext = readBrowserExecutionContext(args);
 
     if (url) {
-      const urlError = validateUrl(url, browserManager.options.allowedOrigins);
+      const urlError = validateBrowserNavigationUrl(url);
       if (urlError) return errorResult(urlError);
     }
 
@@ -556,7 +577,7 @@ export function createFridayAgentBrowserTool(
   ): Promise<FridayAgentToolResult> {
     const url = readStringParam(args, "url", { required: true });
     const executionContext = readBrowserExecutionContext(args);
-    const urlError = validateUrl(url, browserManager.options.allowedOrigins);
+    const urlError = validateBrowserNavigationUrl(url);
     if (urlError) return errorResult(urlError);
 
     // Retry once on browser disconnect — re-open session then navigate
@@ -950,7 +971,7 @@ export function createFridayAgentBrowserTool(
         );
         const url = readStringParam(args, "url");
         if (url) {
-          const urlError = validateUrl(url, browserManager.options.allowedOrigins);
+          const urlError = validateBrowserNavigationUrl(url);
           if (urlError) {
             await page.close().catch(() => {});
             session.tabs.delete(tabId);

--- a/src/agent/tools/friday-agent-tool-registry.ts
+++ b/src/agent/tools/friday-agent-tool-registry.ts
@@ -273,7 +273,10 @@ export function createFridayAgentToolRegistry(
 
   if (options?.browserManager) {
     tools.push(
-      createFridayAgentBrowserTool({ browserManager: options.browserManager }),
+      createFridayAgentBrowserTool({
+        browserManager: options.browserManager,
+        ssrfGuard: options?.ssrfGuard,
+      }),
     );
   }
 

--- a/test/unit/agent/tools/friday-agent-browser-tool.test.ts
+++ b/test/unit/agent/tools/friday-agent-browser-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createFridayAgentBrowserTool } from "#agent";
+import { createFridayAgentBrowserTool, createFridayAgentSsrfGuard } from "#agent";
 import { FRIDAY_BROWSER_ALLOW_ANY_ORIGIN, type FridayBrowserManager, type BrowserSession } from "#browser";
 
 // ─── Mock helpers ───
@@ -122,6 +122,66 @@ describe("FridayAgentBrowserTool", () => {
 
   beforeEach(() => {
     manager = createMockManager();
+  });
+
+  describe("SSRF guard", () => {
+    const blockedUrls = [
+      "http://169.254.169.254/latest/meta-data/",
+      "http://127.0.0.1:8787/admin",
+      "http://localhost/",
+      "http://192.168.1.1/",
+      "http://metadata.google.internal/",
+      "http://[::1]/",
+    ];
+
+    it("blocks private and metadata navigations by default before page.goto", async () => {
+      const actions = [
+        (url: string) => ({ action: "open", sessionId: "test-session", url }),
+        (url: string) => ({ action: "navigate", sessionId: "test-session", url }),
+        (url: string) => ({ action: "tabs", sessionId: "test-session", tabsAction: "new", url }),
+      ];
+
+      for (const buildArgs of actions) {
+        for (const url of blockedUrls) {
+          const isolatedManager = createMockManager();
+          const tool = createFridayAgentBrowserTool({ browserManager: isolatedManager });
+          const result = await tool.execute(buildArgs(url), signal());
+          const page = (await isolatedManager.getPage("test-session")).page;
+
+          expect(result.isError).toBe(true);
+          expect(String(result.content)).toMatch(/SSRF|blocked|private|not allowed/i);
+          expect(page.goto).not.toHaveBeenCalled();
+        }
+      }
+    });
+
+    it("allows public navigation with the default SSRF guard", async () => {
+      const tool = createFridayAgentBrowserTool({ browserManager: manager });
+      const result = await tool.execute(
+        { action: "navigate", sessionId: "test-session", url: "https://example.com/page" },
+        signal(),
+      );
+      const page = (await manager.getPage("test-session")).page;
+
+      expect(result.isError).toBeUndefined();
+      expect(page.goto).toHaveBeenCalledWith("https://example.com/page", { waitUntil: "domcontentloaded" });
+    });
+
+    it("preserves the operator escape hatch for private network browsing", async () => {
+      const ssrfGuard = createFridayAgentSsrfGuard({ allowPrivateNetwork: true });
+      const tool = createFridayAgentBrowserTool({
+        browserManager: manager,
+        ssrfGuard,
+      } as Parameters<typeof createFridayAgentBrowserTool>[0] & { ssrfGuard: typeof ssrfGuard });
+      const result = await tool.execute(
+        { action: "navigate", sessionId: "test-session", url: "http://127.0.0.1:8787/admin" },
+        signal(),
+      );
+      const page = (await manager.getPage("test-session")).page;
+
+      expect(result.isError).toBeUndefined();
+      expect(page.goto).toHaveBeenCalledWith("http://127.0.0.1:8787/admin", { waitUntil: "domcontentloaded" });
+    });
   });
 
   // ─── Tool definition ───


### PR DESCRIPTION
## Summary
- Adds a default-fail-closed SSRF guard to the agent browser tool explicit navigation sinks (`open`, `navigate`, `tabs:new`).
- Threads the existing registry/bootstrap `ssrfGuard` into the browser tool so `allowPrivateNetwork` policy still works.
- Keeps `validateUrl` origin/protocol-only; SSRF is an additive tool-level guard.

## Red-first Evidence
- Evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new33-browser-ssrf-guard-redfirst-20260702T1500-0700`
- Red commit: `563f0e18446d8b2ee2b4ec6d777487cb4179d985` (`test(new33): expose browser ssrf navigation gap`)
- Green commit: `48cb328de00952e78dc8010f9fcb776e76f9d60b` (`fix(new33): guard browser navigation against ssrf`)
- Red: `red-focused-browser-tool.log` / `.exitcode=1`
- Green: `green-focused-browser-tool-final.log` / `.exitcode=0` (44/44 passed)
- Revert-green: `revert-green-focused-browser-tool.log` / `.exitcode=1`

## Validation
- `npx vitest run --project default test/unit/agent/tools/friday-agent-browser-tool.test.ts`
- `npx vitest run --project default test/unit/browser/friday-browser-manager.test.ts`
- `npm run typecheck:src`
- `npx eslint src/agent/tools/friday-agent-browser-tool.ts src/agent/tools/friday-agent-tool-registry.ts test/unit/agent/tools/friday-agent-browser-tool.test.ts` (0 errors; existing warnings only)
- `git diff --check origin/main...HEAD`

## Independent Review
- Reviewer M: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new33-browser-ssrf-guard-redfirst-20260702T1500-0700/reviewer-m-new33.md`, session `NEW-33-reviewer-M-48cb328d`, verdict `PASS`.
- Reviewer N: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new33-browser-ssrf-guard-redfirst-20260702T1500-0700/reviewer-n-new33.md`, session `NEW-33-reviewer-N-20260702`, verdict `PASS`.

## No-degrade / Boundaries
- Public browser navigation still succeeds.
- `allowPrivateNetwork: true` still allows loopback/private browsing for operator-controlled cases.
- Browser manager `validateUrl` remains origin-only; localhost with `FRIDAY_BROWSER_ALLOW_ANY_ORIGIN` remains valid at the manager layer.
- No prod/main direct push, no deploy/restart, no `--admin`.

## Residual Risk
- Tier-1 only: redirect-following, in-page requests, link-click navigations, and DNS rebinding/TOCTOU remain documented follow-ups unless operator/strategist requires Tier-2 request interception in this PR.