### PR TITLE
Use portable UI proof mktemp templates

### DIFF
--- a/rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
+++ b/rust-core/scripts/mission-spine-ui-device-proof-assemble.sh
@@ -150,8 +150,8 @@ desktop_bytes="$(file_bytes "$desktop")"
 channel_bytes="$(file_bytes "$channel")"
 timeline_bytes="$(file_bytes "$timeline")"
 
-negative_evidence_json="$(mktemp "${TMPDIR:-/tmp}/friday-ui-negative-evidence.XXXXXX.json")"
-extra_evidence_json="$(mktemp "${TMPDIR:-/tmp}/friday-ui-extra-evidence.XXXXXX.json")"
+negative_evidence_json="$(mktemp "${TMPDIR:-/tmp}/friday-ui-negative-evidence.XXXXXX")"
+extra_evidence_json="$(mktemp "${TMPDIR:-/tmp}/friday-ui-extra-evidence.XXXXXX")"
 printf '[]\n' >"$negative_evidence_json"
 printf '[]\n' >"$extra_evidence_json"
 cleanup_evidence_json() {

--- a/test/unit/qa/mission-spine-ui-device-proof-assemble-cli.test.ts
+++ b/test/unit/qa/mission-spine-ui-device-proof-assemble-cli.test.ts
@@ -149,6 +149,12 @@ function runAssembler(files: ReturnType<typeof writeEvidenceFiles>, manifestPath
 }
 
 describe("mission-spine-ui-device-proof-assemble", () => {
+  it("uses portable mktemp templates without a suffix after XXXXXX", () => {
+    const script = readFileSync("rust-core/scripts/mission-spine-ui-device-proof-assemble.sh", "utf8");
+
+    expect(script).not.toMatch(/mktemp\s+"[^"\n]*XXXXXX\.[^"\n]+"/u);
+  });
+
   it("carries workbench and transcript browser evidence into the final proof", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-assemble-"));
     try {


### PR DESCRIPTION
## Summary
- make mission-spine UI/device proof assembler mktemp templates portable by ending at `XXXXXX`
- add regression coverage that rejects `mktemp "...XXXXXX.<suffix>"` templates
- keep proof artifact shape, jq assembly, and gate invocation unchanged

## Red-first / evidence
- red `2fdcd138` -> green `c5d48beb`
- valid red: `red-ui-proof-mktemp-v2.test.log` failed on old `mktemp "...XXXXXX.json"` pattern
- revert-red: `revert-red-ui-proof-mktemp.test.log` failed again after reversing green
- evidence root: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new71-portable-ui-proof-mktemp-20260706T1400-0700/`
- reviewers: Kierkegaard PASS, Leibniz PASS

## Verification
- targeted assembler test: 3/3 passed
- `npm run typecheck` passed
- `git diff --check origin/main...HEAD` passed
- branch closure remains NO-GO but restores `local.backstop.release-verify` to PASS; summary `11 PASS / 12 FAIL / 1 BLOCKER`

## Boundaries
No END-BAR GO claim, no prod deploy/restart, no release/latest-install, no organic adoption, no DeepSeek live proof, no provider entitlement claim, and no terminal device/channel attestation.