### PR TITLE
Align UI-W1 served web tokens

### DIFF
--- a/test/unit/ui/desktop-token-contract.test.ts
+++ b/test/unit/ui/desktop-token-contract.test.ts
@@ -1,0 +1,81 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const uiSrcRoot = "ui/src";
+
+const readRepoFile = (path: string) => readFileSync(path, "utf8");
+
+function listSourceFiles(root: string): string[] {
+  const entries = readdirSync(root, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) return listSourceFiles(path);
+    if (!entry.isFile()) return [];
+    if (!/\.(css|tsx?)$/.test(path)) return [];
+    return [path];
+  });
+}
+
+describe("UI-W1 desktop token contract", () => {
+  it("exposes the operator-approved served-web token names and locked values", () => {
+    const tokens = readRepoFile("ui/src/styles/tokens.css");
+    const requiredTokens = new Map([
+      ["--app-bg", "#f7f6f2"],
+      ["--bg", "#f4f3f0"],
+      ["--bg-2", "#eceae6"],
+      ["--surface", "#ffffff"],
+      ["--surface-2", "#f6f5f2"],
+      ["--surface-3", "#efede9"],
+      ["--paper", "rgba(255,255,255,.74)"],
+      ["--paper-strong", "#ffffff"],
+      ["--ink", "#19211e"],
+      ["--ink-soft", "#3c4642"],
+      ["--muted", "#6c756f"],
+      ["--faint", "#97a09a"],
+      ["--line", "rgba(26,40,35,.12)"],
+      ["--hair", "rgba(26,40,35,.08)"],
+      ["--accent", "#0f7d8c"],
+      ["--accent-ink", "#0a5662"],
+      ["--accent-soft", "rgba(15,125,140,.12)"],
+      ["--coral", "#d8634d"],
+      ["--coral-soft", "rgba(216,99,77,.13)"],
+      ["--ok", "#277a5d"],
+      ["--ok-soft", "rgba(39,122,93,.12)"],
+      ["--warn", "#a86a1d"],
+      ["--warn-soft", "rgba(168,106,29,.13)"],
+      ["--danger", "#c2493f"],
+      ["--danger-soft", "rgba(194,73,63,.12)"],
+      ["--r-xl", "30px"],
+      ["--r-lg", "22px"],
+      ["--r-md", "15px"],
+      ["--r-sm", "11px"],
+    ]);
+
+    for (const [name, value] of requiredTokens) {
+      const pattern = new RegExp(`${name}\\s*:\\s*${value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*;`);
+      expect(tokens, `${name} must equal ${value}`).toMatch(pattern);
+    }
+  });
+
+  it("removes old Tailwind semantic color families from served web source", () => {
+    const bannedPattern = /\b(?:bg|border|text|ring|from|to|via|decoration|outline|shadow)-(?:emerald|amber|red|green|yellow|rose)-\d{2,3}(?:\/\d+)?\b/g;
+    const bannedLiteralPattern = /#(?:c77d2e|4f7a5c|128c9e|ed6b61|b87329)\b|rgba\(79,\s*122,\s*92,/gi;
+    const files = listSourceFiles(uiSrcRoot);
+    expect(files.length).toBeGreaterThan(0);
+
+    const violations = files.flatMap((file) => {
+      const source = readRepoFile(file);
+      const classHits = [...source.matchAll(bannedPattern)].map((match) => match[0]);
+      const literalHits = [...source.matchAll(bannedLiteralPattern)].map((match) => match[0]);
+      if (classHits.length === 0 && literalHits.length === 0) return [];
+      return `${relative(process.cwd(), file)}: ${[...classHits, ...literalHits].join(", ")}`;
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps the test scoped to the served web source tree", () => {
+    expect(statSync(uiSrcRoot).isDirectory()).toBe(true);
+  });
+});

--- a/ui/src/components/chat/autonomous-step-indicator.tsx
+++ b/ui/src/components/chat/autonomous-step-indicator.tsx
@@ -11,8 +11,8 @@ export interface AutonomousStepIndicatorProps {
 const DOT_CLASSES: Record<string, string> = {
   pending: "bg-[color:var(--color-text-faint)]",
   executing: "bg-[color:var(--color-accent)] animate-pulse",
-  completed: "bg-emerald-500",
-  failed: "bg-red-500",
+  completed: "bg-[color:var(--ok)]",
+  failed: "bg-[color:var(--danger)]",
 };
 
 export function AutonomousStepIndicator({ goal, locale }: AutonomousStepIndicatorProps) {
@@ -54,15 +54,15 @@ export function AutonomousStepIndicator({ goal, locale }: AutonomousStepIndicato
           <div className="flex items-center gap-1.5">
             {goal.status === "completed" ? (
               <>
-                <Check className="h-3.5 w-3.5 text-emerald-500" />
-                <span className="text-xs font-medium text-emerald-600">
+                <Check className="h-3.5 w-3.5 text-[color:var(--ok)]" />
+                <span className="text-xs font-medium text-[color:var(--ok)]">
                   {localize(locale, "完成", "Done")}
                 </span>
               </>
             ) : (
               <>
-                <X className="h-3.5 w-3.5 text-red-500" />
-                <span className="text-xs font-medium text-red-600">
+                <X className="h-3.5 w-3.5 text-[color:var(--danger)]" />
+                <span className="text-xs font-medium text-[color:var(--danger)]">
                   {localize(locale, "失败", "Failed")}
                 </span>
               </>

--- a/ui/src/components/chat/chat-audit-drawer.tsx
+++ b/ui/src/components/chat/chat-audit-drawer.tsx
@@ -50,9 +50,9 @@ const EVENT_DOTS: Record<string, string> = {
 
 const RECEIPT_TONE_CLASSES = {
   neutral: "border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] text-[color:var(--color-text-secondary)]",
-  warning: "border-amber-300 bg-amber-50 text-amber-900",
-  danger: "border-red-300 bg-red-50 text-red-900",
-  success: "border-emerald-300 bg-emerald-50 text-emerald-900",
+  warning: "border-[color:var(--warn-soft)] bg-[color:var(--warn-soft)] text-[color:var(--warn)]",
+  danger: "border-[color:var(--danger-soft)] bg-[color:var(--danger-soft)] text-[color:var(--danger)]",
+  success: "border-[color:var(--ok-soft)] bg-[color:var(--ok-soft)] text-[color:var(--ok)]",
 } as const;
 
 function formatPayload(event: RunAuditEvent): string {

--- a/ui/src/components/chat/chat-side-panel.tsx
+++ b/ui/src/components/chat/chat-side-panel.tsx
@@ -250,9 +250,9 @@ export function ChatSidePanel() {
                         key={step.id}
                         className={cn(
                           "h-1.5 w-1.5 rounded-full",
-                          step.status === "completed" ? "bg-emerald-500"
+                          step.status === "completed" ? "bg-[color:var(--ok)]"
                             : step.status === "executing" ? "bg-[color:var(--color-accent)] animate-pulse"
-                            : step.status === "failed" ? "bg-red-500"
+                            : step.status === "failed" ? "bg-[color:var(--danger)]"
                             : "bg-[color:var(--color-text-faint)]",
                         )}
                       />
@@ -333,7 +333,7 @@ export function ChatSidePanel() {
           </button>
         </div>
         <div className="mt-1.5 flex items-center gap-1.5 px-1">
-          <span className="h-[5px] w-[5px] rounded-full bg-emerald-400" />
+          <span className="h-[5px] w-[5px] rounded-full bg-[color:var(--ok)]" />
           <span className="text-[10px] text-[color:var(--color-text-faint)]">
             {queuedMessageCount > 0
               ? localize(locale, `已排队 ${queuedMessageCount} 条`, `${queuedMessageCount} queued`)

--- a/ui/src/components/chat/chat-tool-activity.tsx
+++ b/ui/src/components/chat/chat-tool-activity.tsx
@@ -31,9 +31,9 @@ function StatusBadge({ status }: { status: ToolCallViewModel["status"] }) {
         status === "running" &&
           "animate-pulse bg-[color:var(--color-accent-soft)] text-[color:var(--color-accent)]",
         status === "completed" &&
-          "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+          "bg-[color:var(--ok-soft)] text-[color:var(--ok)]",
         status === "failed" &&
-          "bg-red-500/10 text-red-600 dark:text-red-400",
+          "bg-[color:var(--danger-soft)] text-[color:var(--danger)]",
       )}
     >
       {status}
@@ -170,8 +170,8 @@ export function ChatToolActivity({ toolCalls, activeTool }: ChatToolActivityProp
                     call.status === "running"
                       ? "animate-pulse bg-[color:var(--color-accent)]"
                       : call.status === "completed"
-                        ? "bg-emerald-500"
-                        : "bg-red-500",
+                        ? "bg-[color:var(--ok)]"
+                        : "bg-[color:var(--danger)]",
                   )}
                 />
                 <span className="font-medium">{call.toolName}</span>

--- a/ui/src/components/console/shell/splash/shell.tsx
+++ b/ui/src/components/console/shell/splash/shell.tsx
@@ -10,7 +10,7 @@ export interface SplashAction {
 
 export interface SplashPill {
   label: string;
-  tone?: "neutral" | "amber" | "jade" | "rust";
+  tone?: "neutral" | "warn" | "ok" | "danger";
 }
 
 export interface SplashStep {
@@ -32,9 +32,9 @@ export interface SplashShellProps {
 
 const PILL_STYLE: Record<NonNullable<SplashPill["tone"]>, { background: string; color: string }> = {
   neutral: { background: "var(--surface-2)", color: "var(--ink-700)" },
-  amber: { background: "var(--accent-soft)", color: "var(--accent)" },
-  jade: { background: "rgba(79, 122, 92, 0.14)", color: "var(--ok)" },
-  rust: { background: "rgba(176, 80, 58, 0.14)", color: "var(--rust-500)" },
+  warn: { background: "var(--warn-soft)", color: "var(--warn)" },
+  ok: { background: "var(--ok-soft)", color: "var(--ok)" },
+  danger: { background: "var(--danger-soft)", color: "var(--danger)" },
 };
 
 const STEP_DOT: Record<NonNullable<SplashStep["status"]>, string> = {

--- a/ui/src/components/core/learning-insight-card.tsx
+++ b/ui/src/components/core/learning-insight-card.tsx
@@ -52,14 +52,14 @@ export function LearningInsightCard() {
       value: overview.coverage.patterns,
       label: localize(locale, "模式", "Patterns"),
       tone: "text-[color:var(--color-success)]",
-      bg: "bg-emerald-50",
+      bg: "bg-[color:var(--ok-soft)]",
     },
     {
       icon: Shield,
       value: autoFixBuckets.verifiedRepairs,
       label: localize(locale, "已验证修复", "Verified repairs"),
       tone: "text-[color:var(--color-warning)]",
-      bg: "bg-amber-50",
+      bg: "bg-[color:var(--warn-soft)]",
     },
     {
       icon: Brain,
@@ -238,8 +238,8 @@ export function LearningInsightCard() {
           )}
 
           {autoFixBuckets.recordedActions > 0 && overview.rollbackHotspots.length === 0 && (
-            <div className="mt-3 rounded-xl bg-emerald-50 px-3 py-2">
-              <p className="text-xs text-emerald-700">
+            <div className="mt-3 rounded-xl bg-[color:var(--ok-soft)] px-3 py-2">
+              <p className="text-xs text-[color:var(--ok)]">
                 {localize(
                   locale,
                   `Friday 已记录 ${String(autoFixBuckets.recordedActions)} 个修复动作，${String(autoFixBuckets.verifiedRepairs)} 个已验证完成。`,
@@ -250,8 +250,8 @@ export function LearningInsightCard() {
           )}
 
           {overview.rollbackHotspots.length > 0 && (
-            <div className="mt-3 rounded-xl bg-amber-50 px-3 py-2">
-              <p className="text-xs text-amber-700">
+            <div className="mt-3 rounded-xl bg-[color:var(--warn-soft)] px-3 py-2">
+              <p className="text-xs text-[color:var(--warn)]">
                 {localize(
                   locale,
                   `Friday 在 ${String(overview.rollbackHotspots.length)} 个地方尝试修复后发现效果不好，已自动撤销并在学习更好的方案。`,

--- a/ui/src/components/deeplink/deeplink-preview-dialog.tsx
+++ b/ui/src/components/deeplink/deeplink-preview-dialog.tsx
@@ -51,9 +51,9 @@ function buildDeepLinkRequestBody(input: string, confirmed?: boolean): DeepLinkR
 function checkLevelBadge(level: string) {
   switch (level) {
     case "blocking":
-      return <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 ">Blocking</span>;
+      return <span className="rounded-full bg-[color:var(--danger-soft)] px-2 py-0.5 text-xs font-medium text-[color:var(--danger)]">Blocking</span>;
     case "warning":
-      return <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 ">Warning</span>;
+      return <span className="rounded-full bg-[color:var(--warn-soft)] px-2 py-0.5 text-xs font-medium text-[color:var(--warn)]">Warning</span>;
     default:
       return <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-600 ">Advisory</span>;
   }
@@ -111,12 +111,12 @@ export function DeepLinkPreviewDialog(props: { onClose: () => void; onApplied?: 
         />
 
         {previewMutation.error ? (
-          <p className="mt-2 text-xs text-red-600 ">
+          <p className="mt-2 text-xs text-[color:var(--danger)]">
             {previewMutation.error instanceof Error ? previewMutation.error.message : "Preview failed"}
           </p>
         ) : null}
         {applyMutation.error ? (
-          <p className="mt-2 text-xs text-red-600 ">
+          <p className="mt-2 text-xs text-[color:var(--danger)]">
             {applyMutation.error instanceof Error ? applyMutation.error.message : "Import failed"}
           </p>
         ) : null}
@@ -138,11 +138,11 @@ export function DeepLinkPreviewDialog(props: { onClose: () => void; onApplied?: 
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium text-[color:var(--color-text-primary)]">{preview.payload.label}</span>
               {preview.verdict === "ready" ? (
-                <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700 ">Ready</span>
+                <span className="rounded-full bg-[color:var(--ok-soft)] px-2 py-0.5 text-xs font-medium text-[color:var(--ok)]">Ready</span>
               ) : preview.verdict === "needs_review" ? (
-                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 ">Needs Review</span>
+                <span className="rounded-full bg-[color:var(--warn-soft)] px-2 py-0.5 text-xs font-medium text-[color:var(--warn)]">Needs Review</span>
               ) : (
-                <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 ">Blocked</span>
+                <span className="rounded-full bg-[color:var(--danger-soft)] px-2 py-0.5 text-xs font-medium text-[color:var(--danger)]">Blocked</span>
               )}
             </div>
 
@@ -169,7 +169,7 @@ export function DeepLinkPreviewDialog(props: { onClose: () => void; onApplied?: 
             ) : null}
 
             {applyResult ? (
-              <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-800">
+              <div className="rounded-lg border border-[color:var(--ok-soft)] bg-[color:var(--ok-soft)] p-2 text-xs text-[color:var(--ok)]">
                 {applyResult.message}
               </div>
             ) : null}

--- a/ui/src/components/setup/friday-readiness-summary.tsx
+++ b/ui/src/components/setup/friday-readiness-summary.tsx
@@ -222,8 +222,8 @@ export function buildFridayReadinessSummary(
 }
 
 function toneClass(tone: ReadinessBucket["tone"]): string {
-  if (tone === "success") return "border-emerald-200 bg-emerald-50 text-emerald-900";
-  if (tone === "warning") return "border-amber-200 bg-amber-50 text-amber-950";
+  if (tone === "success") return "border-[color:var(--ok-soft)] bg-[color:var(--ok-soft)] text-[color:var(--ok)]";
+  if (tone === "warning") return "border-[color:var(--warn-soft)] bg-[color:var(--warn-soft)] text-[color:var(--warn)]";
   return "border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] text-[color:var(--color-text-primary)]";
 }
 

--- a/ui/src/components/workflows/workflow-builder-right-sidebar.tsx
+++ b/ui/src/components/workflows/workflow-builder-right-sidebar.tsx
@@ -499,7 +499,7 @@ function DraftInspector(props: {
         />
       </label>
       {props.externalDraftReviewRequired ? (
-        <label className="flex items-start gap-3 rounded-[18px] border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+        <label className="flex items-start gap-3 rounded-[18px] border border-[color:var(--warn-soft)] bg-[color:var(--warn-soft)] p-3 text-xs text-[color:var(--warn)]">
           <input
             type="checkbox"
             data-testid="workflow-builder-external-draft-review-confirm"

--- a/ui/src/routes/channels-page.tsx
+++ b/ui/src/routes/channels-page.tsx
@@ -489,14 +489,14 @@ export function ChannelsPage() {
                       isActive
                         ? "bg-[color:var(--color-accent-soft)]"
                         : needsAttention
-                          ? "bg-red-50/50"
+                          ? "bg-[color:var(--danger-soft)]"
                           : "hover:bg-[color:var(--color-bg-subtle)]"
                     }`}
                   >
                     <span className="relative text-lg">
                       {safeChannelEmoji(chKind)}
                       {needsAttention && (
-                        <span className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border-2 border-white bg-red-500" />
+                        <span className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border-2 border-white bg-[color:var(--danger)]" />
                       )}
                     </span>
                     <div className="min-w-0 flex-1">

--- a/ui/src/routes/mcp-page.tsx
+++ b/ui/src/routes/mcp-page.tsx
@@ -22,9 +22,9 @@ function statusBadge(status: string | undefined, locale: import("@/lib/i18n/loca
     case "deferred":
       return <span className="inline-flex items-center gap-1 rounded-full bg-[color:var(--color-bg-subtle)] px-2 py-0.5 text-xs font-medium text-[color:var(--color-text-secondary)]">{localize(locale, "待加载", "Deferred")}</span>;
     case "error":
-      return <span className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium status-error">{localize(locale, "错误", "Error")}</span>;
+      return <span className="inline-flex items-center gap-1 rounded-full bg-[color:var(--danger-soft)] px-2 py-0.5 text-xs font-medium status-error">{localize(locale, "错误", "Error")}</span>;
     case "disconnected":
-      return <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium status-warning">{localize(locale, "已断开", "Disconnected")}</span>;
+      return <span className="inline-flex items-center gap-1 rounded-full bg-[color:var(--warn-soft)] px-2 py-0.5 text-xs font-medium status-warning">{localize(locale, "已断开", "Disconnected")}</span>;
     default:
       return <span className="inline-flex items-center gap-1 rounded-full bg-[color:var(--color-bg-subtle)] px-2 py-0.5 text-xs font-medium text-[color:var(--color-text-tertiary)]">{localize(locale, "未知", "Unknown")}</span>;
   }

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -1184,7 +1184,7 @@ export function SettingsPage() {
                   {connectOAuth.status === "starting" || connectOAuth.status === "completing" ? (
                     <RefreshCw className="mt-0.5 h-4 w-4 animate-spin text-[color:var(--color-accent)]" />
                   ) : connectOAuth.status === "connected" ? (
-                    <CheckCircle2 className="mt-0.5 h-4 w-4 text-green-700" />
+                    <CheckCircle2 className="mt-0.5 h-4 w-4 text-[color:var(--ok)]" />
                   ) : (
                     <KeyRound className="mt-0.5 h-4 w-4 text-[color:var(--color-accent)]" />
                   )}
@@ -1217,7 +1217,7 @@ export function SettingsPage() {
                       </div>
                     ) : null}
                     {connectOAuth.status === "error" && connectOAuth.message ? (
-                      <p className="mt-2 text-xs font-medium text-red-700">{connectOAuth.message}</p>
+                      <p className="mt-2 text-xs font-medium text-[color:var(--danger)]">{connectOAuth.message}</p>
                     ) : null}
                   </div>
                 </div>

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -1919,12 +1919,12 @@ export function SetupPage() {
                   </div>
                 ) : null}
                 {openAICodexOAuth.status === "connected" ? (
-                  <p className="mt-3 text-xs font-medium text-green-700">
+                  <p className="mt-3 text-xs font-medium text-[color:var(--ok)]">
                     {localize(locale, "已连接，可以继续。", "Connected. You can continue.")}
                   </p>
                 ) : null}
                 {openAICodexOAuth.status === "error" && openAICodexOAuth.message ? (
-                  <p className="mt-3 text-xs font-medium text-red-700">{openAICodexOAuth.message}</p>
+                  <p className="mt-3 text-xs font-medium text-[color:var(--danger)]">{openAICodexOAuth.message}</p>
                 ) : null}
               </div>
             </div>
@@ -1948,9 +1948,9 @@ export function SetupPage() {
         {providerFeedback.status !== "idle" && (
           <div className={`mt-5 w-full max-w-md rounded-2xl border px-4 py-3 text-left shadow-sm ${
             providerFeedback.status === "error"
-              ? "border-red-200 bg-red-50"
+              ? "border-[color:var(--danger-soft)] bg-[color:var(--danger-soft)]"
               : providerFeedback.status === "saved"
-                ? "border-green-200 bg-green-50"
+                ? "border-[color:var(--ok-soft)] bg-[color:var(--ok-soft)]"
                 : "border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)]"
           }`}
           >
@@ -1958,16 +1958,16 @@ export function SetupPage() {
               {providerFeedback.status === "checking" ? (
                 <RefreshCw className="mt-0.5 h-4 w-4 animate-spin text-[color:var(--color-accent)]" />
               ) : providerFeedback.status === "saved" ? (
-                <CheckCircle2 className="mt-0.5 h-4 w-4 text-green-700" />
+                <CheckCircle2 className="mt-0.5 h-4 w-4 text-[color:var(--ok)]" />
               ) : (
-                <AlertCircle className="mt-0.5 h-4 w-4 text-red-700" />
+                <AlertCircle className="mt-0.5 h-4 w-4 text-[color:var(--danger)]" />
               )}
               <div className="min-w-0">
                 <p className={`text-sm font-semibold ${
                   providerFeedback.status === "error"
-                    ? "text-red-900"
+                    ? "text-[color:var(--danger)]"
                     : providerFeedback.status === "saved"
-                      ? "text-green-900"
+                      ? "text-[color:var(--ok)]"
                       : "text-[color:var(--color-text-primary)]"
                 }`}
                 >
@@ -1979,9 +1979,9 @@ export function SetupPage() {
                 </p>
                 <p className={`mt-1 text-xs leading-5 ${
                   providerFeedback.status === "error"
-                    ? "text-red-800"
+                    ? "text-[color:var(--danger)]"
                     : providerFeedback.status === "saved"
-                      ? "text-green-800"
+                      ? "text-[color:var(--ok)]"
                       : "text-[color:var(--color-text-secondary)]"
                 }`}
                 >

--- a/ui/src/routes/workflows-page.tsx
+++ b/ui/src/routes/workflows-page.tsx
@@ -86,9 +86,9 @@ function normalizeGraphStatus(status?: string): WorkflowGraphNodeStatus {
 }
 
 function graphStatusClass(status: WorkflowGraphNodeStatus): string {
-  if (status === "completed") return "border-emerald-400/60 bg-emerald-500/10";
-  if (status === "failed" || status === "cancelled") return "border-red-400/60 bg-red-500/10";
-  if (status === "running" || status === "queued" || status === "paused") return "border-amber-400/70 bg-amber-500/10";
+  if (status === "completed") return "border-[color:var(--ok-soft)] bg-[color:var(--ok-soft)]";
+  if (status === "failed" || status === "cancelled") return "border-[color:var(--danger-soft)] bg-[color:var(--danger-soft)]";
+  if (status === "running" || status === "queued" || status === "paused") return "border-[color:var(--warn-soft)] bg-[color:var(--warn-soft)]";
   return "border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface-strong)]";
 }
 
@@ -486,7 +486,7 @@ export function WorkflowsPage() {
                 <p className="mt-2 text-base font-semibold text-[color:var(--color-text-primary)]">{attentionSummary.title}</p>
                 <p className="mt-3 text-sm leading-6 text-[color:var(--color-text-secondary)]">{attentionSummary.summary}</p>
                 {latestDraftRequiresExternalReview ? (
-                  <label className="mt-4 flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+                  <label className="mt-4 flex items-start gap-3 rounded-2xl border border-[color:var(--warn-soft)] bg-[color:var(--warn-soft)] p-3 text-xs text-[color:var(--warn)]">
                     <input
                       type="checkbox"
                       data-testid="workflow-operator-external-draft-review-confirm"

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,500;0,600;0,700;1,500;1,600&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700;800&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,500;0,600;0,700;1,500;1,600&family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap");
 @import "tailwindcss";
 @import "./tokens.css";
 

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -8,10 +8,40 @@
  */
 
 :root {
+  /* ── Canonical gallery tokens (UI-W1) ── */
+  --app-bg: #f7f6f2;
+  --bg: #f4f3f0;
+  --bg-2: #eceae6;
+  --surface: #ffffff;
+  --surface-2: #f6f5f2;
+  --surface-3: #efede9;
+  --paper: rgba(255,255,255,.74);
+  --paper-strong: #ffffff;
+  --ink: #19211e;
+  --ink-soft: #3c4642;
+  --muted: #6c756f;
+  --faint: #97a09a;
+  --line: rgba(26,40,35,.12);
+  --hair: rgba(26,40,35,.08);
+  --accent-ink: #0a5662;
+  --accent-soft: rgba(15,125,140,.12);
+  --coral-soft: rgba(216,99,77,.13);
+  --ok-soft: rgba(39,122,93,.12);
+  --warn-soft: rgba(168,106,29,.13);
+  --danger-soft: rgba(194,73,63,.12);
+  --r-xl: 30px;
+  --r-lg: 22px;
+  --r-md: 15px;
+  --r-sm: 11px;
+  --shadow-soft: 0 1px 2px rgba(16,28,24,.05);
+  --shadow-pop: 0 18px 48px -20px rgba(16,28,24,.3);
+  --shadow-device: 0 40px 90px -36px rgba(16,28,24,.45), 0 8px 24px -12px rgba(16,28,24,.25);
+  --font-desktop: "Space Grotesk", -apple-system, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+
   /* ── Surfaces ── */
-  --surface-0: #f7f6f2; /* page background */
+  --surface-0: var(--app-bg); /* page background */
   --surface-1: rgba(255, 255, 255, 0.68); /* chrome / elevated panel */
-  --surface-2: rgba(255, 255, 255, 0.78); /* cards / floating */
+  --surface-card: rgba(255, 255, 255, 0.78); /* cards / floating */
   --surface-glass: rgba(255, 255, 255, 0.54);
   --surface-glass-strong: rgba(255, 255, 255, 0.76);
   --surface-border: rgba(18, 40, 45, 0.10);
@@ -24,10 +54,8 @@
 
   /* ── Locked cyan/coral action system ── */
   --accent: #0f7d8c;
-  --accent-soft: rgba(15, 125, 140, 0.12);
   --accent-muted: rgba(15, 125, 140, 0.07);
   --coral: #d8634d;
-  --coral-soft: rgba(216, 99, 77, 0.14);
 
   /* ── Truth colors ── */
   --ok: #277a5d;


### PR DESCRIPTION
## Summary
- add a red-first UI-W1 token contract for canonical served-web tokens and forbidden old semantic Tailwind color families in `ui/src`
- add the operator-approved token layer in `ui/src/styles/tokens.css` and Space Grotesk import
- replace detected `emerald`/`amber`/`red`/`green` served-web status classes with token-backed `--ok`, `--warn`, and `--danger` variants

## Red-first evidence
- red commit: `9c2fb0cbcefd203b4220d4feef615eedf2c341d0`
- green commit: `1e87fe883c4a677a6caffaec14954f16e96fc09e`
- evidence: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w1-token-contract-redfirst-20260702T2145-0700`
- valid logs: `red-focused.exit=1`, `green-focused-ui.exit=0`, `green-typecheck-src.exit=0`, `green-build-ui.exit=0`, `green-diff-check.exit=0`, `revert-red-focused.exit=1`

## Reviewers
- Reviewer UI-A: `reviewer-ui-a.md`, verdict `PASS_WITH_RESIDUAL_NOTE`
- Reviewer UI-B: `reviewer-ui-b.md`, verdict `PASS`

## Boundary
- Med UI token-layer prerequisite only; no screen completion claim
- no `src/`, `rust-core`, scripts, prod env, DB, deploy, restart, or #1453 files touched
- broad served-ui fidelity still fails Gate C2 pet reference residuals only; see `broad-served-ui-design-fidelity-green-head-residual.log` / `.exit=1` and do not count it as green evidence for this PR
