### PR TITLE
Fail-close G4 empty memory prune

### DIFF
--- a/src/memory/persistence/friday-memory-item-repository.ts
+++ b/src/memory/persistence/friday-memory-item-repository.ts
@@ -309,6 +309,8 @@ export function createFridayMemoryItemRepository(): FridayMemoryItemRepository {
         params.push(options.olderThan);
       }
 
+      if (conditions.length === 0) return [];
+
       const where = `WHERE ${conditions.join(" AND ")}`;
       const limit = options.limit ?? 1000;
       params.push(limit);

--- a/test/unit/memory/persistence/friday-memory-item-repository.test.ts
+++ b/test/unit/memory/persistence/friday-memory-item-repository.test.ts
@@ -499,6 +499,21 @@ describe("FridayMemoryItemRepository", () => {
     expect(repo.getById(db.writer, "i3")).not.toBeNull();
   });
 
+  it("fail-closes prune with expiredOnly false and no predicate", () => {
+    db.writer.transaction(() => {
+      repo.insert(db.writer, makeItem({ id: "i1", key: "k1", namespace: "ns-a" }));
+      repo.insert(db.writer, makeItem({ id: "i2", key: "k2", namespace: "ns-b" }));
+    })();
+
+    const deleted = db.writer.transaction(() =>
+      repo.prune(db.writer, { expiredOnly: false, nowIso: NOW }),
+    )();
+
+    expect(deleted).toEqual([]);
+    expect(repo.getById(db.writer, "i1")).not.toBeNull();
+    expect(repo.getById(db.writer, "i2")).not.toBeNull();
+  });
+
   // ─── FTS backfill ───
 
   it("FTS index includes pre-existing items after migration (backfill)", () => {


### PR DESCRIPTION
## Summary
- fail-close memory item prune when no predicate is assembled
- add red-first regression proving expiredOnly:false with no predicate returns [] and retains rows

## Evidence
- red: evidence/g4-empty-prune-fail-close-redfirst-20260703T2300-0700/red-valid.log (exit 1)
- green: green-focused.log, green-full-memory-item-repository.log, green-typecheck-src.log, green-diff-check.log, green-eslint-target.log (all exit 0)
- revert-red: revert-red-focused.log (exit 1)
- reviewers: reviewer-1-huygens.md and reviewer-2-averroes.md PASS

## Status
High/G4 sub-slice only; pending-operator-review. No merge requested.