### PR TITLE
Minimize G3 guide lens parser screen text

### DIFF
--- a/src/guide-lens/engine/friday-guide-lens-service.ts
+++ b/src/guide-lens/engine/friday-guide-lens-service.ts
@@ -23,7 +23,7 @@ import { buildFridayGuideLensUiMap } from "./ui-map-builder.js";
 import { resolveFridayGuideLensTarget } from "./target-resolver.js";
 import { analyzeFridayGuideLensScreenshot } from "./screenshot-intake.js";
 import { verifyFridayGuideLensProgress } from "./verification.js";
-import { redactGuideLensText } from "./redaction.js";
+import { minimizeGuideLensParserText } from "./redaction.js";
 
 export interface CreateFridayGuideLensServiceDeps {
   idGenerator: () => string;
@@ -114,7 +114,7 @@ function redactOptionalText(
   text: string | undefined,
   source: "visible_text" | "screenshot_text" | "element_text",
 ): string | undefined {
-  return text ? redactGuideLensText(text, source).text : text;
+  return text ? minimizeGuideLensParserText(text, source).text : text;
 }
 
 function sanitizeElementForParser(element: FridayGuideLensElement): FridayGuideLensElement {

--- a/src/guide-lens/engine/redaction.ts
+++ b/src/guide-lens/engine/redaction.ts
@@ -27,6 +27,21 @@ export interface FridayGuideLensRedactionResult {
   redactions: FridayGuideLensRedaction[];
 }
 
+function pushRedaction(
+  redactions: FridayGuideLensRedaction[],
+  kind: FridayGuideLensRedaction["kind"],
+  source: FridayGuideLensRedaction["source"],
+  count: number,
+): void {
+  if (count <= 0) return;
+  redactions.push({
+    kind,
+    replacement: `[${kind}:redacted]`,
+    source,
+    count,
+  });
+}
+
 export function redactGuideLensText(
   text: string,
   source: FridayGuideLensRedaction["source"],
@@ -46,14 +61,7 @@ export function redactGuideLensText(
       }
       return `[${kind}:redacted]`;
     });
-    if (count > 0) {
-      redactions.push({
-        kind,
-        replacement: `[${kind}:redacted]`,
-        source,
-        count,
-      });
-    }
+    pushRedaction(redactions, kind, source, count);
   }
 
   return {
@@ -62,9 +70,76 @@ export function redactGuideLensText(
   };
 }
 
