### PR TITLE
Recall G4 querySimilar matches in large namespaces

### DIFF
--- a/src/memory/persistence/friday-memory-embedding-repository.ts
+++ b/src/memory/persistence/friday-memory-embedding-repository.ts
@@ -197,15 +197,12 @@ export function createFridayMemoryEmbeddingRepository(): FridayMemoryEmbeddingRe
       }
 
       const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
-      params.push(input.candidateLimit);
-
       const sql = `
         SELECT e.item_id, e.vector_json
         FROM memory_embeddings e
         JOIN memory_items mi ON mi.id = e.item_id
         ${where}
         ORDER BY e.updated_at DESC
-        LIMIT ?
       `;
 
       const candidateRows = db.prepare(sql).all(...params) as Array<{

--- a/test/unit/memory/persistence/friday-memory-embedding-repository.test.ts
+++ b/test/unit/memory/persistence/friday-memory-embedding-repository.test.ts
@@ -252,6 +252,45 @@ describe("FridayMemoryEmbeddingRepository", () => {
     expect(results.length).toBeLessThanOrEqual(2);
   });
 
+  it("recalls an older exact semantic match in a namespace larger than the candidate window", () => {
+    insertMemoryItem("target", "large-ns", "target");
+    db.writer.transaction(() => {
+      repo.upsert(db.writer, makeEmbedding({
+        id: "target-embedding",
+        itemId: "target",
+        providerId: "prov-1",
+        vector: [1.0, 0.0, 0.0],
+        updatedAt: "2026-02-17T09:00:00.000Z",
+      }));
+    })();
+
+    for (let i = 0; i < 250; i++) {
+      const id = `distractor-${String(i).padStart(3, "0")}`;
+      insertMemoryItem(id, "large-ns", id);
+      db.writer.transaction(() => {
+        repo.upsert(db.writer, makeEmbedding({
+          id: `distractor-embedding-${i}`,
+          itemId: id,
+          providerId: "prov-1",
+          vector: [0.0, 1.0, 0.0],
+          updatedAt: "2026-02-18T09:00:00.000Z",
+        }));
+      })();
+    }
+
+    const results = repo.querySimilar(db.writer, {
+      queryVector: [1.0, 0.0, 0.0],
+      model: "text-embedding-3-small",
+      nowIso: NOW,
+      namespace: "large-ns",
+      limit: 1,
+      candidateLimit: 250,
+      minScore: 0.9,
+    });
+
+    expect(results.map((result) => result.itemId)).toEqual(["target"]);
+  });
+
   it("excludes expired items by default", () => {
     const past = "2026-01-01T00:00:00.000Z";
     insertMemoryItem("mi-1", "test", "mi-1", past);


### PR DESCRIPTION
## Scope

G4/cr04 High sub-slice: `querySimilar` must recall an existing semantic match in a namespace larger than the candidate window. This is not full G4 closure and remains `pending-operator-review` unless external operator/军师 SIGN authorizes merge.

Changed files:
- `src/memory/persistence/friday-memory-embedding-repository.ts`
- `test/unit/memory/persistence/friday-memory-embedding-repository.test.ts`

## Red-first evidence

Evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/g4-querysimilar-large-namespace-redfirst-20260703T2230-0700`

- red `6c31dbf3`: `red-valid.log` exits 1, old query returns `[]` instead of `["target"]` when the exact match is older than 250 newer non-similar namespace candidates.
- green `df86b166`: `green-focused.log` exits 0 (`18 passed`), `green-typecheck-src.log` exits 0, `green-diff-check.log` exits 0, `green-eslint-target.log` exits 0 with warnings only.
- revert-red: `revert-red-focused.log` exits 1 after reverting `df86b166` in detached worktree `/private/tmp/friday-g4-querysimilar-revert-red-20260703`.
- superseded: `red-focused.*` exits 127 because deps were not installed yet.

## Reviewers

- Reviewer #1 Turing: `reviewer-1-codex.md`, PASS / no blocking finding; non-blocking caveat that no direct source-filter test was found, but green did not alter source-filter code.
- Reviewer #2 Popper: `reviewer-2-codex.md`, PASS for cr04 sub-slice / pending-operator-review; caveat that `candidateLimit` no longer bounds candidate scan cost while final result limit and filters remain intact.

## No-degrade / boundaries

- Full embedding repository focused suite passes and covers model/namespace/memoryType filters, minScore, expired exclusion, tag exact filtering, invalid vectors, malformed vector skip, and final result `limit`.
- This branch changes no S2 mission-spine/auto-dispatch, prod port, prod DB/env, deployment/restart, operator signature, npm publish, direct main/prod push, or `--admin`.
- Does not close #1486 zip-bomb external review, G4 empty-WHERE pruning, learning pipeline atomicity, Guard namespace isolation, full G4, G2/G3, D1/D6, §6/§15 completeness, or S2.

Open PR overlap before push showed only #1489 guide-lens, #1488 provider-cost, and #1486 studio files; this PR changes memory embedding files only.
