### PR TITLE
Route closure workflow runs through Rust bridge

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,7 +128,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "(^|/)node_modules(/|$)|(^|/)dist(/|$)|(^|/)coverage(/|$)|(^|/)package-lock\\.json$|(^|/)pnpm-lock\\.yaml$|\\.snap$|(^|/)managed-skills/[^/]+/conversion\\.report\\.json$|(^|/)docs/reports/ops/.*\\.csv$|(^|/)docs/reports/ops/real-green-gate/.*\\.json$|(^|/)docs/reports/repo/FRIDAY_.*\\.json$|(^|/)screenshots/.*\\.(json|png|pdf|txt|html)$|(^|/)polish-report\\.html$|(^|/)friday-static\\.prod\\.html$|(^|/)friday-static\\.html$"
+        "(^|/)node_modules(/|$)|(^|/)dist(/|$)|(^|/)coverage(/|$)|(^|/)package-lock\\.json$|(^|/)pnpm-lock\\.yaml$|\\.snap$|(^|/)managed-skills/[^/]+/conversion\\.report\\.json$|(^|/)docs/reports/ops/.*\\.csv$|(^|/)docs/reports/ops/real-green-gate/.*\\.json$|(^|/)docs/reports/repo/FRIDAY_.*\\.json$|(^|/)audit-fix/[^/]+\\.(csv|json)$|(^|/)audit-fix/fix-phase-status/.*\\.(csv|json)$|(^|/)audit-fix/post-fix-evidence/.*\\.(json|csv|txt|png)$|(^|/)audit-fix/runtime/.*\\.(json|jsonl|txt|png|csv)$|(^|/)screenshots/.*\\.(json|png|pdf|txt|html)$|(^|/)polish-report\\.html$|(^|/)friday-static\\.prod\\.html$|(^|/)friday-static\\.html$"
       ]
     }
   ],
@@ -778,14 +778,14 @@
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 139
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "8a8281cec699f5e51330e21dd7fab3531af6ef0c",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 140
       }
     ],
     "test/unit/media-understanding/friday-openai-vision-provider.test.ts": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-04T01:09:01Z"
+  "generated_at": "2026-07-06T18:46:27Z"
 }

--- a/scripts/e2e/friday-closure-lib.mjs
+++ b/scripts/e2e/friday-closure-lib.mjs
@@ -158,10 +158,17 @@ export function buildClosureScratchEnv(baseEnv = process.env, paths) {
     FRIDAY_SYSTEM_ENABLED: baseEnv.FRIDAY_SYSTEM_ENABLED ?? "true",
     FRIDAY_AUTOFIX_DISPATCHER_ENABLED: baseEnv.FRIDAY_AUTOFIX_DISPATCHER_ENABLED ?? "true",
     FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: baseEnv.FRIDAY_ROUTE_WORKFLOWS_VIA_RUST ?? "1",
+    FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: baseEnv.FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST ?? "1",
     FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH: baseEnv.FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH
       ?? path.join(paths.state, "friday.db"),
     FRIDAY_HUB_WORKFLOW_CATALOG_BIN: baseEnv.FRIDAY_HUB_WORKFLOW_CATALOG_BIN
       ?? path.join(paths.state, "bin", "hub_workflow_catalog"),
+    FRIDAY_HUB_WORKFLOW_RUN_DB_PATH: baseEnv.FRIDAY_HUB_WORKFLOW_RUN_DB_PATH
+      ?? path.join(paths.state, "friday.db"),
+    FRIDAY_HUB_WORKFLOW_RUN_BIN: baseEnv.FRIDAY_HUB_WORKFLOW_RUN_BIN
+      ?? path.join(paths.state, "bin", "hub_workflow_run"),
+    FRIDAY_HUB_WORKFLOW_RUN_READBACK_BIN: baseEnv.FRIDAY_HUB_WORKFLOW_RUN_READBACK_BIN
+      ?? path.join(paths.state, "bin", "hub_workflow_run_readback"),
   };
 }
 

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -97,6 +97,30 @@ export function writeClosureRustWorkflowCatalogBridgeBin(
   return binPath;
 }
 
