### PR TITLE
Gate D6 web mobile hero pet proof

### DIFF
--- a/test/e2e/ui/friday-mobile-viewport.e2e.test.ts
+++ b/test/e2e/ui/friday-mobile-viewport.e2e.test.ts
@@ -62,6 +62,36 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("Friday mobile viewport (375px, mock hub br
     expect(overflowState.hasHorizontalOverflow).toBe(false);
   });
 
+  it("home page exposes a D6 mobile-web hero pet surface at 375px width", { timeout: BROWSER_E2E_TIMEOUT_MS }, async () => {
+    env = await createFridayMockBrowserE2eEnv();
+    pageHandle = await env.newPage();
+    await pageHandle.page.setViewportSize({
+      width: MOBILE_VIEWPORT_WIDTH,
+      height: MOBILE_VIEWPORT_HEIGHT,
+    });
+
+    await pageHandle.page.goto("/home");
+    await pageHandle.page.waitForFunction(() => {
+      const bodyText = document.body.textContent?.trim() ?? "";
+      return bodyText.length > 50 && !bodyText.includes("Something went wrong");
+    }, { timeout: 45_000 });
+
+    const mobileHeroPet = pageHandle.page.getByTestId("mobile-web-hero-pet");
+    await mobileHeroPet.waitFor({ state: "visible", timeout: 5_000 });
+    expect(await mobileHeroPet.isVisible()).toBe(true);
+    expect(await mobileHeroPet.getAttribute("data-friday-pet-stage")).toBe("mobile-web");
+    expect(await mobileHeroPet.getAttribute("data-friday-mobile-strategy")).toBe("design-truth-aligned");
+
+    const mobileHome = pageHandle.page.getByTestId("mobile-web-home-surface");
+    await mobileHome.waitFor({ state: "visible", timeout: 5_000 });
+    expect(await mobileHome.isVisible()).toBe(true);
+    const mobileHomeText = await mobileHome.textContent();
+    expect(mobileHomeText).toContain("Friday Home");
+    expect(mobileHomeText).toMatch(/Command Sheet|命令面板/);
+    expect(mobileHomeText).toMatch(/Chat|聊天/);
+    expect(mobileHomeText).toMatch(/Status|状态/);
+  });
+
   it("skills page renders without horizontal overflow at 375px width", { timeout: BROWSER_E2E_TIMEOUT_MS }, async () => {
     env = await createFridayMockBrowserE2eEnv();
     pageHandle = await env.newPage();

--- a/ui/src/routes/home-page.tsx
+++ b/ui/src/routes/home-page.tsx
@@ -245,6 +245,94 @@ function runtimeChipParts(status: SystemHealthStatus, locale: "zh" | "en") {
   };
 }
 
+function MobileWebHomeSurface(props: {
+  locale: "zh" | "en";
+  systemLabel: string;
+  runtimeLabel: string;
+  runtimeColor: string;
+  onOpenChat: () => void;
+  onOpenCommandSheet: () => void;
+}) {
+  const { locale, systemLabel, runtimeLabel, runtimeColor, onOpenChat, onOpenCommandSheet } = props;
+
+  return (
+    <div
+      data-testid="mobile-web-home-surface"
+      data-friday-mobile-strategy="design-truth-aligned"
+      className="mb-5 lg:hidden"
+    >
+      <div className="grid gap-4">
+        <div
+          data-testid="mobile-web-hero-pet"
+          data-friday-pet-stage="mobile-web"
+          data-friday-mobile-strategy="design-truth-aligned"
+          className="relative min-h-[168px] overflow-hidden rounded-[8px] border"
+          style={{
+            background: "#eef3e8",
+            borderColor: "var(--color-border-soft)",
+          }}
+        >
+          <div className="absolute inset-0 bg-[linear-gradient(180deg,#f8faf2_0%,#e5efdd_100%)]" aria-hidden="true" />
+          <img
+            src="/source/pet/g-idle.png"
+            alt={localize(locale, "Friday mobile hero pet", "Friday mobile hero pet")}
+            className="absolute bottom-3 right-4 h-[132px] w-[132px] object-contain"
+            loading="eager"
+          />
+          <div className="relative max-w-[210px] p-4">
+            <p className="text-xs font-semibold text-[color:var(--color-text-faint)]">
+              Friday Home
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold leading-tight text-[color:var(--color-text-primary)]" style={{ fontFamily: "var(--font-serif)" }}>
+              {localize(locale, "状态先行", "Status first")}
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-[color:var(--color-text-secondary)]">
+              {localize(locale, "Chat 与 Status 同屏，Friday 随时可开。", "Chat and Status share the home surface so Friday is always one tap away.")}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            onClick={onOpenChat}
+            className="min-h-[52px] rounded-[8px] border px-3 text-left text-sm font-semibold"
+            style={{
+              background: "var(--color-bg-subtle)",
+              borderColor: "var(--color-border-soft)",
+              color: "var(--color-text-primary)",
+            }}
+          >
+            <span className="block text-xs font-medium text-[color:var(--color-text-faint)]">Chat</span>
+            {localize(locale, "开始新任务", "Start a task")}
+          </button>
+          <button
+            type="button"
+            onClick={onOpenCommandSheet}
+            className="min-h-[52px] rounded-[8px] border px-3 text-left text-sm font-semibold"
+            style={{
+              background: "var(--color-bg-subtle)",
+              borderColor: "var(--color-border-soft)",
+              color: "var(--color-text-primary)",
+            }}
+          >
+            <span className="block text-xs font-medium text-[color:var(--color-text-faint)]">Command Sheet</span>
+            {localize(locale, "打开命令", "Open command")}
+          </button>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 rounded-[8px] border px-3 py-2 text-sm" style={{ borderColor: "var(--color-border-soft)" }}>
+          <span className="font-semibold text-[color:var(--color-text-primary)]">Status</span>
+          <span className="inline-flex items-center gap-2 text-xs text-[color:var(--color-text-secondary)]">
+            <span className="h-2 w-2 rounded-full" style={{ background: runtimeColor }} aria-hidden="true" />
+            {systemLabel} · {runtimeLabel}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function HomePage() {
   const navigate = useAppNavigate();
   const queryClient = useQueryClient();
@@ -526,6 +614,14 @@ export function HomePage() {
         data-testid="home-surface-ready"
         className="rounded-[30px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-surface)] px-5 py-5 shadow-[var(--shadow-floating)]"
       >
+        <MobileWebHomeSurface
+          locale={locale}
+          systemLabel={systemLabel}
+          runtimeLabel={runtimeChip.label}
+          runtimeColor={runtimeChip.color}
+          onOpenChat={() => navigate("/chat")}
+          onOpenCommandSheet={() => requestCommandPaletteOpen()}
+        />
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(390px,430px)] xl:items-start">
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## What changed

- Adds a D6 browser E2E assertion for the 375px `/home` web mobile surface.
- Adds a mobile-only Friday Home surface with a visible hero pet, Chat, Command Sheet, and Status affordances.
- Keeps the existing desktop shell/native mobile surfaces untouched.

## Why

D6 requires the web mobile surface to have explicit design-truth alignment or an explicit descope record, and desktop squeeze/overflow-only proof does not count. This PR takes the agent-doable path: true web mobile proof instead of descope.

## Proof

- Red commit: `13f57ab6` (`test/e2e/ui/friday-mobile-viewport.e2e.test.ts` only)
- Green commit: `8831408a` (`ui/src/routes/home-page.tsx` only)
- Evidence root: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/d6-web-mobile-redfirst-20260705T104327-0700/`
- Red: `red-mobile-viewport.final.exit=1`, missing visible `mobile-web-hero-pet`
- Green: `green-mobile-viewport.final.exit=0`, browser E2E 3/3 passed
- Revert-red: `revert-red-mobile-viewport.exit=1`, missing visible `mobile-web-hero-pet`
- Final green: `final-green-mobile-viewport.exit=0`, browser E2E 3/3 passed
- Typecheck: `green-typecheck-src.exit=0`
- 375px render proof: `mobile-web-home-375.png` and `mobile-web-home-375-summary.json`
- Reviewers: Averroes the 4th PASS, James the 4th PASS

## No degrade

- Existing home and skills 375px horizontal-overflow tests remain green.
- Branch diff touches only `test/e2e/ui/friday-mobile-viewport.e2e.test.ts` and `ui/src/routes/home-page.tsx`.
- No desktop shell, RightRail, iOS, Android, prod DB/env, deployment, restart, signature, or organic provenance action.

## Boundary

This closes the agent-doable D6 web mobile proof path provisionally. It does not claim full UIUX/END-BAR, native-device/operator visual attestation, release/adoption, organic provenance, deployment validation, or unrelated frozen residual closure.
