### PR TITLE
Clarify run-control resume transport truth

### DIFF
--- a/docs/current-source-of-truth.md
+++ b/docs/current-source-of-truth.md
@@ -244,6 +244,7 @@ This document is the current architecture reference for steady-state Friday runt
 - `/v1/secrets*` is the active CRUD surface for encrypted secret metadata and rotation backed by the existing provider secret repository.
 - `GET /v1/workflow-versions/:versionId` is the canonical direct fetch route for workflow versions alongside `/v1/workflows/:workflowId/versions`.
 - `/v1/realtime/*` is the canonical realtime transport surface. WebSocket clients may connect through `/v1/realtime/ws`, and `/v1/ws` remains a thin compatibility alias for the same gateway.
+- Agent-run pause/resume control is intentionally narrower on HTTP than on the sealed-WS owner channel. `POST /v1/agent/runs/:runId/resume` is only a courier for an owner-authorized opaque approval when `FRIDAY_AGENT_RUN_CONTROL_VIA_RUST` is enabled; when that flag is off or the runtime relay is absent, the route short-circuits to 503 before any run lookup. Direct sealed-WS clients remain the run-control transport for operator/native surfaces that hold the owner session material.
 - `/v1/workflow-approvals*` is the canonical workflow approval surface; `/v1/approvals*` remains a compatibility alias for legacy or SSD-shaped clients.
 - `npm run check:architecture-boundaries` is the canonical repo-level import guard for core infrastructure layers (`state`, `security`, `channels`, `providers`) and must stay green before merge.
 - `npm run check:security-doctor` is the canonical repo-level guard for secret refs, capability-grant evidence, provider/channel doctor surfaces, and their targeted safety tests.

--- a/test/unit/docs/run-control-resume-truth.test.ts
+++ b/test/unit/docs/run-control-resume-truth.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("run-control resume truth documentation", () => {
+  it("documents that HTTP resume is intentionally narrower than sealed-WS run control", () => {
+    const sourceOfTruth = readFileSync("docs/current-source-of-truth.md", "utf8");
+
+    expect(sourceOfTruth).toContain("/v1/agent/runs/:runId/resume");
+    expect(sourceOfTruth).toContain("FRIDAY_AGENT_RUN_CONTROL_VIA_RUST");
+    expect(sourceOfTruth).toMatch(/sealed-WS/i);
+    expect(sourceOfTruth).toMatch(/short-circuit[s]? to 503/i);
+    expect(sourceOfTruth).toContain("before any run lookup");
+  });
+});


### PR DESCRIPTION
## Summary
- Documents the F1-MAX §7.3 run-control truth boundary: HTTP resume is narrower than sealed-WS owner-channel run control.
- Adds a focused docs truth test that requires the HTTP courier flag/503 boundary and sealed-WS distinction to stay documented.

## Evidence
- Original red: fd2517d3 / red.exit=1, SoT docs lacked the resume boundary.
- Original green: 1559d6da / green-focused.exit=0.
- Revert-red: revert-red.exit=1.
- Rebased onto origin/main=7c632510 with final red 73071df9 and final green 00c30dad.
- Rebase validation: rebase-7c632510-focused-20260703T1618.exit=0, rebase-7c632510-diff-check-20260703T1618.exit=0.
- Open PR overlap before push returned [].

## Reviewers
- Kierkegaard / session 019f233a-3266-70a3-8d91-1941373cd3e2 / PASS / evidence/f1max-resume-asymmetry-doc-redfirst-20260702T0805-0700/reviewer-1-kierkegaard.md
- Cicero / session 019f233a-49ab-7f40-a846-cf62fb708b49 / PASS / evidence/f1max-resume-asymmetry-doc-redfirst-20260702T0805-0700/reviewer-2-cicero.md

## Boundaries
- Docs/test truth fix only; no runtime behavior changed.
- Does not deploy, restart, touch prod env/DB, operator signatures, npm publish, S2 mission-spine/auto-dispatch, or --admin.
- Does not claim HTTP/WS runtime execution proof; it closes the source-of-truth documentation tail for F1-MAX §7.3.