### PR TITLE
Detect G1 audit chain tail deletion

### DIFF
--- a/rust-core/crates/friday-storage/src/audit.rs
+++ b/rust-core/crates/friday-storage/src/audit.rs
@@ -54,7 +54,7 @@ fn hash_entry(prev: &[u8; 32], canon: &[u8]) -> [u8; 32] {
 fn last_hash(conn: &Connection) -> rusqlite::Result<[u8; 32]> {
     let row: Option<Vec<u8>> = conn
         .query_row(
-            "SELECT entry_hash FROM audit_ledger ORDER BY rowid DESC LIMIT 1",
+            "SELECT entry_hash FROM audit_chain_head WHERE chain_id = 1",
             [],
             |r| r.get(0),
         )
@@ -97,6 +97,17 @@ pub fn append_audit(
             created_at
         ],
     )?;
+    let updated = tx.execute(
+        "UPDATE audit_chain_head
+            SET last_audit_id = ?1,
+                entry_hash = ?2,
+                row_count = row_count + 1
+          WHERE chain_id = 1",
+        rusqlite::params![audit_id, &entry[..]],
+    )?;
+    if updated != 1 {
+        return Err(rusqlite::Error::QueryReturnedNoRows);
+    }
     Ok(entry)
 }
 
@@ -122,6 +133,7 @@ pub fn verify_audit_chain(conn: &Connection) -> Result<usize> {
 
     let mut prev = GENESIS_PREV_HASH;
     let mut count = 0usize;
+    let mut last_audit_id: Option<String> = None;
     for row in rows {
         let (audit_id, prev_hash, entry_hash, actor, action, payload_ref, created_at) = row?;
         if prev_hash.as_slice() != prev.as_slice() {
@@ -139,7 +151,32 @@ pub fn verify_audit_chain(conn: &Connection) -> Result<usize> {
             return Err(StorageError::AuditChainBroken(audit_id));
         }
         prev = expected;
+        last_audit_id = Some(audit_id);
         count += 1;
+    }
+    let head: Option<(Option<String>, Vec<u8>, i64)> = conn
+        .query_row(
+            "SELECT last_audit_id, entry_hash, row_count
+               FROM audit_chain_head
+              WHERE chain_id = 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .optional()?;
+    let Some((anchored_last_id, anchored_hash, anchored_count)) = head else {
+        return Err(StorageError::AuditChainBroken(
+            "<audit_chain_head>".to_string(),
+        ));
+    };
+    let broken_id = anchored_last_id
+        .clone()
+        .or_else(|| last_audit_id.clone())
+        .unwrap_or_else(|| "<audit_chain_head>".to_string());
+    if anchored_count != count as i64
+        || anchored_hash.as_slice() != prev.as_slice()
+        || anchored_last_id.as_deref() != last_audit_id.as_deref()
+    {
+        return Err(StorageError::AuditChainBroken(broken_id));
     }
     Ok(count)
 }

--- a/rust-core/crates/friday-storage/src/schema.rs
+++ b/rust-core/crates/friday-storage/src/schema.rs
@@ -173,6 +173,9 @@ pub const HUB_ONLY_TABLES: &[&str] = &[
     // NOT chained and never references the audit ledger. It holds NO row id/body that was
     // deleted — only integer counts — so it carries no secret/PII content class.
     "retention_log",
+    // G1: singleton tail anchor for the Hub audit hash chain. This is separate
+    // from the ledger rows so deletion of the final row is detectable.
+    "audit_chain_head",
 ];
 
 /// Tables present only on a phone (never created on the Hub).
@@ -711,6 +714,16 @@ pub fn hub_migrations() -> Vec<Migration> {
             destructive: false,
             up: m0042_activity_item_owner,
         },
+        // G1: persist the audit chain tail outside `audit_ledger` so `verify_audit_chain`
+        // can detect tail deletion in addition to row mutation and middle deletion.
+        // The migration is additive Hub-only; existing databases seed the anchor from the
+        // currently present chain tail and fresh databases seed genesis/zero rows.
+        Migration {
+            version: 43,
+            name: "audit_chain_head",
+            destructive: false,
+            up: m0043_audit_chain_head,
+        },
     ]
 }
 
