### PR TITLE
Record CLI retired skill-run gap without passing it

### DIFF
--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -726,7 +726,9 @@ function signSatelliteChallenge(privateKeyPem, challengeNonce) {
   return signer.sign(privateKeyPem, "base64");
 }
 
-function describeCommandFailure(result) {
+const TS_RETIRED_RUNTIME_COMMAND_CODE = /\b(TS_RUNTIME_[A-Z0-9_]+_RETIRED)\b/u;
+
+export function describeCommandFailure(result) {
   const parts = [
     `${result.description} failed`,
     `code ${String(result.code)}`,
@@ -739,6 +741,12 @@ function describeCommandFailure(result) {
   }
   if (result.forcedKill) {
     parts.push("forced-kill");
+  }
+  const retiredRuntimeCode = typeof result.output === "string"
+    ? result.output.match(TS_RETIRED_RUNTIME_COMMAND_CODE)?.[1]
+    : null;
+  if (retiredRuntimeCode) {
+    parts.push(`retired-runtime ${retiredRuntimeCode}`);
   }
   return parts.join(" ");
 }

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import {
   closeWritableStream,
   createLedger,
+  describeCommandFailure,
   markInterruptedClosureLedger,
   persistLedger,
   runStep,
@@ -136,6 +137,62 @@ describe("run-friday-closure helpers", () => {
     expect(snapshot.completedAt).toBeTruthy();
     expect(snapshot.entries.at(-1)?.status).toBe(FRIDAY_CLOSURE_STATUSES.FAIL);
     expect(snapshot.entries.at(-1)?.details?.interrupted).toBe(true);
+    expect(snapshot.verdict).toBe("NO-GO");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("records retired CLI command failures as gaps without leaking command output or making them pass", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-closure-cli-gap-"));
+    const paths = {
+      runId: "cli-gap-run",
+      root: dir,
+      state: join(dir, "state"),
+      skills: join(dir, "skills"),
+      artifacts: join(dir, "artifacts"),
+      logs: join(dir, "logs"),
+      exports: join(dir, "exports"),
+      responses: join(dir, "responses"),
+      transcripts: join(dir, "transcripts"),
+    };
+    for (const value of Object.values(paths)) {
+      if (typeof value === "string") {
+        fs.mkdirSync(value, { recursive: true });
+      }
+    }
+
+    const failureMessage = describeCommandFailure({
+      description: "friday run output-current-date-time",
+      code: 1,
+      output: [
+        "Fatal error: FridayDomainError: Skill run execution is fail-closed",
+        "code: 'TS_RUNTIME_SKILL_RUNS_RETIRED'",
+        "super-secret-output-that-must-not-enter-ledger",
+      ].join("\n"),
+    });
+    expect(failureMessage).toContain("TS_RUNTIME_SKILL_RUNS_RETIRED");
+    expect(failureMessage).not.toContain("super-secret-output-that-must-not-enter-ledger");
+
+    const ledger = createLedger(paths);
+    persistLedger(ledger);
+    await runStep(ledger, {
+      id: "local.cli.convert-import-pack-run",
+      stage: "local.cli",
+      description: "Exercise friday convert/import/pack/run through the compiled CLI",
+    }, async () => {
+      throw new Error(failureMessage);
+    });
+
+    const snapshot = JSON.parse(readFileSync(join(dir, "ledger.json"), "utf8"));
+    const entry = snapshot.entries.at(-1);
+    expect(entry.status).toBe(FRIDAY_CLOSURE_STATUSES.FAIL);
+    expect(entry.details.recordedGap).toMatchObject({
+      status: "recorded-gap",
+      reason: "ts_runtime_retired_fail_closed",
+      code: "TS_RUNTIME_SKILL_RUNS_RETIRED",
+      notPass: true,
+    });
+    expect(entry.details.recordedGap.manifestSurfaceIds).toContain("skills_run");
     expect(snapshot.verdict).toBe("NO-GO");
 
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Scope

NEW-58: record the `friday run` retired skill-run CLI failure as an honest closure `recordedGap` without making it pass.

This is closure-harness honesty work only. It does not re-enable TypeScript skill execution, does not run prod/deploy/operator actions, and does not close END-BAR, Suite13, S2, release/latest-install, organic adoption, provider entitlement, or operator/device attestation.

## Red-First Evidence

- Red commit: `6f0ee5a3` (`test(new58): expose CLI retired gap attribution`)
- Green commit: `d9570e56` (`fix(new58): record CLI retired runtime gaps`)
- Evidence directory: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new58-cli-retired-gap-redfirst-20260705T2340-0700/`
- Red log: `red-cli-retired-gap.log`, exit `1`
- Green log: `green-cli-retired-gap.log`, exit `0`
- Valid revert-red: `revert-red-cli-retired-gap.log`, exit `1`
- Closure no-degrade proof: `closure-after-new58-digest.json` keeps verdict `NO-GO`; `local.cli.convert-import-pack-run` remains `FAIL` with `recordedGap.notPass=true`

## Reviewers

- Godel the 4th, session `019f362a-0039-7233-aad0-e80c8212802b`, verdict `PASS`
- Carson the 4th, session `019f362a-00bf-7e92-a4ae-624d7c5c1b61`, verdict `PASS`

## Local Verification

- `pnpm vitest run test/unit/e2e/run-friday-closure.test.ts test/unit/e2e/friday-closure-lib.test.ts`
- Result: 2 files passed, 20 tests passed

## Handoff

- Ledger entry committed in Friday-Handoff-Log: `ab27dc21` (`docs: record new58 cli retired gap attribution`)
