### PR TITLE
Fix G2 cached token usage totals

### DIFF
--- a/src/providers/cost/friday-provider-usage-normalizer.ts
+++ b/src/providers/cost/friday-provider-usage-normalizer.ts
@@ -47,7 +47,7 @@ function normalizeOpenAiCompletions(body: Record<string, unknown>): FridayProvid
     output,
     cacheRead,
     cacheWrite,
-    total: input + output + cacheRead + cacheWrite,
+    total: input + output,
   };
 }
 
@@ -70,7 +70,7 @@ function normalizeOpenAiResponses(body: Record<string, unknown>): FridayProvider
     output,
     cacheRead,
     cacheWrite,
-    total: input + output + cacheRead + cacheWrite,
+    total: input + output,
   };
 }
 

--- a/test/unit/providers/cost/friday-provider-cost-controls.test.ts
+++ b/test/unit/providers/cost/friday-provider-cost-controls.test.ts
@@ -4,8 +4,10 @@ import type { FridaySqliteLayer } from "#state";
 import type { FridayProviderKind, FridayResolvedProviderRoute } from "#providers";
 import {
   createFridayProviderBudgetService,
+  createFridayProviderCostCalculator,
   createFridayProviderCostRouter,
   createFridayProviderPricingCatalog,
+  createFridayProviderUsageNormalizer,
   createFridayProviderUsageRepository,
 } from "#providers";
 
@@ -50,6 +52,68 @@ function route(id: string, kind: FridayProviderKind, model: string): FridayResol
 }
 
 describe("Friday provider cost controls", () => {
+  describe("usage normalization", () => {
+    it("does not double-count OpenAI cached input tokens in total usage", () => {
+      const normalizer = createFridayProviderUsageNormalizer();
+
+      const usage = normalizer.normalize("openai-responses", {
+        usage: {
+          input_tokens: 1_000,
+          output_tokens: 200,
+          input_tokens_details: { cached_tokens: 300 },
+        },
+      });
+
+      expect(usage).toEqual({
+        input: 1_000,
+        output: 200,
+        cacheRead: 300,
+        cacheWrite: 0,
+        total: 1_200,
+      });
+    });
+
+    it("does not double-count OpenAI chat-completions cached prompt tokens in total usage", () => {
+      const normalizer = createFridayProviderUsageNormalizer();
+
+      const usage = normalizer.normalize("openai-completions", {
+        usage: {
+          prompt_tokens: 800,
+          completion_tokens: 120,
+          prompt_tokens_details: { cached_tokens: 250 },
+        },
+      });
+
+      expect(usage).toEqual({
+        input: 800,
+        output: 120,
+        cacheRead: 250,
+        cacheWrite: 0,
+        total: 920,
+      });
+    });
+  });
+
+  describe("subscription pricing mirror", () => {
+    it("keeps OpenAI Codex subscription usage out of OpenAI API dollar pricing", () => {
+      const catalog = createFridayProviderPricingCatalog();
+      const calculator = createFridayProviderCostCalculator({ pricingCatalog: catalog });
+
+      expect(catalog.getPricing("openai-codex", "gpt-5.4-mini")).toMatchObject({
+        inputPer1MUsd: 0,
+        outputPer1MUsd: 0,
+        cacheReadPer1MUsd: 0,
+        cacheWritePer1MUsd: 0,
+        qualityTier: "unknown",
+      });
+      expect(calculator.calculate({
+        providerKind: "openai-codex",
+        model: "gpt-5.4-mini",
+        usage: { input: 10_000, output: 2_000, cacheRead: 5_000, cacheWrite: 0, total: 12_000 },
+      })).toBe(0);
+    });
+  });
+
   describe("pricing catalog", () => {
     it("uses the longest matching model pattern before the generic fallback", () => {
       const catalog = createFridayProviderPricingCatalog();


### PR DESCRIPTION
## Summary
- Fix OpenAI chat-completions and Responses usage normalization so cached input tokens remain a separate cacheRead field but are not added a second time into total tokens.
- Add red-first coverage for both OpenAI API shapes.
- Add no-degrade/refuted protection that OpenAI Codex subscription usage is not priced as fabricated OpenAI API dollars.

## Evidence
- Red commit: 8837bc0a test(g2): expose cached token double count
- Green commit: 338760e2 fix(g2): avoid cached token double count
- Evidence dir: /Users/jarvis/Desktop/Friday-Handoff-Log/evidence/g2-cost-metering-redfirst-20260703T2220-0700
- red-valid.exit=1, green-focused.exit=0, revert-red-valid.exit=1, green-typecheck-src.exit=0, green-diff-check.exit=0
- Reviewers: Hilbert the 3rd PASS / pending-operator-review; Fermat the 3rd PASS

## Boundaries
G2 is High. This PR must remain pending operator/军师 review and must not be self-merged. This closes only the cached-token double-count code slice; real provider-call ledger reconciliation and true subscription quota mirror remain outside this sub-slice.