### PR TITLE
Document source setup recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@
 
 > **Friday isn't a model, and it isn't a chatbot.** The "brains" are the cloud AIs *you* already pay for (BYOK: Codex, Claude, DeepSeek, …). Friday is the **boss that puts them to work** — and the boss, plus your keys, your data, and your memory, all live on your own machine. **You own the boss; you just rent the brains.**
 
+## Quickstart
+
+Friday runs from source today and requires Node.js 22 or newer.
+
+On macOS with Homebrew:
+
+```bash
+brew install node@22
+git clone https://github.com/thesongzhu/Friday.git
+cd Friday
+open "Friday Setup.command"
+```
+
+If setup reports an older or missing Node.js, install Node.js 22+, then run `Friday Setup.command` again.
+
 ## What Is Friday?
 
 The trick with AI agents isn't prompting them yourself all day — it's building **the loop that prompts them for you**. Friday is that loop, turned into a product and made safe:

--- a/scripts/ops/friday-first-run.sh
+++ b/scripts/ops/friday-first-run.sh
@@ -21,6 +21,18 @@ info() { printf "[friday] %s\n" "$*"; }
 warn() { printf "[friday] warning: %s\n" "$*" >&2; }
 fail() { printf "[friday] error: %s\n" "$*" >&2; exit 1; }
 
+node_recovery_hint() {
+  cat <<'EOF'
+Install Node.js 22+. Then run Friday Setup.command again.
+
+macOS with Homebrew:
+  brew install node@22
+
+Other install options:
+  https://nodejs.org/
+EOF
+}
+
 absolute_install_path() {
   local target="$1"
   local parent
@@ -146,12 +158,12 @@ relocate_for_launchd_if_needed
 info "Preparing Friday from ${REPO_DIR}"
 cd "${REPO_DIR}"
 
-command -v node >/dev/null 2>&1 || fail "Node.js ${MIN_NODE_VERSION}+ is required. Install Node.js, then run this again."
-command -v npm >/dev/null 2>&1 || fail "npm is required. Install Node.js with npm, then run this again."
+command -v node >/dev/null 2>&1 || fail "Node.js ${MIN_NODE_VERSION}+ is required. $(node_recovery_hint)"
+command -v npm >/dev/null 2>&1 || fail "npm is required. Install Node.js ${MIN_NODE_VERSION}+ with npm. $(node_recovery_hint)"
 
 NODE_MAJOR="$(node -v | sed 's/^v//' | cut -d. -f1)"
 if [[ "${NODE_MAJOR}" -lt "${MIN_NODE_VERSION}" ]]; then
-  fail "Node.js ${MIN_NODE_VERSION}+ is required. Found $(node -v)."
+  fail "Node.js ${MIN_NODE_VERSION}+ is required. Found $(node -v). $(node_recovery_hint)"
 fi
 
 info "Installing dependencies"

--- a/test/unit/ops/friday-autostart-scripts.test.ts
+++ b/test/unit/ops/friday-autostart-scripts.test.ts
@@ -32,6 +32,17 @@ describe("Friday autostart scripts", () => {
     expect(setupCommand).toContain("scripts/ops/friday-first-run.sh");
   });
 
+  it("keeps source-install quickstart and Node preflight recovery copy actionable", () => {
+    const readme = readFileSync("README.md", "utf8");
+    const firstRun = readFileSync("scripts/ops/friday-first-run.sh", "utf8");
+
+    expect(readme).toContain("## Quickstart");
+    expect(readme).toContain("Friday Setup.command");
+    expect(readme).toContain("brew install node@22");
+    expect(firstRun).toContain("brew install node@22");
+    expect(firstRun).toContain("Then run Friday Setup.command again");
+  });
+
   it("starts Friday at login, keeps it alive, and opens the UI after health is ready", () => {
     const installer = readFileSync("scripts/ops/install-friday-launchagent.sh", "utf8");
     const serviceRunner = readFileSync("scripts/ops/friday-service-run.sh", "utf8");


### PR DESCRIPTION
## Scope
MAX-ADD-4a / source setup quickstart + Node preflight recovery (LOW/INFO tail). This only adds source-install quickstart docs and actionable Node 22 recovery copy for the first-run script.

## Red-first evidence
- Original red: `0c918c8d`; final rebased red: `a8e2b7eb` (`test(maxadd4): expose setup quickstart gap`)
- Original green: `d691118a`; final rebased green: `27be22fa` (`fix(maxadd4): document source setup recovery`)
- Evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/maxadd4-setup-quickstart-redfirst-20260702T0710-0700`
- Red: `red.log` / `.exit=1`
- Revert-red: `revert-red.log` / `.exit=1`

## Rebase / no-degrade
Rebased onto `origin/main=97a7572686e492f19e7d32430bd1c951acdb990c`.
- `npx vitest run test/unit/ops/friday-autostart-scripts.test.ts --reporter=verbose` -> `8 passed`
- Missing-node shell proof: `rebase-97a75726-node-preflight-message-valid-20260703T1252.log` confirms non-zero exit before install/build and includes `brew install node@22` plus `Then run Friday Setup.command again`.
- `npx eslint test/unit/ops/friday-autostart-scripts.test.ts scripts/ops/friday-first-run.sh --quiet` -> pass
- `git diff --check origin/main..HEAD` -> pass
- Changed files only: `README.md`, `scripts/ops/friday-first-run.sh`, `test/unit/ops/friday-autostart-scripts.test.ts`

Note: `rebase-97a75726-node-preflight-message-20260703T1249.*` is an invalid attempted invocation (`--preflight-only` was passed as repo dir) and is not used as evidence; the `...valid...` proof supersedes it.

## Independent reviewers
- Huygens, session `019f2325-346a-73f2-b49b-71e460509503`, verdict PASS
- Herschel, session `019f2325-34dc-7bc3-a2bf-8f4c98470b67`, verdict PASS

## Boundaries
No install/build/launchd behavior change beyond recovery copy, no runtime/security/provider/skills/S2 changes, no prod deploy/restart, no prod DB/env write. This does not close npm freshness, full MAX-ADD-4, D3 launchd, S2, or operator device attestation.