### PR TITLE
Record retired closure gaps without passing them

### DIFF
--- a/scripts/e2e/friday-closure-lib.mjs
+++ b/scripts/e2e/friday-closure-lib.mjs
@@ -160,6 +160,44 @@ export function buildClosureScratchEnv(baseEnv = process.env, paths) {
   };
 }
 
+const TS_RETIRED_RUNTIME_CODE = /\b(TS_RUNTIME_[A-Z0-9_]+_RETIRED)\b/u;
+
+export function classifyRetiredRuntimeClosureFailure(errorText, manifest = null) {
+  const text = typeof errorText === "string" ? errorText : String(errorText ?? "");
+  const match = text.match(TS_RETIRED_RUNTIME_CODE);
+  if (!match) {
+    return null;
+  }
+  const code = match[1];
+  const surfaces = Array.isArray(manifest?.surfaces) ? manifest.surfaces : [];
+  const manifestSurfaceIds = surfaces
+    .filter((surface) => {
+      if (surface?.classification !== "fail_closed" || surface?.executes_product_logic !== false) {
+        return false;
+      }
+      const declaredCode =
+        surface?.family_code
+        ?? surface?.familyCode
+        ?? surface?.errorCode
+        ?? surface?.expectedErrorCode
+        ?? surface?.code;
+      if (declaredCode === code) {
+        return true;
+      }
+      return JSON.stringify(surface).includes(code);
+    })
+    .map((surface) => surface.id)
+    .filter((id) => typeof id === "string" && id.trim().length > 0);
+
+  return {
+    status: "recorded-gap",
+    reason: "ts_runtime_retired_fail_closed",
+    code,
+    manifestSurfaceIds,
+    notPass: true,
+  };
+}
+
 function entryHasHiddenClosureFailure(entry) {
   if (!entry || typeof entry !== "object") {
     return false;

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -13,6 +13,7 @@ import {
   FRIDAY_CLOSURE_STATUSES,
   collectCloudBlockers,
   createClosureRunId,
+  classifyRetiredRuntimeClosureFailure,
   resolveReadinessReport,
   resolveClosureRoot,
   resolveClosureVerdict,
@@ -22,6 +23,15 @@ import { acquireWorkspaceRunLock, releaseWorkspaceRunLock } from "../quality/wor
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const DIST_CLI = path.join(REPO_ROOT, "dist", "cli", "friday-cli.js");
+const TS_RUNTIME_RETIREMENT_MANIFEST = (() => {
+  try {
+    return JSON.parse(
+      fs.readFileSync(path.join(REPO_ROOT, "docs", "ops", "ts-runtime-retirement-manifest.json"), "utf8"),
+    );
+  } catch {
+    return null;
+  }
+})();
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_TIMEOUT_MS = 180_000;
 const ALL_MODES = process.argv.includes("--all");
@@ -530,9 +540,12 @@ export async function runStep(ledger, { id, stage, description }, fn) {
     entry.details = { ...(entry.details || {}), ...(result?.details || {}) };
   } catch (error) {
     entry.status = FRIDAY_CLOSURE_STATUSES.FAIL;
+    const errorText = error instanceof Error ? error.message : String(error);
+    const recordedGap = classifyRetiredRuntimeClosureFailure(errorText, TS_RUNTIME_RETIREMENT_MANIFEST);
     entry.details = {
       ...(entry.details || {}),
-      error: error instanceof Error ? error.message : String(error),
+      error: errorText,
+      ...(recordedGap ? { recordedGap } : {}),
     };
   } finally {
     entry.completedAt = nowIso();

--- a/test/unit/e2e/friday-closure-lib.test.ts
+++ b/test/unit/e2e/friday-closure-lib.test.ts
@@ -8,6 +8,7 @@ import {
   collectCloudBlockers,
   createClosureRunId,
   parseEnabledChannelKinds,
+  classifyRetiredRuntimeClosureFailure,
   resolveClosureVerdict,
   resolveCloudContractReport,
   resolveReadinessReport,
@@ -208,6 +209,38 @@ describe("friday closure lib", () => {
     ]);
 
     expect(verdict.summary).toEqual({ pass: 0, fail: 1, blocker: 0 });
+    expect(verdict.verdict).toBe("NO-GO");
+  });
+
+  it("classifies retired TS runtime closure failures as recorded gaps without making them pass", () => {
+    const recordedGap = classifyRetiredRuntimeClosureFailure(
+      "Session create failed: {\"error\":{\"code\":\"TS_RUNTIME_SESSION_RETIRED\"}}",
+      {
+        surfaces: [
+          {
+            id: "sessions_create",
+            family_code: "TS_RUNTIME_SESSION_RETIRED",
+            classification: "fail_closed",
+            executes_product_logic: false,
+          },
+        ],
+      },
+    );
+
+    expect(recordedGap).toEqual({
+      status: "recorded-gap",
+      reason: "ts_runtime_retired_fail_closed",
+      code: "TS_RUNTIME_SESSION_RETIRED",
+      manifestSurfaceIds: ["sessions_create"],
+      notPass: true,
+    });
+    const verdict = resolveClosureVerdict([
+      {
+        id: "local.sessions-agent-memory",
+        status: FRIDAY_CLOSURE_STATUSES.FAIL,
+        details: { recordedGap },
+      },
+    ]);
     expect(verdict.verdict).toBe("NO-GO");
   });
 });


### PR DESCRIPTION
## Scope

NEW-57: record retired TS runtime closure failures as honest `recordedGap` entries without making them pass.

This is closure-harness honesty work only. It does not reopen retired TS runtime product paths and does not close END-BAR, Suite13, S2, prod deploy/currentness, release/latest-install, organic adoption, provider entitlement, or operator/device attestation.

## Red-First Evidence

- Red commit: `39098299` (`test(new57): expose retired closure gap attribution`)
- Green commit: `4019087d` (`fix(new57): record retired closure gaps`)
- Evidence directory: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new57-closure-retired-gap-redfirst-20260705T223837-0700/`
- Red log: `red-closure-recorded-gap.log`, exit `1`
- Green logs: `green-closure-unit-after-manifest-match.log`, `final-green-closure-unit.log`, both exit `0`
- Valid revert-red: `revert-red-valid2-closure-recorded-gap.log`, exit `1`
- Closure no-degrade proof: `short-closure-after-manifest-match/recorded-gap-digest.json` keeps verdict `NO-GO`; recorded gaps are still `FAIL` with `notPass: true`

## Reviewers

- Hilbert the 4th, session `019f35f4-a6f5-7243-9d46-66c196dab49e`, verdict `PASS`
- Carver the 4th, session `019f35f4-ea3c-73c3-bc50-4fef11c5c247`, verdict `PASS`

## Local Verification

- `pnpm vitest run test/unit/e2e/friday-closure-lib.test.ts test/unit/e2e/run-friday-closure.test.ts`
- Result: 2 files passed, 19 tests passed

## Handoff

- Ledger entry committed in Friday-Handoff-Log: `373b20dc` (`docs: record new57 closure gap attribution`)
