### PR TITLE
Refresh Rust boot truth labels

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -383,7 +383,7 @@ fn run() -> Result<(), ServerError> {
     let listener = AgentRunWsListener::bind_loopback(port).map_err(|_| ServerError::Bind)?;
     let addr = listener.local_addr().map_err(|_| ServerError::Bind)?;
     eprintln!(
-        "hub_agent_run_server: listening (loopback-only) on {addr} — DARK (S-C: authed dispatch arm, no production caller)"
+        "hub_agent_run_server: listening (loopback-only) on {addr} — S-C authed dispatch arm active"
     );
 
     // (2b) Rust-owned session-lifecycle REAPER tick (DARK, DEFAULT-OFF). Spawn a background

--- a/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs
@@ -263,7 +263,7 @@ fn run() -> Result<(), ServerError> {
     let listener = ReadWsListener::bind_loopback(port).map_err(|_| ServerError::Bind)?;
     let addr = listener.local_addr().map_err(|_| ServerError::Bind)?;
     eprintln!(
-        "hub_read_projection_server: listening (loopback-only) on {addr} — DARK (S-R1: read-projection arm, no LaunchAgent, no production caller)"
+        "hub_read_projection_server: listening (loopback-only) on {addr} — S-R1 read-projection arm active"
     );
 
     // (3) Long-lived accept loop. Each connection establishes the shared sealed session, then serves

--- a/test/unit/ops/friday-rust-bin-truth-labels.test.ts
+++ b/test/unit/ops/friday-rust-bin-truth-labels.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const writeServerSource = readFileSync("rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs", "utf8");
+const readServerSource = readFileSync("rust-core/crates/friday-hub/src/bin/hub_read_projection_server.rs", "utf8");
+
+describe("Rust bin boot truth labels", () => {
+  it("does not label the live agent-run server boot line as dark or callerless", () => {
+    const bootLine = extractListeningBootLine(writeServerSource, "hub_agent_run_server");
+
+    expect(bootLine).toContain("listening (loopback-only)");
+    expect(bootLine).toContain("S-C");
+    expect(bootLine).not.toMatch(/\bDARK\b/);
+    expect(bootLine).not.toContain("no production caller");
+  });
+
+  it("does not label the live read-projection server boot line as dark, callerless, or launchagent-free", () => {
+    const bootLine = extractListeningBootLine(readServerSource, "hub_read_projection_server");
+
+    expect(bootLine).toContain("listening (loopback-only)");
+    expect(bootLine).toContain("S-R1");
+    expect(bootLine).not.toMatch(/\bDARK\b/);
+    expect(bootLine).not.toContain("no production caller");
+    expect(bootLine).not.toContain("no LaunchAgent");
+  });
+});
+
+function extractListeningBootLine(source: string, binName: string): string {
+  const line = source
+    .split("\n")
+    .find((candidate) => candidate.includes(`${binName}: listening (loopback-only)`));
+  expect(line, `${binName} listening boot line`).toBeDefined();
+  return line ?? "";
+}


### PR DESCRIPTION
## Summary
- refresh stale Rust bin boot truth labels for the live agent-run and read-projection servers
- remove outdated `DARK` / callerless / LaunchAgent-free wording from boot stderr copy
- keep listener/runtime/auth/flags/deploy behavior unchanged

## Red-first evidence
- original red commit: `8781544f test(f1max): expose stale rust boot labels`
- final rebased red commit: `4aff8b38 test(f1max): expose stale rust boot labels`
- original red/revert-red evidence: `evidence/f1max-boot-label-redfirst-20260702T0735-0700/red.log`, `revert-red.log`
- final rebase evidence: `rebase-06df52b9-20260703T1412.log` exit 0

## Green evidence
- original green commit: `4da34f50 fix(f1max): refresh rust boot truth labels`
- final rebased green commit: `13928b45 fix(f1max): refresh rust boot truth labels`
- `npx vitest run test/unit/ops/friday-rust-bin-truth-labels.test.ts --reporter=verbose` exit 0 (`2/2`)
- `cargo check -p friday-hub --bins` exit 0
- `git diff --check origin/main..HEAD` exit 0

## Reviewers
- Existing §12.2 handoff records reviewer PASS files for this LOW/MAX-ADD-4 tail.

## No-degrade
- No runtime wiring, listener, auth, flag, accept loop, deployment script, or LaunchAgent behavior changed.
- This is only a boot truth-label repair; it does not claim full MAX-ADD-4 closure, npm freshness, F1-MAX resume/workflow-catalog closure, or any operator-gated runtime validation.
