### PR TITLE
Validate OpenAI provider keys in closure lifecycle

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_capability_doctor.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_capability_doctor.rs
@@ -552,7 +552,8 @@ mod tests {
             .with(
                 KeyProvider::Anthropic,
                 KeyValidationOutcome::Invalid { status: 401 },
-            );
+            )
+            .with(KeyProvider::OpenAi, KeyValidationOutcome::Valid);
         let rendered = render_composite(&cli, &keys).expect("renders");
         let v = parse(&rendered);
 
@@ -579,7 +580,7 @@ mod tests {
 
         // Key section: exactly the four safe keys per entry, in KeyProvider::all() order.
         let keys_arr = v["key_validation"].as_array().expect("key array");
-        assert_eq!(keys_arr.len(), 2);
+        assert_eq!(keys_arr.len(), 3);
         for entry in keys_arr {
             let obj = entry.as_object().unwrap();
             assert_eq!(obj.len(), 4, "key entry must carry exactly 4 safe keys");
@@ -597,11 +598,16 @@ mod tests {
         assert_eq!(keys_arr[1]["label"], "invalid");
         assert_eq!(keys_arr[1]["status"], 401);
         assert!(keys_arr[1]["detail"].is_null());
+        // openai valid: label valid, no status/detail.
+        assert_eq!(keys_arr[2]["provider"], "openai");
+        assert_eq!(keys_arr[2]["label"], "valid");
+        assert!(keys_arr[2]["status"].is_null());
+        assert!(keys_arr[2]["detail"].is_null());
 
-        // Confirmed-valid: only deepseek (anthropic invalid).
+        // Confirmed-valid: deepseek and openai (anthropic invalid).
         assert_eq!(
             v["confirmed_valid_keys"].as_array().unwrap(),
-            &vec![serde_json::json!("deepseek")]
+            &vec![serde_json::json!("deepseek"), serde_json::json!("openai")]
         );
         let route_readiness = v["route_readiness"]
             .as_array()

--- a/rust-core/crates/friday-hub/src/capability_doctor.rs
+++ b/rust-core/crates/friday-hub/src/capability_doctor.rs
@@ -12,8 +12,8 @@
 //! so they are kept as DISTINCT sections rather than fused per provider:
 //! - `Codex` has a CLI login but NO HTTP key-validation path → it appears ONLY in the
 //!   CLI-detect section (no synthesized key verdict — there is nothing to validate).
-//! - `DeepSeek` has an API key but is NOT a CLI provider → it appears ONLY in the
-//!   key-validation section (no CLI-detect signal).
+//! - `DeepSeek` / `OpenAI` have API keys but are NOT CLI providers → they appear
+//!   ONLY in the key-validation section (no CLI-detect signal).
 //! - `Claude` (CLI subscription login) and `Anthropic` (API key) are DISTINCT
 //!   credentials. They are reported SEPARATELY — the CLI signal in the CLI-detect
 //!   section, the key signal in the key-validation section — and are NEVER folded into
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn composite_covers_both_taxonomies_in_canonical_order_no_collapse() {
         // CLI: codex logged-in, claude logged-out. Keys: deepseek valid, anthropic
-        // invalid. The composite must carry BOTH sets, each per-provider, side by
+        // invalid, openai valid. The composite must carry BOTH sets, each per-provider, side by
         // side — never merging claude-CLI with anthropic-key.
         let cli = MockCliProbe::new()
             .set(Provider::Codex, "Logged in using ChatGPT")
@@ -192,7 +192,8 @@ mod tests {
             .with(
                 KeyProvider::Anthropic,
                 KeyValidationOutcome::Invalid { status: 401 },
-            );
+            )
+            .with(KeyProvider::OpenAi, KeyValidationOutcome::Valid);
 
         let doc = CapabilityDoctor::run(&cli, &keys);
 
@@ -203,14 +204,20 @@ mod tests {
         assert_eq!(doc.cli_statuses[1].provider, Provider::Claude);
         assert!(!doc.cli_statuses[1].authenticated);
 
-        // Key section: 2 credentials in KeyProvider::all() order, each its own outcome.
-        assert_eq!(doc.key_signals.len(), 2);
+        // Key section: 3 credentials in KeyProvider::all() order, each its own outcome.
+        assert_eq!(doc.key_signals.len(), 3);
         assert_eq!(doc.key_signals[0].provider, KeyProvider::DeepSeek);
         assert_eq!(doc.key_signals[0].outcome, KeyValidationOutcome::Valid);
         assert_eq!(doc.key_signals[1].provider, KeyProvider::Anthropic);
         assert_eq!(
             doc.key_signals[1].outcome,
             KeyValidationOutcome::Invalid { status: 401 }
+        );
+        assert_eq!(doc.key_signals[2].provider, KeyProvider::OpenAi);
+        assert_eq!(doc.key_signals[2].outcome, KeyValidationOutcome::Valid);
+        assert_eq!(
+            doc.confirmed_valid_keys(),
+            vec![KeyProvider::DeepSeek, KeyProvider::OpenAi]
         );
     }
 

--- a/rust-core/crates/friday-hub/src/provider_key_validation.rs
+++ b/rust-core/crates/friday-hub/src/provider_key_validation.rs
@@ -20,6 +20,9 @@
 //!   ([`friday_anthropic::ClaudeClient::chat`]). Anthropic has no `/models` discovery
 //!   in-crate, so this spends a tiny amount of quota (~one or two tokens). Documented
 //!   in the live harness run-doc.
+//! - **OpenAI** — an authenticated `GET /v1/models` against `OPENAI_API_KEY` (or
+//!   `FRIDAY_OPENAI_API_KEY`) and `E2E_OPENAI_BASE_URL`/`https://api.openai.com`.
+//!   Authenticated but spends no completion quota.
 //!
 //! ## No-fallback + honesty mapping (the core of this module)
 //! The mapping deliberately partitions a genuinely-bad credential from a transient
@@ -52,6 +55,17 @@
 use friday_anthropic::{ClaudeClient, ClaudeError, DEFAULT_MODEL as CLAUDE_DEFAULT_MODEL};
 use friday_deepseek::{DeepSeekClient, DeepSeekError};
 use friday_providers::{KeyProvider, KeyValidationOutcome, KeyValidationProbe};
+
+const OPENAI_ENV_KEY: &str = "OPENAI_API_KEY";
+const FRIDAY_OPENAI_ENV_KEY: &str = "FRIDAY_OPENAI_API_KEY";
+const OPENAI_BASE_URL_ENV_KEY: &str = "E2E_OPENAI_BASE_URL";
+const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com";
+
+fn read_env_non_empty(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
 
 /// Map a DeepSeek `discover_models` result into a typed key-validation outcome.
 /// PURE (no network) so every arm is unit-tested directly.
@@ -109,6 +123,29 @@ pub fn map_claude_result<T>(result: Result<T, ClaudeError>) -> KeyValidationOutc
     }
 }
 
+/// Map an OpenAI-compatible `/v1/models` HTTP status into a typed
+/// key-validation outcome. PURE (no network): only 401/403 are a bad key, 429 and
+/// 5xx/408 are unavailable, and other client errors are not confirmed.
+pub fn map_openai_status(status: Result<u16, &'static str>) -> KeyValidationOutcome {
+    match status {
+        Ok(code) if (200..=299).contains(&code) => KeyValidationOutcome::Valid,
+        Ok(code @ (401 | 403)) => KeyValidationOutcome::Invalid { status: code },
+        Ok(429) => KeyValidationOutcome::Unavailable {
+            detail: "rate_limited",
+        },
+        Ok(408) => KeyValidationOutcome::Unavailable {
+            detail: "provider_unavailable",
+        },
+        Ok(code) if (500..=599).contains(&code) => KeyValidationOutcome::Unavailable {
+            detail: "provider_unavailable",
+        },
+        Ok(_) => KeyValidationOutcome::Unavailable {
+            detail: "client_error",
+        },
+        Err(detail) => KeyValidationOutcome::Unavailable { detail },
+    }
+}
+
 /// The real, secret-bearing key-validation probe. Constructs the provider client
 /// `from_env` (FAILS CLOSED to [`KeyValidationOutcome::CredentialMissing`] if the
 /// key is absent — never a fallback) and runs ONE minimal authenticated round-trip,
@@ -145,6 +182,29 @@ impl LiveKeyValidationProbe {
             }
         }
     }
+
+    /// Validate OpenAI via an authenticated `GET /v1/models` (no completion quota).
+    fn validate_openai(&self) -> KeyValidationOutcome {
+        let Some(api_key) = read_env_non_empty(OPENAI_ENV_KEY)
+            .or_else(|| read_env_non_empty(FRIDAY_OPENAI_ENV_KEY))
+        else {
+            return KeyValidationOutcome::CredentialMissing;
+        };
+        let base_url = read_env_non_empty(OPENAI_BASE_URL_ENV_KEY)
+            .unwrap_or_else(|| DEFAULT_OPENAI_BASE_URL.to_string());
+        let url = format!("{}/v1/models", base_url.trim_end_matches('/'));
+        let result = ureq::AgentBuilder::new()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .get(&url)
+            .set("Authorization", &format!("Bearer {api_key}"))
+            .call();
+        match result {
+            Ok(response) => map_openai_status(Ok(response.status())),
+            Err(ureq::Error::Status(code, _)) => map_openai_status(Ok(code)),
+            Err(ureq::Error::Transport(_)) => map_openai_status(Err("transport")),
+        }
+    }
 }
 
 impl KeyValidationProbe for LiveKeyValidationProbe {
@@ -152,6 +212,7 @@ impl KeyValidationProbe for LiveKeyValidationProbe {
         match provider {
             KeyProvider::DeepSeek => self.validate_deepseek(),
             KeyProvider::Anthropic => self.validate_anthropic(),
+            KeyProvider::OpenAi => self.validate_openai(),
         }
     }
 }
