### PR TITLE
Route CLI skill run through Rust gate

### DIFF
--- a/src/cli/friday-cli.ts
+++ b/src/cli/friday-cli.ts
@@ -32,8 +32,10 @@ process.on("uncaughtException", (error) => {
 });
 
 import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import { execFile } from "node:child_process";
 import { dirname, isAbsolute, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import {
   buildFridayChannelSecretRef,
   buildFridayChannelSecretRefKey,
@@ -79,6 +81,8 @@ import {
   runFridayCliAuthStatus,
 } from "./friday-cli-auth.js";
 import { cmdRuns } from "./friday-cli-runs.js";
+
+const execFileAsync = promisify(execFile);
 
 // ─── Arg parser ───
 
@@ -1463,12 +1467,23 @@ interface FridayCliSkillRunResult {
   stderr?: string;
 }
 
+type FridayCliExecFile = (
+  file: string,
+  args: readonly string[],
+  options: {
+    env?: NodeJS.ProcessEnv;
+    timeout?: number;
+    maxBuffer?: number;
+  },
+) => Promise<{ stdout: string | Buffer; stderr: string | Buffer }>;
+
 export interface FridayCliRunCommandDeps {
   createHub?: typeof createFridayHub;
   fetchFn?: typeof fetch;
   env?: NodeJS.ProcessEnv;
   logger?: Pick<typeof console, "log" | "error">;
   setExitCode?: (code: number) => void;
+  execFileFn?: FridayCliExecFile;
 }
 
 function printCliSkillRunResult(
@@ -1560,6 +1575,200 @@ async function runCliSkillRemotely(params: {
   };
 }
 
+function isCliRustSkillRunRouteEnabled(env: NodeJS.ProcessEnv): boolean {
+  const raw = env.FRIDAY_ROUTE_SKILL_RUNS_VIA_RUST?.trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+function throwRustSkillRunRouteUnavailable(message: string): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_SKILL_RUNS_RUST_ROUTE_UNAVAILABLE",
+    message,
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_skill_run_entrypoint_required",
+      },
+    },
+  );
+}
+
+function requireCliRustSkillRunEnv(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name]?.trim();
+  if (!value) {
+    throwRustSkillRunRouteUnavailable(
+      `Rust skill-run route is enabled but ${name} is not configured.`,
+    );
+  }
+  return value;
+}
+
+function splitCliRustSkillRunList(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function resolveCliRustManagedSkillsRoot(parsed: ParsedArgs, env: NodeJS.ProcessEnv): string {
+  const configured = env.FRIDAY_D21_MANAGED_SKILLS_ROOT?.trim();
+  if (configured) {
+    return configured;
+  }
+  const firstSkillDir = parsed.skillDirs[0]?.trim();
+  if (firstSkillDir) {
+    return firstSkillDir;
+  }
+  throwRustSkillRunRouteUnavailable(
+    "Rust skill-run route is enabled but no managed skills root is configured.",
+  );
+}
+
+function parseCliRustSkillRunJson(stdout: string): Record<string, unknown> {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throwRustSkillRunRouteUnavailable("Rust skill-run route returned empty stdout.");
+  }
+  const parsed = safeJsonParse(trimmed);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throwRustSkillRunRouteUnavailable("Rust skill-run route returned invalid JSON.");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function cliRustSkillRunString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function cliRustSkillRunNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+async function runCliSkillViaRust(params: {
+  parsed: ParsedArgs;
+  env: NodeJS.ProcessEnv;
+  execFileFn: FridayCliExecFile;
+}): Promise<FridayCliSkillRunResult> {
+  const skillId = params.parsed.skillId;
+  if (!skillId) {
+    throwRustSkillRunRouteUnavailable("Rust skill-run route is enabled but skillId is missing.");
+  }
+
+  const env = params.env;
+  const bin = requireCliRustSkillRunEnv(env, "FRIDAY_D21_SKILL_RUN_LOCAL_BIN");
+  const dbPath = requireCliRustSkillRunEnv(env, "FRIDAY_D21_SKILL_RUN_LOCAL_DB_PATH");
+  const operatorVkPath = requireCliRustSkillRunEnv(env, "FRIDAY_D21_OPERATOR_VK_PATH");
+  const approvalJson = requireCliRustSkillRunEnv(env, "FRIDAY_D21_SKILL_RUN_APPROVAL_JSON");
+  const missionId = requireCliRustSkillRunEnv(env, "FRIDAY_D21_SKILL_RUN_MISSION_ID");
+  const workItemId = requireCliRustSkillRunEnv(env, "FRIDAY_D21_SKILL_RUN_WORK_ITEM_ID");
+  const operatorPrincipalId = requireCliRustSkillRunEnv(
+    env,
+    "FRIDAY_D21_SKILL_RUN_OPERATOR_PRINCIPAL_ID",
+  );
+  const managedSkillsRoot = resolveCliRustManagedSkillsRoot(params.parsed, env);
+  const timeoutMsRaw = env.FRIDAY_D21_SKILL_RUN_TIMEOUT_MS?.trim();
+  const timeoutMs = timeoutMsRaw ? Number.parseInt(timeoutMsRaw, 10) : 30_000;
+  const effectiveTimeoutMs = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 30_000;
+
+  const args = [
+    "run-local",
+    "--db",
+    dbPath,
+    "--operator-vk-path",
+    operatorVkPath,
+    "--approval-json",
+    approvalJson,
+    "--managed-skills-root",
+    managedSkillsRoot,
+    "--skill-id",
+    skillId,
+    "--mission-id",
+    missionId,
+    "--work-item-id",
+    workItemId,
+    "--operator-principal-id",
+    operatorPrincipalId,
+    "--timeout-ms",
+    String(effectiveTimeoutMs),
+  ];
+
+  const nowMs = env.FRIDAY_D21_SKILL_RUN_NOW_MS?.trim();
+  if (nowMs) {
+    args.push("--now-ms", nowMs);
+  }
+
+  const adoptedSkillIds = splitCliRustSkillRunList(env.FRIDAY_D21_ADOPTED_SKILL_IDS);
+  for (const adoptedSkillId of adoptedSkillIds) {
+    args.push("--adopted-skill-id", adoptedSkillId);
+  }
+
+  const approvedFirstRunSkillIds = splitCliRustSkillRunList(
+    env.FRIDAY_D21_APPROVED_FIRST_RUN_SKILL_IDS,
+  );
+  const firstRunIds = approvedFirstRunSkillIds.length > 0 ? approvedFirstRunSkillIds : [skillId];
+  for (const approvedFirstRunSkillId of firstRunIds) {
+    args.push("--approved-first-run-skill-id", approvedFirstRunSkillId);
+  }
+
+  if (env.FRIDAY_D21_REQUIRE_DARWIN_SANDBOX?.trim() === "1") {
+    args.push("--require-darwin-sandbox");
+  }
+
+  let stdout = "";
+  let stderr = "";
+  try {
+    const result = await params.execFileFn(bin, args, {
+      env: {
+        ...env,
+        FRIDAY_D21_SKILL_RUN_LOCAL: "1",
+      },
+      timeout: effectiveTimeoutMs + 5_000,
+      maxBuffer: 1024 * 1024,
+    });
+    stdout = Buffer.isBuffer(result.stdout) ? result.stdout.toString("utf8") : result.stdout;
+    stderr = Buffer.isBuffer(result.stderr) ? result.stderr.toString("utf8") : result.stderr;
+  } catch (error) {
+    const maybeStdout = (error as { stdout?: string | Buffer }).stdout;
+    if (typeof maybeStdout === "string" || Buffer.isBuffer(maybeStdout)) {
+      stdout = Buffer.isBuffer(maybeStdout) ? maybeStdout.toString("utf8") : maybeStdout;
+    }
+    const maybeStderr = (error as { stderr?: string | Buffer }).stderr;
+    if (typeof maybeStderr === "string" || Buffer.isBuffer(maybeStderr)) {
+      stderr = Buffer.isBuffer(maybeStderr) ? maybeStderr.toString("utf8") : maybeStderr;
+    }
+    if (!stdout.trim()) {
+      throwRustSkillRunRouteUnavailable("Rust skill-run route failed before emitting a receipt.");
+    }
+  }
+
+  const receipt = parseCliRustSkillRunJson(stdout);
+  const ok = receipt.ok === true;
+  const runId = cliRustSkillRunString(receipt.run_ref)
+    ?? cliRustSkillRunString(receipt.proof_ref)
+    ?? `rust-skill-run:${skillId}`;
+  const status = cliRustSkillRunString(receipt.status)
+    ?? (ok ? "skill_executed_not_completed" : cliRustSkillRunString(receipt.error_kind) ?? "failed");
+
+  return {
+    runId,
+    status,
+    durationMs: 0,
+    output: {
+      truthLabel: cliRustSkillRunString(receipt.truth_label),
+      runsSkill: receipt.runs_skill === true,
+      executesSkill: receipt.executes_skill === true,
+      completesWorkItem: receipt.completes_work_item === true,
+      proofRef: cliRustSkillRunString(receipt.proof_ref),
+      skillId: cliRustSkillRunString(receipt.skill_id),
+      exitCode: cliRustSkillRunNumber(receipt.exit_code),
+      outputSha256: cliRustSkillRunString(receipt.output_sha256),
+      outputLen: cliRustSkillRunNumber(receipt.output_len),
+    },
+    stderr: stderr.trim().length > 0 ? stderr : undefined,
+  };
+}
+
 export async function runCliSkillCommand(
   parsed: ParsedArgs,
   deps: FridayCliRunCommandDeps = {},
@@ -1599,6 +1808,20 @@ export async function runCliSkillCommand(
   }
 
   const config = buildConfig(parsed);
+
+  if (
+    parsed.skillId !== "ai-inference"
+    && isCliRustSkillRunRouteEnabled(env)
+  ) {
+    const result = await runCliSkillViaRust({
+      parsed,
+      env,
+      execFileFn: deps.execFileFn ?? execFileAsync,
+    });
+    printCliSkillRunResult(logger, result);
+    markCliSkillRunFailure(logger, result, setExitCode);
+    return;
+  }
 
   // ─── TS Runtime Retirement — local-mode skill-run fail-closed guard ───
   // The REMOTE branch above already returned via the route-guarded HTTP surface.

--- a/src/cli/friday-cli.ts
+++ b/src/cli/friday-cli.ts
@@ -1506,7 +1506,7 @@ function printCliSkillRunResult(
 }
 
 function isCliSkillRunSuccessful(result: FridayCliSkillRunResult): boolean {
-  return result.status === "completed";
+  return result.status === "completed" || result.status === "skill_executed_not_completed";
 }
 
 function markCliSkillRunFailure(

--- a/test/unit/cli/friday-cli.test.ts
+++ b/test/unit/cli/friday-cli.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   cmdRuns,
   finalizeCliCommand,
@@ -869,6 +869,87 @@ describe("runCliSkillCommand", () => {
 
     // The guard fires BEFORE hub creation → the executor sink is never reached.
     expect(createHubCalled).toBe(false);
+  });
+
+  it("routes a governed local skill run through the Rust skill-run bin when the Rust route flag and operator materials are present", async () => {
+    const parsed = parseArgs(argv("run", "output-current-date-time", "--skills-dir", "/tmp/friday-managed-skills"));
+    let createHubCalled = false;
+    const logs: string[] = [];
+    const execFileFn = vi.fn(async () => ({
+      stdout: JSON.stringify({
+        truth_label: "d21_skill_run_local",
+        ok: true,
+        runs_skill: true,
+        executes_skill: true,
+        completes_work_item: false,
+        run_ref: "proof://skill-run-local/run-1",
+        proof_ref: "proof://skill-run-local/proof-1",
+        skill_id: "output-current-date-time",
+        status: "skill_executed_not_completed",
+        exit_code: 0,
+        output_sha256: "a".repeat(64),
+        output_len: 32,
+      }),
+      stderr: "",
+    }));
+
+    await runCliSkillCommand(parsed, {
+      env: {
+        FRIDAY_ROUTE_SKILL_RUNS_VIA_RUST: "1",
+        FRIDAY_D21_SKILL_RUN_LOCAL_BIN: "/tmp/hub_skill_run_local",
+        FRIDAY_D21_SKILL_RUN_LOCAL_DB_PATH: "/tmp/friday-hub.sqlite",
+        FRIDAY_D21_OPERATOR_VK_PATH: "/tmp/operator.vk",
+        FRIDAY_D21_SKILL_RUN_APPROVAL_JSON: "/tmp/approval.json",
+        FRIDAY_D21_SKILL_RUN_MISSION_ID: "mission-cli",
+        FRIDAY_D21_SKILL_RUN_WORK_ITEM_ID: "work-cli",
+        FRIDAY_D21_SKILL_RUN_OPERATOR_PRINCIPAL_ID: "operator",
+      },
+      createHub: (async () => {
+        createHubCalled = true;
+        throw new Error("createHub must not be called when the Rust skill-run route is active");
+      }) as FridayCliRunCommandDeps["createHub"],
+      fetchFn: async () => {
+        throw new Error("fetch should not be called for local Rust execution");
+      },
+      logger: {
+        log: (...args: unknown[]) => logs.push(args.map((value) => String(value)).join(" ")),
+        error: (...args: unknown[]) => logs.push(args.map((value) => String(value)).join(" ")),
+      },
+      execFileFn,
+    } as FridayCliRunCommandDeps & { execFileFn: typeof execFileFn });
+
+    expect(createHubCalled).toBe(false);
+    expect(execFileFn).toHaveBeenCalledTimes(1);
+    expect(execFileFn).toHaveBeenCalledWith(
+      "/tmp/hub_skill_run_local",
+      expect.arrayContaining([
+        "run-local",
+        "--db",
+        "/tmp/friday-hub.sqlite",
+        "--operator-vk-path",
+        "/tmp/operator.vk",
+        "--approval-json",
+        "/tmp/approval.json",
+        "--managed-skills-root",
+        "/tmp/friday-managed-skills",
+        "--skill-id",
+        "output-current-date-time",
+        "--mission-id",
+        "mission-cli",
+        "--work-item-id",
+        "work-cli",
+        "--operator-principal-id",
+        "operator",
+        "--approved-first-run-skill-id",
+        "output-current-date-time",
+      ]),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          FRIDAY_D21_SKILL_RUN_LOCAL: "1",
+        }),
+      }),
+    );
+    expect(logs.some((line) => line.includes("Run proof://skill-run-local/run-1 — skill_executed_not_completed"))).toBe(true);
   });
 
   it("fails fast when only one remote-hub env var is configured", async () => {

--- a/test/unit/cli/friday-cli.test.ts
+++ b/test/unit/cli/friday-cli.test.ts
@@ -874,6 +874,7 @@ describe("runCliSkillCommand", () => {
   it("routes a governed local skill run through the Rust skill-run bin when the Rust route flag and operator materials are present", async () => {
     const parsed = parseArgs(argv("run", "output-current-date-time", "--skills-dir", "/tmp/friday-managed-skills"));
     let createHubCalled = false;
+    let exitCode: number | undefined;
     const logs: string[] = [];
     const execFileFn = vi.fn(async () => ({
       stdout: JSON.stringify({
@@ -915,10 +916,14 @@ describe("runCliSkillCommand", () => {
         log: (...args: unknown[]) => logs.push(args.map((value) => String(value)).join(" ")),
         error: (...args: unknown[]) => logs.push(args.map((value) => String(value)).join(" ")),
       },
+      setExitCode: (code) => {
+        exitCode = code;
+      },
       execFileFn,
     } as FridayCliRunCommandDeps & { execFileFn: typeof execFileFn });
 
     expect(createHubCalled).toBe(false);
+    expect(exitCode).toBeUndefined();
     expect(execFileFn).toHaveBeenCalledTimes(1);
     expect(execFileFn).toHaveBeenCalledWith(
       "/tmp/hub_skill_run_local",


### PR DESCRIPTION
## Summary

NEW-65 Medium S2 replacement-route slice: add a default-off `friday run` local-mode Rust route for governed skill execution.

- keeps default/unset non-`ai-inference` local skill runs fail-closed with `TS_RUNTIME_SKILL_RUNS_RETIRED` before TS hub creation
- when `FRIDAY_ROUTE_SKILL_RUNS_VIA_RUST=1|true`, requires explicit operator/Rust materials before invoking `hub_skill_run_local`
- passes operator VK + signed approval JSON to Rust; TypeScript does not sign, mint approvals, or mark WorkItems done
- maps Rust refs-only receipt output to CLI refs/hash/len projection
- treats Rust status `skill_executed_not_completed` as CLI command success while preserving `completesWorkItem=false`

## Red-first evidence

Evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new65-cli-skill-run-rust-route-20260706T0700-0700/`

- red `8d1c271a` -> `red-vitest.log`, exit 1, failed with `TS_RUNTIME_SKILL_RUNS_RETIRED`
- green `21456808` -> `green-focused-vitest.log`, `green-cli-vitest.log`, `green-typecheck-src.log`, `green-ts-runtime-retirement.log`, all exit 0
- revert-red `revert-red-vitest.log`, exit 1, failed again after reverting green implementation
- red2 `6aab3264` -> `red2-rust-status-vitest.log`, exit 1, exposed CLI exitCode=1 for Rust success receipt status
- green2 `6906a2b5` -> `green2-focused-vitest.log`, `green2-cli-vitest.log`, `green2-typecheck-src.log`, `green2-ts-runtime-retirement.log`, all exit 0

## Verification

- `npm exec vitest -- run test/unit/cli/friday-cli.test.ts` -> 103 passed
- `npm run typecheck:src` -> passed
- `npm run check:ts-runtime-retirement` -> passed, routeCount 592, failures []
- `git diff --check origin/main...HEAD` -> clean
- secret marker scan over NEW-65 evidence -> no matches

## Independent review

- Rawls the 4th, session `019f3787-ac71-7c81-8637-1cf68c5e9314`, verdict PASS
- Hypatia the 4th, session `019f3787-c712-7a52-a54c-f9203f6c949c`, verdict PASS

## Boundary

This does not enable live/prod skill-run routing by itself. Operator cutover still must provide the Rust bin, hub DB, operator VK, signed approval JSON, mission/work item ids, operator principal, and managed skills root. This PR does not close END-BAR, full S2, provider entitlement, DeepSeek live proof, Suite13 full/eight-angle, final frozen completeness, prod deploy/currentness, release/latest-install, organic adoption, or terminal visual/device/channel attestation.