@@ -861,6 +874,14 @@ CREATE TABLE audit_ledger (
     created_at  INTEGER NOT NULL
 );
 CREATE INDEX idx_audit_created ON audit_ledger(created_at);";
+
+const DDL_AUDIT_CHAIN_HEAD: &str = "
+CREATE TABLE IF NOT EXISTS audit_chain_head (
+    chain_id      INTEGER PRIMARY KEY CHECK(chain_id = 1),
+    last_audit_id TEXT,
+    entry_hash    BLOB NOT NULL CHECK(length(entry_hash) = 32),
+    row_count     INTEGER NOT NULL CHECK(row_count >= 0)
+);";
 
 const DDL_MEMORY_ITEM: &str = "
 CREATE TABLE memory_item (
@@ -2686,4 +2707,19 @@ fn m0040_mission_body_snapshot(tx: &Transaction) -> rusqlite::Result<()> {
 
 fn m0041_retention_log(tx: &Transaction) -> rusqlite::Result<()> {
     tx.execute_batch(DDL_RETENTION_LOG)
+}
+
+fn m0043_audit_chain_head(tx: &Transaction) -> rusqlite::Result<()> {
+    tx.execute_batch(DDL_AUDIT_CHAIN_HEAD)?;
+    tx.execute_batch(
+        "INSERT OR REPLACE INTO audit_chain_head
+             (chain_id, last_audit_id, entry_hash, row_count)
+         SELECT 1,
+                (SELECT audit_id FROM audit_ledger ORDER BY rowid DESC LIMIT 1),
+                COALESCE(
+                    (SELECT entry_hash FROM audit_ledger ORDER BY rowid DESC LIMIT 1),
+                    zeroblob(32)
+                ),
+                (SELECT COUNT(*) FROM audit_ledger);",
+    )
 }

--- a/rust-core/crates/friday-storage/tests/audit.rs
+++ b/rust-core/crates/friday-storage/tests/audit.rs
@@ -83,3 +83,22 @@ fn deleting_a_row_breaks_the_chain() {
         other => panic!("expected AuditChainBroken(au2), got {other:?}"),
     }
 }
+
+#[test]
+fn deleting_tail_row_breaks_the_chain() {
+    let p = temp_db_path("audit-tail-del");
+    let mut db = Db::open_hub(&p).unwrap();
+    append(&mut db, "au0", "pairing", 0);
+    append(&mut db, "au1", "model_call", 1);
+    append(&mut db, "au2", "revoke", 2);
+    assert_eq!(audit::verify_audit_chain(db.conn()).unwrap(), 3);
+
+    db.conn()
+        .execute("DELETE FROM audit_ledger WHERE audit_id = 'au2'", [])
+        .unwrap();
+
+    match audit::verify_audit_chain(db.conn()) {
+        Err(StorageError::AuditChainBroken(id)) => assert_eq!(id, "au2"),
+        other => panic!("expected AuditChainBroken(au2), got {other:?}"),
+    }
+}

--- a/rust-core/crates/friday-storage/tests/migration.rs
+++ b/rust-core/crates/friday-storage/tests/migration.rs
@@ -151,10 +151,10 @@ fn forward_migration_v41_to_v42_adds_activity_owner_to_null_preserving_pre_v42_r
             )
             .unwrap();
     }
-    // Reopen with the full set -> forward-migrate to v42 (adds the additive owner ALTER).
+    // Reopen with the full set -> forward-migrate through v42 (adds the additive owner
+    // ALTER) and any later additive migrations.
     let db = Db::open_hub(&p).unwrap();
     assert_eq!(db.version().unwrap(), hub_max_version());
-    assert_eq!(hub_max_version(), 42, "M6 lands the hub at code_max 42");
     assert_eq!(
         db.count("activity_item").unwrap(),
         1,
@@ -208,6 +208,41 @@ fn forward_migration_v41_to_v42_adds_activity_owner_to_null_preserving_pre_v42_r
         db.mark_activity_done("owned-1", Some("alice"), 5).unwrap(),
         "owner allowed"
     );
