### PR TITLE
Retry transient provider failures with backoff

### DIFF
--- a/src/providers/routing/friday-provider-fallback.ts
+++ b/src/providers/routing/friday-provider-fallback.ts
@@ -427,10 +427,8 @@ export function createFridayProviderFallback(
               timestamp: new Date().toISOString(),
             });
 
-            const retryAfterMs = extractRetryAfterMs(err, nowMs);
             if (
               canRetrySameProvider(classified.reason)
-              && retryAfterMs !== undefined
               && retryIndex < sameProviderMaxRetries
             ) {
               const delayMs = boundedSameProviderRetryDelayMs({

--- a/test/integration/cross-layer/friday-provider-failover-roundtrip.integration.test.ts
+++ b/test/integration/cross-layer/friday-provider-failover-roundtrip.integration.test.ts
@@ -96,8 +96,11 @@ describe("friday provider failover roundtrip", () => {
 
     expect(result.result).toBe("response from success-1");
     expect(result.route.provider.id).toBe("success-1");
-    expect(result.attempts).toHaveLength(1);
-    expect(result.attempts[0]!.providerId).toBe("fail-1");
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts.map((attempt) => attempt.providerId)).toEqual([
+      "fail-1",
+      "fail-1",
+    ]);
   });
 
   it("puts failed provider in cooldown after transient error", async () => {

--- a/test/unit/providers/routing/friday-provider-fallback.test.ts
+++ b/test/unit/providers/routing/friday-provider-fallback.test.ts
@@ -801,9 +801,11 @@ describe("FridayProviderFallback", () => {
         },
       });
 
-      expect(result.attempts).toHaveLength(1);
-      expect(result.attempts[0].error).toContain("[REDACTED]");
-      expect(result.attempts[0].error).not.toContain("sk-test-abc");
+      expect(result.attempts).toHaveLength(2);
+      for (const attempt of result.attempts) {
+        expect(attempt.error).toContain("[REDACTED]");
+        expect(attempt.error).not.toContain("sk-test-abc");
+      }
     });
 
     it("redacts Google AIza API keys and ya29 OAuth tokens in attempt error logs", async () => {

--- a/test/unit/providers/routing/friday-provider-fallback.test.ts
+++ b/test/unit/providers/routing/friday-provider-fallback.test.ts
@@ -522,6 +522,45 @@ describe("FridayProviderFallback", () => {
       });
     });
 
+    it("retries the same provider once with backoff when transient errors omit retry-after", async () => {
+      const sleptMs: number[] = [];
+      const fb = createFridayProviderFallback({
+        sameProviderRetryBaseDelayMs: 125,
+        sameProviderRetryMaxDelayMs: 1_000,
+        sleepMs: async (ms) => {
+          sleptMs.push(ms);
+        },
+      });
+      const deepseek = makeProvider("ds", "deepseek", true, "deepseek-v4-flash", ["deepseek-v4-flash"]);
+      let calls = 0;
+
+      const result = await fb.runWithFallback({
+        candidates: [{ provider: deepseek, model: "deepseek-v4-flash" }],
+        run: async () => {
+          calls += 1;
+          if (calls === 1) {
+            const err: any = new Error("socket hang up while contacting provider");
+            err.code = "ECONNRESET";
+            throw err;
+          }
+          return "ok-after-backoff";
+        },
+      });
+
+      expect(result.result).toBe("ok-after-backoff");
+      expect(result.route.provider.id).toBe("ds");
+      expect(calls).toBe(2);
+      expect(sleptMs).toEqual([125]);
+      expect(result.attempts).toHaveLength(1);
+      expect(result.attempts[0]).toMatchObject({
+        providerId: "ds",
+        providerKind: "deepseek",
+        model: "deepseek-v4-flash",
+        reason: "transient",
+        code: "ECONNRESET",
+      });
+    });
+
     it("records all failed attempts in order", async () => {
       const fb = createFridayProviderFallback();
       const p1 = makeProvider("p1", "openai");


### PR DESCRIPTION
## Scope

B8-residual MED sub-slice: same-provider retry/backoff when transient provider errors omit `Retry-After`. This preserves existing `Retry-After` priority and does not close the broader B8/deepseek backlog.

## Red-first

- Red commit: `f128c456 test(b8): expose same-provider retry gap` (test-only)
- Green commit: `19857ce3 fix(b8): retry transient provider failures with backoff`
- Revert-red evidence: `revert-red-focused.log` returns to `All providers failed (1)` after temporarily reverting the green fix.

Evidence path: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/b8-provider-same-retry-redfirst-20260703T2008-0700`
Handoff commit: `9d762a8 Record B8 provider retry handoff`

## Validation

- `red-valid.log` exit 1
- `green-focused-2.log` exit 0 (`47 passed`)
- `green-typecheck-src.log` exit 0
- `green-diff-check.log` exit 0
- `restore-green-focused.log` exit 0
- Reviewer #1: Sagan `019f2b1c-5b1f-7972-950c-8fb672192ddc` PASS
- Reviewer #2: Erdos `019f2b1c-7722-7a42-a87c-c9849d4527ea` PASS

## Merge status

MED item: may auto-squash-merge only after full PR-CI true green, born-current/no-overlap recheck, clean merge state, red-first provenance, two reviewer files, and no-degrade evidence remain intact. No `--admin`, no direct main/prod push, no deploy/restart, no prod env/DB write, no operator signature, no npm publish, and no S2 work.