### PR TITLE
Fix Vite symlinked font asset loading

### DIFF
--- a/test/unit/ui/friday-vite-dev-server-fs-allow.test.ts
+++ b/test/unit/ui/friday-vite-dev-server-fs-allow.test.ts
@@ -1,0 +1,16 @@
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import viteConfig from "../../../ui/vite.config";
+
+describe("Friday UI Vite dev server fs allow list", () => {
+  it("allows symlinked node_modules font assets from temporary worktrees", () => {
+    const repoRoot = realpathSync(resolve(__dirname, "../../.."));
+    const nodeModulesRealPath = realpathSync(resolve(repoRoot, "node_modules"));
+    const allowList = viteConfig.server?.fs?.allow ?? [];
+
+    expect(allowList).toContain(repoRoot);
+    expect(allowList).toContain(nodeModulesRealPath);
+  });
+});

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,9 +1,16 @@
+import { existsSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 const apiProxyTarget = process.env.FRIDAY_UI_API_PROXY_TARGET ?? "http://127.0.0.1:3141";
+const repoRoot = realpathIfExists(resolve(__dirname, ".."));
+const nodeModulesRoot = realpathIfExists(resolve(repoRoot, "node_modules"));
+
+function realpathIfExists(path: string): string {
+  return existsSync(path) ? realpathSync(path) : path;
+}
 
 function hasPackageSegment(id: string, packageName: string): boolean {
   const normalized = id.replaceAll("\\", "/");
@@ -95,6 +102,9 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 5173,
     strictPort: true,
+    fs: {
+      allow: [repoRoot, nodeModulesRoot],
+    },
     proxy: {
       "/v1": {
         target: apiProxyTarget,


### PR DESCRIPTION
## Summary
- add NEW-44 red-first coverage for Vite dev-server fs allow when proof worktrees symlink `node_modules`
- allow only the repo realpath and the real `node_modules` path so @fontsource font assets load in temporary worktrees
- verify desktop/mobile preview no longer emits the old 403 font failures

## Red-first evidence
- Red commit: `43e976ae` (`test: expose vite symlinked node_modules font loading`), test-only, `red-focused.exit=1`
- Green commit: `f7f57af7657bfed66f2baa541205bb419e95bafb` (`fix: allow symlinked ui font assets in vite dev`), config-only
- Revert-red: `revert-red-focused.exit=1` after temporarily reversing the green config
- Evidence directory: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new44-vite-symlink-node-modules-fonts-20260705T0230-0700/`

## Verification
- `npm run test -- test/unit/ui/friday-vite-dev-server-fs-allow.test.ts`
- `npm run build:ui`
- Playwright desktop/mobile preview: `green-playwright-summary.json` shows HTTP 200 and `errors=[]`
- Reviewer A: `019f319d-21b7-75b3-9cf4-4a60e9a3f7a2`, PASS for red/green/revert-red/scope
- Reviewer B: `019f319d-5c6e-71a3-a226-a56155940403`, PASS for no-degrade/runtime evidence

## No-degrade / boundary
- Does not widen Vite serving to `$HOME` or `/`
- Does not change production build settings
- Does not change `/v1` API proxy
- Does not claim authenticated app flow, real device proof, channel proof, strict UI/device proof, Suite-13 exercised-green, integrated tape, END-BAR, release/adoption, prod DB/env/flag truth, signatures, organic provenance, deployment validation, or any High/Blocker terminal closure
