### PR TITLE
Require prebuilt workflow catalog bridge bin

### DIFF
--- a/src/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.ts
@@ -11,7 +11,7 @@ import { FridayDomainError } from "#errors";
  * WORKFLOW catalog-MUTATION surface.
  *
  * It clones the execFile shape of `friday-rust-hub-run-task-bridge-service.ts`: it spawns
- * the prebuilt `hub_workflow_catalog` binary (or falls back to `cargo run --bin`), drives
+ * the prebuilt `hub_workflow_catalog` binary, drives
  * the five catalog ops the retired TS `workflows.*` mutation surface maps to —
  * `create / update / archive / publish / deploy` — and validates the bin's REFS-ONLY
  * stdout into a receipt. The bin emits ONLY safe identifiers/labels/counts and a BOUNDED
@@ -147,7 +147,7 @@ export interface CreateFridayRustHubWorkflowCatalogBridgeServiceOptions {
    * bin migrates on open (see the file header). Absent ⇒ the bridge fails closed.
    */
   readonly dbPath?: string;
-  /** Path to a prebuilt `hub_workflow_catalog` binary; falls back to `cargo run --bin` when absent. */
+  /** Path to a prebuilt `hub_workflow_catalog` binary. Absent ⇒ use repo release bin or fail closed. */
   readonly adapterBin?: string;
   readonly timeoutMs?: number;
 }
