### PR TITLE
Mark OpenAI Codex OAuth route live in SoT

### DIFF
--- a/docs/current-source-of-truth.md
+++ b/docs/current-source-of-truth.md
@@ -264,7 +264,7 @@ This document is the current architecture reference for steady-state Friday runt
 - Scope taxonomy is defined by the current auth model, including `security.read` / `security.write`, `fleet.read`, `diagnosis.read` / `diagnosis.write`, and the workflow, skill, plugin, and session scopes present in `src/api/model/friday-api-auth.types.ts`.
 - Provider kind and routing semantics are defined by the current provider model and cost-routing types. `openai-compatible` and `google` are canonical provider kinds; historical SSD wording around `"custom"` providers is not the active contract.
 - Anthropic provider auth is API-key only. Anthropic OAuth/bearer/token paths remain fail-closed compatibility surfaces and must not be advertised as supported provider auth modes.
-- OpenAI subscription/Codex account sign-in is **not** a current steady-state auth surface for Friday's `api.openai.com` provider path. The active OpenAI provider contract remains API-scoped `api-key` / `bearer-token` credentials. Subscription-based Codex access should be treated as a future Codex client/backend integration rather than a drop-in OAuth mode for the current HTTP provider path.
+- OpenAI Codex device OAuth is a current user-owned subscription-auth route for the separate `openai-codex` provider kind: `POST /v1/auth/oauth/openai-codex/device/initiate` and `POST /v1/auth/oauth/openai-codex/device/complete` are live provider OAuth surfaces. The `api.openai.com` provider path remains API-scoped `api-key` / `bearer-token`; Codex subscription auth must not be described as a drop-in OAuth mode for that OpenAI API provider.
 
 ## Deep link protocol
 

--- a/test/unit/docs/current-source-of-truth-openai-codex.test.ts
+++ b/test/unit/docs/current-source-of-truth-openai-codex.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("current-source-of-truth OpenAI Codex subscription auth copy", () => {
+  it("marks the live OpenAI Codex device OAuth route as current rather than future-only", () => {
+    const sot = readFileSync("docs/current-source-of-truth.md", "utf8");
+    const providerRoutes = readFileSync("src/api/http/routes/friday-provider-routes.ts", "utf8");
+
+    expect(providerRoutes).toContain('operationId: "auth.oauth.openai.codex.device.initiate"');
+    expect(providerRoutes).toContain('operationId: "auth.oauth.openai.codex.device.complete"');
+    expect(providerRoutes).toContain('path: "/v1/auth/oauth/openai-codex/device/initiate"');
+    expect(providerRoutes).toContain('path: "/v1/auth/oauth/openai-codex/device/complete"');
+
+    expect(sot).toContain("OpenAI Codex device OAuth");
+    expect(sot).toContain("/v1/auth/oauth/openai-codex/device/initiate");
+    expect(sot).not.toContain("Subscription-based Codex access should be treated as a future Codex client/backend integration");
+    expect(sot).not.toContain("OpenAI subscription/Codex account sign-in is **not** a current steady-state auth surface");
+  });
+});


### PR DESCRIPTION
## Summary
- Update `docs/current-source-of-truth.md` to mark OpenAI Codex device OAuth as a current `openai-codex` provider route.
- Preserve the boundary that `api.openai.com` provider auth remains API key / bearer token and Codex subscription auth is not a drop-in OpenAI API OAuth mode.
- Add a docs-code consistency regression against the live provider route operationIds and paths.

## Red-first evidence
- Red commit: `6e5ada5c` only adds `test/unit/docs/current-source-of-truth-openai-codex.test.ts`.
- Green commit: `ee801387` only updates `docs/current-source-of-truth.md`.
- Evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/max-add3-codex-sot-live-redfirst-20260703T0553-0700/`
- Red: `red-codex-sot-live.exit=1`
- Green focused: `green-codex-sot-live.exit=0`
- No-degrade: `green-codex-provider-routes-no-degrade.exit=0`
- Grep skeptic: `green-codex-sot-grep-skeptic.exit=1` with empty log
- Revert-red: `revert-red-codex-sot-live.exit=1`

## Independent review
- Reviewer A: Goodall the 2nd, session `019f2809-e002-7741-924d-390904603cfc`, PASS.
- Reviewer B: Euclid the 2nd, session `019f2809-fad5-7c21-9c58-4ae70a3a80a6`, PASS.

## No-degrade
- Provider routes/service/OpenAI Codex OAuth tests remain green.
- Runtime auth/S2/High/prod/deploy/operator-signature surfaces untouched.
