### PR TITLE
Remove Anthropic OAuth setup advertising

### DIFF
--- a/src/providers/model/friday-provider-templates.ts
+++ b/src/providers/model/friday-provider-templates.ts
@@ -55,7 +55,7 @@ const TEMPLATE_META: Partial<Record<FridayProviderKind, FridayProviderTemplateMe
   },
   anthropic: {
     displayName: "Anthropic API",
-    description: "Claude HTTP path with support for API keys, OAuth, and setup tokens inside Friday's supervised runtime.",
+    description: "Claude HTTP path with API key authentication inside Friday's supervised runtime.",
     tier: "official",
     status: "ready",
     modelDefaults: {

--- a/test/unit/providers/model/friday-provider-templates.test.ts
+++ b/test/unit/providers/model/friday-provider-templates.test.ts
@@ -88,4 +88,12 @@ describe("friday-provider-templates", () => {
       });
     }
   });
+
+  it("does not advertise Anthropic OAuth or setup-token onboarding", () => {
+    const anthropic = getFridayProviderTemplate("anthropic");
+
+    expect(anthropic?.description).toContain("API key");
+    expect(anthropic?.description).not.toMatch(/oauth|setup tokens?/i);
+    expect(anthropic?.authModes).toEqual(["api-key"]);
+  });
 });

--- a/test/unit/ui/setup-provider-regressions.test.ts
+++ b/test/unit/ui/setup-provider-regressions.test.ts
@@ -115,6 +115,16 @@ describe("setup provider regressions", () => {
     expect(providerTruthHookSource).toContain("moonshot|kimi|月之暗面");
   });
 
+  it("does not advertise Anthropic OAuth or setup-token onboarding in the setup recommendation", () => {
+    const setupSource = readFileSync("ui/src/routes/setup-page.tsx", "utf8");
+
+    expect(setupSource).toContain('case "anthropic"');
+    expect(setupSource).toContain('auth: "API key"');
+    expect(setupSource).not.toContain('auth: "API key, token/setup-token, or OAuth"');
+    expect(setupSource).not.toContain("Anthropic OAuth");
+    expect(setupSource).not.toContain("Anthropic setup-token");
+  });
+
   it("keeps mission workbench empty state user-facing instead of engineering-unavailable copy", () => {
     const missionWorkbenchSource = readFileSync("ui/src/routes/mission-workbench-page.tsx", "utf8");
 

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -265,7 +265,7 @@ export function getProviderBootstrapRecommendation(kind: ProviderKind): SetupPro
     case "anthropic":
       return {
         backend: "HTTP first, Claude CLI optional later",
-        auth: "API key, token/setup-token, or OAuth",
+        auth: "API key",
         why: "Anthropic HTTP keeps tool-capable runs and verification inside Friday while Claude CLI stays a text-only backend.",
         boundary: "Claude CLI should not be treated as a native-tool backend for runs that require Friday tools.",
         operatorNote: "Attach Claude CLI later in Settings when you want a consumer-plan text route beside the HTTP provider.",


### PR DESCRIPTION
## Summary
- Remove Anthropic OAuth/setup-token advertising from provider template copy and setup recommendation.
- Add regressions covering both provider template and setup-page Anthropic recommendation surfaces.

## Red-first evidence
- Red commit: `60751007` only adds tests.
- Green commit: `a1a73b78` only changes `src/providers/model/friday-provider-templates.ts` and `ui/src/routes/setup-page.tsx`.
- Evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/max-add2-anthropic-oauth-truth-redfirst-20260703T0545-0700/`
- Red: `red-anthropic-oauth-ad-copy.exit=1`
- Green focused: `green-anthropic-oauth-ad-copy-valid.exit=0`
- No-degrade: `green-anthropic-auth-no-degrade-valid.exit=0`
- Product grep skeptic: `green-anthropic-oauth-product-grep-skeptic.exit=1` with empty log
- Revert-red: `revert-red-anthropic-oauth-ad-copy.exit=1`

## Independent review
- Reviewer A: Dewey the 2nd, session `019f2803-532b-7313-8c07-6f2e1e547685`, PASS.
- Reviewer B: Zeno the 2nd, session `019f2803-6b9d-7f12-9362-4566fc66dbb0`, PASS.

## No-degrade
- Anthropic remains API-key-only in setup/template copy.
- Existing Anthropic OAuth fail-closed/service/capability behavior remains covered by no-degrade tests.
- OpenAI Codex OAuth and non-Anthropic OAuth/channel authorization copy were not removed.
- Runtime/S2/High/prod/deploy/operator-signature surfaces untouched.
