### PR TITLE
Persist auto-dispatch interop DB for diagnostics

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -6277,6 +6277,29 @@ mod tests {
     }
 
     #[test]
+    fn interop_db_path_override_is_explicit_and_stable() {
+        let override_path = std::env::temp_dir().join("friday-interop-persist-red.sqlite");
+        let selected = interop_db_path(
+            "persist-red",
+            Some(override_path.to_string_lossy().as_ref()),
+        );
+        assert_eq!(
+            selected, override_path,
+            "manual interop evidence runs need an explicit DB path so Workbench projection can audit the completed_with_proof rows"
+        );
+
+        let generated = interop_db_path("persist-red", None);
+        assert!(
+            generated
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .contains("friday-execrun-interop-persist-red-"),
+            "default interop tests keep their isolated temp DB naming"
+        );
+    }
+
+    #[test]
     fn sealed_proof_round_trips_and_rejects_malformed() {
         let k = DataKey::generate();
         let sealed = seal(&k, AUTH_CHALLENGE, SESSION_AAD).unwrap();

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -6289,12 +6289,14 @@ mod tests {
         );
 
         let generated = interop_db_path("persist-red", None);
+        let generated_name = generated
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
         assert!(
-            generated
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or_default()
-                .contains("friday-execrun-interop-persist-red-"),
+            generated_name.starts_with("friday-execrun-interop-")
+                && generated_name.contains("-persist-red-")
+                && generated_name.ends_with(".sqlite"),
             "default interop tests keep their isolated temp DB naming"
         );
     }
@@ -6939,6 +6941,7 @@ mod tests {
         answer: &str,
     ) -> (HubRuntime<FinishTransport>, TempWs) {
         let ws = TempWs::new(tag);
+        let persist_db_path = std::env::var("FRIDAY_INTEROP_PERSIST_DB_PATH").ok();
         let client = DeepSeekClient::with_transport(
             FinishTransport {
                 answer: answer.to_string(),
@@ -6948,13 +6951,7 @@ mod tests {
         let agent = DeepSeekAgentLlmClient::new(client);
         let rt = HubRuntime::new(
             HubConfig {
-                db_path: std::env::temp_dir()
-                    .join(format!(
-                        "friday-execrun-interop-{}-{}-{}.sqlite",
-                        std::process::id(),
-                        tag,
-                        C.fetch_add(1, Ordering::Relaxed)
-                    ))
+                db_path: interop_db_path(tag, persist_db_path.as_deref())
                     .to_string_lossy()
                     .into_owned(),
                 workspace_root: ws.0.clone(),
@@ -6970,6 +6967,21 @@ mod tests {
         )
         .unwrap();
         (rt, ws)
+    }
+
+    fn interop_db_path(tag: &str, persist_db_path: Option<&str>) -> std::path::PathBuf {
+        if let Some(path) = persist_db_path
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            return std::path::PathBuf::from(path);
+        }
+        std::env::temp_dir().join(format!(
+            "friday-execrun-interop-{}-{}-{}.sqlite",
+            std::process::id(),
+            tag,
+            C.fetch_add(1, Ordering::Relaxed)
+        ))
     }
 
     /// The fixed TS-client X25519 secret scalar (same fixture as `CLIENT_SECRET` above): the TS


### PR DESCRIPTION
## Summary
- add a test-only persisted DB path override for the ignored mission route auto-dispatch interop harness
- keep default interop DB naming isolated unless FRIDAY_INTEROP_PERSIST_DB_PATH is explicitly supplied
- preserve a scratch interop DB for Workbench/timeline diagnostics without changing production runtime behavior

## Verification
- red: red-valid.exit=101 / E0425 missing interop_db_path
- green: green-target-rerun.exit=0
- revert-green: revert-green-target.exit=101
- persisted ignored interop: persisted-interop.exit=0
- cargo fmt --all -- --check: cargo-fmt-check.exit=0
- git diff --check: git-diff-check.exit=0
- independent reviewers: Parfit PASS, Bacon PASS

## Boundaries
This is a Low/Med test-harness/proofability PR only. The scratch DB, Workbench, stress, and observations artifacts are diagnostic and explicitly not UI/device proof, not END-BAR, not operator live proof, and not a High/Blocker terminal claim. Strict UI/device still lacks real same-run mobile provider-action visibility, stale/offline/error negative controls, channel/telegram proof, selected UIUX runtime capture, and integrated tape closure.