### PR TITLE
Recover NEW-6 finished post-loop provider bindings

### DIFF
--- a/rust-core/crates/friday-hub/src/crash_recovery.rs
+++ b/rust-core/crates/friday-hub/src/crash_recovery.rs
@@ -92,13 +92,24 @@
 //!     outcome/error, so a Codex process that dies mid-turn leaves the same stale
 //!     `ReadyToDispatch + executing == 1` signal PASS-2 can reconcile. The remaining gap is the
 //!     same dispatch→first-SET window above.
+//!   * **The post-loop provider-binding window is closed narrowly.** If the loop already persisted
+//!     `run_result=finished` and the process then dies before provider-timeline binding, the row is
+//!     `ReadyToDispatch + executing == 0`, but it is distinguishable from the dispatch hand-off
+//!     state by the same WorkItem's durable `route-decision:agent-loop:{run_id}` plus that finished
+//!     `run_result`. Recovery replays ONLY that missing attach, completing the WorkItem with the
+//!     run as proof. A ready row without both durable witnesses is still untouched.
 //!
 //! GATING: none. The boot PASS-1+PASS-2 reconcile is a hard safety sweep. The loop-side marker
 //! writes are also flag-independent (see the no-degrade posture above), while WorkItem-status timing
 //! stays unchanged vs pre-#24b (binding driven after the loop).
 
-use friday_core::{WorkItemStatus, WorkflowRunState};
+use friday_core::{RouteDecisionCard, WorkItem, WorkItemStatus, WorkflowRunState};
 use friday_storage::{Db, StorageError};
+
+use crate::mission_runtime::{
+    answer_produced_outcome_receipt_for_work_item, attach_agent_loop_provider_state,
+    AgentLoopProviderRestState,
+};
 
 /// The actor recorded on the lifecycle audit row for a crash-recovery abort.
 const CRASH_RECOVERY_ACTOR: &str = "crash-recovery";