@@ -317,5 +378,39 @@ mod tests {
         // probe and never calls validate.
         let _probe = LiveKeyValidationProbe::new();
         let _probe2 = LiveKeyValidationProbe;
+    }
+
+    #[test]
+    fn openai_status_mapping_partitions_auth_from_transient_without_network() {
+        assert_eq!(map_openai_status(Ok(200)), KeyValidationOutcome::Valid);
+        assert_eq!(
+            map_openai_status(Ok(401)),
+            KeyValidationOutcome::Invalid { status: 401 }
+        );
+        assert_eq!(
+            map_openai_status(Ok(403)),
+            KeyValidationOutcome::Invalid { status: 403 }
+        );
+        for (status, detail) in [
+            (408, "provider_unavailable"),
+            (429, "rate_limited"),
+            (500, "provider_unavailable"),
+            (503, "provider_unavailable"),
+            (400, "client_error"),
+            (404, "client_error"),
+        ] {
+            let outcome = map_openai_status(Ok(status));
+            assert_eq!(outcome, KeyValidationOutcome::Unavailable { detail });
+            assert!(
+                !matches!(outcome, KeyValidationOutcome::Invalid { .. }),
+                "non-auth OpenAI status must never be branded Invalid"
+            );
+        }
+        assert_eq!(
+            map_openai_status(Err("transport")),
+            KeyValidationOutcome::Unavailable {
+                detail: "transport"
+            }
+        );
     }
 }

