### PR TITLE
Constrain G4 memory guard default namespaces

### DIFF
--- a/src/memory/guard/services/friday-memory-guard-service.ts
+++ b/src/memory/guard/services/friday-memory-guard-service.ts
@@ -311,9 +311,9 @@ function scopeNamespaceFilter(
         ? descendants
         : [scopePrefix, ...descendants];
 
-    // Also include channel-scoped namespaces and "default" for the current user.
+    // Also include channel-scoped namespaces for the current user.
     // Without this, items from session memory extraction (tenant.X.channel.Y.user.Z)
-    // and agent memory_store ("default") are invisible in the user's memory list.
+    // are invisible in the user's memory list.
     // Channel namespaces use session chatId as user segment (not the real userId),
     // so for the same hub we include all channel-scoped namespaces.
     if (context.subject.userId) {
@@ -322,7 +322,7 @@ function scopeNamespaceFilter(
         quotaRepo.listNamespacesByPrefix(readDb, channelPrefix, FRIDAY_MEMORY_GUARD_SCOPE_PREFIX_MAX_NAMESPACES),
       );
       // Include all channel namespaces within the same hub (they all belong to this tenant)
-      const expanded = [...new Set([...result, ...channelDescendants, "default"])];
+      const expanded = [...new Set([...result, ...channelDescendants])];
       return expanded;
     }
 
@@ -664,7 +664,7 @@ export function createFridayMemoryGuardService(
         // Scope check on all items — allow items from the expanded namespace query.
         // scopedNamespace already restricts which namespaces are queried, so items
         // returned by core.list() are pre-filtered. The scope check here is a safety
-        // net. For expanded namespaces (channel-scoped, "default"), we trust the
+        // net. For expanded channel-scoped namespaces, we trust the
         // query filter since it was built from the user's context.
         const allowedNamespaces = Array.isArray(scopedNamespace)
           ? new Set(scopedNamespace as string[])

--- a/src/memory/guard/services/friday-memory-guard-service.ts
+++ b/src/memory/guard/services/friday-memory-guard-service.ts
@@ -312,17 +312,17 @@ function scopeNamespaceFilter(
         : [scopePrefix, ...descendants];
 
     // Also include channel-scoped namespaces for the current user.
-    // Without this, items from session memory extraction (tenant.X.channel.Y.user.Z)
-    // are invisible in the user's memory list.
-    // Channel namespaces use session chatId as user segment (not the real userId),
-    // so for the same hub we include all channel-scoped namespaces.
+    // Keep this filtered to the current user segment; default list/search/prune
+    // must never sweep every channel namespace in the same hub.
     if (context.subject.userId) {
       const channelPrefix = `${FRIDAY_MEMORY_GUARD_TENANT_PREFIX}.${context.subject.hubId}.${FRIDAY_MEMORY_GUARD_CHANNEL_SEGMENT}`;
       const channelDescendants = db.withReadConnection((readDb) =>
         quotaRepo.listNamespacesByPrefix(readDb, channelPrefix, FRIDAY_MEMORY_GUARD_SCOPE_PREFIX_MAX_NAMESPACES),
       );
-      // Include all channel namespaces within the same hub (they all belong to this tenant)
-      const expanded = [...new Set([...result, ...channelDescendants])];
+      const scopedChannelDescendants = channelDescendants.filter((namespace) =>
+        isExpandedChannelUserNamespaceInScope(namespace, context)
+      );
+      const expanded = [...new Set([...result, ...scopedChannelDescendants])];
       return expanded;
     }
 

--- a/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
+++ b/test/e2e/ui/friday-reflex-review-center-real-browser.e2e.test.ts
@@ -1040,7 +1040,14 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday Reflex Review Center real-browser f
           const published = workflowRuntime.crud.publishVersion(workflow.id, version.versionNumber);
           approvedWorkflowId = workflow.id;
           approvedWorkflowVersionId = published.id;
-          const sopMemory = await memoryService.store(
+          const sopMemory = await memoryGuardFactory.forContext({
+            principalId: DP10_DOGFOOD_USER_ID,
+            subject: {
+              hubId: DP10_DOGFOOD_TENANT_ID,
+              userId: DP10_DOGFOOD_USER_ID,
+              accessLevel: "tenant",
+            },
+          }).store(
             "default",
             [
               "DP10_DOGFOOD_APPROVED_SOP",

--- a/test/unit/memory/guard/services/friday-memory-guard-service-namespace-isolation.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-namespace-isolation.test.ts
@@ -16,6 +16,16 @@ describe("FridayMemoryGuardService — Namespace Isolation", () => {
     );
   });
 
+  it("prefixes the default namespace for tenant access level", async () => {
+    const { guard, core } = createGuardTestSetup();
+    await guard.store("default", "content");
+    expect(core.store).toHaveBeenCalledWith(
+      "tenant.default.user.user1.default",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it("does not prefix namespace for system access level", async () => {
     const { guard, core } = createGuardTestSetup({
       subject: { hubId: "default", accessLevel: "system" },
@@ -126,10 +136,18 @@ describe("FridayMemoryGuardService — Namespace Isolation", () => {
       expect.objectContaining({
         namespace: expect.arrayContaining([
           "tenant.default.user.user1",
-          "default",
         ]),
       }),
     );
+  });
+
+  it("does not include the bare default namespace in tenant default list scope", async () => {
+    const { guard, core } = createGuardTestSetup();
+    await guard.list();
+    const callArgs = vi.mocked(core.list).mock.calls[0];
+    const namespaces = callArgs[0]?.namespace;
+    expect(Array.isArray(namespaces)).toBe(true);
+    expect(namespaces).not.toContain("default");
   });
 
   it("list filters out items outside scope", async () => {
@@ -153,10 +171,18 @@ describe("FridayMemoryGuardService — Namespace Isolation", () => {
       expect.objectContaining({
         namespace: expect.arrayContaining([
           "tenant.default.user.user1",
-          "default",
         ]),
       }),
     );
+  });
+
+  it("does not include the bare default namespace in tenant default search scope", async () => {
+    const { guard, core } = createGuardTestSetup();
+    await guard.search("hello");
+    const callArgs = vi.mocked(core.search).mock.calls[0];
+    const namespaces = callArgs[1]?.namespace;
+    expect(Array.isArray(namespaces)).toBe(true);
+    expect(namespaces).not.toContain("default");
   });
 
   it("search filters results outside scope", async () => {
@@ -192,10 +218,18 @@ describe("FridayMemoryGuardService — Namespace Isolation", () => {
       expect.objectContaining({
         namespace: expect.arrayContaining([
           "tenant.default.user.user1",
-          "default",
         ]),
       }),
     );
+  });
+
+  it("does not include the bare default namespace in tenant default prune scope", async () => {
+    const { guard, core } = createGuardTestSetup();
+    await guard.prune();
+    const callArgs = vi.mocked(core.prune).mock.calls[0];
+    const namespaces = callArgs[0]?.namespace;
+    expect(Array.isArray(namespaces)).toBe(true);
+    expect(namespaces).not.toContain("default");
   });
 
   // ─── Tenant without userId ───

--- a/test/unit/memory/guard/services/friday-memory-guard-service-validation.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-validation.test.ts
@@ -70,7 +70,7 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
 
   describe("namespace prefix descendants", () => {
     it("expands scope prefix to include descendants when listing", async () => {
-      const { guard, core, quotaRepo, db } = createGuardTestSetup();
+      const { guard, core, quotaRepo } = createGuardTestSetup();
       const descendants = [
         "tenant.default.user.user1.notes",
         "tenant.default.user.user1.tasks",
@@ -80,15 +80,15 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
 
       await guard.list();
 
-      // Should call core.list with the prefix itself + expanded descendants + "default"
+      // Should call core.list with the prefix itself + scoped descendants only.
       expect(core.list).toHaveBeenCalledWith(
         expect.objectContaining({
-          namespace: ["tenant.default.user.user1", ...descendants, "default"],
+          namespace: ["tenant.default.user.user1", ...descendants],
         }),
       );
     });
 
-    it("keeps scopePrefix and default namespace available when no descendants found", async () => {
+    it("keeps scopePrefix available when no descendants found", async () => {
       const { guard, core, quotaRepo } = createGuardTestSetup();
       vi.mocked(quotaRepo.listNamespacesByPrefix).mockReturnValue([]);
 
@@ -96,7 +96,7 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
 
       expect(core.list).toHaveBeenCalledWith(
         expect.objectContaining({
-          namespace: ["tenant.default.user.user1", "default"],
+          namespace: ["tenant.default.user.user1"],
         }),
       );
     });
@@ -114,7 +114,7 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
       const callArgs = vi.mocked(core.search).mock.calls[0];
       expect(callArgs[1]).toEqual(
         expect.objectContaining({
-          namespace: ["tenant.default.user.user1", ...descendants, "default"],
+          namespace: ["tenant.default.user.user1", ...descendants],
         }),
       );
     });
@@ -161,7 +161,7 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
 
       expect(core.list).toHaveBeenCalledWith(
         expect.objectContaining({
-          namespace: ["tenant.default.user.user1", "tenant.default.channel.webchat.user.user1.shared", "default"],
+          namespace: ["tenant.default.user.user1", "tenant.default.channel.webchat.user.user1.shared"],
         }),
       );
     });
@@ -177,7 +177,7 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
 
       expect(core.prune).toHaveBeenCalledWith(
         expect.objectContaining({
-          namespace: ["tenant.default.user.user1", ...descendants, "default"],
+          namespace: ["tenant.default.user.user1", ...descendants],
         }),
       );
     });
@@ -266,7 +266,7 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
 
       expect(core.list).toHaveBeenCalledWith(
         expect.objectContaining({
-          namespace: ["tenant.default.user.user1", ...descendants, "default"],
+          namespace: ["tenant.default.user.user1", ...descendants],
         }),
       );
     });
@@ -283,7 +283,7 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
 
       expect(core.list).toHaveBeenCalledWith(
         expect.objectContaining({
-          namespace: [...descendants, "default"],
+          namespace: descendants,
         }),
       );
     });
@@ -300,7 +300,7 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
       const callArgs = vi.mocked(core.search).mock.calls[0];
       expect(callArgs[1]).toEqual(
         expect.objectContaining({
-          namespace: ["tenant.default.user.user1", "tenant.default.user.user1.archive", "default"],
+          namespace: ["tenant.default.user.user1", "tenant.default.user.user1.archive"],
         }),
       );
     });
@@ -316,7 +316,7 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
 
       expect(core.prune).toHaveBeenCalledWith(
         expect.objectContaining({
-          namespace: ["tenant.default.user.user1", "tenant.default.user.user1.old", "default"],
+          namespace: ["tenant.default.user.user1", "tenant.default.user.user1.old"],
         }),
       );
     });

--- a/test/unit/memory/guard/services/friday-memory-guard-service-validation.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-validation.test.ts
@@ -119,21 +119,21 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
       );
     });
 
-    it("search keeps channel-scoped session namespaces returned by expanded scope", async () => {
+    it("search keeps current-user channel-scoped namespaces returned by expanded scope", async () => {
       const { guard, core, quotaRepo } = createGuardTestSetup();
       vi.mocked(quotaRepo.listNamespacesByPrefix).mockImplementation((_db, prefix) => {
         if (prefix === "tenant.default.user.user1") {
           return ["tenant.default.user.user1.notes"];
         }
         if (prefix === "tenant.default.channel") {
-          return ["tenant.default.channel.webchat.user.memextract-123.shared"];
+          return ["tenant.default.channel.webchat.user.user1.shared"];
         }
         return [];
       });
       vi.mocked(core.search).mockResolvedValue([
         createMockSearchResult({
           item: createMockMemoryItem({
-            namespace: "tenant.default.channel.webchat.user.memextract-123.shared",
+            namespace: "tenant.default.channel.webchat.user.user1.shared",
             content: "User prefers rg over grep",
           }),
         }),
@@ -142,7 +142,7 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
       const results = await guard.search("rg grep");
 
       expect(results).toHaveLength(1);
-      expect(results[0]?.item.namespace).toBe("tenant.default.channel.webchat.user.memextract-123.shared");
+      expect(results[0]?.item.namespace).toBe("tenant.default.channel.webchat.user.user1.shared");
     });
 
     it("list still includes channel-scoped session namespaces when direct user descendants are empty", async () => {
@@ -162,6 +162,78 @@ describe("FridayMemoryGuardService — CX Review Fixes", () => {
       expect(core.list).toHaveBeenCalledWith(
         expect.objectContaining({
           namespace: ["tenant.default.user.user1", "tenant.default.channel.webchat.user.user1.shared"],
+        }),
+      );
+    });
+
+    it("does not include unrelated channel namespaces in default list scope", async () => {
+      const { guard, core, quotaRepo } = createGuardTestSetup();
+      vi.mocked(quotaRepo.listNamespacesByPrefix).mockImplementation((_db, prefix) => {
+        if (prefix === "tenant.default.user.user1") {
+          return [];
+        }
+        if (prefix === "tenant.default.channel") {
+          return [
+            "tenant.default.channel.webchat.user.user1.shared",
+            "tenant.default.channel.webchat.user.other-user.shared",
+          ];
+        }
+        return [];
+      });
+
+      await guard.list();
+
+      expect(core.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          namespace: ["tenant.default.user.user1", "tenant.default.channel.webchat.user.user1.shared"],
+        }),
+      );
+    });
+
+    it("does not include unrelated channel namespaces in default search scope", async () => {
+      const { guard, core, quotaRepo } = createGuardTestSetup();
+      vi.mocked(quotaRepo.listNamespacesByPrefix).mockImplementation((_db, prefix) => {
+        if (prefix === "tenant.default.user.user1") {
+          return [];
+        }
+        if (prefix === "tenant.default.channel") {
+          return [
+            "tenant.default.channel.webchat.user.user1.shared",
+            "tenant.default.channel.webchat.user.other-user.shared",
+          ];
+        }
+        return [];
+      });
+
+      await guard.search("hello");
+
+      expect(vi.mocked(core.search).mock.calls[0][1]).toEqual(
+        expect.objectContaining({
+          namespace: ["tenant.default.user.user1", "tenant.default.channel.webchat.user.user1.shared"],
+        }),
+      );
+    });
+
+    it("does not include unrelated channel namespaces in default prune scope", async () => {
+      const { guard, core, quotaRepo } = createGuardTestSetup();
+      vi.mocked(quotaRepo.listNamespacesByPrefix).mockImplementation((_db, prefix) => {
+        if (prefix === "tenant.default.user.user1") {
+          return [];
+        }
+        if (prefix === "tenant.default.channel") {
+          return [
+            "tenant.default.channel.webchat.user.user1.old",
+            "tenant.default.channel.webchat.user.other-user.old",
+          ];
+        }
+        return [];
+      });
+
+      await guard.prune();
+
+      expect(core.prune).toHaveBeenCalledWith(
+        expect.objectContaining({
+          namespace: ["tenant.default.user.user1", "tenant.default.channel.webchat.user.user1.old"],
         }),
       );
     });


### PR DESCRIPTION
## Summary
- removes bare `default` from tenant default memory guard list/search/prune scope
- filters expanded channel namespaces to the current user segment before passing them to core
- keeps scoped `default` writes (`tenant.<hub>.user.<user>.default`) and current-user channel namespaces covered

## Red-first evidence
- red1: `d22ef938` (`test(g4): expose guard bare default namespace leak`), `red-valid.exit=1`
- green1: `a415ffcb` (`fix(g4): scope guard default namespace per tenant`), `green-memory-guard-suite-2.exit=0`
- revert1: `revert2-red-focused.exit=1`
- reviewer gap red2: `db0db93e` (`test(g4): expose guard channel namespace expansion leak`), `red2-reviewer-channel-gap.exit=1`
- green2: `3eb14428` (`fix(g4): filter guard channel namespaces by user`), `green2-memory-guard-suite.exit=0`
- revert2: `revert3-red2-focused.exit=1`

Evidence directory: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/g4-guard-namespace-isolation-redfirst-20260703T2245-0700`

## Verification
- `npx vitest run test/unit/memory/guard/services --reporter=verbose` -> 146/146 passed
- `npm run typecheck:src` -> passed
- `npm run lint -- --quiet src/memory/guard/services/friday-memory-guard-service.ts test/unit/memory/guard/services/friday-memory-guard-service-namespace-isolation.test.ts test/unit/memory/guard/services/friday-memory-guard-service-validation.test.ts` -> passed
- `git diff --check HEAD` -> passed

## Reviewers
- reviewer #1 Hooke (`019f2b7b-c4e7-7c31-8a1f-4000609963d5`): PASS, caveat about historical channel namespaces that used chat/session ids in the `user` segment
- reviewer #2 James (`019f2b7b-e594-7fe0-a15e-da6ae62d04ed`): initial FAIL on channel expansion, addendum PASS after red2/green2; caveat that API/real SQLite coverage would be stronger

## Boundary
G4 is High. This PR must remain `pending-operator-review` until external operator/advisor SIGN. No auto-merge. This covers only the Guard default/channel namespace isolation sub-slice; it does not close full G4, querySimilar #1490, zip-bomb #1486, learning pipeline atomicity, empty-WHERE pruning, G2/G3, S2, deployment, prod DB/env writes, or operator-gated actions.
