### PR TITLE
Fail-close mobile approval refused proof evidence

### DIFF
--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalApproveIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalApproveIntegrationTests.swift
@@ -133,9 +133,10 @@ private func writeMobileApprovalApproveProofIfRequested(
     return
   }
 
-  let proof: [String: Any] = [
+  let proofStatus = result.accepted ? "pass" : "fail"
+  var proof: [String: Any] = [
     "truth_label": "ios_mobile_live_approval_approve_write_client_proof_signed_artifact_relay_not_sim_tap_not_endbar",
-    "status": "pass",
+    "status": proofStatus,
     "generated_at_utc": ISO8601DateFormatter().string(from: Date()),
     "run_id": result.runId,
     "approval_id": approvalId,
@@ -157,13 +158,16 @@ private func writeMobileApprovalApproveProofIfRequested(
         "screen": "approval",
         "action_id": "check",
         "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
-        "status": "pass",
+        "status": proofStatus,
         "evidence_ref": "proof://mobile/approval-approve/\(result.runId)",
         "truth_label": "explicit_mobile_approval_approve_runtime_evidence_from_live_swift_write_client",
       ],
     ],
     "caveat": "Mobile Swift write-client approve proof only. The signed artifact is supplied externally; the app never reads a signing key or mints a signature. Not a simulator tap, END-BAR, GO-LIVE, release, or adoption.",
   ]
+  if !result.accepted {
+    proof["failure_reason"] = result.status
+  }
 
   let data = try JSONSerialization.data(withJSONObject: proof, options: [.prettyPrinted, .sortedKeys])
   let url = URL(fileURLWithPath: rawPath)
@@ -296,7 +300,7 @@ private func appendMobileFridayChatApproveEvidenceIfRequested(
     "screen": "fridayChat",
     "action_id": "check",
     "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
-    "status": "pass",
+    "status": result.accepted ? "pass" : "fail",
     "evidence_ref": "proof://mobile/fridaychat-approval-approve/\(result.runId)",
     "truth_label": "explicit_mobile_fridaychat_approve_runtime_evidence_from_view_model_relaying_signed_blob_verbatim",
   ])

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalApproveIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalApproveIntegrationTests.swift
@@ -44,10 +44,13 @@ func mobileApprovalApproveProofMarksRefusedResumeAsFailure() throws {
     Issue.record("proof JSON is not an object")
     return
   }
-  #expect(proof["status"] as? String != "pass")
+  #expect(proof["status"] as? String == "fail")
+  #expect(proof["failure_reason"] as? String == "approval_refused")
+  let resume = proof["resume"] as? [String: Any] ?? [:]
+  #expect(resume["accepted"] as? Bool == false)
   let actions = proof["ui_actions"] as? [[String: Any]] ?? []
   #expect(!actions.isEmpty)
-  #expect(actions.allSatisfy { ($0["status"] as? String) != "pass" })
+  #expect(actions.allSatisfy { ($0["status"] as? String) == "fail" })
 }
 
 @MainActor

--- a/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalApproveIntegrationTests.swift
+++ b/apps/friday-ios/Tests/FridayMobileShellCoreTests/LiveApprovalApproveIntegrationTests.swift
@@ -15,6 +15,41 @@ import Testing
 private let liveMobileApprovalApproveEnabled =
   ProcessInfo.processInfo.environment["FRIDAY_MOBILE_LIVE_APPROVAL_APPROVE_TEST"] == "1"
 