+export function writeClosureRustWorkflowRunBridgeBins(
+  runBinPath,
+  readbackBinPath,
+  repoRoot = REPO_ROOT,
+) {
+  const rustCoreDir = path.join(repoRoot, "rust-core");
+  const writeWrapper = (binPath, binName) => {
+    writeText(
+      binPath,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `cd ${shellSingleQuote(rustCoreDir)}`,
+        `exec cargo run -q -p friday-hub --bin ${binName} -- "$@"`,
+        "",
+      ].join("\n"),
+    );
+    fs.chmodSync(binPath, 0o755);
+  };
+  writeWrapper(runBinPath, "hub_workflow_run");
+  writeWrapper(readbackBinPath, "hub_workflow_run_readback");
+  return { runBinPath, readbackBinPath };
+}
+
 export async function closeWritableStream(stream, timeoutMs = 5_000) {
   if (!stream || stream.destroyed || stream.closed) {
     return;
@@ -1419,10 +1443,22 @@ async function runLocalStage(ledger) {
   // so its e2e hubs (which set their own state dirs) are unaffected.
   const closureWorkspaceRoot = path.join(ledger.paths.root, "workspace");
   ensureDir(closureWorkspaceRoot);
+  writeText(
+    path.join(closureWorkspaceRoot, "README.md"),
+    "Friday closure workspace fixture for Rust workflow-run proof path.\n",
+  );
   fridayEnv.FRIDAY_WORKSPACE_ROOT = closureWorkspaceRoot;
   const defaultWorkflowCatalogBin = path.join(ledger.paths.state, "bin", "hub_workflow_catalog");
   if (fridayEnv.FRIDAY_HUB_WORKFLOW_CATALOG_BIN === defaultWorkflowCatalogBin) {
     writeClosureRustWorkflowCatalogBridgeBin(defaultWorkflowCatalogBin);
+  }
+  const defaultWorkflowRunBin = path.join(ledger.paths.state, "bin", "hub_workflow_run");
+  const defaultWorkflowRunReadbackBin = path.join(ledger.paths.state, "bin", "hub_workflow_run_readback");
+  if (
+    fridayEnv.FRIDAY_HUB_WORKFLOW_RUN_BIN === defaultWorkflowRunBin
+    && fridayEnv.FRIDAY_HUB_WORKFLOW_RUN_READBACK_BIN === defaultWorkflowRunReadbackBin
+  ) {
+    writeClosureRustWorkflowRunBridgeBins(defaultWorkflowRunBin, defaultWorkflowRunReadbackBin);
   }
   const serverLogPath = path.join(ledger.paths.logs, "local-friday-server.log");
   const server = spawn(process.execPath, [

--- a/src/api/http/routes/friday-workflow-run-routes.ts
+++ b/src/api/http/routes/friday-workflow-run-routes.ts
@@ -31,6 +31,7 @@ import type {
   FridayStartRunRequest,
   FridayStartRunResponse,
 } from "../../model/friday-api-workflow.types.js";
+import type { FridayRustHubWorkflowRunBridgeService } from "../../mission-spine/friday-rust-hub-workflow-run-bridge-service.js";
 
 export interface FridayWorkflowRunRoutesDeps {
   startRun: (
@@ -90,6 +91,13 @@ export interface FridayWorkflowRunRoutesDeps {
     runId: UUID,
     principal: FridayAuthPrincipal | null,
   ) => Promise<FridayResumeRunResponse>;
+  /**
+   * DARK workflow-run Rust bridge, DEFAULT-OFF. With the flag unset, the routes
+   * keep today's deps-backed behavior. With the flag on, start/read are routed
+   * to the proof-only Rust bridge after auth; absent bridge fails closed.
+   */
+  routeWorkflowRunsViaRust?: boolean;
+  rustWorkflowRunBridge?: FridayRustHubWorkflowRunBridgeService;
 }
 
 function assertWorkflowRunWritePrincipal(
@@ -100,6 +108,38 @@ function assertWorkflowRunWritePrincipal(
     anyOfScopes: ["hub.admin", "workflow.write"],
     anyOfRoles: ["owner", "admin", "operator"],
   });
+}
+
+function assertWorkflowRunReadPrincipal(
+  principal: FridayAuthPrincipal | null | undefined,
+): void {
+  assertBoundPrincipalAuthorityForOperation(principal, "workflow.run.start", "api", {
+    anyOfScopes: ["hub.admin", "workflow.read", "workflow.write"],
+    anyOfRoles: ["owner", "admin", "operator"],
+  });
+}
+
+function rustWorkflowRunBridgeUnavailable(): never {
+  throw new FridayDomainError(
+    "TS_RUNTIME_WORKFLOW_RUN_RUST_BRIDGE_UNAVAILABLE",
+    "Rust workflow-run route bridge is enabled but no bridge service is configured.",
+    {
+      httpStatus: 503,
+      details: {
+        classification: "fail_closed",
+        replacement: "rust_owned_workflow_run_entrypoint_required",
+      },
+    },
+  );
+}
+
+function requireRustWorkflowRunBridge(
+  deps: FridayWorkflowRunRoutesDeps,
+): FridayRustHubWorkflowRunBridgeService {
+  if (!deps.rustWorkflowRunBridge) {
+    rustWorkflowRunBridgeUnavailable();
+  }
+  return deps.rustWorkflowRunBridge;
 }
 
 export function createFridayWorkflowRunRoutes(
@@ -129,6 +169,12 @@ export function createFridayWorkflowRunRoutes(
             { httpStatus: 400 },
           );
         }
+        if (deps.routeWorkflowRunsViaRust === true) {
+          return requireRustWorkflowRunBridge(deps).startRun(
+            body as unknown as FridayStartRunRequest,
+            ctx.principal,
+          );
+        }
         return deps.startRun(body as unknown as FridayStartRunRequest, ctx.principal);
       },
     },
@@ -139,6 +185,10 @@ export function createFridayWorkflowRunRoutes(
       auth: { public: true },
       async handler(ctx) {
         const { runId } = ctx.params as { runId: UUID };
+        if (deps.routeWorkflowRunsViaRust === true) {
+          assertWorkflowRunReadPrincipal(ctx.principal ?? null);
+          return requireRustWorkflowRunBridge(deps).getRun(runId, ctx.principal);
+        }
         return deps.getRun(runId, ctx.principal);
       },
     },

--- a/src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.ts
@@ -1,0 +1,306 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { FridayDomainError } from "#errors";
+import type { FridayAuthPrincipal } from "../model/friday-api-common.types.js";
+import type { FridayStartRunRequest } from "../model/friday-api-workflow.types.js";
+import type { FridayWorkflowRunEntity, WorkflowRunStatus } from "#workflows";
+
+const execFileAsync = promisify(execFile);
+
+export interface FridayRustHubWorkflowRunBridgeService {
+  startRun(
+    input: FridayStartRunRequest,
+    principal: FridayAuthPrincipal | null,
+  ): Promise<{ run: FridayWorkflowRunEntity }>;
+  getRun(
+    runId: string,
+    principal: FridayAuthPrincipal | null,
+  ): Promise<{ run: FridayWorkflowRunEntity }>;
+}
+
+export interface CreateFridayRustHubWorkflowRunBridgeServiceOptions {
+  readonly repoRoot?: string;
+  readonly dbPath?: string;
+  readonly workspaceRoot?: string;
+  readonly runBin?: string;
+  readonly readbackBin?: string;
+  readonly timeoutMs?: number;
+}
+
+interface RustWorkflowRunProjection {
+  readonly runId: string;
+  readonly workflowId: string;
+  readonly workflowVersionId: string;
+  readonly status: WorkflowRunStatus;
+  readonly triggerType: string;
+  readonly startedAt: string;
+  readonly pausedAt?: string;
+  readonly finishedAt?: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly proofRequired?: boolean;
+  readonly evidenceStatus: "available";
+  readonly completionVerification: "verified" | "proof_pending" | "blocked";
+  readonly failure?: {
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("TS_RUNTIME_WORKFLOW_RUN_RUST_BRIDGE_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      classification: "fail_closed",
+      replacement: "rust_owned_workflow_run_entrypoint_required",
+      bridge: "rust_wired_dev",
+      proofOnly: true,
+    },
+  });
+}
+
+function resolveDefaultRepoRoot(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, "../../..");
+}
+
+function readTimeoutMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function resolvePrebuiltBin(
+  explicitBin: string | undefined,
+  rustCoreRoot: string,
+  name: string,
+): string | undefined {
+  if (explicitBin) return resolve(explicitBin);
+  const releaseBin = resolve(rustCoreRoot, "target", "release", name);
+  return existsSync(releaseBin) ? releaseBin : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function reqString(root: Record<string, unknown>, key: string): string {
+  const value = root[key];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw unavailable(`Rust workflow-run bridge payload is missing ${key}.`);
+  }
+  return value;
+}
+
+function reqNumber(root: Record<string, unknown>, key: string): number {
+  const value = root[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw unavailable(`Rust workflow-run bridge payload is missing ${key}.`);
+  }
+  return value;
+}
+
+function optNumber(root: Record<string, unknown>, key: string): number | undefined {
+  const value = root[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isoFromMs(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function mapStatus(status: string): WorkflowRunStatus {
+  if (status === "completed" || status === "failed") return status;
+  if (status === "awaiting_checkpoint") return "paused";
+  throw unavailable("Rust workflow-run bridge returned an unsupported status.");
+}
+
+function parseProjection(
+  payload: unknown,
+  fallback: {
+    workflowId?: string;
+    workflowVersionId?: string;
+    triggerType?: string;
+    proofRequired?: boolean;
+  } = {},
+): RustWorkflowRunProjection {
+  const root = asRecord(payload);
+  if (!root) {
+    throw unavailable("Rust workflow-run bridge returned a non-object payload.");
+  }
+  if (root.ok !== true || root.truth_label !== "rust_wired_dev" || root.proof_only !== true) {
+    throw unavailable("Rust workflow-run bridge did not return an ok rust_wired_dev proof receipt.");
+  }
+  const runId = reqString(root, "run_id");
+  const workflowId = typeof fallback.workflowId === "string" && fallback.workflowId
+    ? fallback.workflowId
+    : reqString(root, "workflow_id");
+  const version = typeof fallback.workflowVersionId === "string" && fallback.workflowVersionId
+    ? fallback.workflowVersionId
+    : `rust-version:${String(reqNumber(root, "version"))}`;
+  const statusRaw = reqString(root, "status");
+  const status = mapStatus(statusRaw);
+  const createdAtMs = reqNumber(root, "created_at_ms");
+  const updatedAtMs = reqNumber(root, "updated_at_ms");
+  const firstPendingSeq = optNumber(root, "first_pending_seq");
+  const failure = status === "failed"
+    ? { code: "RUST_WORKFLOW_RUN_FAILED", message: "redacted" }
+    : undefined;
+  return {
+    runId,
+    workflowId,
+    workflowVersionId: version,
+    status,
+    triggerType: fallback.triggerType ?? "manual",
+    startedAt: isoFromMs(createdAtMs),
+    pausedAt: statusRaw === "awaiting_checkpoint" ? isoFromMs(updatedAtMs) : undefined,
+    finishedAt: status === "completed" || status === "failed" ? isoFromMs(updatedAtMs) : undefined,
+    createdAt: isoFromMs(createdAtMs),
+    updatedAt: isoFromMs(updatedAtMs),
+    proofRequired: fallback.proofRequired,
+    evidenceStatus: "available",
+    completionVerification: status === "completed"
+      ? "verified"
+      : firstPendingSeq === undefined || firstPendingSeq === null
+        ? "blocked"
+        : "proof_pending",
+    failure,
+  };
+}
+
+function toRunEntity(projection: RustWorkflowRunProjection): FridayWorkflowRunEntity {
+  return {
+    id: projection.runId,
+    workflowId: projection.workflowId,
+    workflowVersionId: projection.workflowVersionId,
+    status: projection.status,
+    triggerType: projection.triggerType,
+    startedAt: projection.startedAt,
+    pausedAt: projection.pausedAt,
+    finishedAt: projection.finishedAt,
+    createdAt: projection.createdAt,
+    updatedAt: projection.updatedAt,
+    proofRequired: projection.proofRequired,
+    evidenceStatus: projection.evidenceStatus,
+    completionVerification: projection.completionVerification,
+    failure: projection.failure,
+  };
+}
+
+async function runJsonBin(
+  bin: string | undefined,
+  args: string[],
+  options: { cwd: string; timeoutMs: number },
+): Promise<unknown> {
+  if (!bin) {
+    throw unavailable("Rust workflow-run bridge requires a prebuilt binary.");
+  }
+  let stdout = "";
+  try {
+    const result = await execFileAsync(bin, args, {
+      cwd: options.cwd,
+      timeout: options.timeoutMs,
+      maxBuffer: 2 * 1024 * 1024,
+      env: { ...process.env, RUST_BACKTRACE: "0" },
+    });
+    stdout = result.stdout;
+  } catch {
+    throw unavailable("Rust workflow-run bridge could not produce a refs-only receipt.");
+  }
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    throw unavailable("Rust workflow-run bridge returned invalid JSON.");
+  }
+}
+
+export function createFridayRustHubWorkflowRunBridgeService(
+  options: CreateFridayRustHubWorkflowRunBridgeServiceOptions = {},
+): FridayRustHubWorkflowRunBridgeService {
+  const repoRoot = resolve(
+    options.repoRoot ?? process.env.FRIDAY_REPO_ROOT ?? resolveDefaultRepoRoot(),
+  );
+  const rustCoreRoot = resolve(
+    process.env.FRIDAY_MISSION_SPINE_RUST_CORE_ROOT ?? join(repoRoot, "rust-core"),
+  );
+  const dbPathRaw = options.dbPath
+    ?? process.env.FRIDAY_HUB_WORKFLOW_RUN_DB_PATH
+    ?? process.env.FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH;
+  const workspaceRootRaw = options.workspaceRoot ?? process.env.FRIDAY_WORKSPACE_ROOT;
+  const runBin = resolvePrebuiltBin(
+    options.runBin ?? process.env.FRIDAY_HUB_WORKFLOW_RUN_BIN,
+    rustCoreRoot,
+    "hub_workflow_run",
+  );
+  const readbackBin = resolvePrebuiltBin(
+    options.readbackBin ?? process.env.FRIDAY_HUB_WORKFLOW_RUN_READBACK_BIN,
+    rustCoreRoot,
+    "hub_workflow_run_readback",
+  );
+  const timeoutMs =
+    options.timeoutMs ?? readTimeoutMs(process.env.FRIDAY_HUB_WORKFLOW_RUN_TIMEOUT_MS, 120_000);
+
+  function requireDbPath(): string {
+    if (!dbPathRaw) {
+      throw unavailable("Rust workflow-run bridge requires a DB path.");
+    }
+    const dbPath = resolve(dbPathRaw);
+    if (!existsSync(dbPath)) {
+      throw unavailable("Rust workflow-run bridge DB is not present for this runtime.");
+    }
+    return dbPath;
+  }
+
+  function requireWorkspaceRoot(): string {
+    if (!workspaceRootRaw) {
+      throw unavailable("Rust workflow-run bridge requires a workspace root.");
+    }
+    const workspaceRoot = resolve(workspaceRootRaw);
+    if (!existsSync(workspaceRoot)) {
+      throw unavailable("Rust workflow-run bridge workspace root is not present.");
+    }
+    return workspaceRoot;
+  }
+
+  return {
+    async startRun(input) {
+      if (input.workflowVersionId) {
+        throw unavailable("Rust workflow-run bridge does not accept TypeScript workflowVersionId values.");
+      }
+      const dbPath = requireDbPath();
+      const workspaceRoot = requireWorkspaceRoot();
+      const args = [
+        "--db",
+        dbPath,
+        "--workspace",
+        workspaceRoot,
+        "--workflow-id",
+        input.workflowId,
+      ];
+      const parsed = await runJsonBin(runBin, args, { cwd: repoRoot, timeoutMs });
+      return {
+        run: toRunEntity(parseProjection(parsed, {
+          workflowId: input.workflowId,
+          triggerType: input.triggerType,
+          proofRequired: input.proofRequired,
+        })),
+      };
+    },
+    async getRun(runId) {
+      const dbPath = requireDbPath();
+      const parsed = await runJsonBin(readbackBin, [
+        "--db",
+        dbPath,
+        "--run-id",
+        runId,
+      ], { cwd: repoRoot, timeoutMs });
+      return { run: toRunEntity(parseProjection(parsed)) };
+    },
+  };
+}

--- a/src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.ts
@@ -144,7 +144,9 @@ function parseProjection(
   const version = typeof fallback.workflowVersionId === "string" && fallback.workflowVersionId
     ? fallback.workflowVersionId
     : `rust-version:${String(reqNumber(root, "version"))}`;
-  const statusRaw = reqString(root, "status");
+  const statusRaw = typeof root.status === "string" && root.status.trim() !== ""
+    ? root.status
+    : reqString(root, "run_state");
   const status = mapStatus(statusRaw);
   const createdAtMs = reqNumber(root, "created_at_ms");
   const updatedAtMs = reqNumber(root, "updated_at_ms");
@@ -245,6 +247,12 @@ export function createFridayRustHubWorkflowRunBridgeService(
   );
   const timeoutMs =
     options.timeoutMs ?? readTimeoutMs(process.env.FRIDAY_HUB_WORKFLOW_RUN_TIMEOUT_MS, 120_000);
+  const metadataByRunId = new Map<string, {
+    workflowId: string;
+    workflowVersionId: string;
+    triggerType: string;
+    proofRequired?: boolean;
+  }>();
 
   function requireDbPath(): string {
     if (!dbPathRaw) {
@@ -284,15 +292,26 @@ export function createFridayRustHubWorkflowRunBridgeService(
         input.workflowId,
       ];
       const parsed = await runJsonBin(runBin, args, { cwd: repoRoot, timeoutMs });
+      const run = toRunEntity(parseProjection(parsed, {
+        workflowId: input.workflowId,
+        triggerType: input.triggerType,
+        proofRequired: input.proofRequired,
+      }));
+      metadataByRunId.set(run.id, {
+        workflowId: run.workflowId,
+        workflowVersionId: run.workflowVersionId,
+        triggerType: run.triggerType,
+        proofRequired: run.proofRequired,
+      });
       return {
-        run: toRunEntity(parseProjection(parsed, {
-          workflowId: input.workflowId,
-          triggerType: input.triggerType,
-          proofRequired: input.proofRequired,
-        })),
+        run,
       };
     },
     async getRun(runId) {
+      const metadata = metadataByRunId.get(runId);
+      if (!metadata) {
+        throw unavailable("Rust workflow-run readback requires start-run metadata in this runtime.");
+      }
       const dbPath = requireDbPath();
       const parsed = await runJsonBin(readbackBin, [
         "--db",
@@ -300,7 +319,7 @@ export function createFridayRustHubWorkflowRunBridgeService(
         "--run-id",
         runId,
       ], { cwd: repoRoot, timeoutMs });
-      return { run: toRunEntity(parseProjection(parsed)) };
+      return { run: toRunEntity(parseProjection(parsed, metadata)) };
     },
   };
 }

--- a/src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.ts
@@ -299,6 +299,9 @@ export function createFridayRustHubWorkflowRunBridgeService(
     if (!principal) {
       throw new FridayDomainError("UNAUTHORIZED", "Authentication required", { httpStatus: 401 });
     }
+    if (principal.scopes.includes("hub.admin") || principal.role === "owner" || principal.role === "admin") {
+      return;
+    }
     if (metadata.ownerPrincipalId && metadata.ownerPrincipalId === principal.principalId) return;
     if (metadata.ownerUserId && principal.userId && metadata.ownerUserId === principal.userId) return;
     if (

--- a/src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.ts
@@ -116,9 +116,31 @@ function isoFromMs(ms: number): string {
 }
 
 function mapStatus(status: string): WorkflowRunStatus {
-  if (status === "completed" || status === "failed") return status;
+  if (status === "done" || status === "completed") return "completed";
+  if (status === "failed") return status;
   if (status === "awaiting_checkpoint") return "paused";
   throw unavailable("Rust workflow-run bridge returned an unsupported status.");
+}
+
+function parseStartRefs(payload: unknown): {
+  runId: string;
+  workflowId: string;
+  workflowVersionId: string;
+  triggerType: string;
+} {
+  const root = asRecord(payload);
+  if (!root) {
+    throw unavailable("Rust workflow-run bridge returned a non-object payload.");
+  }
+  if (root.ok !== true || root.truth_label !== "rust_wired_dev" || root.proof_only !== true) {
+    throw unavailable("Rust workflow-run bridge did not return an ok rust_wired_dev proof receipt.");
+  }
+  return {
+    runId: reqString(root, "run_id"),
+    workflowId: reqString(root, "workflow_id"),
+    workflowVersionId: `rust-version:${String(reqNumber(root, "version"))}`,
+    triggerType: "manual",
+  };
 }
 
 function parseProjection(
@@ -292,20 +314,21 @@ export function createFridayRustHubWorkflowRunBridgeService(
         input.workflowId,
       ];
       const parsed = await runJsonBin(runBin, args, { cwd: repoRoot, timeoutMs });
-      const run = toRunEntity(parseProjection(parsed, {
-        workflowId: input.workflowId,
-        triggerType: input.triggerType,
+      const refs = parseStartRefs(parsed);
+      const metadata = {
+        workflowId: refs.workflowId,
+        workflowVersionId: refs.workflowVersionId,
+        triggerType: input.triggerType ?? refs.triggerType,
         proofRequired: input.proofRequired,
-      }));
-      metadataByRunId.set(run.id, {
-        workflowId: run.workflowId,
-        workflowVersionId: run.workflowVersionId,
-        triggerType: run.triggerType,
-        proofRequired: run.proofRequired,
-      });
-      return {
-        run,
       };
+      metadataByRunId.set(refs.runId, metadata);
+      const readback = await runJsonBin(readbackBin, [
+        "--db",
+        dbPath,
+        "--run-id",
+        refs.runId,
+      ], { cwd: repoRoot, timeoutMs });
+      return { run: toRunEntity(parseProjection(readback, metadata)) };
     },
     async getRun(runId) {
       const metadata = metadataByRunId.get(runId);

--- a/src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.ts
@@ -274,7 +274,45 @@ export function createFridayRustHubWorkflowRunBridgeService(
     workflowVersionId: string;
     triggerType: string;
     proofRequired?: boolean;
+    ownerPrincipalId?: string;
+    ownerUserId?: string;
+    ownerTenantId?: string;
+    ownerSatelliteId?: string;
   }>();
+
+  function principalTenantId(principal: FridayAuthPrincipal | null): string | undefined {
+    if (!principal) return undefined;
+    return typeof principal.tenantId === "string" && principal.tenantId.trim().length > 0
+      ? principal.tenantId.trim()
+      : principal.principalId;
+  }
+
+  function assertRunReadAuthorized(
+    metadata: {
+      ownerPrincipalId?: string;
+      ownerUserId?: string;
+      ownerTenantId?: string;
+      ownerSatelliteId?: string;
+    },
+    principal: FridayAuthPrincipal | null,
+  ): void {
+    if (!principal) {
+      throw new FridayDomainError("UNAUTHORIZED", "Authentication required", { httpStatus: 401 });
+    }
+    if (metadata.ownerPrincipalId && metadata.ownerPrincipalId === principal.principalId) return;
+    if (metadata.ownerUserId && principal.userId && metadata.ownerUserId === principal.userId) return;
+    if (
+      metadata.ownerSatelliteId
+      && principal.principalType === "satellite"
+      && metadata.ownerSatelliteId === principal.principalId
+    ) return;
+    if (metadata.ownerTenantId && principalTenantId(principal) === metadata.ownerTenantId) return;
+    throw new FridayDomainError(
+      "WORKFLOW_RUN_FORBIDDEN",
+      "You do not have permission to access this workflow run",
+      { httpStatus: 403 },
+    );
+  }
 
   function requireDbPath(): string {
     if (!dbPathRaw) {
@@ -299,7 +337,13 @@ export function createFridayRustHubWorkflowRunBridgeService(
   }
 
   return {
-    async startRun(input) {
+    async startRun(input, principal) {
+      if (input.dryRun === true) {
+        throw unavailable("Rust workflow-run bridge does not support dryRun requests.");
+      }
+      if (input.triggerType !== "manual") {
+        throw unavailable("Rust workflow-run bridge only supports manual trigger runs.");
+      }
       if (input.workflowVersionId) {
         throw unavailable("Rust workflow-run bridge does not accept TypeScript workflowVersionId values.");
       }
@@ -320,6 +364,10 @@ export function createFridayRustHubWorkflowRunBridgeService(
         workflowVersionId: refs.workflowVersionId,
         triggerType: input.triggerType ?? refs.triggerType,
         proofRequired: input.proofRequired,
+        ownerPrincipalId: principal?.principalId,
+        ownerUserId: principal?.userId,
+        ownerTenantId: principalTenantId(principal),
+        ownerSatelliteId: principal?.principalType === "satellite" ? principal.principalId : undefined,
       };
       metadataByRunId.set(refs.runId, metadata);
       const readback = await runJsonBin(readbackBin, [
@@ -330,11 +378,12 @@ export function createFridayRustHubWorkflowRunBridgeService(
       ], { cwd: repoRoot, timeoutMs });
       return { run: toRunEntity(parseProjection(readback, metadata)) };
     },
-    async getRun(runId) {
+    async getRun(runId, principal) {
       const metadata = metadataByRunId.get(runId);
       if (!metadata) {
         throw unavailable("Rust workflow-run readback requires start-run metadata in this runtime.");
       }
+      assertRunReadAuthorized(metadata, principal);
       const dbPath = requireDbPath();
       const parsed = await runJsonBin(readbackBin, [
         "--db",

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -176,6 +176,7 @@ import type { FridayRustHubRunAnswerReadbackService } from "../mission-spine/fri
 import { createFridayRustHubProvidersDetectService } from "../mission-spine/friday-rust-hub-providers-detect-bridge-service.js";
 import { createFridayRustHubCapabilityDoctorService } from "../mission-spine/friday-rust-hub-capability-doctor-bridge-service.js";
 import { createFridayRustHubWorkflowCatalogBridgeService } from "../mission-spine/friday-rust-hub-workflow-catalog-bridge-service.js";
+import { createFridayRustHubWorkflowRunBridgeService } from "../mission-spine/friday-rust-hub-workflow-run-bridge-service.js";
 import { createFridayD20SignedBatchWorktreeService } from "../mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.js";
 import { resolveRustAgentRunWsClientX25519Secret } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
@@ -3127,6 +3128,10 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   const rustWorkflowCatalogBridge = routeWorkflowsViaRust
     ? deps.rustWorkflowCatalogBridge ?? createFridayRustHubWorkflowCatalogBridgeService()
     : undefined;
+  const routeWorkflowRunsViaRust = deps.routeWorkflowRunsViaRust === true;
+  const rustWorkflowRunBridge = routeWorkflowRunsViaRust
+    ? deps.rustWorkflowRunBridge ?? createFridayRustHubWorkflowRunBridgeService()
+    : undefined;
 
   // Register workflow routes (real service wiring)
   for (const route of createFridayWorkflowRoutes({
@@ -3449,6 +3454,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 
   // Register run routes (real service wiring)
   for (const route of createFridayWorkflowRunRoutes({
+    routeWorkflowRunsViaRust,
+    rustWorkflowRunBridge,
     startRun: async (input, principal) => {
       if (deps.allowTestOnlyWorkflowRunExecution !== true) {
         void input;

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -38,6 +38,7 @@ import type { FridayRustHubProvidersDetectService } from "../mission-spine/frida
 import type { FridayRustHubCapabilityDoctorService } from "../mission-spine/friday-rust-hub-capability-doctor-bridge-service.js";
 import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
 import type { FridayRustHubWorkflowCatalogBridgeService } from "../mission-spine/friday-rust-hub-workflow-catalog-bridge-service.js";
+import type { FridayRustHubWorkflowRunBridgeService } from "../mission-spine/friday-rust-hub-workflow-run-bridge-service.js";
 import type { FridayD20SignedBatchWorktreeService } from "../mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.js";
 import type { FridayMediaUnderstandingRoutesDeps } from "../http/routes/friday-media-understanding-routes.js";
 import type { FridaySocialImportRoutesDeps } from "../http/routes/friday-social-import-routes.js";
@@ -251,6 +252,14 @@ export interface CreateFridayApiRuntimeDeps {
    * evidence-export truth.
    */
   allowTestOnlyWorkflowRunExecution?: boolean;
+  /**
+   * DARK workflow-run Rust bridge (DEFAULT-FALSE): routes POST/GET workflow-run
+   * start/read through the proof-only Rust `hub_workflow_run` +
+   * `hub_workflow_run_readback` bridge. Default/unset preserves the existing
+   * fail-closed TS-retirement path.
+   */
+  routeWorkflowRunsViaRust?: boolean;
+  rustWorkflowRunBridge?: FridayRustHubWorkflowRunBridgeService;
   /**
    * Test-oracle only: allows legacy TypeScript skill run execution in isolated
    * mock/unit validation. Production/runtime callers must leave this unset so

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1991,6 +1991,8 @@ export interface FridayHubConfig {
    * `FRIDAY_ROUTE_WORKFLOWS_VIA_RUST` env knob).
    */
   routeWorkflowsViaRust?: boolean;
+  /** Workflow-run start/read Rust bridge flag; default false / env fallback. */
+  routeWorkflowRunsViaRust?: boolean;
   /**
    * (Lane B-2) ORGANIC mission-spine POST routes bridge (DARK): "wire a real dispatch adapter into
    * `missionSpine.dispatch` so `/v1/mission-spine/intake|lifecycle|work-item-status` become CALLABLE"

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -1080,6 +1080,23 @@ export function resolveRouteWorkflowsViaRust(
 }
 
 /**
+ * Tier-2 WORKFLOW-RUN route bridge (DARK): single source of truth resolving the
+ * `routeWorkflowRunsViaRust` flag from explicit config or
+ * `FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST`. DEFAULT-FALSE so run start/read keep
+ * today's fail-closed TS-retirement behavior unless the operator opts in.
+ */
+export function resolveRouteWorkflowRunsViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+/**
  * (Lane B-2) ORGANIC mission-spine POST routes bridge (DARK): single source of truth resolving the
  * `routeMissionSpineViaRust` flag from (1) an EXPLICIT {@link FridayHubConfig.routeMissionSpineViaRust}
  * and, only as a fallback, (2) the `FRIDAY_MISSION_SPINE_ROUTES_VIA_RUST` env var — the operator knob
@@ -7543,6 +7560,7 @@ export async function createFridayHub(
     // else incl. unset → false). With nothing set (the default) this is `false`, so the
     // `=== true` gate is never satisfied → byte-identical to today's fail-closed retirement 503.
     routeWorkflowsViaRust: resolveRouteWorkflowsViaRust(config.routeWorkflowsViaRust),
+    routeWorkflowRunsViaRust: resolveRouteWorkflowRunsViaRust(config.routeWorkflowRunsViaRust),
     allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,
     allowTestOnlyAutonomyLifecycleExecution: config.allowTestOnlyAutonomyLifecycleExecution,
     allowTestOnlyStandingAgendaExecution: config.allowTestOnlyStandingAgendaExecution,

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -44,6 +44,7 @@ export {
   resolveRouteRunOutcomeLearningViaRust,
   resolveMissionAutoDispatch,
   resolveRouteProvidersViaRust,
+  resolveRouteWorkflowRunsViaRust,
   resolveRouteWorkflowsViaRust,
   sanitizeFridayChannelVisibleReply,
   shouldFailClosedForFridayWorkspaceContext,

--- a/test/unit/api/http/routes/friday-workflow-run-routes.test.ts
+++ b/test/unit/api/http/routes/friday-workflow-run-routes.test.ts
@@ -393,6 +393,91 @@ describe("FridayWorkflowRunRoutes", () => {
     );
   });
 
+  describe("DARK Rust workflow-run route bridge (routeWorkflowRunsViaRust)", () => {
+    function makeStubBridge() {
+      return {
+        startRun: vi.fn(async () => ({
+          run: { ...stubRun, id: "rust-run-1", status: "completed" as const },
+        })),
+        getRun: vi.fn(async () => ({
+          run: { ...stubRun, id: "rust-run-1", status: "completed" as const },
+        })),
+      };
+    }
+
+    it("flag-OFF is byte-identical to the normal route deps and never consults the bridge", async () => {
+      const bridge = makeStubBridge();
+      const startRun = vi.fn(async () => ({ run: stubRun }));
+      const localRoutes = createFridayWorkflowRunRoutes({
+        ...stubDeps,
+        startRun,
+        rustWorkflowRunBridge: bridge,
+      } as FridayWorkflowRunRoutesDeps & { rustWorkflowRunBridge: typeof bridge });
+      const route = localRoutes.find((r) => r.operationId === "runs.start")!;
+
+      await expect(route.handler(makeCtx({ params: {}, body: { workflowId: "wf-1" } })))
+        .resolves.toEqual({ run: stubRun });
+      expect(startRun).toHaveBeenCalledTimes(1);
+      expect(bridge.startRun).not.toHaveBeenCalled();
+    });
+
+    it("flag-ON routes start/get to the Rust bridge after auth", async () => {
+      const bridge = makeStubBridge();
+      const startRun = vi.fn(async () => ({ run: stubRun }));
+      const getRun = vi.fn(() => ({ run: stubRun }));
+      const localRoutes = createFridayWorkflowRunRoutes({
+        ...stubDeps,
+        startRun,
+        getRun,
+        routeWorkflowRunsViaRust: true,
+        rustWorkflowRunBridge: bridge,
+      } as FridayWorkflowRunRoutesDeps & {
+        routeWorkflowRunsViaRust: true;
+        rustWorkflowRunBridge: typeof bridge;
+      });
+
+      const startRoute = localRoutes.find((r) => r.operationId === "runs.start")!;
+      await expect(
+        startRoute.handler(makeCtx({ params: {}, body: { workflowId: "wf-1", triggerType: "manual" } })),
+      ).resolves.toMatchObject({ run: { id: "rust-run-1", status: "completed" } });
+      expect(startRun).not.toHaveBeenCalled();
+      expect(bridge.startRun).toHaveBeenCalledWith(
+        { workflowId: "wf-1", triggerType: "manual" },
+        expect.objectContaining({ principalId: "user-1" }),
+      );
+
+      const getRoute = localRoutes.find((r) => r.operationId === "runs.get")!;
+      await expect(
+        getRoute.handler(makeCtx({
+          params: { runId: "rust-run-1" },
+          principal: makePrincipal({ scopes: ["workflow.read"] }),
+        })),
+      ).resolves.toMatchObject({ run: { id: "rust-run-1", status: "completed" } });
+      expect(getRun).not.toHaveBeenCalled();
+      expect(bridge.getRun).toHaveBeenCalledWith(
+        "rust-run-1",
+        expect.objectContaining({ principalId: "user-1" }),
+      );
+    });
+
+    it("flag-ON without a bridge fails closed before falling back to TypeScript execution", async () => {
+      const startRun = vi.fn(async () => ({ run: stubRun }));
+      const localRoutes = createFridayWorkflowRunRoutes({
+        ...stubDeps,
+        startRun,
+        routeWorkflowRunsViaRust: true,
+      } as FridayWorkflowRunRoutesDeps & { routeWorkflowRunsViaRust: true });
+      const route = localRoutes.find((r) => r.operationId === "runs.start")!;
+
+      await expect(route.handler(makeCtx({ params: {}, body: { workflowId: "wf-1" } })))
+        .rejects.toMatchObject({
+          code: "TS_RUNTIME_WORKFLOW_RUN_RUST_BRIDGE_UNAVAILABLE",
+          httpStatus: 503,
+        });
+      expect(startRun).not.toHaveBeenCalled();
+    });
+  });
+
   it("POST /v1/workflow-runs/:runId/cancel requires workflow.write", () => {
     const route = routes.find((r) => r.operationId === "runs.cancel");
     expect(route).toBeDefined();

--- a/test/unit/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.test.ts
@@ -44,7 +44,7 @@ describe("FridayRustHubWorkflowRunBridgeService", () => {
         proof_only: true,
         ok: true,
         run_id: "rust-run-1",
-        run_state: "completed",
+        run_state: "done",
         created_at_ms: 1_700_000_000_000,
         updated_at_ms: 1_700_000_001_000,
         first_pending_seq: null,

--- a/test/unit/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.test.ts
@@ -1,0 +1,85 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { createFridayRustHubWorkflowRunBridgeService } from "../../../../src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.js";
+
+function writeJsonBin(path: string, payload: Record<string, unknown>): void {
+  writeFileSync(
+    path,
+    [
+      "#!/usr/bin/env node",
+      `console.log(${JSON.stringify(JSON.stringify(payload))});`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  chmodSync(path, 0o755);
+}
+
+describe("FridayRustHubWorkflowRunBridgeService", () => {
+  it("maps start + readback refs-only receipts into public run entities", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-wf-run-bridge-"));
+    try {
+      const dbPath = join(dir, "friday.db");
+      const workspaceRoot = join(dir, "workspace");
+      const runBin = join(dir, "hub_workflow_run");
+      const readbackBin = join(dir, "hub_workflow_run_readback");
+      writeFileSync(dbPath, "", "utf8");
+      mkdirSync(workspaceRoot);
+
+      writeJsonBin(runBin, {
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        run_id: "rust-run-1",
+        workflow_id: "wf-1",
+        version: 1,
+        status: "completed",
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+      });
+      writeJsonBin(readbackBin, {
+        truth_label: "rust_wired_dev",
+        proof_only: true,
+        ok: true,
+        run_id: "rust-run-1",
+        run_state: "completed",
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_001_000,
+        first_pending_seq: null,
+        step_count: 1,
+      });
+
+      const service = createFridayRustHubWorkflowRunBridgeService({
+        dbPath,
+        workspaceRoot,
+        runBin,
+        readbackBin,
+      });
+
+      const started = await service.startRun({
+        workflowId: "wf-1",
+        triggerType: "manual",
+      }, null);
+      expect(started.run).toMatchObject({
+        id: "rust-run-1",
+        workflowId: "wf-1",
+        workflowVersionId: "rust-version:1",
+        status: "completed",
+      });
+
+      const read = await service.getRun("rust-run-1", null);
+      expect(read.run).toMatchObject({
+        id: "rust-run-1",
+        workflowId: "wf-1",
+        workflowVersionId: "rust-version:1",
+        status: "completed",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.test.ts
@@ -38,8 +38,6 @@ describe("FridayRustHubWorkflowRunBridgeService", () => {
         workflow_id: "wf-1",
         version: 1,
         status: "completed",
-        created_at_ms: 1_700_000_000_000,
-        updated_at_ms: 1_700_000_001_000,
       });
       writeJsonBin(readbackBin, {
         truth_label: "rust_wired_dev",

--- a/test/unit/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.test.ts
@@ -104,6 +104,30 @@ describe("FridayRustHubWorkflowRunBridgeService", () => {
         httpStatus: 403,
       });
 
+      await expect(service.getRun("rust-run-1", {
+        principalType: "user",
+        principalId: "tenant-admin",
+        tenantId: "tenant-b",
+        userId: "admin-user",
+        role: "admin",
+        scopes: ["workflow.read"],
+        tokenId: "token-admin",
+        tokenKind: "access",
+        issuedAt: "2026-07-06T00:00:00.000Z",
+      })).resolves.toMatchObject({ run: { id: "rust-run-1", status: "completed" } });
+
+      await expect(service.getRun("rust-run-1", {
+        principalType: "user",
+        principalId: "tenant-hub-admin",
+        tenantId: "tenant-b",
+        userId: "hub-admin-user",
+        role: "viewer",
+        scopes: ["hub.admin"],
+        tokenId: "token-hub-admin",
+        tokenKind: "access",
+        issuedAt: "2026-07-06T00:00:00.000Z",
+      })).resolves.toMatchObject({ run: { id: "rust-run-1", status: "completed" } });
+
       await expect(service.startRun({
         workflowId: "wf-1",
         triggerType: "manual",

--- a/test/unit/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { createFridayRustHubWorkflowRunBridgeService } from "../../../../src/api/mission-spine/friday-rust-hub-workflow-run-bridge-service.js";
+import type { FridayAuthPrincipal } from "../../../../src/api/model/friday-api-auth.types.js";
 
 function writeJsonBin(path: string, payload: Record<string, unknown>): void {
   writeFileSync(
@@ -57,11 +58,22 @@ describe("FridayRustHubWorkflowRunBridgeService", () => {
         runBin,
         readbackBin,
       });
+      const owner: FridayAuthPrincipal = {
+        principalType: "user",
+        principalId: "tenant-a",
+        tenantId: "tenant-a",
+        userId: "user-a",
+        role: "operator",
+        scopes: ["workflow.write", "workflow.read"],
+        tokenId: "token-owner",
+        tokenKind: "access",
+        issuedAt: "2026-07-06T00:00:00.000Z",
+      };
 
       const started = await service.startRun({
         workflowId: "wf-1",
         triggerType: "manual",
-      }, null);
+      }, owner);
       expect(started.run).toMatchObject({
         id: "rust-run-1",
         workflowId: "wf-1",
@@ -69,12 +81,44 @@ describe("FridayRustHubWorkflowRunBridgeService", () => {
         status: "completed",
       });
 
-      const read = await service.getRun("rust-run-1", null);
+      const read = await service.getRun("rust-run-1", owner);
       expect(read.run).toMatchObject({
         id: "rust-run-1",
         workflowId: "wf-1",
         workflowVersionId: "rust-version:1",
         status: "completed",
+      });
+
+      await expect(service.getRun("rust-run-1", {
+        principalType: "user",
+        principalId: "tenant-b",
+        tenantId: "tenant-b",
+        userId: "user-b",
+        role: "viewer",
+        scopes: ["workflow.read"],
+        tokenId: "token-other",
+        tokenKind: "access",
+        issuedAt: "2026-07-06T00:00:00.000Z",
+      })).rejects.toMatchObject({
+        code: "WORKFLOW_RUN_FORBIDDEN",
+        httpStatus: 403,
+      });
+
+      await expect(service.startRun({
+        workflowId: "wf-1",
+        triggerType: "manual",
+        dryRun: true,
+      }, owner)).rejects.toMatchObject({
+        code: "TS_RUNTIME_WORKFLOW_RUN_RUST_BRIDGE_UNAVAILABLE",
+        httpStatus: 503,
+      });
+
+      await expect(service.startRun({
+        workflowId: "wf-1",
+        triggerType: "webhook",
+      }, owner)).rejects.toMatchObject({
+        code: "TS_RUNTIME_WORKFLOW_RUN_RUST_BRIDGE_UNAVAILABLE",
+        httpStatus: 503,
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -716,6 +716,65 @@ describe("API Runtime — Extended Route Registration", () => {
     expect(execution.getRun).not.toHaveBeenCalled();
   });
 
+  it("routes live workflow run start/read to the Rust bridge when routeWorkflowRunsViaRust is on", async () => {
+    const { workflowRuntime, execution } = makeWorkflowRuntimeSpies();
+    const rustRun = {
+      id: "rust-run-1",
+      workflowId: "workflow-1",
+      workflowVersionId: "rust-version:1",
+      status: "completed" as const,
+      triggerType: "manual",
+      startedAt: NOW,
+      finishedAt: NOW,
+      createdAt: NOW,
+      updatedAt: NOW,
+      evidenceStatus: "available" as const,
+      completionVerification: "verified" as const,
+    };
+    const rustWorkflowRunBridge = {
+      startRun: vi.fn(async () => ({ run: rustRun })),
+      getRun: vi.fn(async () => ({ run: rustRun })),
+    };
+    const runtime = createFridayApiRuntime({
+      ...makeBaseDeps(),
+      workflowRuntime,
+      routeWorkflowRunsViaRust: true,
+      rustWorkflowRunBridge,
+    } as CreateFridayApiRuntimeDeps & {
+      routeWorkflowRunsViaRust: true;
+      rustWorkflowRunBridge: typeof rustWorkflowRunBridge;
+    });
+
+    const startRoute = runtime.routes.getRoutes().find((r) => r.operationId === "runs.start");
+    expect(startRoute).toBeDefined();
+    await expect(startRoute!.handler({
+      requestId: "req-workflow-run-rust-start",
+      receivedAt: NOW,
+      params: {},
+      query: {},
+      body: { workflowId: "workflow-1", triggerType: "manual" },
+      headers: {},
+      principal: makePrincipal({ role: "admin", scopes: ["workflow.write", "workflow.read"] }),
+    })).resolves.toMatchObject({ run: { id: "rust-run-1", status: "completed" } });
+
+    const getRoute = runtime.routes.getRoutes().find((r) => r.operationId === "runs.get");
+    expect(getRoute).toBeDefined();
+    await expect(getRoute!.handler({
+      requestId: "req-workflow-run-rust-get",
+      receivedAt: NOW,
+      params: { runId: "rust-run-1" },
+      query: {},
+      body: null,
+      headers: {},
+      principal: makePrincipal({ role: "admin", scopes: ["workflow.read"] }),
+    })).resolves.toMatchObject({ run: { id: "rust-run-1", status: "completed" } });
+
+    expect(rustWorkflowRunBridge.startRun).toHaveBeenCalledTimes(1);
+    expect(rustWorkflowRunBridge.getRun).toHaveBeenCalledTimes(1);
+    expect(execution.startRun).not.toHaveBeenCalled();
+    expect(execution.getRun).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["runs.cancel", { reason: "operator requested" }, "cancelRun"],
     ["runs.retry", { nodeIds: ["node-1"] }, "retryRun"],

--- a/test/unit/e2e/friday-closure-lib.test.ts
+++ b/test/unit/e2e/friday-closure-lib.test.ts
@@ -85,8 +85,12 @@ describe("friday closure lib", () => {
     expect(scratch.FRIDAY_CHANNELS_JSON).toBe('{"enabled":true,"instances":[]}');
     expect(scratch.FRIDAY_BROWSER_HEADLESS).toBe("true");
     expect(scratch.FRIDAY_ROUTE_WORKFLOWS_VIA_RUST).toBe("1");
+    expect(scratch.FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST).toBe("1");
     expect(scratch.FRIDAY_HUB_WORKFLOW_CATALOG_DB_PATH).toBe("/tmp/friday-state/friday.db");
     expect(scratch.FRIDAY_HUB_WORKFLOW_CATALOG_BIN).toBe("/tmp/friday-state/bin/hub_workflow_catalog");
+    expect(scratch.FRIDAY_HUB_WORKFLOW_RUN_DB_PATH).toBe("/tmp/friday-state/friday.db");
+    expect(scratch.FRIDAY_HUB_WORKFLOW_RUN_BIN).toBe("/tmp/friday-state/bin/hub_workflow_run");
+    expect(scratch.FRIDAY_HUB_WORKFLOW_RUN_READBACK_BIN).toBe("/tmp/friday-state/bin/hub_workflow_run_readback");
     expect(Object.keys(scratch)).not.toContain(`FRIDAY_ALLOW_LOCAL_${"BYPASS_LOGIN"}`);
 
     const explicit = buildClosureScratchEnv(

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -16,6 +16,7 @@ import {
   runStep,
   stopManagedChildProcess,
   writeClosureRustWorkflowCatalogBridgeBin,
+  writeClosureRustWorkflowRunBridgeBins,
 } from "../../../scripts/e2e/run-friday-closure.mjs";
 import { FRIDAY_CLOSURE_STATUSES } from "../../../scripts/e2e/friday-closure-lib.mjs";
 
@@ -85,6 +86,23 @@ describe("run-friday-closure helpers", () => {
     expect(script).toContain("cargo run -q -p friday-hub --bin hub_workflow_catalog");
     expect(script).toContain('exec cargo run -q -p friday-hub --bin hub_workflow_catalog -- "$@"');
     expect(fs.statSync(binPath).mode & 0o111).not.toBe(0);
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes closure-local Rust workflow run bridge wrappers", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-closure-rust-run-bin-"));
+    const runBinPath = join(dir, "bin", "hub_workflow_run");
+    const readbackBinPath = join(dir, "bin", "hub_workflow_run_readback");
+
+    writeClosureRustWorkflowRunBridgeBins(runBinPath, readbackBinPath);
+
+    const runScript = readFileSync(runBinPath, "utf8");
+    const readbackScript = readFileSync(readbackBinPath, "utf8");
+    expect(runScript).toContain('exec cargo run -q -p friday-hub --bin hub_workflow_run -- "$@"');
+    expect(readbackScript).toContain('exec cargo run -q -p friday-hub --bin hub_workflow_run_readback -- "$@"');
+    expect(fs.statSync(runBinPath).mode & 0o111).not.toBe(0);
+    expect(fs.statSync(readbackBinPath).mode & 0o111).not.toBe(0);
 
     rmSync(dir, { recursive: true, force: true });
   });

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -10,6 +10,7 @@ import {
   resolveRouteRunOutcomeLearningViaRust,
   resolveMissionAutoDispatch,
   resolveRouteProvidersViaRust,
+  resolveRouteWorkflowRunsViaRust,
   resolveRouteWorkflowsViaRust,
 } from "#hub";
 import type { FridayHubConfig } from "#hub";
@@ -513,6 +514,36 @@ describe("resolveRouteWorkflowsViaRust", () => {
     expect(resolveRouteWorkflowsViaRust(true, emptyEnv())).toBe(true);
     expect(resolveRouteWorkflowsViaRust(false, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "1" })).toBe(false);
     expect(resolveRouteWorkflowsViaRust(false, { FRIDAY_ROUTE_WORKFLOWS_VIA_RUST: "true" })).toBe(false);
+  });
+});
+
+// ─── Tier-2 workflow-run route bridge: routeWorkflowRunsViaRust (DARK, default-off) ───
+
+describe("resolveRouteWorkflowRunsViaRust", () => {
+  it("defaults to false when neither config nor env is set", () => {
+    expect(resolveRouteWorkflowRunsViaRust(undefined, emptyEnv())).toBe(false);
+  });
+
+  it("parses FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST 1/true (case-insensitive, trimmed) as true", () => {
+    expect(resolveRouteWorkflowRunsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "1" })).toBe(true);
+    expect(resolveRouteWorkflowRunsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "true" })).toBe(true);
+    expect(resolveRouteWorkflowRunsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "TRUE" })).toBe(true);
+    expect(resolveRouteWorkflowRunsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "  1  " })).toBe(true);
+  });
+
+  it("treats 0, false, empty, and garbage env values as false (fail-safe off)", () => {
+    expect(resolveRouteWorkflowRunsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "0" })).toBe(false);
+    expect(resolveRouteWorkflowRunsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "false" })).toBe(false);
+    expect(resolveRouteWorkflowRunsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "" })).toBe(false);
+    expect(resolveRouteWorkflowRunsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "yes" })).toBe(false);
+    expect(resolveRouteWorkflowRunsViaRust(undefined, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "on" })).toBe(false);
+  });
+
+  it("uses explicit config over the env (true wins; false beats env true)", () => {
+    expect(resolveRouteWorkflowRunsViaRust(true, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "0" })).toBe(true);
+    expect(resolveRouteWorkflowRunsViaRust(true, emptyEnv())).toBe(true);
+    expect(resolveRouteWorkflowRunsViaRust(false, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "1" })).toBe(false);
+    expect(resolveRouteWorkflowRunsViaRust(false, { FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST: "true" })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- add default-off workflow-run Rust start/readback bridge for proof-only local closure
- wire runtime/env/closure harness wrappers for FRIDAY_ROUTE_WORKFLOW_RUNS_VIA_RUST
- fail-close unsupported dryRun/non-manual triggers and preserve per-run/privileged readback authorization

## Evidence
- Red/green logs and reviewer evidence: /Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new69-workflow-run-rust-bridge-20260706T1115-0700
- Expanded tests: green-expanded-v5.test.exit=0 (201 tests)
- Typecheck: green-typecheck-v5.exit=0
- Local closure: closure-v4 verdict NO-GO, PASS=7 FAIL=13; local.workflows.generator PASS runStatus=completed

## Boundaries
- Low / proof-only END-BAR local closure slice
- No production workflow execution claim, no deploy/restart, no release/latest-install, no organic adoption, no END-BAR GO
- Default-off outside explicit operator/env route flag
