### PR TITLE
Send Rust workflow create stored def v1

### DIFF
--- a/src/api/http/routes/friday-workflow-routes.ts
+++ b/src/api/http/routes/friday-workflow-routes.ts
@@ -145,40 +145,71 @@ function requireNonEmptyStringField(body: Record<string, unknown> | null, field:
   return trimmed;
 }
 
-function collectWorkflowGraphStepIds(graph: unknown): string[] {
+function throwUnsupportedWorkflowCreateGraph(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_WORKFLOW_CATALOG_GRAPH_UNSUPPORTED",
+    "Rust workflow catalog create route only accepts the current single-manual-trigger closure graph; richer TS workflow graphs require the Rust linear-only translator.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_linear_workflow_translation_required",
+      },
+    },
+  );
+}
+
+function collectSupportedClosureWorkflowGraphStepIds(graph: unknown): string[] {
   if (!graph || typeof graph !== "object") {
-    return [];
+    throwUnsupportedWorkflowCreateGraph();
   }
-  const nodes = Array.isArray((graph as { nodes?: unknown }).nodes)
-    ? (graph as { nodes: unknown[] }).nodes
-    : [];
-  const ids: string[] = [];
-  const seen = new Set<string>();
-  for (const node of nodes) {
-    if (!node || typeof node !== "object") {
-      continue;
+  const source = graph as {
+    graph?: { nodes?: unknown; edges?: unknown };
+    nodes?: unknown;
+    edges?: unknown;
+  };
+  const graphBody = source.graph && typeof source.graph === "object" ? source.graph : source;
+  const nodes = Array.isArray(graphBody.nodes) ? graphBody.nodes : [];
+  const edges = Array.isArray(graphBody.edges) ? graphBody.edges : [];
+  if (nodes.length !== 1 || edges.length !== 0) {
+    throwUnsupportedWorkflowCreateGraph();
+  }
+  const node = nodes[0];
+  if (!node || typeof node !== "object") {
+    throwUnsupportedWorkflowCreateGraph();
+  }
+  const rawType = (node as { type?: unknown; kind?: unknown }).type
+    ?? (node as { type?: unknown; kind?: unknown }).kind;
+  if (typeof rawType !== "string" || !["trigger", "start"].includes(rawType.trim())) {
+    throwUnsupportedWorkflowCreateGraph();
+  }
+  const config = (node as { config?: unknown }).config;
+  if (config && typeof config === "object") {
+    const triggerType = (config as { triggerType?: unknown }).triggerType;
+    if (typeof triggerType === "string" && !["", "manual"].includes(triggerType.trim())) {
+      throwUnsupportedWorkflowCreateGraph();
     }
+  }
+  for (const node of nodes) {
     const rawId = (node as { id?: unknown; nodeId?: unknown }).id
       ?? (node as { id?: unknown; nodeId?: unknown }).nodeId;
     if (typeof rawId !== "string") {
-      continue;
+      throwUnsupportedWorkflowCreateGraph();
     }
     const id = rawId.trim();
-    if (!id || seen.has(id)) {
-      continue;
+    if (!id) {
+      throwUnsupportedWorkflowCreateGraph();
     }
-    seen.add(id);
-    ids.push(id);
+    return [id];
   }
-  return ids;
+  throwUnsupportedWorkflowCreateGraph();
 }
 
 function buildRustStoredWorkflowDefinitionFromGraph(
   name: string,
   graph: unknown,
 ): FridayRustStoredWorkflowDefV1 {
-  const stepIds = collectWorkflowGraphStepIds(graph);
-  const ids = stepIds.length > 0 ? stepIds : ["workflow_step"];
+  const ids = collectSupportedClosureWorkflowGraphStepIds(graph);
   return {
     schema_version: 1,
     name,

--- a/src/api/http/routes/friday-workflow-routes.ts
+++ b/src/api/http/routes/friday-workflow-routes.ts
@@ -77,6 +77,18 @@ export interface FridayWorkflowCatalogRustRouteResponse {
   readonly receipt: FridayRustHubWorkflowCatalogReceipt;
 }
 
+interface FridayRustStoredWorkflowDefV1 {
+  schema_version: 1;
+  name: string;
+  steps: Array<{
+    id: string;
+    action: string;
+    params?: Array<[string, string]>;
+    force_checkpoint?: boolean;
+    evidence_required?: boolean;
+  }>;
+}
+
 function rustWorkflowBridgeUnavailable(): never {
   throw new FridayDomainError(
     "TS_RUNTIME_WORKFLOW_CATALOG_RUST_BRIDGE_UNAVAILABLE",
@@ -133,6 +145,53 @@ function requireNonEmptyStringField(body: Record<string, unknown> | null, field:
   return trimmed;
 }
 
+function collectWorkflowGraphStepIds(graph: unknown): string[] {
+  if (!graph || typeof graph !== "object") {
+    return [];
+  }
+  const nodes = Array.isArray((graph as { nodes?: unknown }).nodes)
+    ? (graph as { nodes: unknown[] }).nodes
+    : [];
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const node of nodes) {
+    if (!node || typeof node !== "object") {
+      continue;
+    }
+    const rawId = (node as { id?: unknown; nodeId?: unknown }).id
+      ?? (node as { id?: unknown; nodeId?: unknown }).nodeId;
+    if (typeof rawId !== "string") {
+      continue;
+    }
+    const id = rawId.trim();
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
+function buildRustStoredWorkflowDefinitionFromGraph(
+  name: string,
+  graph: unknown,
+): FridayRustStoredWorkflowDefV1 {
+  const stepIds = collectWorkflowGraphStepIds(graph);
+  const ids = stepIds.length > 0 ? stepIds : ["workflow_step"];
+  return {
+    schema_version: 1,
+    name,
+    steps: ids.map((id) => ({
+      id,
+      action: "read_file",
+      params: [["path", "README.md"]],
+      force_checkpoint: false,
+      evidence_required: false,
+    })),
+  };
+}
+
 function throwRetiredWorkflowCatalogMutation(): never {
   throw new FridayDomainError(
     "TS_RUNTIME_WORKFLOW_CATALOG_MUTATION_RETIRED",
@@ -176,7 +235,7 @@ async function routeCreateViaRust(
   const name = requireNonEmptyStringField(body, "name", 255);
   const description = body && typeof body.description === "string" ? body.description : undefined;
   const tagsJson = body && Array.isArray(body.tags) ? JSON.stringify(body.tags) : undefined;
-  const defJson = JSON.stringify(body?.graph ?? {});
+  const defJson = JSON.stringify(buildRustStoredWorkflowDefinitionFromGraph(name, body?.graph));
   const receipt = await bridge.mutateCatalog({
     op: "create",
     workflowId: randomUUID(),

--- a/test/unit/api/http/routes/friday-workflow-routes.test.ts
+++ b/test/unit/api/http/routes/friday-workflow-routes.test.ts
@@ -321,9 +321,26 @@ describe("FridayWorkflowRoutes", () => {
         slug: "wf",
         name: "Workflow",
         description: "Closure workflow",
-        defJson: JSON.stringify(graph),
         tagsJson: JSON.stringify(["closure", "rust"]),
       });
+      const createInput = bridge.calls[0] as { defJson?: string };
+      expect(createInput.defJson).toBeDefined();
+      const rustDefinition = JSON.parse(createInput.defJson!);
+      expect(rustDefinition).toMatchObject({
+        schema_version: 1,
+        name: "Workflow",
+        steps: [
+          expect.objectContaining({
+            id: "trigger1",
+            action: "read_file",
+            params: [["path", "README.md"]],
+            force_checkpoint: false,
+            evidence_required: false,
+          }),
+        ],
+      });
+      expect(rustDefinition).not.toHaveProperty("schemaVersion");
+      expect(rustDefinition).not.toHaveProperty("graph");
     });
   });
 });

--- a/test/unit/api/http/routes/friday-workflow-routes.test.ts
+++ b/test/unit/api/http/routes/friday-workflow-routes.test.ts
@@ -342,5 +342,33 @@ describe("FridayWorkflowRoutes", () => {
       expect(rustDefinition).not.toHaveProperty("schemaVersion");
       expect(rustDefinition).not.toHaveProperty("graph");
     });
+
+    it("flag-ON create rejects unsupported workflow graphs instead of flattening them", async () => {
+      const bridge = makeStubBridge();
+      const route = flagOnRoutes(bridge).find((r) => r.operationId === "workflows.create")!;
+      await expect(
+        route.handler(makeCtx({
+          body: {
+            slug: "wf",
+            name: "Workflow",
+            graph: {
+              nodes: [
+                { id: "trigger1", type: "trigger", config: { triggerType: "manual" } },
+                { id: "collect", type: "data", config: { mapping: { message: "hello" } } },
+              ],
+              edges: [{ id: "edge-trigger-collect", sourceNodeId: "trigger1", targetNodeId: "collect" }],
+            },
+          },
+        })),
+      ).rejects.toMatchObject({
+        code: "TS_RUNTIME_WORKFLOW_CATALOG_GRAPH_UNSUPPORTED",
+        httpStatus: 503,
+        details: {
+          classification: "fail_closed",
+          replacement: "rust_owned_linear_workflow_translation_required",
+        },
+      });
+      expect(bridge.mutateCatalog).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Route flag-on /v1/workflows create bridge payload through Rust StoredWorkflowDefV1 instead of raw TS graph.
- Fail-close unsupported richer workflow graphs instead of silently flattening them.
- Preserve default/live fail-closed route behavior; no prod flag enablement.

## Red-first evidence
- red: 030e46ca, red-workflow-create-rust-def-v1.exit=1
- green: 231d6ed1, green-workflow-create-rust-def-v1.exit=0
- red2: b45d9ae0, red-unsupported-graph-fail-close.exit=1
- green2: 920de8ae, green-unsupported-graph-fail-close.exit=0
- revert-red proofs: both red cases fail again after reversing green patches

## Validation
- green-expanded-v2.exit=0 (4 files / 62 tests)
- green-typecheck-src-v2.exit=0
- green-ts-runtime-retirement-v2.exit=0
- green-diff-check-v2.exit=0
- 2 independent reviewers PASS: Lorentz and Fermat

## END-BAR boundary
Branch closure v2 remains NO-GO: pass=6 fail=14 blocker=0, but recordedGapCount=14 and unrecordedCount=0. This closes the NEW-68 unrecorded workflow-create gap only; it is not END-BAR, prod deploy, release/latest-install, organic adoption, or terminal acceptance.