### PR TITLE
Gate NEW-5 proof anti-mock contamination in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,27 @@ jobs:
       - name: SSD marker lint
         run: node scripts/quality/check-ssd-markers.mjs
 
+  # ── MECHANISM-5a: Proof Anti-Mock Contamination Gate ──
+  proof-no-mock-leaks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Proof no-mock leak gate
+        run: npm run check:proof:no-mock-leaks
+
   # ── MECHANISM-5b: Scope/Alignment Guard ──
   alignment-guard:
     runs-on: ubuntu-latest
@@ -467,7 +488,7 @@ jobs:
   quality-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [build, test, migrations, security, contracts, ssd-lint, alignment-guard, agent-parity, secrets, ts-runtime-retirement, prod-flag-tests, mechanism-wiring, client-ship-gate]
+    needs: [build, test, migrations, security, contracts, ssd-lint, proof-no-mock-leaks, alignment-guard, agent-parity, secrets, ts-runtime-retirement, prod-flag-tests, mechanism-wiring, client-ship-gate]
     if: ${{ always() }}
 
     steps:
@@ -479,6 +500,7 @@ jobs:
           echo "Security:           ${{ needs.security.result }}"
           echo "Contracts:          ${{ needs.contracts.result }}"
           echo "SSD Lint:           ${{ needs.ssd-lint.result }}"
+          echo "Proof No-Mock Leaks:${{ needs.proof-no-mock-leaks.result }}"
           echo "Alignment Guard:    ${{ needs.alignment-guard.result }}"
           echo "Agent Parity:       ${{ needs.agent-parity.result }}"
           echo "Secrets:            ${{ needs.secrets.result }}"
@@ -496,6 +518,7 @@ jobs:
             "${{ needs.security.result }}" \
             "${{ needs.contracts.result }}" \
             "${{ needs.ssd-lint.result }}" \
+            "${{ needs.proof-no-mock-leaks.result }}" \
             "${{ needs.alignment-guard.result }}" \
             "${{ needs.agent-parity.result }}" \
             "${{ needs.secrets.result }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,22 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        env:
+          npm_config_fetch_retries: 5
+          npm_config_fetch_retry_mintimeout: 10000
+          npm_config_fetch_retry_maxtimeout: 120000
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then
+              exit 0
+            else
+              status=$?
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit "$status"
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Proof no-mock leak gate
         run: npm run check:proof:no-mock-leaks

