### PR TITLE
Attribute Clawdbot reference sources

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -13,6 +13,9 @@ ported from, or designed for compatibility with OpenClaw / Clawdbot behavior,
 including legacy SKILL.md compatibility, agent runtime references, scheduler
 guard behavior, and benchmark/adoption materials.
 
+The vendored TypeScript reference files under `docs/clawdbot-reference/` are
+covered by `docs/clawdbot-reference/NOTICE.md`.
+
 Original copyright and license notice:
 
 MIT License

--- a/docs/byok-design.md
+++ b/docs/byok-design.md
@@ -172,6 +172,8 @@ Validation-on-save behavior:
 
 ## 4. Clawdbot reuse map
 
+Attribution for retained reference files lives in `docs/clawdbot-reference/NOTICE.md`.
+
 | Clawdbot source | Reuse | Friday adaptation |
 |---|---|---|
 | `<openclaw-repo>/src/config/zod-schema.core.ts:35-70` and `<openclaw-repo>/src/config/zod-schema.core.ts:84-91` | `ModelDefinitionSchema`, `ModelProviderSchema`, `ModelsConfigSchema` structure. | Keep field shapes (`baseUrl`, `auth`, `models`, `api`) but persist in SQLite row + `config_json` instead of file config tree. |

--- a/docs/clawdbot-reference/NOTICE.md
+++ b/docs/clawdbot-reference/NOTICE.md
@@ -1,0 +1,26 @@
+# OpenClaw / Clawdbot Reference Attribution
+
+The TypeScript files in this directory are retained as historical reference
+material for Friday's BYOK and agent-runtime compatibility work. They are not
+compiled into Friday's runtime.
+
+These reference files were derived from or preserved to compare against
+OpenClaw / Clawdbot source material:
+
+- `attempt.ts`
+- `bash-tools-exec.ts`
+- `pi-embedded-subscribe-tools.ts`
+- `pi-embedded-subscribe.ts`
+- `sessions-spawn-tool.ts`
+- `subagent-registry.ts`
+- `tools-common.ts`
+- `workspace.ts`
+
+Upstream project: OpenClaw / Clawdbot
+
+License: MIT License
+
+Original copyright notice: Copyright (c) 2025 Peter Steinberger
+
+Friday's repository-level `NOTICE` file preserves the full upstream MIT license
+text for OpenClaw / Clawdbot material.

--- a/test/unit/docs/clawdbot-reference-attribution.test.ts
+++ b/test/unit/docs/clawdbot-reference-attribution.test.ts
@@ -1,0 +1,32 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const referenceDir = "docs/clawdbot-reference";
+const noticePath = join(referenceDir, "NOTICE.md");
+
+describe("Clawdbot reference attribution", () => {
+  it("keeps vendored Clawdbot reference files covered by an explicit attribution notice", () => {
+    const referenceFiles = readdirSync(referenceDir)
+      .filter((file) => file.endsWith(".ts"))
+      .sort();
+
+    expect(referenceFiles).toHaveLength(8);
+    expect(existsSync(noticePath)).toBe(true);
+
+    const notice = readFileSync(noticePath, "utf8");
+    expect(notice).toContain("OpenClaw / Clawdbot");
+    expect(notice).toContain("MIT License");
+    expect(notice).toMatch(/Copyright \(c\) 2025 Peter Steinberger/);
+
+    for (const file of referenceFiles) {
+      expect(notice).toContain(file);
+    }
+  });
+
+  it("links the BYOK reuse map to the attribution notice", () => {
+    const byokDesign = readFileSync("docs/byok-design.md", "utf8");
+
+    expect(byokDesign).toContain("docs/clawdbot-reference/NOTICE.md");
+  });
+});


### PR DESCRIPTION
CXM-10 / MAX-ADD-4 tail, Low.\n\nRed-first preserved after rebase onto origin/main=17fe73d3:\n- red: 0cadc58a test(cxm10): expose Clawdbot attribution gap\n- green: 6a911d80 fix(cxm10): attribute Clawdbot reference sources\n\nLocal gates:\n- npx vitest run test/unit/docs/clawdbot-reference-attribution.test.ts --reporter=verbose\n- git diff --check HEAD~2..HEAD\n\nScope: NOTICE/docs attribution only; no runtime, prod, deploy, S2, or High files touched. Open PR file-overlap checked against #1465 and #1468: none.