### PR TITLE
Fix UI real-use explicit action evidence classification

### DIFF
--- a/scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs
+++ b/scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs
@@ -154,11 +154,15 @@ function actionEvidenceFailures(path, missionId, expectedSurface) {
   const truth = string(value.truth || value.truth_label || value.truthLabel);
   const acceptedTruths = new Set([
     "accessibility_click_action_runtime_evidence_real_ui_not_endbar",
-    "action_runtime_evidence_from_explicit_ios_ui_actions_not_endbar",
-    "action_runtime_evidence_from_explicit_macos_ui_actions_not_endbar",
   ]);
+  if (expectedSurface === "mobile") acceptedTruths.add("action_runtime_evidence_from_explicit_ios_ui_actions_not_endbar");
+  if (expectedSurface === "desktop") acceptedTruths.add("action_runtime_evidence_from_explicit_macos_ui_actions_not_endbar");
   if (!acceptedTruths.has(truth)) {
-    failures.push("action_runtime_evidence_truth_mismatch");
+    failures.push(
+      truth.startsWith("action_runtime_evidence_from_explicit_")
+        ? "action_runtime_evidence_truth_surface_mismatch"
+        : "action_runtime_evidence_truth_mismatch",
+    );
   }
   if (string(value.status) !== "ready") {
     failures.push("action_runtime_evidence_not_ready");

--- a/scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs
+++ b/scripts/ops/check-friday-ui-real-use-mobile-desktop-report.mjs
@@ -151,7 +151,13 @@ function actionEvidenceFailures(path, missionId, expectedSurface) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return ["action_runtime_evidence_invalid_json"];
   }
-  if (string(value.truth || value.truth_label || value.truthLabel) !== "accessibility_click_action_runtime_evidence_real_ui_not_endbar") {
+  const truth = string(value.truth || value.truth_label || value.truthLabel);
+  const acceptedTruths = new Set([
+    "accessibility_click_action_runtime_evidence_real_ui_not_endbar",
+    "action_runtime_evidence_from_explicit_ios_ui_actions_not_endbar",
+    "action_runtime_evidence_from_explicit_macos_ui_actions_not_endbar",
+  ]);
+  if (!acceptedTruths.has(truth)) {
     failures.push("action_runtime_evidence_truth_mismatch");
   }
   if (string(value.status) !== "ready") {

--- a/test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts
+++ b/test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts
@@ -163,6 +163,54 @@ describe("Friday UI real-use mobile/desktop report", () => {
     expect(report.blockers).toEqual([]);
   });
 
+  it("does not accept explicit UI action runtime truth from the wrong platform", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-ui-real-use-explicit-platform-"));
+    const value = summary(dir);
+    writeFileSync(value.captures.mobile.action_runtime_evidence, JSON.stringify({
+      truth: "action_runtime_evidence_from_explicit_macos_ui_actions_not_endbar",
+      status: "ready",
+      missionId: value.missionId,
+      actions: [
+        {
+          surface: "mobile",
+          action_id: "chat:typing",
+          status: "pass",
+          evidence_ref: value.captures.mobile.proof,
+          mission_id: value.missionId,
+        },
+      ],
+    }, null, 2));
+    writeFileSync(value.captures.desktop.action_runtime_evidence, JSON.stringify({
+      truth: "action_runtime_evidence_from_explicit_ios_ui_actions_not_endbar",
+      status: "ready",
+      missionId: value.missionId,
+      actions: [
+        {
+          surface: "desktop",
+          action_id: "desktop/fridayChat/act",
+          status: "pass",
+          evidence_ref: value.captures.desktop.proof,
+          mission_id: value.missionId,
+        },
+      ],
+    }, null, 2));
+    const summaryPath = writeJson(dir, "summary.json", value);
+
+    const report = run([`--ui-device-summary=${summaryPath}`, "--require-ready"], true);
+
+    expect(report.status).toBe("blocked");
+    expect(report.blockers).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: "mobile_real_surface_capture",
+        detail: expect.stringContaining("action_runtime_evidence_truth_surface_mismatch"),
+      }),
+      expect.objectContaining({
+        code: "desktop_real_surface_capture",
+        detail: expect.stringContaining("action_runtime_evidence_truth_surface_mismatch"),
+      }),
+    ]));
+  });
+
   it("marks channel-deferred summaries as deferred, not strict-ready", () => {
     const dir = mkdtempSync(join(tmpdir(), "friday-ui-real-use-"));
     const summaryPath = writeJson(dir, "summary.json", summary(dir, {

--- a/test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts
+++ b/test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts
@@ -122,6 +122,47 @@ describe("Friday UI real-use mobile/desktop report", () => {
     expect(report.blockers).toEqual([]);
   });
 
+  it("accepts explicit mobile and desktop UI action runtime evidence from live write/read captures", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-ui-real-use-explicit-actions-"));
+    const value = summary(dir);
+    writeFileSync(value.captures.mobile.action_runtime_evidence, JSON.stringify({
+      truth: "action_runtime_evidence_from_explicit_ios_ui_actions_not_endbar",
+      status: "ready",
+      missionId: value.missionId,
+      actions: [
+        {
+          surface: "mobile",
+          action_id: "chat:typing",
+          status: "pass",
+          evidence_ref: value.captures.mobile.proof,
+          mission_id: value.missionId,
+          truth_label: "explicit_ui_action_runtime_evidence_not_endbar_not_adoption",
+        },
+      ],
+    }, null, 2));
+    writeFileSync(value.captures.desktop.action_runtime_evidence, JSON.stringify({
+      truth: "action_runtime_evidence_from_explicit_macos_ui_actions_not_endbar",
+      status: "ready",
+      missionId: value.missionId,
+      actions: [
+        {
+          surface: "desktop",
+          action_id: "desktop/fridayChat/act",
+          status: "pass",
+          evidence_ref: value.captures.desktop.proof,
+          mission_id: value.missionId,
+          truth_label: "explicit_ui_action_runtime_evidence_not_endbar_not_adoption",
+        },
+      ],
+    }, null, 2));
+    const summaryPath = writeJson(dir, "summary.json", value);
+
+    const report = run([`--ui-device-summary=${summaryPath}`, "--require-ready"]);
+
+    expect(report.status).toBe("strict_uiux_real_use_ready");
+    expect(report.blockers).toEqual([]);
+  });
+
   it("marks channel-deferred summaries as deferred, not strict-ready", () => {
     const dir = mkdtempSync(join(tmpdir(), "friday-ui-real-use-"));
     const summaryPath = writeJson(dir, "summary.json", summary(dir, {


### PR DESCRIPTION
## Summary

Fixes NEW-46: the UI real-use mobile/desktop report now accepts real explicit iOS/macOS live-write/read action-runtime evidence, while binding each explicit truth to its platform.

## Red-first evidence

- Red 1: `ea1aa7ed` test-only, `red-ui-real-use-target.exit=1`.
- Green 1: `3508ac23` implementation-only, `green-ui-real-use-target.exit=0`.
- Revert-green 1: `revert-green-rerun-ui-real-use-target.exit=1` after reverting `3508ac23`.
- Red 2: `4eeac775` test-only wrong-platform negative, `red2-platform-binding-target.exit=1`.
- Green 2: `9ada7b3e` implementation-only platform binding, `green2-platform-binding-target.exit=0`.
- Revert-green 2: `revert-green2-target.exit=1` after reverting `9ada7b3e`.

Evidence directory: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new46-ui-real-use-explicit-action-evidence-20260705T0458-0700/`.

## Verification

- `npm run test -- test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts` passed 10/10.
- Related QA passed 20/20:
  - `test/unit/qa/friday-ui-real-use-mobile-desktop-report-cli.test.ts`
  - `test/unit/qa/friday-integrated-end-to-end-tape-report-cli.test.ts`
  - `test/unit/qa/friday-endbar-readiness-aggregator.test.ts`
- Current UI report generation exits 0 and now passes `mobile_real_surface_capture` and `desktop_real_surface_capture`; it remains blocked on timeline/stress/product-closure/strict-readiness.

## Reviewers

- Reviewer A `019f3212-e3bf-7ec2-8105-46f74680c1f4`: PASS.
- Reviewer B `019f3212-f74c-75b0-a44b-84a496b83706`: PASS.

## Boundary

This does not claim END-BAR, strict UI/device proof, selected UIUX conformance, integrated tape readiness, release/adoption, deployment validation, prod DB/env truth, organic provenance, or operator visual attestation. END-BAR remains blocked with 2/5 groups satisfied.
