### PR TITLE
Avoid duplicate Claude keychain lookup

### DIFF
--- a/scripts/ops/friday-claude-mission-proof-of-life-keychain.sh
+++ b/scripts/ops/friday-claude-mission-proof-of-life-keychain.sh
@@ -52,10 +52,13 @@ passphrase_file_ok() {
 }
 
 read_provisioned_passphrase() {
-  if command -v security >/dev/null 2>&1 \
-    && security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w >/dev/null 2>&1; then
-    security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w
-    return 0
+  if command -v security >/dev/null 2>&1; then
+    local keychain_passphrase
+    if keychain_passphrase="$(security find-generic-password -a "${KEYCHAIN_ACCOUNT}" -s "${KEYCHAIN_SERVICE}" -w 2>/dev/null)" \
+      && [ -n "${keychain_passphrase}" ]; then
+      printf '%s\n' "${keychain_passphrase}"
+      return 0
+    fi
   fi
 
   if passphrase_file_ok; then

--- a/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
+++ b/test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts
@@ -1,6 +1,14 @@
-import { readFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { spawnSync } from "node:child_process";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = process.cwd();
@@ -208,5 +216,78 @@ describe("Claude mission proof operator gate", () => {
     ).toBeLessThan(
       source.indexOf('PASSPHRASE="$(read_provisioned_passphrase)"'),
     );
+  });
+
+  it("uses one keychain lookup before streaming the passphrase to proof", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "friday-claude-keychain-"));
+    try {
+      const binDir = join(tempRoot, "bin");
+      const fakeSecurityCount = join(tempRoot, "security-count");
+      const wrapperPath = join(
+        tempRoot,
+        "friday-claude-mission-proof-of-life-keychain.sh",
+      );
+      const fakeProofPath = join(
+        tempRoot,
+        "friday-claude-mission-proof-of-life.sh",
+      );
+      const fakeSecurityPath = join(binDir, "security");
+
+      mkdirSync(binDir);
+      writeFileSync(wrapperPath, readFileSync(keychainWrapper, "utf8"));
+      chmodSync(wrapperPath, 0o700);
+      writeFileSync(
+        fakeProofPath,
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${FRIDAY_CLAUDE_MISSION_PROOF_PREFLIGHT_ONLY:-0}" = "1" ]; then
+  echo "preflight-ok"
+  exit 0
+fi
+if [ "\${FRIDAY_CLAUDE_MISSION_PROOF_PASSPHRASE_STDIN:-0}" != "1" ]; then
+  echo "missing stdin mode" >&2
+  exit 12
+fi
+IFS= read -r passphrase
+printf 'proof-passphrase=%s\\n' "\${passphrase}"
+`,
+      );
+      chmodSync(fakeProofPath, 0o700);
+      writeFileSync(
+        fakeSecurityPath,
+        `#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [ -f "\${FRIDAY_FAKE_SECURITY_COUNT}" ]; then
+  count="$(cat "\${FRIDAY_FAKE_SECURITY_COUNT}")"
+fi
+count=$((count + 1))
+printf '%s\\n' "\${count}" > "\${FRIDAY_FAKE_SECURITY_COUNT}"
+printf 'keychain-passphrase\\n'
+`,
+      );
+      chmodSync(fakeSecurityPath, 0o700);
+
+      const result = spawnSync(wrapperPath, {
+        cwd: tempRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FRIDAY_CLAUDE_MISSION_PROOF_PASSPHRASE_FILE: join(
+            tempRoot,
+            "missing-passphrase",
+          ),
+          FRIDAY_FAKE_SECURITY_COUNT: fakeSecurityCount,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("preflight-ok");
+      expect(result.stdout).toContain("proof-passphrase=keychain-passphrase");
+      expect(readFileSync(fakeSecurityCount, "utf8").trim()).toBe("1");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Scope
MAX-06-Claude / keychain proof automation duplicate lookup (LOW / MAX-ADD-4 tail). This only changes the Claude proof wrapper and its unit test; Codex keychain half remains a separately tracked residual.

## Red-first evidence
- Original red: `0077ca3a` / final rebased red: `13fb8d84` (`test(max06): expose claude keychain double lookup`)
- Original green: `0c25f4a3` / final rebased green: `ed4a24d1` (`fix(max06): avoid duplicate claude keychain lookup`)
- Evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/max06-claude-keychain-automation-redfirst-20260702T0825-0700`
- Red log: `red.log` / `.exit=1`
- Revert-red: `revert-red.log` / `.exit=1`

## Rebase / no-degrade
Rebased onto `origin/main=b806c25d389ef5a0cd9322cd48c8e884f6c96dc9`.
- `npx vitest run test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts --reporter=verbose` -> `7 passed` (`rebase-b806c25d-focused-20260703T1129.log`)
- `bash -n scripts/ops/friday-claude-mission-proof-of-life-keychain.sh` -> pass
- `git diff --check origin/main..HEAD` -> pass
- Changed files only: `scripts/ops/friday-claude-mission-proof-of-life-keychain.sh`, `test/unit/scripts/ops/friday-claude-mission-proof-gates.test.ts`

## Independent reviewers
- Laplace, session `019f2340-36ec-76d0-9185-fbef2a9a925a`, verdict PASS
- Schrodinger, session `019f2340-3763-7fc1-8b36-2129ed12d41b`, verdict PASS

## Boundaries
No prod deploy/restart, no prod DB/env write, no operator signature, no S2 mission-spine/auto-dispatch, no runtime/provider/security files. This does not close MAX-06 overall, npm freshness, F1-MAX, MAX41, A11, G2/G3/G4, D1/D6, §6/§15, or S2.