### PR TITLE
Allow workbench probe mission override

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/mission_workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/bin/mission_workbench_projection.rs
@@ -73,6 +73,8 @@ mod tests {
         let db = Db::open_hub(&path).unwrap();
         let now = 1_780_640_000_000;
         let conversation_id = "fconv_mission_workbench_probe";
+        let expected_mission_id = env::var("FRIDAY_MISSION_WORKBENCH_PROBE_MISSION_ID")
+            .unwrap_or_else(|_| "mission_workbench_probe_20260605".to_string());
         let mission_id = "mission_workbench_probe_20260605";
         let work_provider = "work_probe_provider";
         let work_done = "work_probe_done";
@@ -373,6 +375,11 @@ mod tests {
 
         let snapshot =
             friday_hub::workbench_projection::project_workbench(&db, Some(mission_id)).unwrap();
+        assert_eq!(
+            snapshot.get("missionId").and_then(serde_json::Value::as_str),
+            Some(expected_mission_id.as_str()),
+            "probe DB must honor FRIDAY_MISSION_WORKBENCH_PROBE_MISSION_ID so strict UI/device can bind Workbench to the same mission"
+        );
         let status_labels = snapshot
             .get("statusLabels")
             .and_then(serde_json::Value::as_array)

--- a/rust-core/crates/friday-hub/src/bin/mission_workbench_projection.rs
+++ b/rust-core/crates/friday-hub/src/bin/mission_workbench_projection.rs
@@ -75,7 +75,7 @@ mod tests {
         let conversation_id = "fconv_mission_workbench_probe";
         let expected_mission_id = env::var("FRIDAY_MISSION_WORKBENCH_PROBE_MISSION_ID")
             .unwrap_or_else(|_| "mission_workbench_probe_20260605".to_string());
-        let mission_id = "mission_workbench_probe_20260605";
+        let mission_id = expected_mission_id.as_str();
         let work_provider = "work_probe_provider";
         let work_done = "work_probe_done";
         let work_retryable = "work_probe_retryable";


### PR DESCRIPTION
## Summary
- Allows the ignored `mission_workbench_projection` ops probe to honor `FRIDAY_MISSION_WORKBENCH_PROBE_MISSION_ID`.
- Keeps the default probe mission unchanged when the env var is absent.
- Enables strict UI/device work to generate a Workbench snapshot contract for the same mission id instead of cross-mission evidence splicing.

## Red-first evidence
Evidence: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new53-workbench-probe-mission-override-redfirst-20260705T160156-0700/`

- Red commit `8c1077ad`: `red-custom-mission-test.exit=101` proves the hardcoded probe ignored `mission-interop-route-auto`.
- Green commit `96ca57c4`: `green-custom-mission-test.exit=0`; `green-workbench-snapshot-contract.exit=0` with `readyForLiveCaptureInput=true` and `failures=[]` for `mission-interop-route-auto`.
- Revert-red: `revert-green-custom-mission-test.exit=101` after reverting the green commit.

## Verification
- `green-default-mission-test.exit=0`
- `green-workbench-projection-tests.exit=0`
- `green-cargo-fmt-check.exit=0`
- Reviewers: `reviewer-dalton-pass.txt`, `reviewer-nash-pass.txt`

## Boundary
This is an ops-only proofability change in an ignored probe test. It does not change production projection logic, does not touch prod DB/ports/operator key/deploy/release/organic paths, and does not claim END-BAR. A strict runner attempt intentionally failed closed on `channel_live_proof_head_mismatch`; channel proof must be refreshed at the current head before END-BAR can be claimed.
