### PR TITLE
De-flake CI npm installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,21 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        env:
+          npm_config_fetch_retries: 5
+          npm_config_fetch_retry_mintimeout: 10000
+          npm_config_fetch_retry_maxtimeout: 120000
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then
+              exit 0
+            fi
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Typecheck
         run: npm run typecheck
@@ -58,7 +72,21 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        env:
+          npm_config_fetch_retries: 5
+          npm_config_fetch_retry_mintimeout: 10000
+          npm_config_fetch_retry_maxtimeout: 120000
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then
+              exit 0
+            fi
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
@@ -108,7 +136,21 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        env:
+          npm_config_fetch_retries: 5
+          npm_config_fetch_retry_mintimeout: 10000
+          npm_config_fetch_retry_maxtimeout: 120000
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then
+              exit 0
+            fi
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Adversarial suite integrity check
         run: node scripts/quality/check-adversarial-suite.mjs
@@ -133,7 +175,21 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        env:
+          npm_config_fetch_retries: 5
+          npm_config_fetch_retry_mintimeout: 10000
+          npm_config_fetch_retry_maxtimeout: 120000
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then
+              exit 0
+            fi
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Contract tests (routes + types)
         run: npm run test:contracts
@@ -191,7 +247,21 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        env:
+          npm_config_fetch_retries: 5
+          npm_config_fetch_retry_mintimeout: 10000
+          npm_config_fetch_retry_maxtimeout: 120000
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then
+              exit 0
+            fi
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Run agent parity acceptance suite
         run: npm run test:integration:agent-parity
@@ -327,7 +397,21 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        env:
+          npm_config_fetch_retries: 5
+          npm_config_fetch_retry_mintimeout: 10000
+          npm_config_fetch_retry_maxtimeout: 120000
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then
+              exit 0
+            fi
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Verify L1 mechanism wiring matrix
         run: npm run test:mechanism-wiring
@@ -353,7 +437,21 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        env:
+          npm_config_fetch_retries: 5
+          npm_config_fetch_retry_mintimeout: 10000
+          npm_config_fetch_retry_maxtimeout: 120000
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then
+              exit 0
+            fi
+            status=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Validate client ship gate wiring
         run: npm run check:client-ship-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,9 @@ jobs:
           for attempt in 1 2 3; do
             if npm ci; then
               exit 0
+            else
+              status=$?
             fi
-            status=$?
             if [ "$attempt" -eq 3 ]; then
               exit "$status"
             fi
@@ -80,8 +81,9 @@ jobs:
           for attempt in 1 2 3; do
             if npm ci; then
               exit 0
+            else
+              status=$?
             fi
-            status=$?
             if [ "$attempt" -eq 3 ]; then
               exit "$status"
             fi
@@ -144,8 +146,9 @@ jobs:
           for attempt in 1 2 3; do
             if npm ci; then
               exit 0
+            else
+              status=$?
             fi
-            status=$?
             if [ "$attempt" -eq 3 ]; then
               exit "$status"
             fi
@@ -183,8 +186,9 @@ jobs:
           for attempt in 1 2 3; do
             if npm ci; then
               exit 0
+            else
+              status=$?
             fi
-            status=$?
             if [ "$attempt" -eq 3 ]; then
               exit "$status"
             fi
@@ -255,8 +259,9 @@ jobs:
           for attempt in 1 2 3; do
             if npm ci; then
               exit 0
+            else
+              status=$?
             fi
-            status=$?
             if [ "$attempt" -eq 3 ]; then
               exit "$status"
             fi
@@ -405,8 +410,9 @@ jobs:
           for attempt in 1 2 3; do
             if npm ci; then
               exit 0
+            else
+              status=$?
             fi
-            status=$?
             if [ "$attempt" -eq 3 ]; then
               exit "$status"
             fi
@@ -445,8 +451,9 @@ jobs:
           for attempt in 1 2 3; do
             if npm ci; then
               exit 0
+            else
+              status=$?
             fi
-            status=$?
             if [ "$attempt" -eq 3 ]; then
               exit "$status"
             fi