+}
+
+#[test]
+fn forward_migration_v42_to_v43_seeds_empty_audit_chain_head() {
+    // G1 additive migration v43: the Hub audit chain gets a singleton tail anchor.
+    // A pre-v43 database with no audit rows must migrate to the genesis head.
+    let p = temp_db_path("audit-chain-head-mig");
+    {
+        let mut migs = hub_migrations();
+        migs.retain(|m| m.version <= 42);
+        let db = Db::open(&p, Profile::Hub, &migs, "v42").unwrap();
+        assert_eq!(db.version().unwrap(), 42);
+        assert!(
+            db.conn()
+                .prepare("SELECT row_count FROM audit_chain_head")
+                .is_err(),
+            "audit_chain_head must not exist before v43"
+        );
+    }
+
+    let db = Db::open_hub(&p).unwrap();
+    assert_eq!(db.version().unwrap(), hub_max_version());
+    let (last_audit_id, hash_len, row_count): (Option<String>, i64, i64) = db
+        .conn()
+        .query_row(
+            "SELECT last_audit_id, length(entry_hash), row_count
+               FROM audit_chain_head
+              WHERE chain_id = 1",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(last_audit_id, None);
+    assert_eq!(hash_len, 32);
+    assert_eq!(row_count, 0);
 }
 
 #[test]

--- a/src/state/sqlite/friday-rust-hub-schema-handshake.ts
+++ b/src/state/sqlite/friday-rust-hub-schema-handshake.ts
@@ -6,7 +6,7 @@ import Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 
 export const FRIDAY_HUB_AGENT_RUN_DB_PATH_ENV = "FRIDAY_HUB_AGENT_RUN_DB_PATH";
-export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 42;
+export const FRIDAY_EXPECTED_RUST_HUB_SCHEMA_VERSION = 43;
 
 export type FridayRustHubSchemaHandshakeStatus = "ok" | "skipped";
 


### PR DESCRIPTION
## Scope

G1 / Rust audit_ledger verifyChain tamper evidence (MED). This PR makes tail deletion detectable by anchoring the audit chain tail outside audit_ledger.

## Red-first evidence

- Red commit: 6cb4cd8f test-only, adds rust-core/crates/friday-storage/tests/audit.rs tail-delete test.
- Red: evidence/g1-audit-chain-tamper-redfirst-20260704T1940-0700/red-tail-delete.log exits 101 because verify_audit_chain returned Ok(2) after deleting au2.
- Green commit: 4fa4cf6f adds audit_chain_head, same-transaction head update, and verify comparison.
- Green local checks: audit test, migration test, schema_profile test, atomic test, cargo check, and diff-check all exit 0 in the evidence directory.
- Revert-red: evidence/g1-audit-chain-tamper-redfirst-20260704T1940-0700/revert-red-tail-delete-valid.log exits 101 after reverting 4fa4cf6f, returning to expected AuditChainBroken(au2), got Ok(2).

## Independent review

- Goodall the 3rd / 019f302b-b428-7c03-80a3-b025dd79a2f6: APPROVE.
- Euclid the 3rd / 019f302c-7e70-7232-830e-c102f2333db7: APPROVE.

Both reviewers used fresh scratch worktrees and independently reran red, green, and revert-red.

## No-overlap / boundaries

- Born-current before push: merge-base matched origin/main 7cb01894e0f2db21e2dac9542f07f9447f0ccef7.
- Open PR #1502 touches only setup TypeScript files; this PR touches only rust-core/crates/friday-storage files.
- G1 is MED: after full PR-CI true green, born-current/no-overlap still holds, and red-first/reviewer evidence remains intact, this may be squash-merged under the Low/Med auto-merge rule. No --admin, no prod deploy/restart, no prod DB/env writes, no signature or organic provenance.

## Caveat

Migration v43 can anchor only the ledger tail visible at migration time; a tail row deleted before any chain-external anchor existed cannot be reconstructed retroactively. Post-fix appends and verifies detect subsequent tail deletion.