### PR TITLE
Cap studio zip inflate output

### DIFF
--- a/src/studio/friday-studio-service.ts
+++ b/src/studio/friday-studio-service.ts
@@ -1382,7 +1382,16 @@ function readZipEntryContent(zip: Buffer, localHeaderOffset: number, compressedS
     return Buffer.from(compressed);
   }
   if (method === 8) {
-    return zlib.inflateRawSync(compressed);
+    try {
+      return zlib.inflateRawSync(compressed, { maxOutputLength: MAX_IMPORT_FILE_BYTES });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ERR_BUFFER_TOO_LARGE") {
+        throw new FridayDomainError("VALIDATION_ERROR", `Zip entry expanded beyond limit: ${fileName}`, {
+          httpStatus: 400,
+        });
+      }
+      throw error;
+    }
   }
   throw new FridayDomainError("VALIDATION_ERROR", `Unsupported zip compression method ${method}: ${fileName}`, {
     httpStatus: 400,

--- a/test/unit/studio/friday-studio-service.test.ts
+++ b/test/unit/studio/friday-studio-service.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import * as zlib from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { FridaySsrfBlockedError } from "../../../src/agent/security/friday-agent-ssrf-guard.js";
@@ -45,6 +46,59 @@ function makePublicUrlGuard(options?: { dnsBlockedHost?: string }) {
       }
     },
   };
+}
+
+function makeDeflatedZipWithDeclaredSize(input: {
+  relativePath: string;
+  content: Buffer;
+  declaredUncompressedSize: number;
+}): Buffer {
+  const name = Buffer.from(input.relativePath, "utf8");
+  const compressed = zlib.deflateRawSync(input.content);
+  const local = Buffer.alloc(30);
+  local.writeUInt32LE(0x04034b50, 0);
+  local.writeUInt16LE(20, 4);
+  local.writeUInt16LE(0, 6);
+  local.writeUInt16LE(8, 8);
+  local.writeUInt16LE(0, 10);
+  local.writeUInt16LE(0, 12);
+  local.writeUInt32LE(0, 14);
+  local.writeUInt32LE(compressed.length, 18);
+  local.writeUInt32LE(input.declaredUncompressedSize, 22);
+  local.writeUInt16LE(name.length, 26);
+  local.writeUInt16LE(0, 28);
+  const localEntry = Buffer.concat([local, name, compressed]);
+
+  const central = Buffer.alloc(46);
+  central.writeUInt32LE(0x02014b50, 0);
+  central.writeUInt16LE(20, 4);
+  central.writeUInt16LE(20, 6);
+  central.writeUInt16LE(0, 8);
+  central.writeUInt16LE(8, 10);
+  central.writeUInt16LE(0, 12);
+  central.writeUInt16LE(0, 14);
+  central.writeUInt32LE(0, 16);
+  central.writeUInt32LE(compressed.length, 20);
+  central.writeUInt32LE(input.declaredUncompressedSize, 24);
+  central.writeUInt16LE(name.length, 28);
+  central.writeUInt16LE(0, 30);
+  central.writeUInt16LE(0, 32);
+  central.writeUInt16LE(0, 34);
+  central.writeUInt16LE(0, 36);
+  central.writeUInt32LE(0, 38);
+  central.writeUInt32LE(0, 42);
+  const centralEntry = Buffer.concat([central, name]);
+
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(1, 8);
+  end.writeUInt16LE(1, 10);
+  end.writeUInt32LE(centralEntry.length, 12);
+  end.writeUInt32LE(localEntry.length, 16);
+  end.writeUInt16LE(0, 20);
+  return Buffer.concat([localEntry, centralEntry, end]);
 }
 
 describe("createFridayStudioService", () => {
@@ -278,6 +332,23 @@ describe("createFridayStudioService", () => {
     });
     expect(zipImport.pack.packJsonPath).toBe("pack.json");
     expect(zipImport.pack.productIds).toEqual(["guided_browser_automation"]);
+  });
+
+  it("rejects zip imports that expand past the studio file limit during inflate", () => {
+    const service = createFridayStudioService({ workspaceRoot: makeTempDir() });
+    const zip = makeDeflatedZipWithDeclaredSize({
+      relativePath: "pack.json",
+      content: Buffer.from(" ".repeat(11 * 1024 * 1024)),
+      declaredUncompressedSize: 1024,
+    });
+
+    expect(() =>
+      service.importLocalPack({
+        kind: "zip",
+        fileName: "zip-bomb.zip",
+        zipBase64: zip.toString("base64"),
+      }),
+    ).toThrow(/Zip entry expanded beyond limit: pack\.json/);
   });
 
   it("validates an integration builder run as a capability candidate", async () => {


### PR DESCRIPTION
## Scope

G4 High sub-slice only: studio zip-bomb / `inflateRawSync` output cap. This does not close full G4. It does not cover empty-WHERE pruning, learning pipeline atomicity, Guard namespace isolation, or querySimilar large-namespace recall.

## Red-first

- Red commit: `54fe0a14 test(g4): expose studio zip inflate bomb` (test-only)
- Green commit: `637d9e00 fix(g4): cap studio zip inflate output`
- Revert-red evidence: `revert-red-focused.log` fails with the old post-inflate `Import file too large: pack.json` behavior after temporarily reverting the green fix.

Evidence path: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/g4-studio-zip-bomb-limit-redfirst-20260703T194633-0700`
Handoff commit: `7e2b33c Record G4 zip-bomb handoff`

## Validation

- `green-focused.log` exit 0
- `green-full-studio-service.log` exit 0 (`12 passed`)
- `green-typecheck-src.log` exit 0
- `green-diff-check.log` exit 0
- Reviewer #1: Leibniz `019f2b08-8ff0-7e60-8dd4-07ac582a55c6` - NOT READY for process closure, PASS only for red-first small slice
- Reviewer #2: Hypatia `019f2b08-a920-7e10-8079-4871da17312d` - PASS for technical sub-slice, NOT PASS for G4 overall

## Merge status

High item: pending-operator-review. Do not merge without external operator/advisor SIGN. No `--admin`, no direct main/prod push, no deploy/restart, no prod env/DB write, no npm publish, no operator signature, and no S2 work.