+@Test
+func mobileApprovalApproveProofMarksRefusedResumeAsFailure() throws {
+  let dir = FileManager.default.temporaryDirectory.appendingPathComponent(
+    "friday-mobile-approval-approve-refused-\(UUID().uuidString)",
+    isDirectory: true)
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  defer { try? FileManager.default.removeItem(at: dir) }
+
+  let proofURL = dir.appendingPathComponent("mobile-approval-approve-proof.json")
+  setenv("FRIDAY_MOBILE_APPROVAL_APPROVE_PROOF_OUT", proofURL.path, 1)
+  defer { unsetenv("FRIDAY_MOBILE_APPROVAL_APPROVE_PROOF_OUT") }
+
+  try writeMobileApprovalApproveProofIfRequested(
+    result: ResumeRelayResult(
+      runId: "run-refused",
+      op: "resume",
+      accepted: false,
+      status: "approval_refused",
+      auditRef: "run-refused:resume:receipt"),
+    approvalId: "approval-refused",
+    signedApprovalPath: dir.appendingPathComponent("signed-approval.json").path,
+    signedBlobByteCount: 439,
+    writeConfig: AgentRunServerConfig(host: "127.0.0.1", port: 48750))
+
+  let data = try Data(contentsOf: proofURL)
+  guard let proof = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+    Issue.record("proof JSON is not an object")
+    return
+  }
+  #expect(proof["status"] as? String != "pass")
+  let actions = proof["ui_actions"] as? [[String: Any]] ?? []
+  #expect(!actions.isEmpty)
+  #expect(actions.allSatisfy { ($0["status"] as? String) != "pass" })
+}
+
 @MainActor
 @Test(.enabled(if: liveMobileApprovalApproveEnabled))
 func liveMobileApprovalApproveRelaysOperatorSignedBlobVerbatim() async throws {

--- a/scripts/ops/friday-mobile-approval-approve-proof.sh
+++ b/scripts/ops/friday-mobile-approval-approve-proof.sh
@@ -120,13 +120,19 @@ const path = require("node:path");
 const [swiftProofPath, outPath] = process.argv.slice(2);
 const swiftProof = JSON.parse(fs.readFileSync(swiftProofPath, "utf8"));
 const actionRows = Array.isArray(swiftProof.ui_actions) ? swiftProof.ui_actions : [];
+const allActionsPassed = actionRows.length > 0
+  && actionRows.every((row) => row && row.status === "pass");
+const proofPassed = swiftProof.status === "pass" && allActionsPassed;
 const evidence = {
   truth: "mobile_approval_approve_action_runtime_evidence_signed_artifact_relay_not_sim_tap_not_endbar",
-  status: actionRows.length > 0 ? "ready" : "blocked",
+  status: proofPassed ? "ready" : "blocked",
   actions: actionRows,
   source_proof: swiftProofPath,
   run_id: swiftProof.run_id,
   approval_id: swiftProof.approval_id,
+  failure_reason: proofPassed
+    ? null
+    : (swiftProof.failure_reason || swiftProof.resume?.status || "mobile_approval_approve_not_passed"),
   caveat:
     "Approve action evidence only: mobile Swift write-client relay of an externally supplied signed artifact. It does not prove simulator tap, END-BAR, release, or adoption.",
 };

--- a/test/unit/qa/friday-mobile-approval-approve-proof-cli.test.ts
+++ b/test/unit/qa/friday-mobile-approval-approve-proof-cli.test.ts
@@ -134,4 +134,63 @@ exit 0
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("does not mark refused Swift approve action evidence ready", () => {
+    const root = mkdtempSync(join(tmpdir(), "friday-mobile-approval-approve-refused-"));
+    try {
+      const swiftProof = join(root, "mobile-approval-approve-proof.json");
+      const signedApproval = writeFile(root, "signed-approval.json", "{\"signed\":true}\n");
+      const fakeSwift = writeFile(root, "swift", `#!/usr/bin/env bash
+cat > "${swiftProof}" <<'JSON'
+{
+  "truth_label": "ios_mobile_live_approval_approve_write_client_proof_signed_artifact_relay_not_sim_tap_not_endbar",
+  "status": "fail",
+  "failure_reason": "approval_refused",
+  "run_id": "run-refused-1",
+  "approval_id": "approval-refused-1",
+  "resume": {
+    "accepted": false,
+    "status": "approval_refused"
+  },
+  "ui_actions": [
+    {
+      "surface": "mobile",
+      "screen": "approval",
+      "action_id": "check",
+      "capability_id": "security_approval_bound_principal_gate_cat10_netnew",
+      "status": "fail",
+      "evidence_ref": "proof://mobile/approval-approve/run-refused-1"
+    }
+  ]
+}
+JSON
+exit 0
+`);
+      chmodSync(fakeSwift, 0o755);
+      const out = join(root, "action-runtime-evidence.json");
+
+      execFileSync("bash", [wrapper], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FRIDAY_MOBILE_APPROVAL_APPROVE_LIVE: "1",
+          FRIDAY_MOBILE_APPROVAL_APPROVE_STEP: "approve",
+          FRIDAY_MOBILE_APPROVAL_APPROVE_RUN_ID: "run-refused-1",
+          FRIDAY_MOBILE_APPROVAL_APPROVE_APPROVAL_ID: "approval-refused-1",
+          FRIDAY_MOBILE_APPROVAL_APPROVE_SIGNED_APPROVAL: signedApproval,
+          FRIDAY_MOBILE_APPROVAL_APPROVE_SWIFT_PROOF_OUT: swiftProof,
+          FRIDAY_MOBILE_APPROVAL_APPROVE_ACTION_RUNTIME_OUT: out,
+          PATH: `${root}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      const actionEvidence = JSON.parse(readFileSync(out, "utf8")) as {
+        status?: string;
+      };
+      expect(actionEvidence.status).toBe("blocked");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- NEW-54: fail-close mobile approval approve Swift proof output when a live resume is refused.
- NEW-55: fail-close action-runtime evidence conversion so refused/fail Swift proof output is `blocked`, not `ready`.
- Preserves accepted/pass happy path and does not change hub signature verification or signer custody.

## Red-first structure

- `1b990563` red: `test: expose mobile approval refused proof false pass`
- `1f49627c` green: `fix: fail close refused mobile approval proof`
- `21f22646` red: `test: expose refused mobile approval runtime evidence ready`
- `0ff66c02` green: `fix: block refused mobile approval runtime evidence`
- `c69e428b` hardening: exact refused assertions for `fail`, `failure_reason`, `accepted=false`

## Evidence

- NEW-54: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new54-mobile-approval-approve-proof-failclose-20260705T1938-0700/`
- NEW-55: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new55-mobile-approval-action-runtime-refused-failclose-20260705T1942-0700/`
- Live signed-artifact rerun after NEW-54: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/mobile-approve-proof-pending-current-20260705T160035-0700/artifacts/mobile-approval-approve-proof-after-new54.json`
- Handoff ledger commit: `1d2e1b3c docs: record new54 new55 mobile approval failclose`

## Boundary

The operator-supplied signed artifact still returned `accepted=false` / `approval_refused` in the live rerun. This PR does **not** claim approve success, END-BAR, release, prod deploy, organic adoption, or operator visual/device terminal completion. It only prevents refused approval evidence from being mislabeled as pass/ready.

## Local verification

- `swift test --package-path apps/friday-ios --filter mobileApprovalApproveProofMarksRefusedResumeAsFailure`
- `pnpm vitest run test/unit/qa/friday-mobile-approval-approve-proof-cli.test.ts`
- `git diff --check origin/main..HEAD`
- Independent reviewer PASS: Parfit, Gauss, Turing sessions recorded in handoff ledger.