@@ -179,7 +190,7 @@ pub fn is_stale_executing_candidate(status: WorkItemStatus) -> bool {
 pub struct ReconcileOutcome {
     /// Non-terminal rows scanned.
     pub scanned: usize,
-    /// Genuinely-orphaned rows advanced to `FailedTerminal` with the crash-recovery marker.
+    /// Genuinely-orphaned rows advanced to a safe resting state.
     pub aborted: usize,
     /// Orphaned rows whose legal transition failed (logged + skipped; the sweep continues).
     pub skipped: usize,
@@ -248,6 +259,15 @@ pub fn reconcile_orphaned_work_items(
         };
 
         if !abort {
+            match recover_finished_post_loop_agent_binding(db, &item, now_ms) {
+                Ok(true) => {
+                    outcome.aborted += 1;
+                }
+                Ok(false) => {}
+                Err(_) => {
+                    outcome.skipped += 1;
+                }
+            }
             continue;
         }
 
@@ -294,6 +314,94 @@ pub fn reconcile_orphaned_work_items(
     }
 
     Ok(outcome)
+}
+
+fn recover_finished_post_loop_agent_binding(
+    db: &Db,
+    item: &WorkItem,
+    now_ms: i64,
+) -> Result<bool, StorageError> {
+    if item.status != WorkItemStatus::ReadyToDispatch {
+        return Ok(false);
+    }
+    if db
+        .get_work_item_execution_state(&item.work_item_id)?
+        .is_some_and(|state| state.executing)
+    {
+        return Ok(false);
+    }
+
+    let Some((decision, run_id)) = latest_finished_agent_loop_decision(db, item)? else {
+        return Ok(false);
+    };
+    let Some(mission) = db.get_mission(&item.mission_id)? else {
+        return Ok(false);
+    };
+    let Some(result) = friday_storage::get_run_result(db.conn(), &run_id)? else {
+        return Ok(false);
+    };
+    if result.status != "finished" {
+        return Ok(false);
+    }
+
+    let proof_ref = format!("friday://agent-run/{run_id}");
+    let completion_proof_receipt = answer_produced_outcome_receipt_for_work_item(
+        db,
+        &decision.work_item_id,
+        &run_id,
+        &result.answer,
+        now_ms,
+    )?;
+    match attach_agent_loop_provider_state(
+        db,
+        &decision.mission_id,
+        &decision.work_item_id,
+        &mission.friday_conversation_id,
+        &run_id,
+        AgentLoopProviderRestState::Completed,
+        &proof_ref,
+        completion_proof_receipt.as_deref(),
+        true,
+        now_ms,
+    )? {
+        crate::mission_preflight::MissionAttachmentOutcome::Attached {
+            work_item_status: WorkItemStatus::CompletedWithProof,
+            ..
+        } => Ok(true),
+        _ => Ok(false),
+    }
+}
+
+fn latest_finished_agent_loop_decision(
+    db: &Db,
+    item: &WorkItem,
+) -> Result<Option<(RouteDecisionCard, String)>, StorageError> {
+    let mut decisions = db.list_route_decisions_for_mission(&item.mission_id)?;
+    decisions.retain(|decision| decision.work_item_id == item.work_item_id);
+    decisions.sort_by_key(|decision| (decision.created_at_ms, decision.decision_id.clone()));
+    for decision in decisions.into_iter().rev() {
+        let Some(run_id) = decision
+            .decision_id
+            .strip_prefix("route-decision:agent-loop:")
+            .filter(|run_id| !run_id.is_empty())
+        else {
+            continue;
+        };
+        if !decision
+            .trace_refs
+            .iter()
+            .any(|trace| trace == &format!("agent-run:{run_id}"))
+        {
+            continue;
+        }
+        let run_id = run_id.to_string();
+        if friday_storage::get_run_result(db.conn(), &run_id)?
+            .is_some_and(|result| result.status == "finished")
+        {
+            return Ok(Some((decision, run_id)));
+        }
+    }
+    Ok(None)
 }
 
 /// The deterministic id PREFIX of a scheduled workflow run (`sched:<schedule_id>:<slot_ts>` —

--- a/rust-core/crates/friday-hub/src/crash_recovery.rs
+++ b/rust-core/crates/friday-hub/src/crash_recovery.rs
@@ -377,29 +377,34 @@ fn latest_finished_agent_loop_decision(
     item: &WorkItem,
 ) -> Result<Option<(RouteDecisionCard, String)>, StorageError> {
     let mut decisions = db.list_route_decisions_for_mission(&item.mission_id)?;
-    decisions.retain(|decision| decision.work_item_id == item.work_item_id);
+    decisions.retain(|decision| {
+        decision.work_item_id == item.work_item_id
+            && decision
+                .decision_id
+                .strip_prefix("route-decision:agent-loop:")
+                .is_some_and(|run_id| {
+                    !run_id.is_empty()
+                        && decision
+                            .trace_refs
+                            .iter()
+                            .any(|trace| trace == &format!("agent-run:{run_id}"))
+                })
+    });
     decisions.sort_by_key(|decision| (decision.created_at_ms, decision.decision_id.clone()));
-    for decision in decisions.into_iter().rev() {
-        let Some(run_id) = decision
-            .decision_id
-            .strip_prefix("route-decision:agent-loop:")
-            .filter(|run_id| !run_id.is_empty())
-        else {
-            continue;
-        };
-        if !decision
-            .trace_refs
-            .iter()
-            .any(|trace| trace == &format!("agent-run:{run_id}"))
-        {
-            continue;
-        }
-        let run_id = run_id.to_string();
-        if friday_storage::get_run_result(db.conn(), &run_id)?
-            .is_some_and(|result| result.status == "finished")
-        {
-            return Ok(Some((decision, run_id)));
-        }
+    let Some(decision) = decisions.pop() else {
+        return Ok(None);
+    };
+    let Some(run_id) = decision
+        .decision_id
+        .strip_prefix("route-decision:agent-loop:")
+    else {
+        return Ok(None);
+    };
+    let run_id = run_id.to_string();
+    if friday_storage::get_run_result(db.conn(), &run_id)?
+        .is_some_and(|result| result.status == "finished")
+    {
+        return Ok(Some((decision, run_id)));
     }
     Ok(None)
 }

--- a/rust-core/crates/friday-hub/tests/crash_recovery.rs
+++ b/rust-core/crates/friday-hub/tests/crash_recovery.rs
@@ -567,6 +567,41 @@ fn post_loop_reconcile_completes_finished_agent_loop_before_provider_binding() {
     );
 }
 
+#[test]
+fn post_loop_reconcile_leaves_agent_loop_route_without_finished_result_untouched() {
+    // No-degrade guard for NEW-6: a route decision alone is not proof that the loop finished.
+    // Without `run_result=finished`, this is still indistinguishable from an ordinary ready row.
+    let db = Db::open_hub(&temp_db("post-loop-no-result")).unwrap();
+    let mission = format!("mission-{}", unique("post-loop-no-result"));
+    seed_mission(&db, &mission);
+    seed_work_item(
+        &db,
+        &mission,
+        "wi-post-loop-no-result",
+        WorkItemStatus::ReadyToDispatch,
+    );
+    set_executing(&db, "wi-post-loop-no-result", false, RECONCILE_AT - 1);
+    seed_agent_loop_route_decision(
+        &db,
+        "wi-post-loop-no-result",
+        "run-post-loop-no-result",
+        NOW + 10,
+    );
+
+    let audit_before = verify_audit_chain(db.conn()).unwrap();
+    let outcome = reconcile_orphaned_work_items(&db, RECONCILE_AT).unwrap();
+
+    assert_eq!(outcome.aborted, 0);
+    assert_eq!(outcome.skipped, 0);
+    assert_eq!(
+        status_of(&db, "wi-post-loop-no-result"),
+        WorkItemStatus::ReadyToDispatch,
+        "a route decision without finished run_result is not enough to recover"
+    );
+    assert_eq!(blocking_reason_of(&db, "wi-post-loop-no-result"), None);
+    assert_eq!(verify_audit_chain(db.conn()).unwrap(), audit_before);
+}
+
 // ── #784(b): boot reconcile of orphaned SCHEDULED workflow runs ───────────────────────────────
 // A scheduled run executes synchronously inside one tick, so a `Pending`/`Running` `sched:` run at
 // boot is a daemon that DIED mid-tick. Left non-terminal it permanently WEDGES its schedule (the

--- a/rust-core/crates/friday-hub/tests/crash_recovery.rs
+++ b/rust-core/crates/friday-hub/tests/crash_recovery.rs
@@ -47,13 +47,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use friday_core::{
     ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
-    TruthStatus, WorkItem, WorkItemStatus, WorkLane,
+    RouteDecisionCard, TruthStatus, WorkItem, WorkItemStatus, WorkLane,
 };
 use friday_hub::crash_recovery::{
     reconcile_orphaned_work_items, CRASH_RECOVERY_MARKER, EXECUTION_STATE_STALE_THRESHOLD_MS,
 };
 use friday_storage::audit::verify_audit_chain;
-use friday_storage::Db;
+use friday_storage::{persist_run_result, Db, RunResult};
 
 static C: AtomicU64 = AtomicU64::new(0);
 const NOW: i64 = 1_700_000_000_000;
@@ -162,6 +162,21 @@ fn seed_work_item(db: &Db, mission_id: &str, work_item_id: &str, status: WorkIte
         updated_at_ms: NOW,
     })
     .unwrap();