--- a/rust-core/crates/friday-providers/src/key_validation.rs
+++ b/rust-core/crates/friday-providers/src/key_validation.rs
@@ -31,7 +31,8 @@
 //! that contract, so this module ships ONLY the call-free seam: the
 //! [`KeyValidationProbe`] trait + the provider-agnostic typed [`KeyValidationOutcome`]
 //! + a [`MockKeyValidationProbe`] for tests. The REAL, secret-bearing,
-//! quota-touching impl (driving `friday-anthropic`/`friday-deepseek`) lives in
+//! quota-touching impl (driving `friday-anthropic`/`friday-deepseek` and OpenAI
+//! `/v1/models`) lives in
 //! `friday-hub`, where provider secrets already live — mirroring how R6's
 //! `ProviderDoctor` lives in the hub and composes this crate's `detect`.
 //!
@@ -63,6 +64,9 @@ pub enum KeyProvider {
     /// NOTE: this is a DIFFERENT credential than the `claude` CLI login that
     /// [`crate::detect`] checks for [`crate::Provider::Claude`].
     Anthropic,
+    /// OpenAI API route key (`OPENAI_API_KEY` / `FRIDAY_OPENAI_API_KEY`). Validated
+    /// by authenticated `GET /v1/models` — spends no completion quota.
+    OpenAi,
 }
 
 impl KeyProvider {
@@ -71,6 +75,7 @@ impl KeyProvider {
         match self {
             KeyProvider::DeepSeek => "deepseek",
             KeyProvider::Anthropic => "anthropic",
+            KeyProvider::OpenAi => "openai",
         }
     }
 
@@ -80,14 +85,19 @@ impl KeyProvider {
         match self {
             KeyProvider::DeepSeek => "FRIDAY_DEEPSEEK_API_KEY",
             KeyProvider::Anthropic => "FRIDAY_ANTHROPIC_API_KEY",
+            KeyProvider::OpenAi => "OPENAI_API_KEY",
         }
     }
 
     /// The canonical, ordered set of every credential that has a key-validation
     /// path. The composite capability-doctor iterates this. Order is stable
-    /// (`deepseek`, `anthropic`) so a doctor result is deterministic.
+    /// (`deepseek`, `anthropic`, `openai`) so a doctor result is deterministic.
     pub fn all() -> &'static [KeyProvider] {
-        &[KeyProvider::DeepSeek, KeyProvider::Anthropic]
+        &[
+            KeyProvider::DeepSeek,
+            KeyProvider::Anthropic,
+            KeyProvider::OpenAi,
+        ]
     }
 }
 
