### PR TITLE
Route workflow create through Rust catalog bridge

### DIFF
--- a/src/api/http/routes/friday-workflow-routes.ts
+++ b/src/api/http/routes/friday-workflow-routes.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type { UUID } from "#workflows";
 import { FridayDomainError } from "#errors";
@@ -49,9 +50,9 @@ export interface FridayWorkflowRoutesDeps {
    * `hub_workflow_catalog` bin (#657) via {@link rustWorkflowCatalogBridge} (after auth)
    * instead of the retired TS path, returning a refs-only receipt. DEFAULT/unset ⇒
    * byte-identical to today's fail-closed `TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED`
-   * 503 (this flag's branch is never entered). `create` (graph→def compiler out of scope)
-   * and the catalog pointer-`deploy` (semantic mismatch with the richer draft-deploy route)
-   * are intentionally NOT route-wired — they remain fail-closed/retired even with the flag on.
+   * 503 (this flag's branch is never entered). The catalog pointer-`deploy` remains
+   * intentionally NOT route-wired because it has a semantic mismatch with the richer draft-deploy
+   * route.
    */
   routeWorkflowsViaRust?: boolean;
   /**
@@ -112,6 +113,26 @@ function requirePositiveIntField(body: Record<string, unknown> | null, field: st
   return value;
 }
 
+function requireNonEmptyStringField(body: Record<string, unknown> | null, field: string, maxLen: number): string {
+  const value = body ? body[field] : undefined;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      `${field} is required and must be a non-empty string`,
+      { httpStatus: 400 },
+    );
+  }
+  const trimmed = value.trim();
+  if (trimmed.length > maxLen) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      `${field} must be at most ${String(maxLen)} characters`,
+      { httpStatus: 400 },
+    );
+  }
+  return trimmed;
+}
+
 function throwRetiredWorkflowCatalogMutation(): never {
   throw new FridayDomainError(
     "TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED",
@@ -140,6 +161,32 @@ function assertWorkflowWritePrincipal(
     anyOfScopes: ["hub.admin", "workflow.write"],
     anyOfRoles: ["owner", "admin", "operator"],
   });
+}
+
+/**
+ * Flag-on (DARK) `workflows.create` → Rust `hub_workflow_catalog create`. Auth has ALREADY run
+ * in the handler. The route returns a refs-only receipt because the Rust bridge deliberately
+ * withholds verbatim name/description/tags and the definition body.
+ */
+async function routeCreateViaRust(
+  bridge: FridayRustHubWorkflowCatalogBridgeService,
+  body: Record<string, unknown> | null,
+): Promise<FridayWorkflowCatalogRustRouteResponse> {
+  const slug = requireNonEmptyStringField(body, "slug", 128);
+  const name = requireNonEmptyStringField(body, "name", 255);
+  const description = body && typeof body.description === "string" ? body.description : undefined;
+  const tagsJson = body && Array.isArray(body.tags) ? JSON.stringify(body.tags) : undefined;
+  const defJson = JSON.stringify(body?.graph ?? {});
+  const receipt = await bridge.mutateCatalog({
+    op: "create",
+    workflowId: randomUUID(),
+    slug,
+    name,
+    description,
+    tagsJson,
+    defJson,
+  });
+  return { routedVia: "rust_hub_workflow_catalog", receipt };
 }
 
 /**
@@ -242,6 +289,13 @@ export function createFridayWorkflowRoutes(
       path: "/v1/workflows",
       auth: { public: true },
       async handler(ctx) {
+        if (deps.routeWorkflowsViaRust === true) {
+          assertWorkflowWritePrincipal(ctx.principal ?? null, "workflow.create");
+          return routeCreateViaRust(
+            requireRustWorkflowBridge(deps),
+            ctx.body as Record<string, unknown> | null,
+          );
+        }
         assertWorkflowCatalogMutationTestOracleAllowed(deps);
         assertWorkflowWritePrincipal(ctx.principal ?? null, "workflow.create");
         const body = ctx.body as Record<string, unknown> | null;

--- a/test/unit/api/http/routes/friday-workflow-routes.test.ts
+++ b/test/unit/api/http/routes/friday-workflow-routes.test.ts
@@ -300,17 +300,30 @@ describe("FridayWorkflowRoutes", () => {
       });
     });
 
-    it("flag-ON does NOT route create or deploy (they stay retired/fail-closed)", async () => {
+    it("flag-ON create routes an authorized request to the bridge (refs-only response)", async () => {
       const bridge = makeStubBridge();
       const route = flagOnRoutes(bridge).find((r) => r.operationId === "workflows.create")!;
-      // create is NOT route-wired (graph→def compiler out of scope) → today's retirement 503.
-      await expect(
-        route.handler(makeCtx({ body: { slug: "wf", name: "Workflow", graph: {} } })),
-      ).rejects.toMatchObject({
-        code: "TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED",
-        httpStatus: 503,
+      const graph = { nodes: [{ id: "trigger1", type: "trigger" }], edges: [] };
+      const res = await route.handler(makeCtx({
+        body: {
+          slug: "wf",
+          name: "Workflow",
+          description: "Closure workflow",
+          tags: ["closure", "rust"],
+          graph,
+        },
+      }));
+      expect(res).toMatchObject({ routedVia: "rust_hub_workflow_catalog" });
+      expect(bridge.mutateCatalog).toHaveBeenCalledTimes(1);
+      expect(bridge.calls[0]).toMatchObject({
+        op: "create",
+        workflowId: expect.any(String),
+        slug: "wf",
+        name: "Workflow",
+        description: "Closure workflow",
+        defJson: JSON.stringify(graph),
+        tagsJson: JSON.stringify(["closure", "rust"]),
       });
-      expect(bridge.mutateCatalog).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Scope
- NEW-63 / S2 workflow catalog create route replacement slice.
- Wires flag-on `POST /v1/workflows` to the existing Rust `hub_workflow_catalog create` bridge and keeps flag-off default fail-closed.
- Does not touch #1526 files.

## Red-first
- Red commit: `917f1114 test(new63): require workflow create rust route` (test only).
- Green commit: `f64c958d fix(new63): route workflow create via rust catalog`.
- Evidence: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new63-workflow-create-rust-route-redfirst-20260706T044000-0700`.
- Red: `red-workflow-create-route.exit=1` (flag-on create still returned `TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED`).
- Green: `green-workflow-create-route-2.exit=0`; route test `21 passed`.
- Revert-red: `revert-red-workflow-create-route-valid2.exit=1` after reverting green in a temp worktree.

## Verification
- `npm exec -- vitest run --project default test/unit/api/http/routes/friday-workflow-routes.test.ts` -> pass.
- `npm run typecheck:src` -> pass.
- `npm exec -- vitest run --project default test/unit/api/http/routes/friday-workflow-routes.test.ts test/unit/api/mission-spine/friday-rust-hub-workflow-catalog-bridge-service.test.ts` -> pass, 37 tests.
- `git diff --check origin/main..HEAD` -> pass.

## Independent Review
- Reviewer A: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new63-workflow-create-rust-route-redfirst-20260706T044000-0700/reviewer-faraday-new63-workflow-create-rust-route.md` -> PASS.
- Reviewer B: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new63-workflow-create-rust-route-redfirst-20260706T044000-0700/reviewer-sartre-new63-workflow-create-rust-route.md` -> PASS.

## No-degrade
- Flag-off create still returns retired `TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED` and does not call TS service.
- Flag-on create enforces workflow write auth before bridge lookup/call.
- Response remains refs-only `{ routedVia, receipt }`; no forged legacy full workflow/version response.
- Open PR overlap snapshot: `open-prs-before-new63.json`; #1526 touches only rust-core proof-gate files.