### PR TITLE
Emit desktop AX destination visibility events

### DIFF
--- a/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
+++ b/scripts/ops/friday-desktop-ax-accessibility-capture.mjs
@@ -207,19 +207,33 @@ function actionPlan() {
   const destinationFilter = new Set(destinationsCsv.split(",").map((value) => value.trim()).filter(Boolean));
   return parseDesktopDestinations()
     .filter((destination) => destinationFilter.size === 0 || destinationFilter.has(destination.destination))
-    .flatMap((destination) =>
-    destination.runtimeActionIds.map((runtimeActionId) => ({
-      runtimeActionId,
-      destination: defaultActionMap.get(runtimeActionId)?.destination || destination.destination,
-      title: destination.title,
-      tier: destination.tier,
-      ...(defaultActionMap.get(runtimeActionId) || {
+    .flatMap((destination) => {
+      const navigationTarget = {
+        runtimeActionId: `desktop/${destination.destination}/destination-visible`,
+        destination: destination.destination,
+        title: destination.title,
+        tier: destination.tier,
         screen: destination.destination,
         accessibility_id: `friday.desktop.nav.${destination.destination}`,
         event: "mission_workbench_visible",
         interaction: "visible",
-      }),
-    })));
+      };
+      return [
+        navigationTarget,
+        ...destination.runtimeActionIds.map((runtimeActionId) => ({
+          runtimeActionId,
+          destination: defaultActionMap.get(runtimeActionId)?.destination || destination.destination,
+          title: destination.title,
+          tier: destination.tier,
+          ...(defaultActionMap.get(runtimeActionId) || {
+            screen: destination.destination,
+            accessibility_id: `friday.desktop.nav.${destination.destination}`,
+            event: "mission_workbench_visible",
+            interaction: "visible",
+          }),
+        })),
+      ];
+    });
 }
 
 function jsonOut(path, value) {
@@ -667,6 +681,7 @@ if (blockers.length === 0) {
         action_id: `desktop/${destination}/destination-visible`,
         capability_id: `desktop/${destination}/destination-visible`,
         accessibility_id: `friday.desktop.nav.${destination}`,
+        event: "mission_workbench_visible",
         interaction: "visible",
         status: "pass",
         evidence_ref: rawPath,
@@ -684,6 +699,7 @@ if (blockers.length === 0) {
         action_id: `desktop/${destination}/destination-visible`,
         capability_id: `desktop/${destination}/destination-visible`,
         accessibility_id: `friday.desktop.nav.${destination}`,
+        event: "mission_workbench_visible",
         interaction: "visible",
         status: "pass",
         evidence_ref: rawPath,

--- a/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
+++ b/test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts
@@ -30,6 +30,12 @@ describe("friday-desktop-ax-accessibility-capture contract", () => {
       expect(summary.status).toBe("plan_ready");
       expect(summary.targetCount).toBeGreaterThan(0);
       expect(summary.targets).toContainEqual(expect.objectContaining({
+        runtimeActionId: "desktop/operations/destination-visible",
+        accessibility_id: "friday.desktop.nav.operations",
+        event: "mission_workbench_visible",
+        interaction: "visible",
+      }));
+      expect(summary.targets).toContainEqual(expect.objectContaining({
         runtimeActionId: "desktop/operations/refresh",
         accessibility_id: "friday.desktop.refresh",
         interaction: "visible",


### PR DESCRIPTION
## Summary
- add NEW-45 red-first coverage for automatic desktop AX `destination-visible` observations
- emit `mission_workbench_visible` for safe destination navigation visibility in the desktop AX capture script
- keep `friday-ui-device-accessibility-click-capture.mjs` strict; the normalizer is not relaxed

## Red-first evidence
- Red commit: `7fac2950` (`test: expose desktop ax destination event gaps`), test-only, `red-focused.exit=1`
- Green commit: `87271ca93a0cbc2ebd6fe4d585482d4c1fb76d40` (`fix: emit desktop ax destination events`), script-only
- Revert-red: `revert-red-focused.exit=1` after temporarily reversing the green commit
- Evidence directory: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new45-desktop-ax-destination-events-20260705T0316-0700/`

## Verification
- `npm run test -- test/unit/qa/friday-desktop-ax-accessibility-capture-contract.test.ts`
- `npm run build:ui`
- Real macOS app AX capture against `dist/macos/FridayHubConsole.app`: `observed_count=15`, `missing_count=0`, `blockers=[]`
- Accessibility-click normalizer: `status=ready`, `eventRows=15`, `actionRuntimeRows=15`, `blockers=[]`
- Reviewer A: `019f31ca-147b-7e20-aae5-c30fcc896e73`, PASS for red-first/scope
- Reviewer B: `019f31ca-2d00-7690-bbd7-117318fc983d`, PASS for runtime/no-degrade

## No-degrade / boundary
- Does not modify the strict normalizer
- Does not click governed or destructive actions
- Does not change UI/product runtime/API proxy/provider/security/prod DB/env/deploy/signing/release paths
- This is desktop AX visibility evidence only (`live_read_not_mission_bound`); it is not strict UI/device completion, END-BAR, adoption, release, channel/timeline/mobile proof, or mission-bound runtime action closure