@@ -160,6 +170,7 @@ pub trait KeyValidationProbe {
 pub struct MockKeyValidationProbe {
     deepseek: Option<KeyValidationOutcome>,
     anthropic: Option<KeyValidationOutcome>,
+    openai: Option<KeyValidationOutcome>,
 }
 
 impl MockKeyValidationProbe {
@@ -172,6 +183,7 @@ impl MockKeyValidationProbe {
         match provider {
             KeyProvider::DeepSeek => self.deepseek = Some(outcome),
             KeyProvider::Anthropic => self.anthropic = Some(outcome),
+            KeyProvider::OpenAi => self.openai = Some(outcome),
         }
         self
     }
@@ -184,6 +196,7 @@ impl KeyValidationProbe for MockKeyValidationProbe {
         match provider {
             KeyProvider::DeepSeek => self.deepseek,
             KeyProvider::Anthropic => self.anthropic,
+            KeyProvider::OpenAi => self.openai,
         }
         .unwrap_or(KeyValidationOutcome::CredentialMissing)
     }
@@ -197,14 +210,24 @@ mod tests {
     fn key_provider_all_is_stable_complete_and_labeled() {
         assert_eq!(
             KeyProvider::all(),
-            &[KeyProvider::DeepSeek, KeyProvider::Anthropic]
+            &[
+                KeyProvider::DeepSeek,
+                KeyProvider::Anthropic,
+                KeyProvider::OpenAi,
+            ]
         );
         assert_eq!(KeyProvider::DeepSeek.as_str(), "deepseek");
         assert_eq!(KeyProvider::Anthropic.as_str(), "anthropic");
+        assert_eq!(KeyProvider::OpenAi.as_str(), "openai");
         assert_eq!(KeyProvider::DeepSeek.env_key(), "FRIDAY_DEEPSEEK_API_KEY");
         assert_eq!(KeyProvider::Anthropic.env_key(), "FRIDAY_ANTHROPIC_API_KEY");
+        assert_eq!(KeyProvider::OpenAi.env_key(), "OPENAI_API_KEY");
         // Every variant the match in `as_str` knows about is present in `all()`.
-        for p in [KeyProvider::DeepSeek, KeyProvider::Anthropic] {
+        for p in [
+            KeyProvider::DeepSeek,
+            KeyProvider::Anthropic,
+            KeyProvider::OpenAi,
+        ] {
             assert!(KeyProvider::all().contains(&p));
         }
     }
@@ -254,6 +277,11 @@ mod tests {
             probe.validate(KeyProvider::Anthropic),
             KeyValidationOutcome::CredentialMissing,
             "an unset provider must NOT inherit another provider's Valid"
+        );
+        assert_eq!(
+            probe.validate(KeyProvider::OpenAi),
+            KeyValidationOutcome::CredentialMissing,
+            "an unset OpenAI provider must NOT inherit another provider's Valid"
         );
     }
 }

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -2053,6 +2053,9 @@ async function runLocalStage(ledger) {
       }
       modelProviderId = await createClosureProvider(baseUrl, token, closureProvider);
       const validateResult = await apiFetch(baseUrl, token, "POST", `/v1/providers/${modelProviderId}/validate`);
+      const capabilityDoctor = await apiFetch(baseUrl, token, "POST", "/v1/capabilities/doctor", {
+        validateKeys: true,
+      }, { timeoutMs: 180_000 });
       const budgetSet = await apiFetch(baseUrl, token, "PUT", "/v1/providers/budget", {
         monthlyLimitUsd: 25,
       });
@@ -2064,6 +2067,7 @@ async function runLocalStage(ledger) {
         providerKind: closureProvider.kind,
         providerEnvVar: closureProvider.envVar,
         validateResult,
+        capabilityDoctor,
         budgetSet,
         budgetGet,
         usageGet,
@@ -2072,7 +2076,10 @@ async function runLocalStage(ledger) {
       if (validateResult.status !== 200 || !validateResult.json.ok) {
         throw new Error(`Provider validate failed: ${JSON.stringify(validateResult.json)}`);
       }
-      assertClosureProviderValidationReady(validateResult.json, closureProvider.kind);
+      if (capabilityDoctor.status !== 200 || !capabilityDoctor.json.ok) {
+        throw new Error(`Capability doctor failed: ${JSON.stringify(capabilityDoctor.json)}`);
+      }
+      assertClosureProviderValidationReady(capabilityDoctor.json, closureProvider.kind);
       if (budgetSet.status !== 200 || !budgetSet.json.ok) {
         throw new Error(`Budget set failed: ${JSON.stringify(budgetSet.json)}`);
       }

--- a/scripts/e2e/run-friday-closure.mjs
+++ b/scripts/e2e/run-friday-closure.mjs
@@ -1320,7 +1320,21 @@ export function buildClosureProviderCreateRequest(providerConfig) {
   };
 }
 
-export function assertClosureProviderValidationReady(validateJson) {
+function closureProviderKeyValidationLabel(providerKind) {
+  const normalized = String(providerKind ?? "").trim().toLowerCase();
+  if (normalized === "deepseek" || normalized === "deepseek-pro") {
+    return "deepseek";
+  }
+  if (normalized === "openai" || normalized === "openai-compatible") {
+    return "openai";
+  }
+  if (normalized === "anthropic" || normalized === "claude") {
+    return "anthropic";
+  }
+  return normalized;
+}
+
+export function assertClosureProviderValidationReady(validateJson, selectedProviderKind) {
   const validation = validateJson?.data?.validation;
   if (validation?.status === "ok") {
     return;
@@ -1334,7 +1348,27 @@ export function assertClosureProviderValidationReady(validateJson) {
   ) {
     throw new Error(
       "Provider validate failed: TS_RUNTIME_PROVIDER_PROBE_RETIRED " +
-        "Rust capability doctor returned proof-only CLI status without key validation.",
+      "Rust capability doctor returned proof-only CLI status without key validation.",
+    );
+  }
+
+  if (
+    data?.truthLabel === "rust_capability_doctor"
+    && data?.proofOnly === true
+    && data?.keyValidationProbed === true
+  ) {
+    const confirmed = Array.isArray(data.confirmedValidKeys) ? data.confirmedValidKeys : [];
+    const requiredProvider = closureProviderKeyValidationLabel(selectedProviderKind);
+    if (
+      requiredProvider
+      && confirmed.some((provider) => String(provider).trim().toLowerCase() === requiredProvider)
+    ) {
+      return;
+    }
+    const suffix = requiredProvider ? `${requiredProvider} key valid` : "selected provider key valid";
+    throw new Error(
+      "Provider validate failed: TS_RUNTIME_PROVIDER_PROBE_RETIRED " +
+        `Rust capability doctor did not confirm ${suffix}.`,
     );
   }
 
@@ -2038,7 +2072,7 @@ async function runLocalStage(ledger) {
       if (validateResult.status !== 200 || !validateResult.json.ok) {
         throw new Error(`Provider validate failed: ${JSON.stringify(validateResult.json)}`);
       }
-      assertClosureProviderValidationReady(validateResult.json);
+      assertClosureProviderValidationReady(validateResult.json, closureProvider.kind);
       if (budgetSet.status !== 200 || !budgetSet.json.ok) {
         throw new Error(`Budget set failed: ${JSON.stringify(budgetSet.json)}`);
       }

--- a/src/api/mission-spine/friday-rust-hub-capability-doctor-bridge-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-capability-doctor-bridge-service.ts
@@ -28,7 +28,7 @@ import { FridayDomainError } from "#errors";
  * ## SURFACE-SHAPE NOTE (deliberate, not a fabrication)
  * The legacy TS `providers.validate`/`providers.doctor` are per-`:providerId` probes;
  * `capabilities.doctor` accepts a providerIds filter. `hub_capability_doctor` has NO
- * providerId input — it is a fixed codex/claude (CLI) + deepseek/anthropic (key)
+ * providerId input — it is a fixed codex/claude (CLI) + deepseek/anthropic/openai (key)
  * doctor. When the flag is ON the routes return THIS refs-only composite — they do NOT
  * synthesize the old per-providerId shapes. That contract change is surfaced (PR body +
  * operator question), not blind-filled.
@@ -56,7 +56,7 @@ export interface FridayRustCapabilityCliEntry {
 
 /** One per-credential refs-only key-validation entry — the coarse safe fields ONLY. */
 export interface FridayRustCapabilityKeyEntry {
-  /** Safe credential label (`deepseek` | `anthropic`). */
+  /** Safe credential label (`deepseek` | `anthropic` | `openai`). */
   readonly provider: string;
   /** Coarse outcome label: `valid` | `invalid` | `unavailable` | `credential_missing`. */
   readonly label: string;

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -196,7 +196,38 @@ describe("run-friday-closure helpers", () => {
         ],
         confirmedValidKeys: ["openai"],
       },
-    })).not.toThrow();
+    }, "openai")).not.toThrow();
+  });
+
+  it("rejects Rust capability-doctor key validation when no key is confirmed valid", () => {
+    expect(() => assertClosureProviderValidationReady({
+      ok: true,
+      data: {
+        truthLabel: "rust_capability_doctor",
+        proofOnly: true,
+        keyValidationProbed: true,
+        keyValidation: [
+          { provider: "openai", label: "invalid", status: 401, detail: null },
+        ],
+        confirmedValidKeys: [],
+      },
+    }, "openai")).toThrow(/did not confirm openai key valid/);
+  });
+
+  it("rejects Rust capability-doctor key validation when only a different provider key is confirmed", () => {
+    expect(() => assertClosureProviderValidationReady({
+      ok: true,
+      data: {
+        truthLabel: "rust_capability_doctor",
+        proofOnly: true,
+        keyValidationProbed: true,
+        keyValidation: [
+          { provider: "openai", label: "invalid", status: 401, detail: null },
+          { provider: "deepseek", label: "valid", status: null, detail: null },
+        ],
+        confirmedValidKeys: ["deepseek"],
+      },
+    }, "openai")).toThrow(/did not confirm openai key valid/);
   });
 
   it("runStep persists an in-progress active step before completion", async () => {

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 
@@ -228,6 +229,22 @@ describe("run-friday-closure helpers", () => {
         confirmedValidKeys: ["deepseek"],
       },
     }, "openai")).toThrow(/did not confirm openai key valid/);
+  });
+
+  it("routes closure provider lifecycle validation through key-validating capability doctor", () => {
+    const source = readFileSync(
+      join(fileURLToPath(new URL(".", import.meta.url)), "../../../scripts/e2e/run-friday-closure.mjs"),
+      "utf8",
+    );
+    const lifecycleBlock = source.slice(
+      source.indexOf('id: "local.providers.lifecycle"'),
+      source.indexOf('id: "local.cli.convert-import-pack-run"'),
+    );
+
+    expect(lifecycleBlock).toContain('"/v1/capabilities/doctor"');
+    expect(lifecycleBlock).toContain("validateKeys: true");
+    expect(lifecycleBlock).toContain("assertClosureProviderValidationReady(capabilityDoctor.json");
+    expect(lifecycleBlock).not.toContain("assertClosureProviderValidationReady(validateResult.json");
   });
 
   it("runStep persists an in-progress active step before completion", async () => {

--- a/test/unit/e2e/run-friday-closure.test.ts
+++ b/test/unit/e2e/run-friday-closure.test.ts
@@ -184,6 +184,21 @@ describe("run-friday-closure helpers", () => {
     })).toThrow(/TS_RUNTIME_PROVIDER_PROBE_RETIRED/);
   });
 
