### PR TITLE
Honor FRIDAY_PORT in Docker healthcheck

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,6 +63,6 @@ ENV FRIDAY_PORT=3141
 EXPOSE 3141
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:3141/v1/health || exit 1
+  CMD curl -f "http://localhost:${FRIDAY_PORT:-3141}/v1/health" || exit 1
 
 CMD ["node", "dist/cli/friday-cli.js", "start"]

--- a/test/unit/docker/dockerfile-healthcheck.test.ts
+++ b/test/unit/docker/dockerfile-healthcheck.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+describe("Docker runtime healthcheck", () => {
+  it("uses FRIDAY_PORT instead of hard-coding the default port", () => {
+    const dockerfile = fs.readFileSync(path.join(REPO_ROOT, "docker", "Dockerfile"), "utf8");
+    const healthcheck = dockerfile
+      .split("\n")
+      .filter((line, index, lines) => {
+        return line.includes("HEALTHCHECK") || lines[index - 1]?.includes("HEALTHCHECK");
+      })
+      .join("\n");
+
+    expect(healthcheck).toContain("FRIDAY_PORT");
+    expect(healthcheck).not.toContain("http://localhost:3141/v1/health");
+  });
+});


### PR DESCRIPTION
MASTER-HANDOFF-070 / MAX-ADD-4 tail, Low.\n\nRed-first preserved after rebase onto origin/main=43e11ac9:\n- red: 4f8e19f9 test(master070): expose docker healthcheck fixed port\n- green: 216274ab fix(master070): honor friday port in docker healthcheck\n\nLocal gates:\n- npx vitest run test/unit/docker/dockerfile-healthcheck.test.ts --reporter=verbose\n- git diff --check HEAD~2..HEAD\n\nScope: docker healthcheck port truth only; no runtime, prod deploy/restart, S2, or High files touched. Open PR file-overlap checked against #1465 and #1468: none.