--- a/test/unit/ci/friday-ci-npm-install-retry.test.ts
+++ b/test/unit/ci/friday-ci-npm-install-retry.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ciWorkflowPath = path.join(process.cwd(), ".github", "workflows", "ci.yml");
+
+describe("CI npm dependency installation", () => {
+  it("uses bounded npm ci retry settings for every dependency install step", () => {
+    const workflow = readFileSync(ciWorkflowPath, "utf8");
+    const installStepCount = (workflow.match(/- name: Install dependencies/g) ?? []).length;
+
+    expect(installStepCount).toBeGreaterThan(0);
+    expect(workflow).not.toMatch(/^\s*run:\s+npm ci\s*$/m);
+    expect(workflow.match(/npm_config_fetch_retries:\s+5/g) ?? []).toHaveLength(installStepCount);
+    expect(workflow.match(/npm_config_fetch_retry_mintimeout:\s+10000/g) ?? []).toHaveLength(installStepCount);
+    expect(workflow.match(/npm_config_fetch_retry_maxtimeout:\s+120000/g) ?? []).toHaveLength(installStepCount);
+    expect(workflow.match(/for attempt in 1 2 3;/g) ?? []).toHaveLength(installStepCount);
+  });
+});

--- a/test/unit/ci/friday-ci-npm-install-retry.test.ts
+++ b/test/unit/ci/friday-ci-npm-install-retry.test.ts
@@ -17,4 +17,13 @@ describe("CI npm dependency installation", () => {
     expect(workflow.match(/npm_config_fetch_retry_maxtimeout:\s+120000/g) ?? []).toHaveLength(installStepCount);
     expect(workflow.match(/for attempt in 1 2 3;/g) ?? []).toHaveLength(installStepCount);
   });
+
+  it("does not fail-open when every npm ci retry attempt fails", () => {
+    const workflow = readFileSync(ciWorkflowPath, "utf8");
+
+    expect(workflow).not.toMatch(/fi\n\s+status=\$\?/);
+    expect(workflow.match(/else\n\s+status=\$\?/g) ?? []).toHaveLength(
+      (workflow.match(/- name: Install dependencies/g) ?? []).length,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a CI workflow guard test for bare npm install steps.
- Wraps CI dependency installs in bounded npm fetch retry settings and a three-attempt npm ci loop.
- Adds a fail-close regression after reviewer A found the first retry wrapper could capture the if compound status and exit 0 after three failures.

## Evidence
- Original main push failure: evidence/main-ci-npm-retry-redfirst-20260703T1530-0700/main-push-ci-d6a7e969-failed.log (contracts / Install dependencies npm ci ECONNRESET, exit 152)
- Red 1: 3336e961, red-focused-valid.exit=1, bare run: npm ci detected
- Green 1: e84f6ecf, green-focused.exit=0
- Revert-red: revert-green-red-focused.exit=1
- Reviewer-refuted red 2: 7cbf4606, red-failopen-focused.exit=1
- Green 2: 8f838ecf, green-failopen-focused.exit=0, green-shell-failclose-probe.exit=42 with captured_status=42 on all three attempts
- YAML parse: green-failopen-yaml-parse.exit=0
- Diff check: final-diff-check.exit=0

## Reviewers
- Reviewer A: Beauvoir the 3rd / session 019f2a1f-3eb4-79c0-9672-92d3bcd62344 / PASS / evidence/main-ci-npm-retry-redfirst-20260703T1530-0700/reviewer-main-ci-npm-retry-a.md
- Reviewer B: Banach the 3rd / session 019f2a1f-60e8-7a43-a49a-43385b5daa01 / PASS / evidence/main-ci-npm-retry-redfirst-20260703T1530-0700/reviewer-main-ci-npm-retry-b.md

## Boundaries
- No product runtime code changed.
- No deploy/restart, prod env/DB write, operator signature, npm publish, S2 mission-spine/auto-dispatch, or --admin action.
- This is a bounded CI de-flake for transient npm registry/network failures; hard install failures still exit non-zero after attempt 3.