### PR TITLE
Preserve closure provider env refs

### DIFF
--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -851,8 +851,8 @@ function resolveClosureProviderConfig(env = process.env) {
   };
 }
 
-async function createClosureProvider(baseUrl, token, providerConfig) {
-  const createRes = await apiFetch(baseUrl, token, "POST", "/v1/providers", {
+export function buildClosureProviderCreateRequest(providerConfig) {
+  return {
     kind: providerConfig.kind,
     name: providerConfig.name,
     baseUrl: providerConfig.baseUrl,
@@ -863,7 +863,12 @@ async function createClosureProvider(baseUrl, token, providerConfig) {
     defaultModel: providerConfig.defaultModel,
     enabled: true,
     validateOnSave: false,
-  });
+    preserveEnvRef: true,
+  };
+}
+
+async function createClosureProvider(baseUrl, token, providerConfig) {
+  const createRes = await apiFetch(baseUrl, token, "POST", "/v1/providers", buildClosureProviderCreateRequest(providerConfig));
   if (createRes.status !== 200 || !createRes.json.ok) {
     throw new Error(`Provider create failed: ${JSON.stringify(createRes.json)}`);
   }

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -6,6 +6,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 
 import {
+  buildClosureProviderCreateRequest,
   closeWritableStream,
   createLedger,
   describeCommandFailure,
@@ -17,6 +18,33 @@ import {
 import { FRIDAY_CLOSURE_STATUSES } from "../../../scripts/e2e/friday-closure-lib.mjs";
 
 describe("run-friday-closure helpers", () => {
+  it("keeps closure provider env refs out of scratch secret storage", () => {
+    const request = buildClosureProviderCreateRequest({
+      kind: "openai",
+      name: "Closure OpenAI",
+      baseUrl: "https://api.openai.com",
+      api: "openai-responses",
+      envVar: "OPENAI_API_KEY",
+      supportedModels: ["gpt-4o-mini", "gpt-4o"],
+      defaultModel: "gpt-4o-mini",
+    });
+
+    expect(request).toMatchObject({
+      kind: "openai",
+      name: "Closure OpenAI",
+      baseUrl: "https://api.openai.com",
+      authMode: "api-key",
+      api: "openai-responses",
+      apiKey: "$OPENAI_API_KEY",
+      supportedModels: ["gpt-4o-mini", "gpt-4o"],
+      defaultModel: "gpt-4o-mini",
+      enabled: true,
+      validateOnSave: false,
+      preserveEnvRef: true,
+    });
+    expect(JSON.stringify(request)).not.toContain("sk-");
+  });
+
   it("closeWritableStream flushes and closes a write stream", async () => {
     const dir = mkdtempSync(join(tmpdir(), "friday-closure-stream-"));
     const filePath = join(dir, "stream.log");


### PR DESCRIPTION
## Scope

NEW-59: keep the END-BAR local closure provider setup on env-ref credentials instead of forcing scratch SecretStore encryption.

This is a Medium tooling/closure-honesty repair. It does not make END-BAR pass and does not claim prod, release/latest-install, organic adoption, operator device attestation, or provider entitlement completion.

## Red-first evidence

- Red commit: `fe849e42 test(new59): expose closure provider env-ref persistence`
  - `red-provider-envref.log`, exit `1`
  - failure: `buildClosureProviderCreateRequest is not a function`
- Green commit: `75b05b13 fix(new59): preserve closure provider env refs`
  - `green-provider-envref.log`, exit `0`
  - `test/unit/e2e/run-friday-closure.test.ts` + `test/unit/e2e/friday-closure-lib.test.ts`, `21 passed`
- Valid revert-red:
  - `revert-red-provider-envref-valid-main.log`, exit `1`
  - same missing helper failure after reverting the green commit

Evidence directory:
`/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new59-closure-provider-envref-redfirst-20260706T0129-0700/`

## No-degrade

- `no-degrade-provider-service.log`, exit `0`: provider service env-ref creation, env-ref migration into encrypted storage, and raw-secret missing-master-key fail-close still pass (`3 passed | 98 skipped`).
- `no-degrade-ts-runtime-retirement.log`, exit `0`: `check:ts-runtime-retirement` still passes (`routeCount=592`, no failures).
- Secret scan found only the synthetic test phrase `secret storage`; no raw key, bearer token, or `*_API_KEY=value` evidence.

## Independent reviewers

- Lovelace the 4th, harness session `019f3681-faa2-7623-8e67-87f422738326`: PASS
  - `reviewer-a-new59-provider-envref.md`
- Avicenna the 4th, harness session `019f3681-fb30-7873-8ebc-63b90242cd4b`: PASS
  - `reviewer-b-new59-provider-envref.md`

## END-BAR boundary

Branch proof rerun:
`/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/endbar-local-closure-after-new59-branch-20260706T0116-0700/closure-ledger-digest.json`

Result remains `NO-GO`: `pass=7 fail=13 blocker=1`, `recordedGapCount=12`.

`local.providers.lifecycle` now reaches `recordedGap.code=TS_RUNTIME_PROVIDER_PROBE_RETIRED` with `notPass=true`. Remaining unrecorded/non-retired failures are `local.uix.templates` and `local.uix.deploy-export`.
