### PR TITLE
Qualify memory empty-state learning copy

### DIFF
--- a/test/unit/ui/ui-truth-regressions.test.ts
+++ b/test/unit/ui/ui-truth-regressions.test.ts
@@ -113,6 +113,9 @@ describe("ui truth regressions", () => {
     expect(memoryPage).toContain("Confidence boost");
     expect(memoryPage).toContain("lastAccessedAt");
     expect(memoryPage).toContain("automatic recall still follows permission, ranking, and context boundaries");
+    expect(memoryPage).not.toContain("Friday will learn as you interact.");
+    expect(memoryPage).not.toContain("会在你使用过程中自动学习");
+    expect(memoryPage).toContain("review or enabled learning flows save them");
   });
 
   it("keeps homepage repair copy inside the supervised proof boundary", () => {

--- a/ui/src/routes/memory-page.tsx
+++ b/ui/src/routes/memory-page.tsx
@@ -223,7 +223,11 @@ export function MemoryPage() {
             <p className="text-sm text-[color:var(--color-text-secondary)]">
               {activeSearch
                 ? localize(locale, "没有匹配的记忆。", "No memories match your search.")
-                : localize(locale, "暂无记忆。Friday 会在你使用过程中自动学习。", "No memories stored yet. Friday will learn as you interact.")}
+                : localize(
+                  locale,
+                  "暂无记忆。经审核或已启用的学习流程保存后，新记忆会显示在这里。",
+                  "No memories stored yet. New memories appear here after review or enabled learning flows save them.",
+                )}
             </p>
           </div>
         </ShellCard>


### PR DESCRIPTION
MASTER-HANDOFF-070 / MAX-ADD-4 tail, Low.\n\nRed-first preserved after rebase onto origin/main=b03bf449:\n- red: 2908c785 test(master070): expose memory empty-state overclaim\n- green: 856c7601 fix(master070): qualify memory empty-state learning copy\n\nLocal gates:\n- npx vitest run test/unit/ui/ui-truth-regressions.test.ts --reporter=verbose\n- git diff --check HEAD~2..HEAD\n\nScope: UI empty-state truth copy only; no memory runtime enablement, prod deploy/restart, S2, or High files touched. Open PR file-overlap checked against #1465 and #1468: none.