+  it("accepts Rust capability-doctor validation when the selected OpenAI key is confirmed valid", () => {
+    expect(() => assertClosureProviderValidationReady({
+      ok: true,
+      data: {
+        truthLabel: "rust_capability_doctor",
+        proofOnly: true,
+        keyValidationProbed: true,
+        keyValidation: [
+          { provider: "openai", label: "valid", status: null, detail: null },
+        ],
+        confirmedValidKeys: ["openai"],
+      },
+    })).not.toThrow();
+  });
+
   it("runStep persists an in-progress active step before completion", async () => {
     const dir = mkdtempSync(join(tmpdir(), "friday-closure-ledger-"));
     const paths = {


### PR DESCRIPTION
## Scope

NEW-76 scoped END-BAR harness slice: add OpenAI to Rust key-validation and wire `local.providers.lifecycle` to the key-validating Rust capability doctor. This PR does **not** claim END-BAR/provider lifecycle done under the current environment.

## Red-first

- Red `02d6632c` only changes `test/unit/e2e/run-friday-closure.test.ts`; `red-openai-key-validation-closure-acceptance.log` exits `1` on `Provider validation status is missing`.
- Green `0617e2cd` adds OpenAI key provider validation plus selected-provider fail-close checks.
- Red `0a1114dc` only changes `test/unit/e2e/run-friday-closure.test.ts`; `red-provider-lifecycle-capability-doctor-wiring.test.log` exits `1` because lifecycle does not call `/v1/capabilities/doctor`.
- Green `8ab7e67e` wires lifecycle to `/v1/capabilities/doctor` with `{ validateKeys: true }` and validates `capabilityDoctor.json`.

## Verification

- `npx vitest run test/unit/e2e/run-friday-closure.test.ts test/unit/api/mission-spine/friday-rust-hub-capability-doctor-bridge-service.test.ts --reporter=default` -> 26 passed.
- `npm run typecheck:src` -> pass.
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-providers key_validation` -> pass.
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-hub provider_key_validation` -> pass.
- `cargo test --manifest-path rust-core/Cargo.toml -p friday-hub --bin hub_capability_doctor` -> pass.
- `cargo fmt --manifest-path rust-core/Cargo.toml --all --check` -> pass.
- `git diff --check` -> pass.

## Independent Review

- Reviewer A: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new76-openai-key-validation-20260706T184446-0700/reviewer-a-new76.md`, session `019f3a4b-6753-7b91-b260-4e987af93410`, final HEAD scoped PASS.
- Reviewer B: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new76-openai-key-validation-20260706T184446-0700/reviewer-b-new76.md`, session `019f3a4b-a44d-7440-be5f-f450a68ffc79`, final HEAD scoped PASS; branch closure/live completion LIMITED.

## NO-GO Boundary

After final wiring, branch closure remains honest NO-GO: `local.providers.lifecycle` still fails because Rust capability doctor did not confirm the selected OpenAI key. Evidence: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new76-openai-key-validation-20260706T184446-0700/branch-closure-green-head-after-wiring-digest.json` and `local-providers-lifecycle-after-wiring.json` show `confirmedValidKeys=[]` and OpenAI `{label:"invalid", status:401}`. Failed/skipped/invalid-command artifacts are retained as non-proof.

## Merge Gate

Per §27 v5: builder requests `military-sign-required`; builder must not merge. Military/advisor SIGN and merge are external.