+}
+
+fn seed_agent_loop_route_decision(db: &Db, work_item_id: &str, run_id: &str, now_ms: i64) {
+    let item = db
+        .get_work_item(work_item_id)
+        .unwrap()
+        .expect("seeded work item exists");
+    let decision = RouteDecisionCard::from_work_item(
+        format!("route-decision:agent-loop:{run_id}"),
+        &item,
+        vec![format!("agent-run:{run_id}")],
+        now_ms,
+        None,
+    );
+    db.upsert_route_decision(&decision).unwrap();
 }
 
 fn status_of(db: &Db, work_item_id: &str) -> WorkItemStatus {
@@ -482,6 +497,74 @@ fn pass2_exactly_at_threshold_is_stale_and_reconciled() {
         "one ms under the threshold is still live"
     );
     assert_eq!(status_of(&db2, "wi-edge2"), WorkItemStatus::ProviderWaiting);
+}
+
+#[test]
+fn post_loop_reconcile_completes_finished_agent_loop_before_provider_binding() {
+    // NEW-6: if the loop returns and persists `run_result=finished`, then the process dies before
+    // the post-loop provider binding, the WorkItem is left at ReadyToDispatch + executing=0. It is
+    // not a mid-call stale heartbeat candidate, but it is also no longer a normal dispatch handoff:
+    // the durable agent-loop route decision + run_result prove the run already finished and only
+    // the provider-timeline bind is missing.
+    let db = Db::open_hub(&temp_db("post-loop-finished")).unwrap();
+    let mission = format!("mission-{}", unique("post-loop-finished"));
+    seed_mission(&db, &mission);
+    seed_work_item(
+        &db,
+        &mission,
+        "wi-post-loop-finished",
+        WorkItemStatus::ReadyToDispatch,
+    );
+    set_executing(&db, "wi-post-loop-finished", false, RECONCILE_AT - 1);
+    seed_agent_loop_route_decision(
+        &db,
+        "wi-post-loop-finished",
+        "run-post-loop-finished",
+        NOW + 10,
+    );
+    persist_run_result(
+        db.conn(),
+        "run-post-loop-finished",
+        &RunResult::new("finished", "durable answer", None),
+        NOW + 11,
+    )
+    .unwrap();
+
+    let audit_before = verify_audit_chain(db.conn()).unwrap();
+    let outcome = reconcile_orphaned_work_items(&db, RECONCILE_AT).unwrap();
+
+    assert_eq!(
+        outcome.aborted, 1,
+        "the post-loop binding orphan must be closed by recovery"
+    );
+    assert_eq!(outcome.skipped, 0);
+    assert_eq!(
+        status_of(&db, "wi-post-loop-finished"),
+        WorkItemStatus::CompletedWithProof,
+        "the finished run_result is the proof for the WorkItem completion"
+    );
+    let work = db
+        .get_work_item("wi-post-loop-finished")
+        .unwrap()
+        .expect("work item remains readable");
+    assert!(
+        work.proof_receipts
+            .contains(&"friday://agent-run/run-post-loop-finished".to_string()),
+        "the recovered completion carries the run proof receipt"
+    );
+    let links = db.list_mission_links(&mission).unwrap();
+    assert!(
+        links.iter().any(|link| {
+            link.work_item_id.as_deref() == Some("wi-post-loop-finished")
+                && link.target_ref.ends_with("#run-post-loop-finished")
+        }),
+        "recovery must recreate the provider-timeline MissionLink"
+    );
+    assert_eq!(
+        verify_audit_chain(db.conn()).unwrap(),
+        audit_before + 5,
+        "recovery drives the five legal provider lifecycle hops"
+    );
 }
 
 // ── #784(b): boot reconcile of orphaned SCHEDULED workflow runs ───────────────────────────────

