### PR TITLE
Provision closure workflow Rust route env

### DIFF
--- a/scripts/e2e/friday-closure-lib.mjs
+++ b/scripts/e2e/friday-closure-lib.mjs
@@ -160,6 +160,8 @@ export function buildClosureScratchEnv(baseEnv = process.env, paths) {
     FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: baseEnv.FRIDAY_ROUTE_WORKFLOWS_VIA_RUST ?? "1",
     FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH: baseEnv.FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH
       ?? path.join(paths.state, "friday.db"),
+    FRIDAY_HUB_WORKFLOW_CATALOG_BIN: baseEnv.FRIDAY_HUB_WORKFLOW_CATALOG_BIN
+      ?? path.join(paths.state, "bin", "hub_workflow_catalog"),
   };
 }
 

--- a/scripts/e2e/friday-closure-lib.mjs
+++ b/scripts/e2e/friday-closure-lib.mjs
@@ -157,6 +157,9 @@ export function buildClosureScratchEnv(baseEnv = process.env, paths) {
     FRIDAY_BROWSER_HEADLESS: "true",
     FRIDAY_SYSTEM_ENABLED: baseEnv.FRIDAY_SYSTEM_ENABLED ?? "true",
     FRIDAY_AUTOFIX_DISPATCHER_ENABLED: baseEnv.FRIDAY_AUTOFIX_DISPATCHER_ENABLED ?? "true",
+    FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: baseEnv.FRIDAY_ROUTE_WORKFLOWS_VIA_RUST ?? "1",
+    FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH: baseEnv.FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH
+      ?? path.join(paths.state, "friday.db"),
   };
 }
 

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -74,6 +74,29 @@ function writeText(filePath, text) {
   fs.writeFileSync(filePath, text, "utf8");
 }
 
