### PR TITLE
Gate NEW-3 readonly secret execution paths

### DIFF
--- a/src/agent/runtime/friday-agent-tool-mutation.ts
+++ b/src/agent/runtime/friday-agent-tool-mutation.ts
@@ -18,6 +18,25 @@ const MUTATING_TOOLS = new Set([
 // Shell commands that are read-only (inspection, listing, searching)
 const READ_ONLY_SHELL_COMMANDS = /^\s*(ls|find|cat|head|tail|wc|grep|rg|awk|sed\s+-n|sort|uniq|diff|file|stat|which|where|type|echo|pwd|date|uname|whoami|id|env|printenv|df|du|free|top\s+-bn|uptime|hostname|nproc|test\s|[\[]\s)/;
 
+const SECRET_READ_PROGRAMS = new Set(["env", "printenv", "cat", "head", "tail", "grep", "rg", "awk", "sed"]);
+const SENSITIVE_ENV_NAME_RE = /\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|secret|password|passwd|credential|private[_-]?key|client[_-]?secret|master[_-]?key)\b/i;
+const SENSITIVE_FILE_ARG_RE = /(?:^|[\/\s])(?:\.env(?:\.[\w.-]+)?|id_(?:rsa|dsa|ecdsa|ed25519)|[^\/\s]+\.(?:pem|key|p12|pfx)|secrets?(?:\.[\w.-]+)?|credentials?(?:\.[\w.-]+)?)(?:$|[\s])/i;
+
+const READ_ONLY_SKILL_RUN_IDS = new Set([
+  "system-health-snapshot",
+]);
+
+function readsSecretMaterial(commandParts: readonly string[]): boolean {
+  const program = commandParts[0]?.replace(/^["']+|["']+$/g, "").split("/").at(-1)?.toLowerCase() ?? "";
+  if (!SECRET_READ_PROGRAMS.has(program)) return false;
+
+  const command = commandParts.join(" ");
+  if (program === "env" || program === "printenv") {
+    return true;
+  }
+  return SENSITIVE_ENV_NAME_RE.test(command) || SENSITIVE_FILE_ARG_RE.test(command);
+}
+
 // Tools that are mutating only for certain actions/sub-operations
 const CONDITIONAL_MUTATING_TOOLS: Record<string, (args: Record<string, unknown>) => boolean> = {
   exec: (args) => {
@@ -35,7 +54,12 @@ const CONDITIONAL_MUTATING_TOOLS: Record<string, (args: Record<string, unknown>)
     //    + inline VAR=value assignments) so wrapped mutating commands don't masquerade as read-only.
     const unwrapped = unwrapCommand(command.split(/\s+/));
     if (unwrapped.approve) return true; // opaque/unverifiable wrapper → mutating (fail safe)
+    if (readsSecretMaterial(unwrapped.inner)) return true;
     return !READ_ONLY_SHELL_COMMANDS.test(unwrapped.inner.join(" "));
+  },
+  skill_run: (args) => {
+    const skillId = typeof args.skillId === "string" ? args.skillId : "";
+    return !READ_ONLY_SKILL_RUN_IDS.has(skillId);
   },
   system: (args) => {
     const action = typeof args.action === "string" ? args.action : "";
@@ -108,7 +132,8 @@ const CONDITIONAL_MUTATING_TOOLS: Record<string, (args: Record<string, unknown>)
     const action = typeof args.action === "string" ? args.action : "";
     return action === "update_preferences" || action === "update_avatar";
   },
-  // skill_run is now in READ_ONLY_TOOLS — skills run in their own sandbox
+  // MCP servers run in their own sandbox with their own security.
+  // Agent readOnly should not block MCP tool calls.
 };
 
 // Tools that are always read-only
@@ -128,7 +153,6 @@ const READ_ONLY_TOOLS = new Set([
   "list_subagents",
   "agents_list",
   "skills_list",
-  "skill_run",   // Skills execute in their own sandbox; agent readOnly shouldn't block them
   "capabilities",
   "task_status",
   "request_tool_pack",

--- a/test/unit/agent/runtime/friday-agent-tool-mutation.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-mutation.test.ts
@@ -28,15 +28,16 @@ describe("isMutatingToolCall", () => {
     expect(isMutatingToolCall("workflow_list", {})).toBe(false);
   });
 
-  it("classifies all skill_run calls as non-mutating (skills run in sandbox)", () => {
-    // skill_run is always read-only — skills execute in their own sandbox
-    expect(isMutatingToolCall("skill_run", {})).toBe(false);
+  it("keeps known diagnostic skill_run calls non-mutating", () => {
     expect(isMutatingToolCall("skill_run", { skillId: "system-health-snapshot" })).toBe(false);
-    expect(isMutatingToolCall("skill_run", { skillId: "idea-clarifier" })).toBe(false);
-    expect(isMutatingToolCall("skill_run", { skillId: "browser-qa-report" })).toBe(false);
-    expect(isMutatingToolCall("skill_run", { skillId: "release-doc-sync" })).toBe(false);
-    expect(isMutatingToolCall("skill_run", { skillId: "browser-qa-fix" })).toBe(false);
-    expect(isMutatingToolCall("skill_run", { skillId: "user-generated-skill" })).toBe(false);
+  });
+
+  it("classifies arbitrary skill_run calls as mutating because skills can expose secrets", () => {
+    expect(isMutatingToolCall("skill_run", {})).toBe(true);
+    expect(isMutatingToolCall("skill_run", { skillId: "browser-qa-report" })).toBe(true);
+    expect(isMutatingToolCall("skill_run", { skillId: "release-doc-sync" })).toBe(true);
+    expect(isMutatingToolCall("skill_run", { skillId: "browser-qa-fix" })).toBe(true);
+    expect(isMutatingToolCall("skill_run", { skillId: "user-generated-skill" })).toBe(true);
   });
 
   // ─── Always read-only ───
@@ -231,7 +232,15 @@ describe("isMutatingToolCall", () => {
   it("keeps plain read-only exec non-mutating (regression guard)", () => {
     expect(isMutatingToolCall("exec", { command: "ls -la" })).toBe(false);
     expect(isMutatingToolCall("exec", { command: "grep -r foo src" })).toBe(false);
-    expect(isMutatingToolCall("exec", { command: "printenv" })).toBe(false);
+  });
+
+  it("classifies secret-reading exec commands as mutating", () => {
+    expect(isMutatingToolCall("exec", { command: "env" })).toBe(true);
+    expect(isMutatingToolCall("exec", { command: "printenv" })).toBe(true);
+    expect(isMutatingToolCall("exec", { command: "printenv OPENAI_API_KEY" })).toBe(true);
+    expect(isMutatingToolCall("exec", { command: "cat .env" })).toBe(true);
+    expect(isMutatingToolCall("exec", { command: "cat ~/.ssh/id_rsa" })).toBe(true);
+    expect(isMutatingToolCall("exec", { command: "grep -r API_KEY .env" })).toBe(true);
   });
 
   it("classifies plain mutating exec as mutating (regression guard)", () => {


### PR DESCRIPTION
## Scope

NEW-3 / readOnly secret execution boundary (MED). This PR is rebuilt on current main after #1450/#1493; it only changes:

- `src/agent/runtime/friday-agent-tool-mutation.ts`
- `test/unit/agent/runtime/friday-agent-tool-mutation.test.ts`

## Red-first evidence

Evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new3-current-main-coverage-20260704T0515-0700`

- Red commit: `0a85d24d28df436be63da6ab128c2758925b9f2c` (test only)
- Green commit: `63d482524de8987bdf58a17a9bf4ed5e6c288f05` (implementation only)
- Current-main red: `red-on-current-main-focused-after-node-modules.exit=1`
- Revert-red: `revert-red-focused-2.exit=1`
- Green: `green-focused-2.exit=0` (47 passed), `green-runtime-neighbor-2.exit=0` (109 passed), `green-typecheck-src-2.exit=0`, `green-diff-check-2.exit=0`, `green-eslint-target-2.exit=0`

Earlier setup/cwd and intermediate MCP-no-degrade failure logs in the same directory are superseded by the `after-node-modules` and `*-2` logs.

## Reviewers

- Reviewer #1: `Planck the 3rd`, session `019f2d0d-7fca-7582-b675-2c64536507ae`, verdict PASS, file `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new3-current-main-coverage-20260704T0515-0700/reviewer-1-planck.md`
- Reviewer #2: `Nash the 3rd`, session `019f2d0d-a26d-74f1-952d-9ce40c5b0e38`, verdict PASS, file `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new3-current-main-coverage-20260704T0515-0700/reviewer-2-nash.md`

## No-degrade

Keeps ordinary read-only exec and env-wrapped read-only exec non-mutating; keeps diagnostic `skill_run` (`system-health-snapshot`) non-mutating; keeps MCP `call_tool` mutating while discovery/read MCP actions remain non-mutating. No S2, provider/keychain, Rust hub/storage, prod/deploy, prod DB/env, signature, or operator-gated paths touched.

## Merge gate

MED item. Auto-merge is allowed only after full PR-CI true green, fresh born-current/no-overlap/clean merge-state recheck, and post-merge main push-CI monitoring. No `--admin`.