--- a/rust-core/crates/friday-hub/tests/crash_recovery.rs
+++ b/rust-core/crates/friday-hub/tests/crash_recovery.rs
@@ -602,6 +602,55 @@ fn post_loop_reconcile_leaves_agent_loop_route_without_finished_result_untouched
     assert_eq!(verify_audit_chain(db.conn()).unwrap(), audit_before);
 }
 
+#[test]
+fn post_loop_reconcile_requires_latest_agent_loop_decision_to_be_finished() {
+    // No-degrade guard: if a newer agent-loop attempt exists for the same still-active WorkItem,
+    // an older finished run is stale history. Recovery must not complete the WorkItem from that
+    // older run while the latest attempt has no finished result.
+    let db = Db::open_hub(&temp_db("post-loop-latest-only")).unwrap();
+    let mission = format!("mission-{}", unique("post-loop-latest-only"));
+    seed_mission(&db, &mission);
+    seed_work_item(
+        &db,
+        &mission,
+        "wi-post-loop-latest-only",
+        WorkItemStatus::ReadyToDispatch,
+    );
+    set_executing(&db, "wi-post-loop-latest-only", false, RECONCILE_AT - 1);
+    seed_agent_loop_route_decision(
+        &db,
+        "wi-post-loop-latest-only",
+        "run-post-loop-old",
+        NOW + 10,
+    );
+    persist_run_result(
+        db.conn(),
+        "run-post-loop-old",
+        &RunResult::new("finished", "old durable answer", None),
+        NOW + 11,
+    )
+    .unwrap();
+    seed_agent_loop_route_decision(
+        &db,
+        "wi-post-loop-latest-only",
+        "run-post-loop-new",
+        NOW + 20,
+    );
+
+    let audit_before = verify_audit_chain(db.conn()).unwrap();
+    let outcome = reconcile_orphaned_work_items(&db, RECONCILE_AT).unwrap();
+
+    assert_eq!(outcome.aborted, 0);
+    assert_eq!(outcome.skipped, 0);
+    assert_eq!(
+        status_of(&db, "wi-post-loop-latest-only"),
+        WorkItemStatus::ReadyToDispatch,
+        "recovery must not complete from an older finished route decision"
+    );
+    assert_eq!(blocking_reason_of(&db, "wi-post-loop-latest-only"), None);
+    assert_eq!(verify_audit_chain(db.conn()).unwrap(), audit_before);
+}
+
 // ── #784(b): boot reconcile of orphaned SCHEDULED workflow runs ───────────────────────────────
 // A scheduled run executes synchronously inside one tick, so a `Pending`/`Running` `sched:` run at
 // boot is a daemon that DIED mid-tick. Left non-terminal it permanently WEDGES its schedule (the


