### PR TITLE
Fail-close B4 empty outcome proof predicate

### DIFF
--- a/rust-core/crates/friday-core/src/mission.rs
+++ b/rust-core/crates/friday-core/src/mission.rs
@@ -754,7 +754,7 @@ impl WorkItem {
         }
         let requirements = self.outcome_requirement_specs();
         if requirements.is_empty() {
-            return true;
+            return false;
         }
         requirements.iter().all(|requirement| {
             self.proof_receipts.iter().any(|receipt| {

--- a/rust-core/crates/friday-core/src/mission.rs
+++ b/rust-core/crates/friday-core/src/mission.rs
@@ -1569,9 +1569,14 @@ mod tests {
 
     #[test]
     fn legacy_requirements_remain_floor_only_for_outcome_predicate() {
-        let done = work("wi-legacy", WorkItemStatus::CompletedWithProof);
+        let mut done = work("wi-legacy", WorkItemStatus::CompletedWithProof);
+        done.proof_receipts = vec!["proof://provider/free-text-receipt".into()];
         assert!(!done.has_outcome_proof_requirements());
-        assert!(done.completion_outcome_is_proven());
+        assert!(done.completion_is_proven());
+        assert!(
+            !done.completion_outcome_is_proven(),
+            "outcome-specific proof must not be true when there are no typed outcome requirements"
+        );
         assert!(outcome_checked_proof_enabled_from(Some("1")));
         assert!(!outcome_checked_proof_enabled_from(Some("true")));
         assert!(!outcome_checked_proof_enabled_from(None));


### PR DESCRIPTION
## Scope

B4-verify narrow repair: fail-close the outcome-specific predicate when a WorkItem has no typed outcome proof requirements.

This does **not** claim global B4 terminal completion, END-BAR, prod, release, organic adoption, or operator/device attestation.

## Red-first

- Red commit: `e69bd842` `test(b4): expose empty outcome predicate proof`
- Green commit: `5bffdbb1` `fix(b4): fail closed empty outcome predicate`
- Red log: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/b4-empty-outcome-predicate-redfirst-20260705T2128-0700/red-empty-outcome-predicate.log`, exit `101`
- Green logs:
  - `green-friday-core-outcome.log`, exit `0`
  - `green-storage-outcome-checked.log`, exit `0`
  - `green-friday-core-mission-tests.log`, exit `0`
  - `green-storage-work-item-lifecycle-full.log`, exit `0`
- Revert-red: `revert-red-empty-outcome-predicate-valid.log`, exit `101`

## No-degrade

- `completion_is_proven()` remains true for legacy `completed_with_proof` plus receipt.
- `completion_outcome_is_proven()` now returns false when there are no parsed typed outcome requirements.
- `friday-core mission::tests`: 14 passed.
- `friday-storage --test work_item_lifecycle`: 21 passed.

## Independent reviewers

- Mendel the 4th: `b4-review-20260705T212804-0700-55372`, PASS.
- Linnaeus the 4th: `b4-reviewer2-20260705T212843-0700-58030`, PASS.

Reviewer verdict files are in `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/b4-empty-outcome-predicate-redfirst-20260705T2128-0700/`.

## High boundary

B4 is High. This PR should remain `pending-operator-review` until operator/军师 external verdict/SIGN. Do not treat self-spawn reviewer PASS as terminal acceptance.
