### PR TITLE
Record deploy export dependent gaps without passing them

### DIFF
--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -573,6 +573,34 @@ function writeCommandEvidence(paths, id, payload) {
   return commandPath;
 }
 
+export function buildDependentClosureBlockerDetails(ledger, upstreamEntryId, reason) {
+  const upstreamEntry = [...(ledger?.entries ?? [])]
+    .reverse()
+    .find((entry) => entry?.id === upstreamEntryId);
+  const upstreamGap = upstreamEntry?.details?.recordedGap;
+  if (!upstreamGap?.code) {
+    return { reason };
+  }
+
+  return {
+    reason,
+    upstreamEntryId,
+    recordedGap: {
+      status: "recorded-gap",
+      reason: "dependent_recorded_gap_fail_closed",
+      code: `DEPENDENT_ON_${upstreamGap.code}`,
+      upstreamCode: upstreamGap.code,
+      ...(Array.isArray(upstreamGap.manifestSurfaceIds)
+        ? { manifestSurfaceIds: upstreamGap.manifestSurfaceIds }
+        : {}),
+      ...(typeof upstreamGap.acceptanceGroupId === "string"
+        ? { acceptanceGroupId: upstreamGap.acceptanceGroupId }
+        : {}),
+      notPass: true,
+    },
+  };
+}
+
 function formatReadinessReport(readiness) {
   const lines = [];
 
@@ -1854,9 +1882,11 @@ async function runLocalStage(ledger) {
       if (!workflowGeneratorResult?.sessionId) {
         return {
           status: FRIDAY_CLOSURE_STATUSES.BLOCKER,
-          details: {
-            reason: "No generated workflow session is available for deploy/export template execution",
-          },
+          details: buildDependentClosureBlockerDetails(
+            ledger,
+            "local.workflows.generator",
+            "No generated workflow session is available for deploy/export template execution",
+          ),
         };
       }
       const deploy = await apiFetch(baseUrl, token, "POST", "/v1/uix/templates/deploy-workflow/execute", {

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -6,6 +6,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 
 import {
+  buildDependentClosureBlockerDetails,
   buildClosureProviderCreateRequest,
   closeWritableStream,
   createLedger,
@@ -276,6 +277,68 @@ describe("run-friday-closure helpers", () => {
       notPass: true,
     });
     expect(snapshot.verdict).toBe("NO-GO");
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("records deploy-export blockers as dependent gaps when workflow generation is already recorded", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-closure-dependent-gap-"));
+    const paths = {
+      runId: "dependent-gap-run",
+      root: dir,
+      state: join(dir, "state"),
+      skills: join(dir, "skills"),
+      artifacts: join(dir, "artifacts"),
+      logs: join(dir, "logs"),
+      exports: join(dir, "exports"),
+      responses: join(dir, "responses"),
+      transcripts: join(dir, "transcripts"),
+    };
+    for (const value of Object.values(paths)) {
+      if (typeof value === "string") {
+        fs.mkdirSync(value, { recursive: true });
+      }
+    }
+
+    const ledger = createLedger(paths);
+    ledger.entries.push({
+      id: "local.workflows.generator",
+      stage: "local.workflows",
+      description: "Generate, approve, and run a workflow through Friday's public workflow generator API",
+      startedAt: new Date("2026-07-06T09:00:00.000Z").toISOString(),
+      completedAt: new Date("2026-07-06T09:00:01.000Z").toISOString(),
+      durationMs: 1000,
+      status: FRIDAY_CLOSURE_STATUSES.FAIL,
+      evidence: {},
+      details: {
+        recordedGap: {
+          status: "recorded-gap",
+          reason: "ts_runtime_retired_fail_closed",
+          code: "TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED",
+          manifestSurfaceIds: ["workflows_generator_sessions_create"],
+          notPass: true,
+        },
+      },
+    });
+
+    const details = buildDependentClosureBlockerDetails(
+      ledger,
+      "local.workflows.generator",
+      "No generated workflow session is available for deploy/export template execution",
+    );
+
+    expect(details).toMatchObject({
+      reason: "No generated workflow session is available for deploy/export template execution",
+      upstreamEntryId: "local.workflows.generator",
+      recordedGap: {
+        status: "recorded-gap",
+        reason: "dependent_recorded_gap_fail_closed",
+        code: "DEPENDENT_ON_TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED",
+        upstreamCode: "TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED",
+        notPass: true,
+      },
+    });
+    expect(details.recordedGap.manifestSurfaceIds).toContain("workflows_generator_sessions_create");
 
     rmSync(dir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
- records deploy/export no-session closure blockers as dependent recorded gaps when workflow generation already recorded a gap
- keeps `local.uix.deploy-export` as `BLOCKER` and END-BAR `NO-GO`
- does not change product workflow/template execution semantics

## Red-first evidence
- red commit: `984f421e` (`test(new61): expose deploy export dependent gap`)
- green commit: `588b4fa6` (`fix(new61): record deploy export dependent gaps`)
- red: `evidence/new61-deploy-export-dependent-gap-redfirst-20260706T0300-0700/red-deploy-export-dependent-gap.log`, exit `1`
- green: `green-deploy-export-dependent-gap.log`, exit `0`, `23 passed`
- revert-red: `revert-red-deploy-export-dependent-gap.log`, exit `1`

## No-degrade / reviewers
- `no-degrade-readiness.exit=0`
- `no-degrade-ts-runtime-retirement.exit=0`
- reviewer A: Faraday the 4th, session `019f36dd-e891-7d13-995a-d983177d01ac`, PASS
- reviewer B: Sartre the 4th, session `019f36de-5c97-7d63-aeb6-7378f59bb3db`, PASS

## END-BAR boundary
Branch proof remains `NO-GO`: `pass=7 fail=13 blocker=1`, `recordedGapCount=14`, `unrecorded=[]`.
`local.uix.deploy-export` remains `BLOCKER` with `DEPENDENT_ON_TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED`, `upstreamCode=TS_RUNTIME_WORKFLOW_GENERATOR_RETIRED`, `notPass=true`.

This PR does not claim END-BAR, prod deploy/currentness, release/latest-install, organic adoption, device/operator attestation, provider entitlement completion, Suite13 completion, S2 completion, or overall terminal accepted.