### PR DESCRIPTION
## Summary
- recover finished agent-loop WorkItems stranded after the post-loop provider-binding window clears executing
- require the latest eligible agent-loop decision to be finished before recovery can complete the WorkItem
- keep route-only/no-finished-result rows untouched

## Red-first evidence
- Red1: feaac142 / evidence/new6-current-main-redfirst-20260704T084407-0700/red1-post-loop.exit=101
- Green1: 9a5679f2 / green1-post-loop.exit=0; green1-post-loop.INVALID-api-drift is excluded as API-drift compile evidence
- Red2: 57fb9e76 / red2-latest-decision.exit=101
- Green2: 3d80f214 / green-focused-post-loop.exit=0, green-crash-recovery-suite.exit=0, green-cargo-check-hub.exit=0, green-diff-check.exit=0
- Revert-red: revert-red1-post-loop.exit=101 and revert-red2-latest-decision.exit=101

## Independent review
- reviewer-1.md: PASS, session new6-reviewer-1-codex-20260704
- reviewer-2.md: PASS, session reviewer-2-codex-new6-20260704T084955-0700

## No-overlap / boundary
- Base: origin/main 7f0e51b83a623216b869163b3c31a4d8448762c2
- Open PR #1497 touches only Suite-13 scripts/tests; NEW-6 touches only rust-core/crates/friday-hub/src/crash_recovery.rs and rust-core/crates/friday-hub/tests/crash_recovery.rs
- This is MED and may be auto-merged only after full PR-CI true green, born-current/no-overlap recheck, and post-merge main push-CI monitoring. No prod deploy/restart, prod DB/env write, signature, organic provenance, or operator-gated action.