+function shellSingleQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+export function writeClosureRustWorkflowCatalogBridgeBin(
+  binPath,
+  repoRoot = REPO_ROOT,
+) {
+  const rustCoreDir = path.join(repoRoot, "rust-core");
+  writeText(
+    binPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `cd ${shellSingleQuote(rustCoreDir)}`,
+      'exec cargo run -q -p friday-hub --bin hub_workflow_catalog -- "$@"',
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(binPath, 0o755);
+  return binPath;
+}
+
 export async function closeWritableStream(stream, timeoutMs = 5_000) {
   if (!stream || stream.destroyed || stream.closed) {
     return;
@@ -1397,6 +1420,10 @@ async function runLocalStage(ledger) {
   const closureWorkspaceRoot = path.join(ledger.paths.root, "workspace");
   ensureDir(closureWorkspaceRoot);
   fridayEnv.FRIDAY_WORKSPACE_ROOT = closureWorkspaceRoot;
+  const defaultWorkflowCatalogBin = path.join(ledger.paths.state, "bin", "hub_workflow_catalog");
+  if (fridayEnv.FRIDAY_HUB_WORKFLOW_CATALOG_BIN === defaultWorkflowCatalogBin) {
+    writeClosureRustWorkflowCatalogBridgeBin(defaultWorkflowCatalogBin);
+  }
   const serverLogPath = path.join(ledger.paths.logs, "local-friday-server.log");
   const server = spawn(process.execPath, [
     DIST_CLI,

--- a/test/unit/e2e/friday-closure-lib.test.ts
+++ b/test/unit/e2e/friday-closure-lib.test.ts
@@ -84,6 +84,8 @@ describe("friday closure lib", () => {
     expect(scratch.FRIDAY_STATE_DIR).toBe("/tmp/friday-state");
     expect(scratch.FRIDAY_CHANNELS_JSON).toBe('{"enabled":true,"instances":[]}');
     expect(scratch.FRIDAY_BROWSER_HEADLESS).toBe("true");
+    expect(scratch.FRIDAY_ROUTE_WORKFLOWS_VIA_RUST).toBe("1");
+    expect(scratch.FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH).toBe("/tmp/friday-state/friday.db");
     expect(Object.keys(scratch)).not.toContain(`FRIDAY_ALLOW_LOCAL_${"BYPASS_LOGIN"}`);
 
     const explicit = buildClosureScratchEnv(

--- a/test/unit/e2e/friday-closure-lib.test.ts
+++ b/test/unit/e2e/friday-closure-lib.test.ts
@@ -86,6 +86,7 @@ describe("friday closure lib", () => {
     expect(scratch.FRIDAY_BROWSER_HEADLESS).toBe("true");
     expect(scratch.FRIDAY_ROUTE_WORKFLOWS_VIA_RUST).toBe("1");
     expect(scratch.FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH).toBe("/tmp/friday-state/friday.db");
+    expect(scratch.FRIDAY_HUB_WORKFLOW_CATALOG_BIN).toBe("/tmp/friday-state/bin/hub_workflow_catalog");
     expect(Object.keys(scratch)).not.toContain(`FRIDAY_ALLOW_LOCAL_${"BYPASS_LOGIN"}`);
 
     const explicit = buildClosureScratchEnv(

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -15,6 +15,7 @@ import {
   persistLedger,
   runStep,
   stopManagedChildProcess,
+  writeClosureRustWorkflowCatalogBridgeBin,
 } from "../../../scripts/e2e/run-friday-closure.mjs";
 import { FRIDAY_CLOSURE_STATUSES } from "../../../scripts/e2e/friday-closure-lib.mjs";
 
@@ -72,6 +73,20 @@ describe("run-friday-closure helpers", () => {
     await stopManagedChildProcess(child, { graceMs: 150, forceKillMs: 150 });
 
     expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+  });
+
+  it("writes a closure-local Rust workflow catalog bridge wrapper", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-closure-rust-bin-"));
+    const binPath = join(dir, "bin", "hub_workflow_catalog");
+
+    writeClosureRustWorkflowCatalogBridgeBin(binPath);
+
+    const script = readFileSync(binPath, "utf8");
+    expect(script).toContain("cargo run -q -p friday-hub --bin hub_workflow_catalog");
+    expect(script).toContain('exec cargo run -q -p friday-hub --bin hub_workflow_catalog -- "$@"');
+    expect(fs.statSync(binPath).mode & 0o111).not.toBe(0);
+
+    rmSync(dir, { recursive: true, force: true });
   });
 
   it("runStep persists an in-progress active step before completion", async () => {


### PR DESCRIPTION
## Scope
NEW-66 Low END-BAR/local closure harness slice. The closure scratch environment now self-provisions the already-merged workflow Rust route materials needed for the workflow catalog/generator bridge: default-on route flag inside scratch, scratch-local catalog DB path, and scratch-local executable wrapper for hub_workflow_catalog.

## Red-first evidence
- Evidence dir: /Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new66-closure-workflow-rust-env-20260706T0821-0700
- red: red.log / red.exit=1, red commit 0cfd91cf5ce2e6b18acea0a8c70682c43e300f91
- green: green.log / green.exit=0, green commit 0dbda7931b7ef2c5b1fb8b0f1ea59a1ba60ee8f1
- revert-red: revert-red.log / revert-red.exit=1
- reviewer-found gap red2: red2-bin.log / red2-bin.exit=1, red commit 5f1701d3f15a17c6d10210e5602f9e41f9851bda
- green2: green2-bin.log / green2-bin.exit=0, green commit 5e6abfc2b9cae4d32e90fda69c8dbd502b59f4a5
- revert-red2: revert-red2-bin.log / revert-red2-bin.exit=1

## Verification
- Expanded no-degrade after bin fix: green-expanded-after-bin.log / green-expanded-after-bin.exit=0 (6 files / 170 tests)
- git diff check: prepush-diff-check.exit=0
- Reviewers: Curie PASS; Bacon PASS after the bin-wrapper red2/green2 repair.

## Boundaries
This does not enable the workflow Rust route for production/default hub creation, does not touch prod DBs, does not mint approvals, does not close #1526, END-BAR 3a-i, full S2, provider entitlement, DeepSeek live proof, Suite13 full/eight-angle, final frozen completeness, prod deploy/currentness, release/latest-install, organic adoption, or terminal visual/device/channel attestation.

Auto-merge eligibility: Low only if full PR-CI green, born-current, no open-PR file overlap, red-first/no-degrade/reviewer evidence remains valid, and no new High/Blocker concern appears.