### PR TITLE
Enable closure plugin lifecycle scratch oracle

### DIFF
--- a/scripts/e2e/friday-closure-lib.mjs
+++ b/scripts/e2e/friday-closure-lib.mjs
@@ -172,6 +172,10 @@ export function buildClosureScratchEnv(baseEnv = process.env, paths) {
       ?? path.join(paths.state, "bin", "hub_workflow_run"),
     FRIDAY_HUB_WORKFLOW_RUN_READBACK_BIN: baseEnv.FRIDAY_HUB_WORKFLOW_RUN_READBACK_BIN
       ?? path.join(paths.state, "bin", "hub_workflow_run_readback"),
+    FRIDAY_PLUGIN_RUNTIME_MODE: baseEnv.FRIDAY_PLUGIN_RUNTIME_MODE ?? "full",
+    FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION: baseEnv.FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION ?? "1",
+    FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION:
+      baseEnv.FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION ?? "1",
     FRIDAY_ROUTE_SKILL_RUNS_VIA_RUST: baseEnv.FRIDAY_ROUTE_SKILL_RUNS_VIA_RUST ?? "1",
     FRIDAY_D21_SKILL_RUN_LOCAL_BIN: baseEnv.FRIDAY_D21_SKILL_RUN_LOCAL_BIN
       ?? path.join(paths.state, "bin", "hub_skill_run_local"),

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -2051,6 +2051,8 @@ export interface FridayResolvedHubConfig {
   serverVersion: string;
   corsOrigins: string[];
   logRequests: boolean;
+  allowTestOnlyAutonomyLifecycleExecution?: boolean;
+  allowTestOnlyPluginExecution?: boolean;
   pluginRuntimeMode: "stub" | "full";
   /** Whether deterministic pipeline execution is globally enabled. */
   pipelineEnabled: boolean;

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -857,9 +857,17 @@ export function resolveFridayHubConfig(
     logRequests = true;
   }
 
+  const allowTestOnlyPluginExecution = resolveTestOnlyFlagFromEnv(
+    input.allowTestOnlyPluginExecution,
+    env.FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION,
+  );
+  const allowTestOnlyAutonomyLifecycleExecution = resolveTestOnlyFlagFromEnv(
+    input.allowTestOnlyAutonomyLifecycleExecution,
+    env.FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION,
+  );
   const pluginRuntimeModeRaw = input.pluginRuntimeMode ?? env.FRIDAY_PLUGIN_RUNTIME_MODE ?? "stub";
   const pluginRuntimeMode = pluginRuntimeModeRaw === "full"
-    && (input.allowTestOnlyPluginExecution === true || input.allowTestOnlyAutonomyLifecycleExecution === true)
+    && (allowTestOnlyPluginExecution === true || allowTestOnlyAutonomyLifecycleExecution === true)
     ? "full"
     : "stub";
   const pipelineRuntimeConfig = resolveFridayPipelineRuntimeConfig(env);
@@ -888,6 +896,8 @@ export function resolveFridayHubConfig(
     serverVersion,
     corsOrigins,
     logRequests,
+    allowTestOnlyAutonomyLifecycleExecution,
+    allowTestOnlyPluginExecution,
     pluginRuntimeMode,
     pipelineEnabled: pipelineRuntimeConfig.enabled,
     pipelineMode: pipelineRuntimeConfig.mode,
@@ -899,6 +909,20 @@ export function resolveFridayHubConfig(
 function isFridayCanonicalGateProtectedProfile(env: NodeJS.ProcessEnv): boolean {
   return env.NODE_ENV?.trim().toLowerCase() === "production"
     || Boolean(env.FRIDAY_RELEASE_TAG?.trim());
+}
+
+function resolveTestOnlyFlagFromEnv(
+  configValue: boolean | undefined,
+  envValue: string | undefined,
+): boolean | undefined {
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (envValue ?? "").trim().toLowerCase();
+  if (raw === "") {
+    return undefined;
+  }
+  return raw === "1" || raw === "true";
 }
 
 export function resolveFridayCanonicalMutatingActionGate(
@@ -1477,13 +1501,24 @@ export async function createFridayHub(
   const capabilityGates = resolveFridayCapabilityGates(process.env);
   const crossChannelIdentityEnabled = process.env.FRIDAY_CROSS_CHANNEL_IDENTITY_ENABLED === "true";
   const crossChannelIdentityMap = parseFridayChannelIdentityMap(process.env.FRIDAY_CHANNEL_IDENTITY_MAP);
+  const configuredAllowTestOnlyPluginExecution = resolveTestOnlyFlagFromEnv(
+    config.allowTestOnlyPluginExecution,
+    process.env.FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION,
+  );
+  const configuredAllowTestOnlyAutonomyLifecycleExecution = resolveTestOnlyFlagFromEnv(
+    config.allowTestOnlyAutonomyLifecycleExecution,
+    process.env.FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION,
+  );
   const configuredPluginRuntimeModeRaw = (
     config.pluginRuntimeMode ??
     process.env.FRIDAY_PLUGIN_RUNTIME_MODE ??
     "stub"
   );
   const configuredPluginRuntimeMode = configuredPluginRuntimeModeRaw === "full"
-    && (config.allowTestOnlyPluginExecution === true || config.allowTestOnlyAutonomyLifecycleExecution === true)
+    && (
+      configuredAllowTestOnlyPluginExecution === true
+      || configuredAllowTestOnlyAutonomyLifecycleExecution === true
+    )
     ? "full"
     : "stub";
 
@@ -7562,7 +7597,7 @@ export async function createFridayHub(
     routeWorkflowsViaRust: resolveRouteWorkflowsViaRust(config.routeWorkflowsViaRust),
     routeWorkflowRunsViaRust: resolveRouteWorkflowRunsViaRust(config.routeWorkflowRunsViaRust),
     allowTestOnlyAgentRunControlExecution: config.allowTestOnlyAgentRunControlExecution,
-    allowTestOnlyAutonomyLifecycleExecution: config.allowTestOnlyAutonomyLifecycleExecution,
+    allowTestOnlyAutonomyLifecycleExecution: configuredAllowTestOnlyAutonomyLifecycleExecution,
     allowTestOnlyStandingAgendaExecution: config.allowTestOnlyStandingAgendaExecution,
     allowTestOnlyAutonomyPolicyMutation: config.allowTestOnlyAutonomyPolicyMutation,
     allowTestOnlyCapabilityAcquisitionExecution: config.allowTestOnlyCapabilityAcquisitionExecution,
@@ -7571,7 +7606,7 @@ export async function createFridayHub(
     allowTestOnlySessionMemoryExtractionExecution: config.allowTestOnlySessionMemoryExtractionExecution,
     allowTestOnlyRealtimeExecution: config.allowTestOnlyRealtimeExecution,
     allowTestOnlySkillConverterExecution: config.allowTestOnlySkillConverterExecution,
-    allowTestOnlyPluginExecution: config.allowTestOnlyPluginExecution,
+    allowTestOnlyPluginExecution: configuredAllowTestOnlyPluginExecution,
     allowTestOnlyProviderDetectExecution: config.allowTestOnlyProviderDetectExecution,
     allowTestOnlyProviderProbeExecution: config.allowTestOnlyProviderProbeExecution,
     allowTestOnlyProviderRoutingControlsExecution: config.allowTestOnlyProviderRoutingControlsExecution,

--- a/test/unit/e2e/friday-closure-lib.test.ts
+++ b/test/unit/e2e/friday-closure-lib.test.ts
@@ -93,6 +93,9 @@ describe("friday closure lib", () => {
     expect(scratch.FRIDAY_HUB_WORKFLOW_RUN_DB_PATH).toBe("/tmp/friday-state/friday.db");
     expect(scratch.FRIDAY_HUB_WORKFLOW_RUN_BIN).toBe("/tmp/friday-state/bin/hub_workflow_run");
     expect(scratch.FRIDAY_HUB_WORKFLOW_RUN_READBACK_BIN).toBe("/tmp/friday-state/bin/hub_workflow_run_readback");
+    expect(scratch.FRIDAY_PLUGIN_RUNTIME_MODE).toBe("full");
+    expect(scratch.FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION).toBe("1");
+    expect(scratch.FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION).toBe("1");
     expect(Object.keys(scratch)).not.toContain(`FRIDAY_ALLOW_LOCAL_${"BYPASS_LOGIN"}`);
 
     const explicit = buildClosureScratchEnv(

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -316,6 +316,18 @@ describe("resolveFridayHubConfig", () => {
     expect(resolved.pluginRuntimeMode).toBe("full");
   });
 
+  it("maps closure scratch plugin lifecycle test-oracle env to explicit config flags", () => {
+    const resolved = resolveFridayHubConfig(makeConfig(), {
+      FRIDAY_PLUGIN_RUNTIME_MODE: "full",
+      FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION: "1",
+      FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION: "1",
+    });
+
+    expect(resolved.allowTestOnlyPluginExecution).toBe(true);
+    expect(resolved.allowTestOnlyAutonomyLifecycleExecution).toBe(true);
+    expect(resolved.pluginRuntimeMode).toBe("full");
+  });
+
   // ─── Deterministic pipeline mode ───
 
   it("defaults deterministic pipeline to enabled enforce mode", () => {


### PR DESCRIPTION
## Scope
NEW-74: make the closure-local `local.plugins.lifecycle` proof run in an explicit scratch/test-oracle plugin lifecycle runtime so install/review-enable/disable/uninstall can be exercised without opening production/default plugin mutations.

This is a Low local END-BAR harness slice. It does not change prod deploy, prod DB, prod ports, release/latest-install, organic adoption, or END-BAR status.

## Red-first
- Red commit: `18011cb5` (test-only), red log: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new74-plugin-lifecycle-closure-20260706T172940-0700/logs/red-plugin-lifecycle-env.test.log`, exit 1, true assertions: missing closure plugin runtime env and missing resolved test-oracle config.
- Green commit: `0580298b`, green logs: `green-plugin-lifecycle-env-v3.test.log`, `green-plugin-expanded-v3.test.log`, `green-typecheck-v3.log`, `green-diff-check-v3.log`, all exit 0.
- Revert-red: `revert-red-plugin-lifecycle-env.test.log`, exit 1, same plugin env/config assertion failures after reversing green while preserving red tests; restore-green exit 0.

## Independent reviewers
- Laplace the 4th, session `019f3a00-786c-7382-a652-3bffc6e1b94a`, PASS: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new74-plugin-lifecycle-closure-20260706T172940-0700/reviewer-a-new74.md`.
- Russell the 4th, session `019f3a00-9e6e-76e2-9631-5e059a344481`, PASS: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new74-plugin-lifecycle-closure-20260706T172940-0700/reviewer-b-new74.md`.

## No-degrade / failed-skipped handling
- Branch closure summary: `branch-closure-v2-summary.json` remains `NO-GO`, counts `PASS=10`, `FAIL=10`. Only `local.plugins.lifecycle` is newly PASS; remaining failures stay FAIL and are not promoted.
- `local-plugins-lifecycle-response.json` proves actual scratch lifecycle: install ok, review-enable active/compatible, disable ok, uninstall ok.
- Default/prod remains guarded: `FRIDAY_PLUGIN_RUNTIME_MODE=full` alone still resolves to stub; full mode requires explicit test-oracle flags, and the flags are defaulted only inside `buildClosureScratchEnv`.

## Tests
- `npm test -- --run test/unit/e2e/friday-closure-lib.test.ts test/unit/hub/friday-hub-bootstrap-env.test.ts`
- `npm test -- --run test/unit/api/http/routes/friday-plugin-routes.test.ts test/unit/api/runtime/friday-api-runtime-plugin-review-enable.test.ts test/unit/e2e/friday-closure-lib.test.ts test/unit/hub/friday-hub-bootstrap-env.test.ts`
- `npm run typecheck`
- `git diff --check`
- `FRIDAY_CLOSURE_SKIP_INSTALL=1 FRIDAY_CLOSURE_SKIP_BACKSTOP=1 npm run test:e2e:closure:local` (expected overall NO-GO, target item PASS)