### PR TITLE
Repair Gate C2 pet reference fidelity oracle

### DIFF
--- a/scripts/ops/check-friday-served-ui-design-fidelity.mjs
+++ b/scripts/ops/check-friday-served-ui-design-fidelity.mjs
@@ -4,7 +4,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import { createServer } from "node:http";
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
-import { dirname, extname, join, relative, resolve } from "node:path";
+import { dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SCRIPT_DIR = resolve(fileURLToPath(import.meta.url), "..");
@@ -191,7 +191,8 @@ function startFileServer(root) {
     const url = new URL(req.url ?? "/", "http://127.0.0.1");
     const decodedPath = decodeURIComponent(url.pathname);
     let filePath = resolve(root, `.${decodedPath}`);
-    if (!filePath.startsWith(root)) {
+    const relativePath = relative(root, filePath);
+    if (relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
       res.writeHead(403);
       res.end("forbidden");
       return;

--- a/scripts/ops/check-friday-served-ui-design-fidelity.mjs
+++ b/scripts/ops/check-friday-served-ui-design-fidelity.mjs
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 import { createServer } from "node:http";
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { dirname, extname, join, relative, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 const SCRIPT_DIR = resolve(fileURLToPath(import.meta.url), "..");
 const ROOT = resolve(SCRIPT_DIR, "../..");
@@ -186,6 +186,41 @@ function readLockedTokens() {
   return { accent, coral, appBg, ok, warn, danger };
 }
 
+function startFileServer(root) {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const decodedPath = decodeURIComponent(url.pathname);
+    let filePath = resolve(root, `.${decodedPath}`);
+    if (!filePath.startsWith(root)) {
+      res.writeHead(403);
+      res.end("forbidden");
+      return;
+    }
+    try {
+      if (statSync(filePath).isDirectory()) {
+        filePath = join(filePath, "index.html");
+      }
+      res.writeHead(200, { "content-type": contentType(filePath) });
+      res.end(readFileSync(filePath));
+    } catch {
+      res.writeHead(404);
+      res.end("not found");
+    }
+  });
+
+  return new Promise((resolveServer, rejectServer) => {
+    server.once("error", rejectServer);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        rejectServer(new Error("reference server did not bind to a tcp port"));
+        return;
+      }
+      resolveServer({ server, url: `http://127.0.0.1:${address.port}` });
+    });
+  });
+}
+
 async function assertReferenceOracle() {
   const checks = [];
   const htmlFiles = [
@@ -218,6 +253,7 @@ async function assertReferenceOracle() {
 
   const chromium = await loadPlaywrightChromium();
   const browser = await chromium.launch({ headless: true });
+  const referenceServer = await startFileServer(designRoot);
   const selectedJsonSha256 = {};
   const selectedHtmlSha256 = {};
   const screenshotSha256 = {};
@@ -235,10 +271,26 @@ async function assertReferenceOracle() {
       const htmlPath = join(designRoot, "html", file);
       selectedHtmlSha256[file] = sha256(readText(htmlPath));
       const page = await browser.newPage({ viewport: { width: file.includes("mobile") ? 390 : 1440, height: 900 } });
-      await page.goto(pathToFileURL(htmlPath).href, { waitUntil: "networkidle" });
+      await page.goto(`${referenceServer.url}/html/${file}`, { waitUntil: "networkidle" });
+      if (file === "pet-anim-v9-reference.html") {
+        await page.waitForFunction(() => Boolean(window.__pet) || Boolean(document.querySelector("canvas")), null, { timeout: 5000 }).catch(() => {});
+      }
       const screenshot = await page.screenshot({ fullPage: true });
       screenshotSha256[file] = sha256(screenshot);
       const snapshot = await page.evaluate(() => {
+        function petState() {
+          if (!window.__pet) return null;
+          if (typeof window.__pet.frame === "number") return `frame:${window.__pet.frame}`;
+          if (typeof window.__pet.state === "function") {
+            try {
+              return `state:${window.__pet.state()}`;
+            } catch {
+              return "state:error";
+            }
+          }
+          return null;
+        }
+
         const probe = document.querySelector("[data-friday-ui], button, [role='button'], canvas, main") ?? document.body;
         const style = getComputedStyle(probe);
         const actions = [...document.querySelectorAll("button, [role='button'], a[href], [data-pet-action]")]
@@ -249,12 +301,18 @@ async function assertReferenceOracle() {
             marker: node.getAttribute("data-friday-ui") ?? node.getAttribute("data-pet-action") ?? null,
             disabled: node.hasAttribute("disabled") || node.getAttribute("aria-disabled") === "true",
           }));
-        const before = typeof window.__pet?.frame === "number" ? window.__pet.frame : null;
+        const before = petState();
         let interactionResult = null;
         if (typeof window.__pet?.interact === "function") {
           interactionResult = window.__pet.interact();
+        } else if (typeof window.__pet?.click === "function") {
+          interactionResult = window.__pet.click();
+        } else if (typeof window.__pet?.step === "function") {
+          interactionResult = window.__pet.step(3);
+        } else {
+          document.querySelector("[data-pet-action], canvas")?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
         }
-        const after = typeof window.__pet?.frame === "number" ? window.__pet.frame : null;
+        const after = petState();
         const canvas = document.querySelector("canvas");
         let canvasNonBlank = false;
         if (canvas instanceof HTMLCanvasElement) {
@@ -286,6 +344,8 @@ async function assertReferenceOracle() {
           pet: {
             hasPetHook: Boolean(window.__pet),
             hasInteract: typeof window.__pet?.interact === "function",
+            hasClick: typeof window.__pet?.click === "function",
+            hasStep: typeof window.__pet?.step === "function",
             canvasNonBlank,
             before,
             after,
@@ -303,7 +363,7 @@ async function assertReferenceOracle() {
         if (!snapshot.pet.canvasNonBlank) {
           checks.push(fail("Gate C2 pet reference canvas is blank"));
         }
-        if (!snapshot.pet.hasPetHook || !snapshot.pet.hasInteract) {
+        if (!snapshot.pet.hasPetHook || !(snapshot.pet.hasInteract || snapshot.pet.hasClick || snapshot.pet.hasStep)) {
           checks.push(fail("Gate C2 pet reference interaction hook is missing"));
         }
         if (!snapshot.pet.changed) {
@@ -313,6 +373,7 @@ async function assertReferenceOracle() {
     }
   } finally {
     await browser.close();
+    await new Promise((resolveClose) => referenceServer.server.close(resolveClose));
   }
 
   report.referenceOracle = {

--- a/test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts
+++ b/test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts
@@ -73,6 +73,31 @@ function writeSelections(root: string, options: { referenceHtml?: boolean; petIn
   return designRoot;
 }
 
+function writeLegacyPetReference(root: string) {
+  const designRoot = writeSelections(root);
+  writeFile(designRoot, "html/pet-anim-v9-reference.html", `
+    <canvas id="pet-canvas" width="96" height="96"></canvas>
+    <button data-pet-action="wag">Wag</button>
+    <script>
+      let frame = 0;
+      const canvas = document.getElementById("pet-canvas");
+      const context = canvas.getContext("2d");
+      function draw(color) {
+        context.clearRect(0, 0, canvas.width, canvas.height);
+        context.fillStyle = color;
+        context.fillRect(8, 8, 48, 48);
+      }
+      draw("#0f7d8c");
+      window.__pet = {
+        state() { return "happy/" + frame; },
+        step() { frame += 1; draw("#d8634d"); },
+        click() { frame += 1; draw("#277a5d"); },
+      };
+    </script>
+  `);
+  return designRoot;
+}
+
 function writeGoodIos(root: string) {
   const iosRoot = join(root, "ios");
   writeFile(iosRoot, "DesignTokens.swift", `
@@ -335,6 +360,31 @@ describe("check-friday-served-ui-design-fidelity", () => {
         "Gate C2 pet reference interaction hook is missing",
         "Gate C2 pet reference frame did not change after interaction",
       ]));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts the legacy selected pet reference click/step hook as an interactive Gate C2 oracle", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-served-ui-gate-c2-legacy-pet-"));
+    try {
+      const result = run(root, writeLegacyPetReference(root), writeGoodDist(root), writeGoodIos(root));
+      expect(result.status).toBe(0);
+      const report = JSON.parse(result.stdout) as {
+        referenceOracle?: {
+          petInteractionReport?: Record<string, {
+            changed?: boolean;
+            canvasNonBlank?: boolean;
+            hasClick?: boolean;
+            hasStep?: boolean;
+          }>;
+        };
+      };
+      const petReport = report.referenceOracle?.petInteractionReport?.["pet-anim-v9-reference.html"];
+      expect(petReport?.canvasNonBlank).toBe(true);
+      expect(petReport?.changed).toBe(true);
+      expect(petReport?.hasClick).toBe(true);
+      expect(petReport?.hasStep).toBe(true);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add red-first coverage for the legacy selected pet reference `window.__pet.state/click/step` hook
- load operator design reference HTML through a local read-only loopback server so relative pet assets render
- keep Gate C2 strict: canvas must be nonblank and interaction must change state/frame; static/blank negative controls remain red
- harden the reference server path guard with `relative(root, filePath)`

## Evidence
- red: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/d1-d6-ui-current-20260704T2125-0700/red-gate-c2-legacy-pet-focused.log` (`exit=1`)
- green focused: `green3-gate-c2-focused.log` (`exit=0`, 15/15)
- revert-red: `revert-red2-gate-c2-focused.log` (`exit=1`)
- real design root: `final-served-ui-design-fidelity-gate-c2.json` (`status=pass`, `failureCount=0`)
- selected visual proof remains honest: `final-selected-visual-proof-with-served.json` (`exit=1`, only `mobile_selected_visual_proof_missing`)
- reviewers: `reviewer-1-plato.md`, `reviewer-2-darwin.md` both PASS

## Boundary
This is a LOW Gate C2 oracle repair only. It does not close D1/D6, mobile selected visual proof, runtime action closure, UI parity, S13, END-BAR, release/adoption, deployment validation, organic/device/signature attestations, or any operator-gated action.

## Checks
- `npx vitest run test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts --reporter=verbose`
- `node scripts/ops/check-friday-served-ui-design-fidelity.mjs --design-root=/Users/jarvis/Desktop/friday-design-handoff-20260602 --out=.../final-served-ui-design-fidelity-gate-c2.json`
- `node scripts/ops/check-friday-uiux-selected-visual-proof.mjs --repo-root=/private/tmp/friday-gate-c2-pet-reference-20260704 --design-root=/Users/jarvis/Desktop/friday-design-handoff-20260602 --served-ui-report=.../final-served-ui-design-fidelity-gate-c2.json --require-complete`
