### PR TITLE
Align closure provider auth modes

### DIFF
--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -870,6 +870,7 @@ function resolveClosureProviderConfig(env = process.env) {
       name: "Closure DeepSeek",
       baseUrl: readEnvValue(env, "FRIDAY_CLOSURE_DEEPSEEK_BASE_URL") ?? "https://api.deepseek.com",
       api: "openai-completions",
+      authMode: "bearer-token",
       supportedModels: ["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"],
       defaultModel: explicitModel ?? "deepseek-v4-flash",
       generationModel: explicitModel ?? "deepseek-v4-pro",
@@ -881,6 +882,7 @@ function resolveClosureProviderConfig(env = process.env) {
       name: "Closure DeepSeek",
       baseUrl: readEnvValue(env, "FRIDAY_CLOSURE_DEEPSEEK_BASE_URL") ?? "https://api.deepseek.com",
       api: "openai-completions",
+      authMode: "bearer-token",
       supportedModels: ["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"],
       defaultModel: explicitModel ?? "deepseek-v4-flash",
       generationModel: explicitModel ?? "deepseek-v4-pro",
@@ -894,6 +896,7 @@ function resolveClosureProviderConfig(env = process.env) {
         ? readEnvValue(env, "FRIDAY_CLOSURE_DEEPSEEK_BASE_URL") ?? "https://api.deepseek.com"
         : readEnvValue(env, "E2E_OPENAI_BASE_URL") ?? "https://api.openai.com",
       api: isDeepSeekStyleApiKey(readEnvValue(env, "OPENAI_API_KEY")) ? "openai-completions" : "openai-responses",
+      authMode: "bearer-token",
       supportedModels: isDeepSeekStyleApiKey(readEnvValue(env, "OPENAI_API_KEY"))
         ? ["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"]
         : ["gpt-4o-mini", "gpt-4o"],
@@ -907,6 +910,7 @@ function resolveClosureProviderConfig(env = process.env) {
       name: "Closure OpenAI",
       baseUrl: readEnvValue(env, "E2E_OPENAI_BASE_URL") ?? "https://api.openai.com",
       api: "openai-responses",
+      authMode: "bearer-token",
       supportedModels: ["gpt-4o-mini", "gpt-4o"],
       defaultModel: explicitModel ?? "gpt-4o-mini",
       generationModel: explicitModel ?? "gpt-4o",
@@ -948,12 +952,25 @@ function resolveClosureProviderConfig(env = process.env) {
   };
 }
 
+function resolveClosureProviderAuthMode(providerConfig) {
+  if (typeof providerConfig.authMode === "string" && providerConfig.authMode.trim() !== "") {
+    return providerConfig.authMode;
+  }
+  if (providerConfig.api === "anthropic-messages" || providerConfig.api === "google-generative-ai") {
+    return "api-key";
+  }
+  if (providerConfig.api === "ollama") {
+    return "none";
+  }
+  return "bearer-token";
+}
+
 export function buildClosureProviderCreateRequest(providerConfig) {
   return {
     kind: providerConfig.kind,
     name: providerConfig.name,
     baseUrl: providerConfig.baseUrl,
-    authMode: "api-key",
+    authMode: resolveClosureProviderAuthMode(providerConfig),
     api: providerConfig.api,
     apiKey: `$${providerConfig.envVar}`,
     supportedModels: providerConfig.supportedModels,

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -38,7 +38,7 @@ describe("run-friday-closure helpers", () => {
       kind: "openai",
       name: "Closure OpenAI",
       baseUrl: "https://api.openai.com",
-      authMode: "api-key",
+      authMode: "bearer-token",
       api: "openai-responses",
       apiKey: "$OPENAI_API_KEY",
       supportedModels: ["gpt-4o-mini", "gpt-4o"],
@@ -48,6 +48,28 @@ describe("run-friday-closure helpers", () => {
       preserveEnvRef: true,
     });
     expect(JSON.stringify(request)).not.toContain("sk-");
+  });
+
+  it("uses provider-catalog auth modes for closure HTTP providers", () => {
+    expect(buildClosureProviderCreateRequest({
+      kind: "deepseek",
+      name: "Closure DeepSeek",
+      baseUrl: "https://api.deepseek.com",
+      api: "openai-completions",
+      envVar: "DEEPSEEK_API_KEY",
+      supportedModels: ["deepseek-chat"],
+      defaultModel: "deepseek-chat",
+    }).authMode).toBe("bearer-token");
+
+    expect(buildClosureProviderCreateRequest({
+      kind: "anthropic",
+      name: "Closure Anthropic",
+      baseUrl: "https://api.anthropic.com",
+      api: "anthropic-messages",
+      envVar: "ANTHROPIC_API_KEY",
+      supportedModels: ["claude-sonnet-4-6"],
+      defaultModel: "claude-sonnet-4-6",
+    }).authMode).toBe("api-key");
   });
 
   it("closeWritableStream flushes and closes a write stream", async () => {


### PR DESCRIPTION
## Scope

NEW-72 aligns the local closure harness provider-create request with the provider catalog auth-mode semantics.

- OpenAI / DeepSeek closure providers now use `bearer-token` instead of a hard-coded `api-key`.
- Anthropic / Google-compatible fallbacks remain `api-key`; Ollama resolves to `none`.
- Provider secrets remain env refs (`apiKey: "$<envVar>"`, `preserveEnvRef: true`); no real key is copied into evidence or scratch config.

This is Low closure correctness / hygiene. It does **not** close END-BAR or provider lifecycle.

## Red-first evidence

Evidence root:
`/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new72-closure-provider-auth-mode-20260706T1510-0700`

- Red commit: `fbbd26d6 test(new72): require closure provider auth modes`
  - `logs/red-auth-mode.test.exit=1`
  - failure: old implementation returned `authMode: "api-key"` for OpenAI/DeepSeek.
- Green commit: `f1edf61b fix(new72): align closure provider auth modes`
  - `logs/green-auth-mode.test.exit=0` (`13 passed`)
- Revert-red:
  - `logs/revert-red-auth-mode.test.exit=1`
  - `logs/restore-green-auth-mode.test.exit=0`

## Verification

- `logs/green-typecheck.exit=0`
- `logs/green-diff-check.exit=0`
- `secret-scan.exit=1` with empty `secret-scan.txt`
- `sha256sums.verify.exit=0`
- Branch closure remains `NO-GO`, summary `11 pass / 12 fail / 1 blocker`:
  - `branch-closure/closure-ledger-digest.json`
  - `branch-closure/non-pass.tsv`

Boundary / no overclaim:

- `local.providers.lifecycle` remains `FAIL` with `TS_RUNTIME_PROVIDER_PROBE_RETIRED` because the Rust capability doctor is proof-only without key validation.
- `local.uix.templates` remains `FAIL` with `PROVIDER_NO_CANDIDATES`.
- `openai-models-auth-probe.json` records current `OPENAI_API_KEY` direct `/v1/models` probe as HTTP `401`; no response body or key value is logged.

## Independent reviewers

- Schrodinger the 4th, session `019f397c-eb68-7281-a859-37331c272e99`, verdict PASS:
  `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new72-closure-provider-auth-mode-20260706T1510-0700/reviewer-schrodinger-new72.md`
- Galileo the 4th, session `019f397d-0773-71f1-8488-d87f0623fe1c`, verdict PASS:
  `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new72-closure-provider-auth-mode-20260706T1510-0700/reviewer-galileo-new72.md`

## Merge policy

Low / agent-doable. May auto squash-merge only after full PR-CI green, branch remains born-current, no open PR overlap exists, and no new High/Blocker concern appears. This PR does not imply END-BAR, prod deploy, release/latest-install, organic adoption, provider entitlement, or terminal accepted.
