### PR TITLE
Close NEW-7 resume completion missions

### DIFF
--- a/rust-core/crates/friday-hub/src/mission_preflight.rs
+++ b/rust-core/crates/friday-hub/src/mission_preflight.rs
@@ -10,10 +10,11 @@
 use friday_core::MemoryState;
 use friday_core::{
     outcome_checked_proof_enabled, requires_context_passport, ApprovalState, FridayConversation,
-    Mission, MissionLink, MissionLinkKind, SurfaceThread, WorkItem, WorkItemStatus, WorkspaceClaim,
+    Mission, MissionLink, MissionLinkKind, MissionStatus, RouteDecisionCard, SurfaceThread,
+    WorkItem, WorkItemStatus, WorkspaceClaim,
 };
 use friday_storage::{memory, mission, workflow, Db, MissionBodySnapshot, StorageError};
-use rusqlite::Connection;
+use rusqlite::Transaction;
 
 use crate::channel_event::ChannelInboundReceipt;
 use crate::provider_timeline::PendingState;
@@ -723,7 +724,7 @@ pub(crate) fn attach_provider_timeline_state_guarded_with_completion_receipt(
 ///
 /// Keep this in lock-step with the `else` branch above: any change to one must change the other.
 pub(crate) fn attach_provider_timeline_state_off_path_in(
-    conn: &Connection,
+    conn: &Transaction<'_>,
     attachment: ProviderTimelineAttachment,
     clear_executing: bool,
     completion_proof_receipt: Option<&str>,
@@ -758,6 +759,7 @@ pub(crate) fn attach_provider_timeline_state_off_path_in(
     }
 
     // OFF path (and same-status no-op): the pre-WI-1 inline write, verbatim.
+    let previous_status = work_item.status;
     work_item.status = next_status;
     work_item.updated_at_ms = attachment.now_ms;
     if next_status == WorkItemStatus::CompletedWithProof {
@@ -785,6 +787,15 @@ pub(crate) fn attach_provider_timeline_state_off_path_in(
         mission::upsert_work_item(conn, &work_item)?;
     }
     mission::upsert_mission(conn, &mission)?;
+    maybe_close_mission_after_off_path_completion(
+        conn,
+        &work_item,
+        previous_status,
+        attachment.proof_ref.as_deref(),
+        "friday-hub:provider-timeline",
+        "provider_timeline_completed_with_proof",
+        attachment.now_ms,
+    )?;
 
     let target_ref = format!(
         "friday://provider-timeline/{}#{}",
@@ -812,6 +823,156 @@ pub(crate) fn attach_provider_timeline_state_off_path_in(
         link_id,
         work_item_status: next_status,
     })
+}
+
+fn maybe_close_mission_after_off_path_completion(
+    conn: &Transaction<'_>,
+    item: &WorkItem,
+    previous_status: WorkItemStatus,
+    proof_ref: Option<&str>,
+    actor_ref: &str,
+    reason: &str,
+    now_ms: i64,
+) -> Result<(), StorageError> {
+    if previous_status == WorkItemStatus::CompletedWithProof
+        || item.status != WorkItemStatus::CompletedWithProof
+    {
+        return Ok(());
+    }
+
+    let Some(mut mission) = mission::get_mission(conn, &item.mission_id)? else {
+        return Ok(());
+    };
+    if !mission.status.can_transition_to(MissionStatus::Done) {
+        return Ok(());
+    }
+
+    let work_items = mission::list_work_items_for_mission(conn, &item.mission_id)?;
+    if work_items.is_empty()
+        || !work_items
+            .iter()
+            .all(|work_item| work_item.status == WorkItemStatus::CompletedWithProof)
+    {
+        return Ok(());
+    }
+    if has_unmaterialized_deferred_follow_up(conn, &item.mission_id, &work_items)? {
+        return Ok(());
+    }
+
+    let Some(proof_ref) = proof_ref else {
+        return Ok(());
+    };
+    let previous_mission_status = mission.status;
+    mission.status = mission
+        .status
+        .try_transition(MissionStatus::Done)
+        .map_err(|err| StorageError::Unsupported(err.to_string()))?;
+    mission.updated_at_ms = now_ms;
+    push_unique(&mut mission.proof_refs, proof_ref.to_string());
+    let lifecycle_entry = format!(
+        "lifecycle:{}:active->done by {}: auto-close after WorkItem '{}' completed_with_proof ({reason})",
+        mission.mission_id, actor_ref, item.work_item_id
+    );
+    mission.decision_path_summary =
+        append_lifecycle_summary(&mission.decision_path_summary, &lifecycle_entry);
+
+    friday_storage::audit::append_audit(
+        conn,
+        &format!("mission_autoclose:{}:{now_ms}", mission.mission_id),
+        actor_ref,
+        &format!(
+            "mission.lifecycle:{}->{}:auto_close_after_work_item:{}",
+            previous_mission_status.as_str(),
+            mission.status.as_str(),
+            item.work_item_id
+        ),
+        Some(mission.mission_id.as_str()),
+        now_ms,
+    )?;
+    mission::upsert_mission(conn, &mission)?;
+
+    let mut conversation = mission::get_conversation(conn, &mission.friday_conversation_id)?
+        .ok_or_else(|| {
+            StorageError::Unsupported(format!(
+                "mission_auto_close conversation '{}' not found",
+                mission.friday_conversation_id
+            ))
+        })?;
+    conversation
+        .active_mission_ids
+        .retain(|id| id != &mission.mission_id);
+    conversation.updated_at_ms = now_ms;
+    mission::upsert_conversation(conn, &conversation)?;
+
+    Ok(())
+}
+
+fn has_unmaterialized_deferred_follow_up(
+    conn: &Transaction<'_>,
+    mission_id: &str,
+    work_items: &[WorkItem],
+) -> Result<bool, StorageError> {
+    let route_decisions = mission::list_route_decisions_for_mission(conn, mission_id)?;
+    for decision in &route_decisions {
+        if decision.deferred_options.is_empty() {
+            continue;
+        }
+        if decision
+            .inheritable_context
+            .iter()
+            .any(|context| context.starts_with("source_route_decision:"))
+        {
+            continue;
+        }
+        if !deferred_route_decision_materialized(decision, &route_decisions, work_items) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn deferred_route_decision_materialized(
+    decision: &RouteDecisionCard,
+    route_decisions: &[RouteDecisionCard],
+    work_items: &[WorkItem],
+) -> bool {
+    let source_marker = format!("source_route_decision:{}", decision.decision_id);
+    if work_items.iter().any(|work_item| {
+        work_item
+            .judgment_memory
+            .inheritable_context
+            .iter()
+            .any(|context| context == &source_marker)
+    }) {
+        return true;
+    }
+
+    route_decisions
+        .iter()
+        .filter(|candidate| {
+            candidate.decision_id != decision.decision_id
+                && candidate.work_item_id == decision.work_item_id
+                && candidate.created_at_ms >= decision.created_at_ms
+                && !candidate.deferred_options.is_empty()
+        })
+        .any(|candidate| {
+            let source_marker = format!("source_route_decision:{}", candidate.decision_id);
+            work_items.iter().any(|work_item| {
+                work_item
+                    .judgment_memory
+                    .inheritable_context
+                    .iter()
+                    .any(|context| context == &source_marker)
+            })
+        })
+}
+
+fn append_lifecycle_summary(existing: &str, entry: &str) -> String {
+    if existing.trim().is_empty() {
+        entry.to_string()
+    } else {
+        format!("{existing}\n{entry}")
+    }
 }
 
 fn validate_preflight_request(request: &MissionPreflightRequest) -> Vec<String> {

--- a/rust-core/crates/friday-hub/tests/resume_mission_workitem_completion.rs
+++ b/rust-core/crates/friday-hub/tests/resume_mission_workitem_completion.rs
@@ -24,7 +24,8 @@ use friday_core::gate::{
 };
 use friday_core::{
     ApprovalState, FridayConversation, HandoffJudgmentMemory, Mission, MissionStatus, Risk,
-    SurfaceKind, SurfaceThread, TruthStatus, VisibilityPolicy, WorkItem, WorkItemStatus, WorkLane,
+    RouteDecisionCard, SurfaceKind, SurfaceThread, TruthStatus, VisibilityPolicy, WorkItem,
+    WorkItemStatus, WorkLane,
 };
 use friday_crypto::{OperatorSigningKey, OperatorVerifyingKey};
 use friday_hub::agent_run_control::resume as bare_resume;
@@ -39,6 +40,7 @@ use friday_hub::{
     ExecError, FsToolExecutor, LoopStatus, RawToolCall, RunPolicy, ToolExecutor, ToolReceipt,
     TurnTrace,
 };
+use friday_storage::audit::verify_audit_chain;
 use friday_storage::{
     agent_run, get_run_result_ref, list_pending_requests_for_run, Db, StorageError,
 };
@@ -375,6 +377,7 @@ fn executed_resume_advances_bound_work_item_to_completed_with_proof() {
     let exec = FsToolExecutor::new(&ws.0);
 
     let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+    let audit_before = verify_audit_chain(db.conn()).unwrap();
     let outcome =
         resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&approval), NOW)
             .unwrap();
@@ -420,6 +423,13 @@ fn executed_resume_advances_bound_work_item_to_completed_with_proof() {
         MissionStatus::Done,
         "operator-approved resume completion must auto-close the single-work-item Mission"
     );
+    assert!(
+        mission
+            .proof_refs
+            .contains(&format!("friday://agent-run/{run_id}")),
+        "Mission auto-close carries the run proof ref: {:?}",
+        mission.proof_refs
+    );
     let conversation = db
         .get_friday_conversation("fconv_ok")
         .unwrap()
@@ -429,6 +439,78 @@ fn executed_resume_advances_bound_work_item_to_completed_with_proof() {
             .active_mission_ids
             .contains(&"mission-ok".to_string()),
         "auto-close must remove the Mission from active_mission_ids"
+    );
+    assert!(
+        verify_audit_chain(db.conn()).unwrap() > audit_before,
+        "resume success keeps the audit chain growing and verifiable"
+    );
+    let autoclose_audit_count: i64 = db
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM audit_ledger \
+             WHERE action LIKE 'mission.lifecycle:active->done:auto_close_after_work_item:%'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        autoclose_audit_count, 1,
+        "auto-close adds one mission lifecycle audit receipt"
+    );
+}
+
+#[test]
+fn executed_resume_does_not_auto_close_with_unmaterialized_deferred_follow_up() {
+    let (sk, vk) = operator();
+    let db = Db::open_hub(&temp_db("deferred")).unwrap();
+    let ws = Workspace::new("deferred");
+    let owner = "owner:alice";
+    let run_id = "run-deferred";
+    seed_mission(&db, "deferred", owner);
+    bind_to_provider_routed(&db, "deferred", "friday-session-deferred", run_id);
+    let item = db
+        .get_work_item("work-deferred")
+        .unwrap()
+        .expect("work item exists");
+    db.upsert_route_decision(&RouteDecisionCard::from_work_item(
+        "route-decision:deferred".into(),
+        &item,
+        vec![format!("agent-run:{run_id}")],
+        NOW - 10,
+        None,
+    ))
+    .unwrap();
+    let (nonce, request) = pause_run(&db, &ws, run_id, owner, &vk, "out-deferred.txt");
+    let exec = FsToolExecutor::new(&ws.0);
+    let approval = ed_approval(&request, &sk, &nonce, Some(FUTURE));
+
+    let outcome =
+        resume_agent_loop_for_mission(&db, &exec, &vk, run_id, &signed_blob(&approval), NOW)
+            .unwrap();
+
+    assert!(outcome.accepted);
+    assert_eq!(
+        work_status(&db, "deferred"),
+        WorkItemStatus::CompletedWithProof
+    );
+    let mission = db
+        .get_mission("mission-deferred")
+        .unwrap()
+        .expect("mission remains readable");
+    assert_eq!(
+        mission.status,
+        MissionStatus::Active,
+        "unmaterialized deferred follow-up keeps the Mission open"
+    );
+    let conversation = db
+        .get_friday_conversation("fconv_deferred")
+        .unwrap()
+        .expect("conversation remains readable");
+    assert!(
+        conversation
+            .active_mission_ids
+            .contains(&"mission-deferred".to_string()),
+        "open Mission must remain in active_mission_ids"
     );
 }
 

--- a/rust-core/crates/friday-hub/tests/resume_mission_workitem_completion.rs
+++ b/rust-core/crates/friday-hub/tests/resume_mission_workitem_completion.rs
@@ -411,6 +411,25 @@ fn executed_resume_advances_bound_work_item_to_completed_with_proof() {
         pt_links[0].target_ref,
         format!("friday://provider-timeline/friday-session-ok#{run_id}")
     );
+    let mission = db
+        .get_mission("mission-ok")
+        .unwrap()
+        .expect("mission remains readable");
+    assert_eq!(
+        mission.status,
+        MissionStatus::Done,
+        "operator-approved resume completion must auto-close the single-work-item Mission"
+    );
+    let conversation = db
+        .get_friday_conversation("fconv_ok")
+        .unwrap()
+        .expect("conversation remains readable");
+    assert!(
+        !conversation
+            .active_mission_ids
+            .contains(&"mission-ok".to_string()),
+        "auto-close must remove the Mission from active_mission_ids"
+    );
 }
 
 // ─────────────────────────── FALSE-PROOF GUARDS ───────────────────────────


### PR DESCRIPTION
## Summary
- auto-close eligible single-work-item Missions after operator-approved resume completion
- remove the Mission from conversation active_mission_ids and append mission_autoclose audit proof
- keep unmaterialized deferred follow-up Missions active

## Red-first evidence
- Red: 9037e39c / evidence/new7-current-main-redfirst-20260704T1335-0700/red-focused.exit=101; valid target failure Mission Active vs Done
- Invalid excluded: red-focused.INVALID-wrong-cwd is a Cargo.toml/cwd harness error
- Green: db2b1a4f / green-focused.exit=0, green-resume-suite.exit=0, green-mission-runtime-lib.exit=0, green-cargo-check-hub.exit=0, green-diff-check.exit=0
- Revert-red: revert-red-focused.exit=101 reproduces Mission Active vs Done after reverting db2b1a4f

## Independent review
- reviewer-1.md: PASS, Descartes the 3rd, harness new7-current-main-redfirst-20260704T1335-0700
- reviewer-2.md: PASS, Locke the 3rd, harness new7-current-main-redfirst-20260704T1335-0700

## No-overlap / boundary
- Base: origin/main 30f8233f6de2807ec4aadd4d5016189ab52aaffb
- Open PR #1497 touches only Suite-13 scripts/tests; NEW-7 touches only rust-core/crates/friday-hub/src/mission_preflight.rs and rust-core/crates/friday-hub/tests/resume_mission_workitem_completion.rs
- This is MED and may be auto-merged only after full PR-CI true green, born-current/no-overlap recheck, and post-merge main push-CI monitoring. No prod deploy/restart, prod DB/env write, signature, organic provenance, or operator-gated action.