### PR TITLE
Provision scratch master key for provider proof

### DIFF
--- a/scripts/ops/run-friday-provider-entitlement-runtime-proof.mjs
+++ b/scripts/ops/run-friday-provider-entitlement-runtime-proof.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import net from "node:net";
+import { randomBytes } from "node:crypto";
 
 const HOST = "127.0.0.1";
 const LOCAL_PASSPHRASE =
@@ -209,6 +210,7 @@ async function loginLocal(baseUrl) {
 }
 
 async function createIsolatedHub(stateDir) {
+  ensureScratchMasterKeyForRuntimeProof();
   const [{ createFridayHub }, { createFridayHttpServer }] = await Promise.all([
     import("#hub"),
     import("#api"),
@@ -236,6 +238,13 @@ async function createIsolatedHub(stateDir) {
   const baseUrl = `http://${HOST}:${String(port)}`;
   const accessToken = await loginLocal(baseUrl);
   return { hub, httpServer, baseUrl, accessToken };
+}
+
+function ensureScratchMasterKeyForRuntimeProof() {
+  if (process.env.FRIDAY_MASTER_KEY || process.env.FRIDAY_MASTER_KEY_SOURCE) {
+    return;
+  }
+  process.env.FRIDAY_MASTER_KEY = randomBytes(32).toString("hex");
 }
 
 async function stopIsolatedHub(runtime) {

--- a/test/unit/qa/friday-provider-entitlement-runtime-proof-cli.test.ts
+++ b/test/unit/qa/friday-provider-entitlement-runtime-proof-cli.test.ts
@@ -72,4 +72,14 @@ describe("Friday provider entitlement runtime proof CLI", () => {
     expect(proof.real_external_api).toBe(false);
     expect(proof.blockers).toEqual([]);
   });
+
+  it("provisions a scratch-only master key before runtime provider creation", () => {
+    const source = readFileSync(script, "utf8");
+
+    expect(source).toContain("ensureScratchMasterKeyForRuntimeProof");
+    expect(source).toContain('process.env.FRIDAY_MASTER_KEY = randomBytes(32).toString("hex")');
+    expect(source.indexOf("ensureScratchMasterKeyForRuntimeProof()")).toBeLessThan(
+      source.indexOf("createFridayHub({"),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add red-first coverage for the provider entitlement runtime proof runner scratch master-key prerequisite
- provision a per-process scratch FRIDAY_MASTER_KEY before starting the isolated proof hub when no external master-key config exists
- preserve honest provider entitlement blocking: OpenAI now advances past provider create and blocks at validation with PROVIDER_AUTH_INVALID / 401

## Evidence
- red commit: ed3bb699fe89b92b8654af466bff7dbb3c4fd363
- green commit: 81dd841dfb262a0c400291a6e7056439c9faff81
- npm run test -- test/unit/qa/friday-provider-entitlement-runtime-proof-cli.test.ts
- git diff --check
- revert-red evidence: /Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new43-provider-proof-scratch-master-key-20260705T001707-0700/revert-red-focused-provider-proof-cli.log
- reviewers: Euler PASS, Singer PASS

## Boundaries
- Med agent-doable proof-runner fix only
- no prod DB/env/deploy/restart/signature/organic action
- no raw provider secret printed
- does not close provider entitlement, END-BAR, release/adoption, provider quota truth, or operator-gated atoms