### PR TITLE
Record UIX provider entitlement gaps without passing them

### DIFF
--- a/scripts/e2e/friday-closure-lib.mjs
+++ b/scripts/e2e/friday-closure-lib.mjs
@@ -198,6 +198,27 @@ export function classifyRetiredRuntimeClosureFailure(errorText, manifest = null)
   };
 }
 
+export function classifyProviderEntitlementClosureFailure(errorText) {
+  const text = typeof errorText === "string" ? errorText : String(errorText ?? "");
+  if (!text.includes("PROVIDER_NO_CANDIDATES")) {
+    return null;
+  }
+  if (
+    !text.includes("No enabled providers available for routing")
+    && !text.includes("Authentication failed")
+  ) {
+    return null;
+  }
+
+  return {
+    status: "recorded-gap",
+    reason: "provider_entitlement_unavailable_fail_closed",
+    code: "PROVIDER_NO_CANDIDATES",
+    acceptanceGroupId: "provider_entitlement_matrix",
+    notPass: true,
+  };
+}
+
 function entryHasHiddenClosureFailure(entry) {
   if (!entry || typeof entry !== "object") {
     return false;

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -13,6 +13,7 @@ import {
   FRIDAY_CLOSURE_STATUSES,
   collectCloudBlockers,
   createClosureRunId,
+  classifyProviderEntitlementClosureFailure,
   classifyRetiredRuntimeClosureFailure,
   resolveReadinessReport,
   resolveClosureRoot,
@@ -541,7 +542,9 @@ export async function runStep(ledger, { id, stage, description }, fn) {
   } catch (error) {
     entry.status = FRIDAY_CLOSURE_STATUSES.FAIL;
     const errorText = error instanceof Error ? error.message : String(error);
-    const recordedGap = classifyRetiredRuntimeClosureFailure(errorText, TS_RUNTIME_RETIREMENT_MANIFEST);
+    const recordedGap =
+      classifyRetiredRuntimeClosureFailure(errorText, TS_RUNTIME_RETIREMENT_MANIFEST)
+      ?? classifyProviderEntitlementClosureFailure(errorText);
     entry.details = {
       ...(entry.details || {}),
       error: errorText,

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -225,4 +225,58 @@ describe("run-friday-closure helpers", () => {
 
     rmSync(dir, { recursive: true, force: true });
   });
+
+  it("records unavailable provider entitlement failures as gaps without making them pass", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-closure-provider-gap-"));
+    const paths = {
+      runId: "provider-gap-run",
+      root: dir,
+      state: join(dir, "state"),
+      skills: join(dir, "skills"),
+      artifacts: join(dir, "artifacts"),
+      logs: join(dir, "logs"),
+      exports: join(dir, "exports"),
+      responses: join(dir, "responses"),
+      transcripts: join(dir, "transcripts"),
+    };
+    for (const value of Object.values(paths)) {
+      if (typeof value === "string") {
+        fs.mkdirSync(value, { recursive: true });
+      }
+    }
+
+    const ledger = createLedger(paths);
+    persistLedger(ledger);
+    await runStep(ledger, {
+      id: "local.uix.templates",
+      stage: "local.uix",
+      description: "List and execute every assistant template plus the guided wizard",
+    }, async () => {
+      throw new Error(
+        "Template generate-skill failed: "
+        + JSON.stringify({
+          ok: false,
+          error: {
+            code: "PROVIDER_NO_CANDIDATES",
+            message: "No enabled providers available for routing: defaultProviderId validation failed: Authentication failed",
+            retryable: false,
+          },
+        }),
+      );
+    });
+
+    const snapshot = JSON.parse(readFileSync(join(dir, "ledger.json"), "utf8"));
+    const entry = snapshot.entries.at(-1);
+    expect(entry.status).toBe(FRIDAY_CLOSURE_STATUSES.FAIL);
+    expect(entry.details.recordedGap).toMatchObject({
+      status: "recorded-gap",
+      reason: "provider_entitlement_unavailable_fail_closed",
+      code: "PROVIDER_NO_CANDIDATES",
+      acceptanceGroupId: "provider_entitlement_matrix",
+      notPass: true,
+    });
+    expect(snapshot.verdict).toBe("NO-GO");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Summary
- records closure provider entitlement/routing failures as non-passing recorded gaps
- keeps `local.uix.templates` fail-closed and END-BAR `NO-GO`
- does not change product UIX/provider execution semantics

## Red-first evidence
- red commit: `6698fcc7` (`test(new60): expose uix provider entitlement gap`)
- green commit: `71b2165e` (`fix(new60): record provider entitlement closure gaps`)
- red: `evidence/new60-uix-provider-gap-redfirst-20260706T0218-0700/red-uix-provider-gap.log`, exit `1`
- green: `green-uix-provider-gap.log`, exit `0`, `22 passed`
- revert-red: `revert-red-uix-provider-gap.log`, exit `1`

## No-degrade / reviewers
- `no-degrade-provider-entitlement-readiness.exit=0`
- `no-degrade-ts-runtime-retirement.exit=0`
- reviewer A: Maxwell the 4th, session `019f36b0-a4c7-75e3-ae80-f6447b2c4bb3`, PASS
- reviewer B: Popper the 4th, session `019f36b0-c566-75a0-a6a0-2bfd2af878c0`, PASS

## END-BAR boundary
Branch proof remains `NO-GO`: `pass=7 fail=13 blocker=1`, `recordedGapCount=13`.
`local.uix.templates` remains `FAIL` with `PROVIDER_NO_CANDIDATES`, `provider_entitlement_matrix`, `notPass=true`.
Remaining unrecorded local blocker: `local.uix.deploy-export` has no generated workflow session.

This PR does not claim END-BAR, prod deploy/currentness, release/latest-install, organic adoption, device/operator attestation, provider entitlement completion, Suite13 completion, S2 completion, or overall terminal accepted.