@@ -179,6 +179,15 @@ function readTimeoutMs(raw: string | undefined, fallback: number): number {
 function resolveDefaultRepoRoot(): string {
   const moduleDir = dirname(fileURLToPath(import.meta.url));
   return resolve(moduleDir, "../../..");
+}
+
+function resolvePrebuiltBin(
+  explicitBin: string | undefined,
+  rustCoreRoot: string,
+): string | undefined {
+  if (explicitBin) return resolve(explicitBin);
+  const releaseBin = resolve(rustCoreRoot, "target", "release", "hub_workflow_catalog");
+  return existsSync(releaseBin) ? releaseBin : undefined;
 }
 
 function asString(value: unknown): string | undefined {
@@ -384,15 +393,14 @@ export function createFridayRustHubWorkflowCatalogBridgeService(
   const rustCoreRoot = resolve(
     process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT ?? join(repoRoot, "rust-core"),
   );
-  const adapterBin = options.adapterBin ?? process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
+  const adapterBin = resolvePrebuiltBin(
+    options.adapterBin ?? process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN,
+    rustCoreRoot,
+  );
   const dbPathRaw = options.dbPath ?? process.env.FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH;
   const timeoutMs =
     options.timeoutMs ??
     readTimeoutMs(process.env.FRIDAY_HUB_WORKFLOW_CATALOG_TIMEOUT_MS, 120_000);
-
-  // One-time guard so the (loud) cargo-run-fallback warning is logged once per service
-  // instance, not on every mutation. Flipped true the first time the fallback is taken.
-  let warnedCargoFallback = false;
 
   return {
     async mutateCatalog(
@@ -414,37 +422,15 @@ export function createFridayRustHubWorkflowCatalogBridgeService(
 
       const adapterArgs = buildAdapterArgs(dbPath, input);
 
-      // Prefer the PREBUILT binary (`FRIDAY_HUB_WORKFLOW_CATALOG_BIN` / `adapterBin`). The
-      // `cargo run` fallback COMPILES the bin in the request hot path (latency + a
-      // non-JSON-stdout failure surface), so emit a LOUD one-time warning when it is taken.
-      const command = adapterBin ?? "cargo";
-      const args = adapterBin
-        ? adapterArgs
-        : [
-            "run",
-            "--quiet",
-            "--manifest-path",
-            join(rustCoreRoot, "Cargo.toml"),
-            "-p",
-            "friday-hub",
-            "--bin",
-            "hub_workflow_catalog",
-            "--",
-            ...adapterArgs,
-          ];
-      if (!adapterBin && !warnedCargoFallback) {
-        warnedCargoFallback = true;
-        console.warn(
-          "[friday][rust-workflow-catalog] FRIDAY_HUB_WORKFLOW_CATALOG_BIN is not set — " +
-            "falling back to `cargo run` in the request hot path (compiles per cold start; " +
-            "adds latency and a failure surface). Set it to a prebuilt hub_workflow_catalog " +
-            "binary at deploy time.",
+      if (!adapterBin) {
+        throw unavailable(
+          "Rust hub_workflow_catalog bridge requires a prebuilt binary; set FRIDAY_HUB_WORKFLOW_CATALOG_BIN or build rust-core/target/release/hub_workflow_catalog.",
         );
       }
 
       let stdout = "";
       try {
-        const result = await execFileAsync(command, args, {
+        const result = await execFileAsync(adapterBin, adapterArgs, {
           cwd: repoRoot,
           timeout: timeoutMs,
           maxBuffer: 2 * 1024 * 1024,

--- a/test/unit/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.test.ts
@@ -169,6 +169,31 @@ describe("friday-rust-hub-workflow-catalog-bridge-service (Tier-2 workflow catal
     }
   });
 
+  it("still honors FRIDAY_HUB_WORKFLOW_CATALOG_BIN when it is configured", async () => {
+    const previousBin = process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
+
+    try {
+      const { binPath, dbPath } = setup(okMock());
+      process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN = binPath;
+      const service = createFridayRustHubWorkflowCatalogBridgeService({ dbPath });
+
+      await expect(
+        service.mutateCatalog({ op: "publish", workflowId: "wf-env-bin", version: 1 }),
+      ).resolves.toMatchObject({
+        truthLabel: "rust_wired_dev",
+        proofOnly: true,
+        op: "publish",
+        workflowId: "wf-env-bin",
+      });
+    } finally {
+      if (previousBin === undefined) {
+        delete process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
+      } else {
+        process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN = previousBin;
+      }
+    }
+  });
+
   it("fails closed instead of cargo-running when no prebuilt bin is available", async () => {
     const previousBin = process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
     const previousRustRoot = process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT;

--- a/test/unit/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -36,6 +36,18 @@ describe("friday-rust-hub-workflow-catalog-bridge-service (Tier-2 workflow catal
     const dbPath = join(scratch, "hub.sqlite");
     writeFileSync(dbPath, "");
     return { binPath, dbPath };
+  }
+
+  function setupPrebuilt(mockSource: string): { repoRoot: string; dbPath: string } {
+    scratch = mkdtempSync(join(tmpdir(), "friday-hub-workflow-catalog-prebuilt-"));
+    const releaseDir = join(scratch, "rust-core", "target", "release");
+    mkdirSync(releaseDir, { recursive: true });
+    const binPath = join(releaseDir, "hub_workflow_catalog");
+    writeFileSync(binPath, `#!/usr/bin/env node\n${mockSource}`);
+    chmodSync(binPath, 0o755);
+    const dbPath = join(scratch, "hub.sqlite");
+    writeFileSync(dbPath, "");
+    return { repoRoot: scratch, dbPath };
   }
 
   /** A scripted mock that emits a valid refs-only receipt echoing the op + any extra fields. */
@@ -123,6 +135,71 @@ describe("friday-rust-hub-workflow-catalog-bridge-service (Tier-2 workflow catal
       isArchived: false,
       deployedVersion: null,
     });
+  });
+
+  it("uses the prebuilt release bin when FRIDAY_HUB_WORKFLOW_CATALOG_BIN is not configured", async () => {
+    const previousBin = process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
+    const previousRustRoot = process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT;
+    delete process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
+    delete process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT;
+
+    try {
+      const { repoRoot, dbPath } = setupPrebuilt(okMock());
+      const service = createFridayRustHubWorkflowCatalogBridgeService({ repoRoot, dbPath });
+
+      await expect(
+        service.mutateCatalog({ op: "publish", workflowId: "wf-prebuilt", version: 1 }),
+      ).resolves.toMatchObject({
+        truthLabel: "rust_wired_dev",
+        proofOnly: true,
+        op: "publish",
+        workflowId: "wf-prebuilt",
+      });
+    } finally {
+      if (previousBin === undefined) {
+        delete process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
+      } else {
+        process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN = previousBin;
+      }
+      if (previousRustRoot === undefined) {
+        delete process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT;
+      } else {
+        process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT = previousRustRoot;
+      }
+    }
+  });
+
+  it("fails closed instead of cargo-running when no prebuilt bin is available", async () => {
+    const previousBin = process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
+    const previousRustRoot = process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT;
+    delete process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
+    delete process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT;
+
+    try {
+      scratch = mkdtempSync(join(tmpdir(), "friday-hub-workflow-catalog-no-bin-"));
+      const dbPath = join(scratch, "hub.sqlite");
+      writeFileSync(dbPath, "");
+      const service = createFridayRustHubWorkflowCatalogBridgeService({ repoRoot: scratch, dbPath });
+
+      await expect(
+        service.mutateCatalog({ op: "publish", workflowId: "wf-no-bin", version: 1 }),
+      ).rejects.toMatchObject({
+        code: "MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE",
+        httpStatus: 503,
+        message: expect.stringContaining("requires a prebuilt binary"),
+      });
+    } finally {
+      if (previousBin === undefined) {
+        delete process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN;
+      } else {
+        process.env.FRIDAY_HUB_WORKFLOW_CATALOG_BIN = previousBin;
+      }
+      if (previousRustRoot === undefined) {
+        delete process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT;
+      } else {
+        process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT = previousRustRoot;
+      }
+    }
   });
 
   it("update: passes --expected-revision and the tri-state clear, never a verbatim body", async () => {


### PR DESCRIPTION
## Summary
- remove the workflow-catalog bridge hot-path `cargo run` fallback
- require an explicit/prebuilt `hub_workflow_catalog` binary before spawning
- fail closed with `MISSION_SPINE_RUST_WORKFLOW_CATALOG_BRIDGE_UNAVAILABLE` when no prebuilt bin is available

## Red-first evidence
- original red commit: `f1877a43 test(f1max): expose workflow catalog cargo fallback`
- final rebased red commit: `872b439d test(f1max): expose workflow catalog cargo fallback`
- original red/revert-red evidence: `evidence/f1max-workflow-catalog-bin-redfirst-20260702T0748-0700/red.log`, `revert-red.log`
- final rebase evidence: `rebase-a3a70e34-20260703T1454.log` exit 0

## Green evidence
- original green commit: `35106c07 fix(f1max): require workflow catalog prebuilt bin`
- final rebased green commit: `1c0d13b6 fix(f1max): require workflow catalog prebuilt bin`
- `npx vitest run test/unit/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.test.ts --reporter=verbose` exit 0 (`16/16`)
- `npm run typecheck:src` exit 0
- target ESLint exit 0
- `git diff --check origin/main..HEAD` exit 0

## Reviewers
- Existing §12.2 handoff records reviewer PASS files for this LOW/MAX-ADD-4 tail.

## No-degrade
- Explicit `FRIDAY_HUB_WORKFLOW_CATALOG_BIN` remains honored.
- Repo prebuilt release bin is tried before fail-close.
- Existing fail-closed/non-JSON/timeout/no-body receipt tests remain green.
- This does not build/deploy a release bin, does not flip runtime routing, and does not close S2 or full MAX-ADD-4.