+function replaceSensitiveText(
+  text: string,
+  pattern: RegExp,
+  replacement: string | ((match: string, ...args: unknown[]) => string),
+): { text: string; count: number } {
+  let count = 0;
+  const next = text.replace(pattern, (match, ...args: unknown[]) => {
+    count += 1;
+    return typeof replacement === "function" ? replacement(match, ...args) : replacement;
+  });
+  return { text: next, count };
+}
+
+export function minimizeGuideLensParserText(
+  text: string,
+  source: FridayGuideLensRedaction["source"],
+): FridayGuideLensRedactionResult {
+  const secret = redactGuideLensText(text, source);
+  let redacted = secret.text;
+  let sensitiveCount = 0;
+
+  const labeled = replaceSensitiveText(
+    redacted,
+    /\b((?:customer|email|phone|shipping\s+address|address|account\s+id|account|order|invoice)\s*(?:id|number|#)?\s*[:#])\s*[^\r\n]+/gi,
+    (_match, label) => `${String(label).trim()} [sensitive_text:redacted]`,
+  );
+  redacted = labeled.text;
+  sensitiveCount += labeled.count;
+
+  for (const pattern of [
+    /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+    /\+?\d[\d\s().-]{7,}\d/g,
+    /\b\d{1,6}\s+[A-Za-z0-9.' -]+(?:street|st|avenue|ave|road|rd|boulevard|blvd|drive|dr|lane|ln|way|court|ct)\b(?:[, ][A-Za-z .-]+)?(?:\s+\d{5}(?:-\d{4})?)?/gi,
+    /\b(?:order|invoice|account|customer|session|user)[\s_-]*(?:id|number|#)?[\s:#-]*[A-Za-z0-9._-]{4,}\b/gi,
+    /\b(?:acct|cus|ord|inv)_[A-Za-z0-9_-]{6,}\b/g,
+  ]) {
+    const replaced = replaceSensitiveText(redacted, pattern, "[sensitive_text:redacted]");
+    redacted = replaced.text;
+    sensitiveCount += replaced.count;
+  }
+
+  if (/(?:@|customer|phone|ship|address|order|account|invoice)/i.test(text)) {
+    const names = replaceSensitiveText(
+      redacted,
+      /\b[A-Z][a-z]{1,30}\s+[A-Z][a-z]{1,30}\b/g,
+      "[sensitive_text:redacted]",
+    );
+    redacted = names.text;
+    sensitiveCount += names.count;
+  }
+
+  return {
+    text: redacted,
+    redactions: [
+      ...secret.redactions,
+      ...(sensitiveCount > 0
+        ? [{
+          kind: "sensitive_text" as const,
+          replacement: "[sensitive_text:redacted]",
+          source,
+          count: sensitiveCount,
+        }]
+        : []),
+    ],
+  };
+}
+
 export function looksSensitiveGuideLensText(text: string): boolean {
   return SECRET_PATTERNS.some(({ pattern }) => {
     pattern.lastIndex = 0;
     return pattern.test(text);
-  });
+  }) || /(?:@|customer|phone|ship|address|order|account|invoice|\+?\d[\d\s().-]{7,}\d)/i.test(text);
 }

--- a/src/guide-lens/engine/redaction.ts
+++ b/src/guide-lens/engine/redaction.ts
@@ -70,17 +70,34 @@ export function redactGuideLensText(
   };
 }
 
-function replaceSensitiveText(
-  text: string,
-  pattern: RegExp,
-  replacement: string | ((match: string, ...args: unknown[]) => string),
-): { text: string; count: number } {
-  let count = 0;
-  const next = text.replace(pattern, (match, ...args: unknown[]) => {
-    count += 1;
-    return typeof replacement === "function" ? replacement(match, ...args) : replacement;
-  });
-  return { text: next, count };
+const PARSER_SAFE_ACTION_TEXT = /^(?:authorize|continue|next|done|save|submit|allow|deny|cancel|ok|open|connect|retry|back|sign in|log in)$/i;
+
+const PARSER_VALUE_LABEL = /^((?:api\s*key|access\s*token|secret\s*key|password|passcode|secret|customer|email|phone|shipping\s+address|address|account\s+id|account|order|invoice|full\s+name|patient|dob|date\s+of\s+birth|mrn|medical\s+record(?:\s+number)?)\s*(?:id|number)?\s*(?::|#)?)\s+(.+)$/i;
+
+const SECRET_PLACEHOLDER = /\[(?:api_key|password|token|secret):redacted\]/;
+
+function minimizeParserLine(line: string): { text: string; redacted: boolean } {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) {
+    return { text: line, redacted: false };
+  }
+  if (PARSER_SAFE_ACTION_TEXT.test(trimmed)) {
+    return { text: trimmed, redacted: false };
+  }
+  if (SECRET_PLACEHOLDER.test(trimmed) && /^\[.*\]$/.test(trimmed)) {
+    return { text: trimmed, redacted: false };
+  }
+
+  const label = trimmed.match(PARSER_VALUE_LABEL);
+  if (label) {
+    const placeholder = label[2].match(SECRET_PLACEHOLDER)?.[0] ?? "[sensitive_text:redacted]";
+    return {
+      text: `${label[1].trim()} ${placeholder}`,
+      redacted: placeholder === "[sensitive_text:redacted]",
+    };
+  }
+
+  return { text: "[sensitive_text:redacted]", redacted: true };
 }
 
 export function minimizeGuideLensParserText(
@@ -88,41 +105,19 @@ export function minimizeGuideLensParserText(
   source: FridayGuideLensRedaction["source"],
 ): FridayGuideLensRedactionResult {
   const secret = redactGuideLensText(text, source);
-  let redacted = secret.text;
+  const minimizedLines: string[] = [];
   let sensitiveCount = 0;
 
-  const labeled = replaceSensitiveText(
-    redacted,
-    /\b((?:customer|email|phone|shipping\s+address|address|account\s+id|account|order|invoice)\s*(?:id|number|#)?\s*[:#])\s*[^\r\n]+/gi,
-    (_match, label) => `${String(label).trim()} [sensitive_text:redacted]`,
-  );
-  redacted = labeled.text;
-  sensitiveCount += labeled.count;
-
-  for (const pattern of [
-    /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
-    /\+?\d[\d\s().-]{7,}\d/g,
-    /\b\d{1,6}\s+[A-Za-z0-9.' -]+(?:street|st|avenue|ave|road|rd|boulevard|blvd|drive|dr|lane|ln|way|court|ct)\b(?:[, ][A-Za-z .-]+)?(?:\s+\d{5}(?:-\d{4})?)?/gi,
-    /\b(?:order|invoice|account|customer|session|user)[\s_-]*(?:id|number|#)?[\s:#-]*[A-Za-z0-9._-]{4,}\b/gi,
-    /\b(?:acct|cus|ord|inv)_[A-Za-z0-9_-]{6,}\b/g,
-  ]) {
-    const replaced = replaceSensitiveText(redacted, pattern, "[sensitive_text:redacted]");
-    redacted = replaced.text;
-    sensitiveCount += replaced.count;
-  }
-
-  if (/(?:@|customer|phone|ship|address|order|account|invoice)/i.test(text)) {
-    const names = replaceSensitiveText(
-      redacted,
-      /\b[A-Z][a-z]{1,30}\s+[A-Z][a-z]{1,30}\b/g,
-      "[sensitive_text:redacted]",
-    );
-    redacted = names.text;
-    sensitiveCount += names.count;
+  for (const line of secret.text.split(/\r?\n/)) {
+    const minimized = minimizeParserLine(line);
+    minimizedLines.push(minimized.text);
+    if (minimized.redacted) {
+      sensitiveCount += 1;
+    }
   }
 
   return {
-    text: redacted,
+    text: minimizedLines.join("\n"),
     redactions: [
       ...secret.redactions,
       ...(sensitiveCount > 0

--- a/test/unit/guide-lens/friday-guide-lens-service.test.ts
+++ b/test/unit/guide-lens/friday-guide-lens-service.test.ts
@@ -262,14 +262,20 @@ describe("createFridayGuideLensService", () => {
         "Phone: +1 (415) 555-0199",
         "Shipping address: 1 Market St, San Francisco, CA 94105",
         "Order #FR-123456",
+        "Project Apollo renewal terms",
+        "Internal Q3 roadmap",
         "Authorize",
       ].join("\n"),
-      screenshotText: "Account ID: acct_live_123456789 for jane.doe@example.com",
+      screenshotText: [
+        "Account ID: acct_live_123456789 for jane.doe@example.com",
+        "Patient: Jane Doe DOB 01/02/1990 MRN A1234567",
+        "Full name: Jane Doe",
+      ].join("\n"),
       elements: [{
         id: "customer-email",
         role: "text",
         label: "Jane Doe jane.doe@example.com",
-        text: "Phone +1 (415) 555-0199",
+        text: "Patient Jane Doe DOB 01/02/1990",
         description: "Ship to 1 Market St, San Francisco, CA 94105",
         source: "accessibility",
         confidence: 0.91,
@@ -287,6 +293,10 @@ describe("createFridayGuideLensService", () => {
     expect(serialized).not.toContain("1 Market St");
     expect(serialized).not.toContain("Jane Doe");
     expect(serialized).not.toContain("FR-123456");
+    expect(serialized).not.toContain("Project Apollo");
+    expect(serialized).not.toContain("Internal Q3");
+    expect(serialized).not.toContain("01/02/1990");
+    expect(serialized).not.toContain("A1234567");
     expect(parserSnapshot.elements?.[0]?.metadata).toBeUndefined();
   });
 

--- a/test/unit/guide-lens/friday-guide-lens-service.test.ts
+++ b/test/unit/guide-lens/friday-guide-lens-service.test.ts
@@ -240,6 +240,56 @@ describe("createFridayGuideLensService", () => {
     expect(result.uiMap.elements.some((element) => element.id === "parser-authorize")).toBe(true);
   });
 
+  it("minimizes sensitive screen text before optional parser adapters", async () => {
+    const parse = vi.fn().mockResolvedValue({
+      provider: "omniparser",
+      used: true,
+      latencyMs: 17,
+      visibleText: "Authorize",
+      elements: [],
+    });
+    const service = createFridayGuideLensService({
+      idGenerator: idGenerator(),
+      nowIso,
+      parserAdapter: { parse },
+      defaultPreferences: { parserProvider: "omniparser" },
+    });
+
+    await service.captureSnapshot({
+      visibleText: [
+        "Customer: Jane Doe",
+        "Email: jane.doe@example.com",
+        "Phone: +1 (415) 555-0199",
+        "Shipping address: 1 Market St, San Francisco, CA 94105",
+        "Order #FR-123456",
+        "Authorize",
+      ].join("\n"),
+      screenshotText: "Account ID: acct_live_123456789 for jane.doe@example.com",
+      elements: [{
+        id: "customer-email",
+        role: "text",
+        label: "Jane Doe jane.doe@example.com",
+        text: "Phone +1 (415) 555-0199",
+        description: "Ship to 1 Market St, San Francisco, CA 94105",
+        source: "accessibility",
+        confidence: 0.91,
+        interactable: false,
+      }],
+    });
+
+    const parserSnapshot = parse.mock.calls[0]?.[0].snapshot;
+    const serialized = JSON.stringify(parserSnapshot);
+
+    expect(serialized).toContain("[sensitive_text:redacted]");
+    expect(serialized).toContain("Authorize");
+    expect(serialized).not.toContain("jane.doe@example.com");
+    expect(serialized).not.toContain("+1 (415) 555-0199");
+    expect(serialized).not.toContain("1 Market St");
+    expect(serialized).not.toContain("Jane Doe");
+    expect(serialized).not.toContain("FR-123456");
+    expect(parserSnapshot.elements?.[0]?.metadata).toBeUndefined();
+  });
+
   it("analyzes screenshots and only asks chatbox when intent is unclear", async () => {
     const service = createFridayGuideLensService({
       idGenerator: idGenerator(),


### PR DESCRIPTION
## Scope

G3 High sub-slice: minimize Guide Lens optional parser snapshots before any third-party parser adapter receives screen text. This is not a full G3 closure and must remain `pending-operator-review` unless external operator/军师 SIGN authorizes merge.

Changed files:
- `src/guide-lens/engine/friday-guide-lens-service.ts`
- `src/guide-lens/engine/redaction.ts`
- `test/unit/guide-lens/friday-guide-lens-service.test.ts`

## Red-first evidence

Evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/g3-guide-lens-minimize-redfirst-20260703T2215-0700`

- red1 `52e69e8d`: `red-valid.log` exits 1, raw email/phone/address/name/order reach parser snapshot.
- green1 `9c3da368`: `green-focused.log`, `green-typecheck-src.log`, `green-diff-check.log`, `green-eslint-target.log` exit 0.
- revert-red1: `revert-red-focused.log` exits 1 after reverting `9c3da368`.
- red2 `060de2aa`: `red2-reviewer-gap.log` exits 1 for reviewer-found Project/Internal + Patient/DOB/MRN gaps.
- green2 `4f378ce9`: `green2-focused.log`, `green2-typecheck-src.log`, `green2-diff-check.log`, `green2-eslint-target.log` exit 0.
- revert-red2: `revert2-valid-red-focused.log` exits 1 after reverting `4f378ce9`.

Superseded/non-authoritative: `red-focused.*` is dependency setup failure; `revert2-red-focused.*` was produced with the wrong cwd and is superseded by `revert2-valid-*`.

## Reviewers

- Reviewer #1 Hooke: initial `reviewer-1-codex.md` found blocking Project/Internal leak; addendum `reviewer-1-codex-addendum.md` = PASS / no remaining blocking finding.
- Reviewer #2 James: initial `reviewer-2-codex.md` found blocking Patient/DOB/MRN leak; addendum `reviewer-2-codex-addendum.md` = PASS / no blocking finding found.

## No-degrade / boundaries

- Existing API-key parser redaction test still passes.
- `Authorize` action text remains available to the parser.
- Parser element metadata remains stripped.
- Local UI map construction is not globally minimized; stricter minimization is wired only into optional parser snapshot sanitization.
- No S2 mission-spine/auto-dispatch, prod port, prod DB/env, deploy/restart, operator signature, npm publish, direct main/prod push, or `--admin`.

Open PR overlap before push showed only #1488 provider-cost files and #1486 studio files, with no G3 guide-lens overlap.
