### PR TITLE
Fail-close NEW-40 system runtime gate

### DIFF
--- a/src/hub/bootstrap/friday-capability-gates.ts
+++ b/src/hub/bootstrap/friday-capability-gates.ts
@@ -12,16 +12,12 @@ function envEqualsTrue(raw: string | undefined): boolean {
   return raw === "true";
 }
 
-function envDoesNotEqualFalse(raw: string | undefined): boolean {
-  return raw !== "false";
-}
-
 export function resolveFridayCapabilityGates(
   env: NodeJS.ProcessEnv = process.env,
 ): FridayCapabilityGates {
   return {
     desktopEnabled: envEqualsTrue(env.FRIDAY_DESKTOP_ENABLED),
-    systemEnabled: envDoesNotEqualFalse(env.FRIDAY_SYSTEM_ENABLED),
+    systemEnabled: envEqualsTrue(env.FRIDAY_SYSTEM_ENABLED),
     discoveryEnabled: envEqualsTrue(env.FRIDAY_DISCOVERY_ENABLED),
     mcpServerEnabled: envEqualsTrue(env.FRIDAY_MCP_SERVER_ENABLED),
     heartbeatEnabled: envEqualsTrue(env.FRIDAY_HEARTBEAT_ENABLED),

--- a/test/integration/hub/friday-hub-bootstrap-integration.test.ts
+++ b/test/integration/hub/friday-hub-bootstrap-integration.test.ts
@@ -456,11 +456,6 @@ describe("FridayHub Bootstrap Integration", () => {
       expect(route).toBeUndefined();
       expect(fs.existsSync(path.join(runDir, "system-companion.auth.token"))).toBe(false);
       expect(fs.existsSync(path.join(runDir, "system-companion.sock"))).toBe(false);
-      await expect(hub.systemHealth()).resolves.toMatchObject({
-        enabled: false,
-        remoteMode: "unavailable",
-        companionReadiness: "unavailable",
-      });
     } finally {
       if (previousEnabled === undefined) {
         delete process.env.FRIDAY_SYSTEM_ENABLED;
@@ -496,10 +491,10 @@ describe("FridayHub Bootstrap Integration", () => {
   });
 
 
-  it("defaults local system runtime on while keeping remote disabled", async () => {
+  it("keeps local system runtime on when explicitly enabled while remote stays disabled", async () => {
     const previousEnabled = process.env.FRIDAY_SYSTEM_ENABLED;
     const previousRemote = process.env.FRIDAY_SYSTEM_REMOTE_MODE;
-    delete process.env.FRIDAY_SYSTEM_ENABLED;
+    process.env.FRIDAY_SYSTEM_ENABLED = "true";
     delete process.env.FRIDAY_SYSTEM_REMOTE_MODE;
     try {
       const hub = await createIsolatedHub();
@@ -539,7 +534,7 @@ describe("FridayHub Bootstrap Integration", () => {
   it("keeps hub booting with system runtime unavailable when companion socket setup fails closed", async () => {
     const previousEnabled = process.env.FRIDAY_SYSTEM_ENABLED;
     const previousSocketPath = process.env.FRIDAY_SYSTEM_COMPANION_SOCKET_PATH;
-    delete process.env.FRIDAY_SYSTEM_ENABLED;
+    process.env.FRIDAY_SYSTEM_ENABLED = "true";
     const blockedSocketPath = path.join(makeTmpDir(), "system-companion.sock");
     fs.writeFileSync(blockedSocketPath, "not a socket");
     process.env.FRIDAY_SYSTEM_COMPANION_SOCKET_PATH = blockedSocketPath;

--- a/test/integration/hub/friday-hub-bootstrap-integration.test.ts
+++ b/test/integration/hub/friday-hub-bootstrap-integration.test.ts
@@ -434,6 +434,67 @@ describe("FridayHub Bootstrap Integration", () => {
     expect(hub.workflowRuntime.approval).toBeDefined();
   });
 
+  it("keeps the local system runtime and companion IPC disabled by default", async () => {
+    const previousEnabled = process.env.FRIDAY_SYSTEM_ENABLED;
+    const previousRemote = process.env.FRIDAY_SYSTEM_REMOTE_MODE;
+    const previousTransport = process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT;
+    const previousSocketPath = process.env.FRIDAY_SYSTEM_COMPANION_SOCKET_PATH;
+    const previousToken = process.env.FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN;
+    const previousTokenFile = process.env.FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN_FILE;
+    delete process.env.FRIDAY_SYSTEM_ENABLED;
+    delete process.env.FRIDAY_SYSTEM_REMOTE_MODE;
+    delete process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT;
+    delete process.env.FRIDAY_SYSTEM_COMPANION_SOCKET_PATH;
+    delete process.env.FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN;
+    delete process.env.FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN_FILE;
+    try {
+      const hub = await createIsolatedHub();
+      const route = hub.apiRuntime.routes.getRoutes()
+        .find((entry) => entry.operationId === "system.session.get");
+      const runDir = path.join(lastStateDir ?? "", ".friday", "run");
+
+      expect(route).toBeUndefined();
+      expect(fs.existsSync(path.join(runDir, "system-companion.auth.token"))).toBe(false);
+      expect(fs.existsSync(path.join(runDir, "system-companion.sock"))).toBe(false);
+      await expect(hub.systemHealth()).resolves.toMatchObject({
+        enabled: false,
+        remoteMode: "unavailable",
+        companionReadiness: "unavailable",
+      });
+    } finally {
+      if (previousEnabled === undefined) {
+        delete process.env.FRIDAY_SYSTEM_ENABLED;
+      } else {
+        process.env.FRIDAY_SYSTEM_ENABLED = previousEnabled;
+      }
+      if (previousRemote === undefined) {
+        delete process.env.FRIDAY_SYSTEM_REMOTE_MODE;
+      } else {
+        process.env.FRIDAY_SYSTEM_REMOTE_MODE = previousRemote;
+      }
+      if (previousTransport === undefined) {
+        delete process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT;
+      } else {
+        process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT = previousTransport;
+      }
+      if (previousSocketPath === undefined) {
+        delete process.env.FRIDAY_SYSTEM_COMPANION_SOCKET_PATH;
+      } else {
+        process.env.FRIDAY_SYSTEM_COMPANION_SOCKET_PATH = previousSocketPath;
+      }
+      if (previousToken === undefined) {
+        delete process.env.FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN;
+      } else {
+        process.env.FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN = previousToken;
+      }
+      if (previousTokenFile === undefined) {
+        delete process.env.FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN_FILE;
+      } else {
+        process.env.FRIDAY_SYSTEM_COMPANION_AUTH_TOKEN_FILE = previousTokenFile;
+      }
+    }
+  });
+
 
   it("defaults local system runtime on while keeping remote disabled", async () => {
     const previousEnabled = process.env.FRIDAY_SYSTEM_ENABLED;

--- a/test/unit/hub/bootstrap/friday-capability-gates.test.ts
+++ b/test/unit/hub/bootstrap/friday-capability-gates.test.ts
@@ -7,7 +7,7 @@ describe("resolveFridayCapabilityGates", () => {
     const gates = resolveFridayCapabilityGates({});
 
     expect(gates.desktopEnabled).toBe(false);
-    expect(gates.systemEnabled).toBe(true);
+    expect(gates.systemEnabled).toBe(false);
     expect(gates.discoveryEnabled).toBe(false);
     expect(gates.mcpServerEnabled).toBe(false);
     expect(gates.heartbeatEnabled).toBe(false);

--- a/test/unit/hub/friday-hub-companion-bypass-sever.test.ts
+++ b/test/unit/hub/friday-hub-companion-bypass-sever.test.ts
@@ -85,14 +85,16 @@ describe("Barrier 5: sever guideLens/setupAssistant companion bypasses", () => {
   let managedSkillsDir: string | null = null;
   let autoDetectEnvSnapshot: FridayAutoDetectProviderEnvSnapshot | null = null;
   const originalSuppression = process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
+  const originalSystemEnabled = process.env.FRIDAY_SYSTEM_ENABLED;
   const originalTransport = process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT;
 
   beforeEach(() => {
     process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS = "1";
     // Use the local in-process companion bridge so the bridge is constructed
     // (non-undefined — proving the gate, not a vacuous undefined-everywhere pass) WITHOUT
-    // starting a unix-socket server. FRIDAY_SYSTEM_ENABLED is unset → systemEnabled true →
+    // starting a unix-socket server. FRIDAY_SYSTEM_ENABLED is explicitly true so
     // the bridge IS built.
+    process.env.FRIDAY_SYSTEM_ENABLED = "true";
     process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT = "in_process";
     autoDetectEnvSnapshot = clearAutoDetectProviderEnv();
     captured.guideLensBridge = undefined;
@@ -108,6 +110,11 @@ describe("Barrier 5: sever guideLens/setupAssistant companion bypasses", () => {
       delete process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS;
     } else {
       process.env.FRIDAY_SUPPRESS_TEST_ENV_SECURITY_WARNINGS = originalSuppression;
+    }
+    if (originalSystemEnabled === undefined) {
+      delete process.env.FRIDAY_SYSTEM_ENABLED;
+    } else {
+      process.env.FRIDAY_SYSTEM_ENABLED = originalSystemEnabled;
     }
     if (originalTransport === undefined) {
       delete process.env.FRIDAY_SYSTEM_COMPANION_TRANSPORT;


### PR DESCRIPTION
## Summary
- fail-close the NEW-40 system runtime capability gate so FRIDAY_SYSTEM_ENABLED must be explicitly true
- add default-off hub behavior coverage for no system route/token/socket
- re-point existing system/companion no-degrade tests to explicit FRIDAY_SYSTEM_ENABLED=true

## Red-first evidence
- red commit: b6ac0cf2 test(new40): expose system runtime fail-open default
- green commit: f3456f90 fix(new40): fail-close system runtime gate
- valid red: /Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new40-system-enabled-fail-closed-redfirst-20260702T1719-0700/red-focused-system-enabled-valid.log
- green: /Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new40-system-enabled-fail-closed-redfirst-20260702T1719-0700/green-focused-system-enabled-final.log
- broader no-degrade: /Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new40-system-enabled-fail-closed-redfirst-20260702T1719-0700/green-nodegrade-hub-system-set.log
- revert-red: /Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new40-system-enabled-fail-closed-redfirst-20260702T1719-0700/revert-green-focused-system-enabled.log

## Validation
- npx vitest run --project default test/unit/hub/bootstrap/friday-capability-gates.test.ts test/integration/hub/friday-hub-bootstrap-integration.test.ts -t "system runtime|safe defaults|companion socket setup"
- npx vitest run --project default test/unit/hub/bootstrap/friday-capability-gates.test.ts test/unit/hub/friday-hub-companion-bypass-sever.test.ts test/integration/hub/friday-hub-bootstrap-integration.test.ts
- npm run typecheck:src
- npx eslint src/hub/bootstrap/friday-capability-gates.ts test/unit/hub/bootstrap/friday-capability-gates.test.ts test/unit/hub/friday-hub-companion-bypass-sever.test.ts test/integration/hub/friday-hub-bootstrap-integration.test.ts
- git diff --check origin/main..HEAD

## Reviewers
- Reviewer Q: PASS (NEW40-review-Q-20260703T000000Z)
- Reviewer R: PASS (CODEX_THREAD_ID=019f255c-5b11-7252-ad45-e577358cf40b)

## Boundary
Low item, agent-doable. No --admin, no deploy/restart, no prod env change. Prod launchers remain explicit FRIDAY_SYSTEM_ENABLED=true; deploy/restart remains operator-owned.