### PR TITLE
Fail-close F3 prerequisite installer approval gate

### DIFF
--- a/src/setup/friday-setup-prerequisite-installer.ts
+++ b/src/setup/friday-setup-prerequisite-installer.ts
@@ -201,7 +201,7 @@ export function createFridayPrerequisiteInstaller(
             verifyCommand: `${software} --version`,
             platform: "all",
             description: `No automatic installer for "${software}". Manual installation required.`,
-            requiresApproval: false,
+            requiresApproval: true,
           });
           continue;
         }
@@ -215,6 +215,14 @@ export function createFridayPrerequisiteInstaller(
     async install(plan, signal) {
       if (signal.aborted) {
         return { software: plan.software, status: "skipped" as const };
+      }
+
+      if (plan.requiresApproval) {
+        return {
+          software: plan.software,
+          status: "skipped" as const,
+          errorMessage: `Approval required before installing "${plan.software}".`,
+        };
       }
 
       // If no install command, cannot install

--- a/test/unit/setup/friday-setup-prerequisite-installer.test.ts
+++ b/test/unit/setup/friday-setup-prerequisite-installer.test.ts
@@ -109,7 +109,7 @@ describe("FridayPrerequisiteInstaller", () => {
           verifyCommand: "node --version",
           platform: "darwin",
           description: "Install Node.js",
-          requiresApproval: true,
+          requiresApproval: false,
         },
         signal(),
       );
@@ -137,7 +137,7 @@ describe("FridayPrerequisiteInstaller", () => {
           verifyCommand: "node --version",
           platform: "darwin",
           description: "Install Node.js",
-          requiresApproval: true,
+          requiresApproval: false,
         },
         signal(),
       );
@@ -234,16 +234,14 @@ describe("FridayPrerequisiteInstaller", () => {
       expect(results[0].version).toBe("22.0.0");
     });
 
-    it("should install missing software and return results", async () => {
+    it("should skip approval-gated missing software instead of executing it", async () => {
       // isInstalled always returns false, so nothing is "already installed"
       const scanner = createMockScanner({
         isInstalled: vi.fn().mockResolvedValue(false),
         getVersion: vi.fn().mockResolvedValue(null),
       });
 
-      const execFn = vi.fn()
-        .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" })        // brew install node
-        .mockResolvedValueOnce({ exitCode: 0, stdout: "v22.0.0\n", stderr: "" }); // node --version verify
+      const execFn = createMockExec();
 
       const installer = createFridayPrerequisiteInstaller({
         environmentScanner: scanner,
@@ -251,11 +249,14 @@ describe("FridayPrerequisiteInstaller", () => {
       });
 
       const results = await installer.installAll(["node"], signal());
-      // Should have install result
-      expect(results.length).toBeGreaterThanOrEqual(1);
-      const installed = results.find((r) => r.status === "installed");
-      expect(installed).toBeDefined();
-      expect(installed!.version).toBe("v22.0.0");
+      expect(execFn).not.toHaveBeenCalled();
+      expect(results).toEqual([
+        expect.objectContaining({
+          software: "node",
+          status: "skipped",
+          errorMessage: expect.stringContaining("Approval required"),
+        }),
+      ]);
     });
   });
 });

--- a/test/unit/setup/friday-setup-prerequisite-installer.test.ts
+++ b/test/unit/setup/friday-setup-prerequisite-installer.test.ts
@@ -73,6 +73,7 @@ describe("FridayPrerequisiteInstaller", () => {
       expect(plans).toHaveLength(1);
       expect(plans[0].installCommand).toBe("");
       expect(plans[0].description).toContain("Manual installation");
+      expect(plans[0].requiresApproval).toBe(true);
     });
 
     it("should use Linux recipes on Linux", async () => {
@@ -143,6 +144,30 @@ describe("FridayPrerequisiteInstaller", () => {
 
       expect(result.status).toBe("failed");
       expect(result.errorMessage).toContain("Permission denied");
+    });
+
+    it("should not execute approval-gated install plans without an approval ticket", async () => {
+      const execFn = createMockExec(0, "v22.0.0\n");
+      const installer = createFridayPrerequisiteInstaller({
+        environmentScanner: createMockScanner(),
+        execCommand: execFn,
+      });
+
+      const result = await installer.install(
+        {
+          software: "node",
+          installCommand: "brew install node",
+          verifyCommand: "node --version",
+          platform: "darwin",
+          description: "Install Node.js",
+          requiresApproval: true,
+        },
+        signal(),
+      );
+
+      expect(execFn).not.toHaveBeenCalled();
+      expect(result.status).toBe("skipped");
+      expect(result.errorMessage).toContain("Approval required");
     });
 
     it("should return failed when no install command exists", async () => {


### PR DESCRIPTION
## Scope

F3 / setup prerequisite installer `requiresApproval` dead-flag fix. This PR is intentionally narrow and changes only:

- `src/setup/friday-setup-prerequisite-installer.ts`
- `test/unit/setup/friday-setup-prerequisite-installer.test.ts`

## Red-first provenance

- Red commit: `3c3ed95b` (`test: expose F3 prerequisite installer approval bypass`) — test-only.
- Green commit: `4a9f3a70` (`fix: fail closed prerequisite installer approval gate`) — implementation + no-degrade test updates.
- Evidence: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/f3-installer-approval-redfirst-20260704T1909-0700/`
  - `red-focused.exit=1`
  - `green-focused.exit=0`
  - `green-unit-setup.exit=0` (7 setup files / 65 tests)
  - `green-typecheck-src.exit=0`
  - `revert-red-focused.exit=1`

## Fix

- Unknown/manual prerequisite plans now default to `requiresApproval: true`.
- `install()` returns `skipped` with `Approval required` before shell execution when `plan.requiresApproval` is true.
- This is strict fail-close. It does not claim to implement a signed approval-ticket resume flow.

## Review / status boundary

Two independent read-only reviewers approved:

- Socrates the 3rd (`019f300b-77e6-7881-987f-3adaa91c2588`): `reviewer-1-socrates.md`
- Laplace the 3rd (`019f300b-8a43-7b72-93fa-609b8dbed29e`): `reviewer-2-laplace.md`

F3 is Blocker/High. This PR must remain `pending-operator-review`; agent must not self-merge without explicit external operator/strategist SIGN.

## No-degrade

- Non-approval plans still execute and verify.
- Non-approval command failures still return `failed` with stderr.
- Already-installed prerequisites still return `not_needed` with version.
- Abort still returns `skipped`.
- Setup assistant reaches prerequisite installation through `prerequisiteInstaller.installAll()`; no separate shell path was changed.

No S2, UI/S13, provider/keychain, Rust runtime, prod/deploy, prod DB/env, signature, organic provenance, or operator-gated production path is touched.