--- a/scripts/quality/release-truth-lib.mjs
+++ b/scripts/quality/release-truth-lib.mjs
@@ -50,10 +50,6 @@ export const DEFAULT_PROOF_INPUTS = [
   "scripts/ops/phase24b-discord-trusted-inbound-listener.mjs",
   "scripts/ops/phase24c-telegram-trusted-inbound-listener.mjs",
   "scripts/ops/phase24d-lark-feishu-trusted-inbound-listener.mjs",
-  "scripts/ops/phase24e-telegram-workflow-candidate-listener.mjs",
-  "scripts/ops/phase24f-discord-workflow-candidate-listener.mjs",
-  "scripts/ops/phase24g-lark-feishu-workflow-candidate-listener.mjs",
-  "scripts/ops/lib/workflow-candidate-proof-harness.mjs",
   "scripts/ops/validate-channel-proof-artifacts.mjs",
   "validation/real-world/lib",
   "test/e2e/live",
@@ -68,6 +64,13 @@ export const MOCK_CONTAMINATION_PATTERNS = [
   { pattern: /localStorage\.setItem\(/g, label: "localStorage.setItem" },
   { pattern: /\bfake transport\b/gi, label: "fake transport" },
   { pattern: /\bfake provider\b/gi, label: "fake provider" },
+  { pattern: /\bscripted\s+mock\s+(?:provider|transport|runtime|bin)\b/gi, label: "scripted mock runtime" },
+  { pattern: /\b(?:stubbed\s+(?:llm\s+)?(?:bridge|provider|runtime|transport)|llm\s+bridge\s+stubbed)\b/gi, label: "stubbed runtime boundary" },
+  { pattern: /\bsynthetic\s+fixtures?\s+(?:drove|drive|driven|accepted|produced)\b/gi, label: "synthetic fixture proof" },
+  { pattern: /\bdry[- ]run\s+proof\b/gi, label: "dry-run proof" },
+  { pattern: /\bplaceholder\s+evidence\b/gi, label: "placeholder evidence" },
+  { pattern: /\bsample\s+proof\b/gi, label: "sample proof" },
+  { pattern: /\btest\s+oracle\b/gi, label: "test oracle" },
 ];
 
 function normalizePath(filePath = "") {

--- a/test/unit/quality/proof-no-mock-leaks-ci-wiring.test.ts
+++ b/test/unit/quality/proof-no-mock-leaks-ci-wiring.test.ts
@@ -1,0 +1,19 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+
+describe("proof no-mock leak gate CI wiring", () => {
+  it("runs the anti-mock proof contamination gate as a required CI job", async () => {
+    const workflowText = await readFile(path.join(repoRoot, ".github", "workflows", "ci.yml"), "utf8");
+    const packageText = await readFile(path.join(repoRoot, "package.json"), "utf8");
+
+    expect(packageText).toContain("\"check:proof:no-mock-leaks\"");
+    expect(workflowText).toMatch(/\n  proof-no-mock-leaks:\n/);
+    expect(workflowText).toContain("npm run check:proof:no-mock-leaks");
+    expect(workflowText).toMatch(/needs: \[[^\]]*proof-no-mock-leaks[^\]]*\]/);
+    expect(workflowText).toContain("Proof No-Mock Leaks:");
+  });
+});

--- a/test/unit/scripts/quality/release-truth-lib.test.ts
+++ b/test/unit/scripts/quality/release-truth-lib.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   classifyEvidenceTarget,
   classifyReleaseProofEnvironment,
+  MOCK_CONTAMINATION_PATTERNS,
+  scanTextForMockLeaks,
 } from "../../../../scripts/quality/release-truth-lib.mjs";
 
 describe("release truth evidence classification", () => {
@@ -36,5 +38,22 @@ describe("release truth evidence classification", () => {
       status: "not_configured",
       missingEnv: ["FRIDAY_AUTH_TOKEN"],
     });
+  });
+
+  it("detects broad mock-contamination proof labels, not only the old six markers", () => {
+    const contaminatedProofPhrases = [
+      "scripted MOCK provider completed the release proof",
+      "stubbed LLM bridge produced the closure artifact",
+      "synthetic fixture drove the real-green result",
+      "dry-run proof was accepted as release evidence",
+      "placeholder evidence bundle marked the run green",
+      "sample proof output stood in for live evidence",
+      "test oracle generated the passing artifact",
+    ];
+
+    expect(MOCK_CONTAMINATION_PATTERNS.length).toBeGreaterThanOrEqual(12);
+    for (const phrase of contaminatedProofPhrases) {
+      expect(scanTextForMockLeaks("release-proof", phrase)).not.toEqual([]);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add a dedicated CI job for `npm run check:proof:no-mock-leaks` and include it in the terminal quality gate
- broaden release-proof mock contamination markers beyond the old six-marker denylist
- keep explicitly stubbed Phase24E/F/G workflow-candidate files out of default release-proof inputs without deleting those scripts

## Red-first evidence
- branch: `codex/new5-antimock-ci-current-20260704`
- base: `origin/main=1ca2e7a6cb51f1171cbca32ce8bd1e79a486b35d`
- red: `c3cb3b10` test-only, valid `red-new5-target.exit=1`
- green: `356ca353` implementation-only
- revert-red: `revert-red-new5-target.exit=1`
- evidence: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new5-current-main-redfirst-20260704T072446-0700`

## Verification
- `green-new5-target.exit=0` (2 files / 4 tests)
- `green-check-proof-no-mock-leaks.exit=0` (48 proof input files)
- `green-typecheck-src.exit=0`
- `green-eslint-target.exit=0` (warnings only)
- `green-diff-check.exit=0`
- reviewer #1 PASS: `reviewer-1.md`
- reviewer #2 PASS: `reviewer-2.md`

## Boundaries
- MED item; eligible for auto-merge only after full PR-CI true green, fresh born-current/no-overlap, and main push-CI monitoring
- no overlap with open #1497 S13 foundation PR
- no prod deploy/restart, prod DB/env write, signature, organic provenance, or operator-gated action