### PR TITLE
Allow better-sqlite3 pnpm native builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Check pnpm native build allowlist
+        run: node scripts/quality/check-pnpm-native-build-allowlist.mjs
+
       - name: Install dependencies
         env:
           npm_config_fetch_retries: 5

--- a/package.json
+++ b/package.json
@@ -307,6 +307,11 @@
     "vite": "^7.3.1",
     "vitest": "^4.0.18"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
+  },
   "imports": {
     "#utilities": "./dist/utilities/index.js",
     "#api": "./dist/api/index.js",

--- a/scripts/quality/check-pnpm-native-build-allowlist.mjs
+++ b/scripts/quality/check-pnpm-native-build-allowlist.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(new URL("..", import.meta.url).pathname, "..");
+const packageJsonPath = resolve(repoRoot, "package.json");
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+
+const requiredNativeBuilds = ["better-sqlite3"];
+const configured = packageJson.pnpm?.onlyBuiltDependencies;
+
+if (!Array.isArray(configured)) {
+  console.error("package.json must define pnpm.onlyBuiltDependencies for native postinstall builds.");
+  process.exit(1);
+}
+
+const missing = requiredNativeBuilds.filter((dependencyName) => !configured.includes(dependencyName));
+if (missing.length > 0) {
+  console.error(`pnpm.onlyBuiltDependencies is missing native build dependencies: ${missing.join(", ")}`);
+  process.exit(1);
+}
+
+const extra = configured.filter((dependencyName) => !requiredNativeBuilds.includes(dependencyName));
+if (extra.length > 0) {
+  console.error(`pnpm.onlyBuiltDependencies contains unaudited entries: ${extra.join(", ")}`);
+  process.exit(1);
+}
+
+console.log(`pnpm native build allowlist ok: ${configured.join(", ")}`);


### PR DESCRIPTION
## Summary

§26(1) deploy-chain hardening: make pnpm native build-script approval explicit for `better-sqlite3`.

The 2026-07-06 deploy incident showed that pnpm 10 can block dependency build scripts while commands still look successful; `better_sqlite3.node` was missing. This PR adds a strict guard and the required `pnpm.onlyBuiltDependencies` entry.

## Scope

Touched files:

- `.github/workflows/ci.yml`
- `package.json`
- `scripts/quality/check-pnpm-native-build-allowlist.mjs`

This PR is intentionally limited to §26(1). It does not implement §26(2) deploy script sequencing or §26(3) schema/lockfile PR-body gates.

## Red / Green

Evidence:

- `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/deploy-native-build-allowlist-20260707T214949-0700/`

Commits:

- Red: `6bc80aef test(deploy): require pnpm native build allowlist`
- Green: `e4ad5d94 fix(deploy): allow better-sqlite3 pnpm native build`

Counted local evidence:

- `red-pnpm-native-build-allowlist.exit=1`: base lacks `package.json.pnpm.onlyBuiltDependencies`
- `green-pnpm-native-build-allowlist.exit=0`: `pnpm native build allowlist ok: better-sqlite3`
- `green-package-json-parse.exit=0`
- `green-diff-check.exit=0`
- `revert-red-pnpm-native-build-allowlist.exit=1`: guard fails again after reverting green

## Reviewers

- Reviewer A Godel (`019f3aea-ef7f-78c2-910e-95b775f5b9ce`): PASS
- Reviewer B Euler (`019f3aeb-10fe-72a1-bc47-1f7682761b98`): PASS

Reviewer caveat retained: direct red/revert-red logs demonstrate missing allowlist; source inspection proves missing `better-sqlite3` and extra unaudited entries also fail closed.

## Boundaries

- `military-sign-required`: this PR must wait for military/advisor SIGN.
- Builder must not merge.
- No auto-merge, no `--admin`, no prod/main direct push.
- This is not prod deploy/currentness, not END-BAR, and not proof that the operator machine has built `better-sqlite3`.


## Superseding born-current rebase update — 2026-07-06 22:45 PT

Rebased after `origin/main` advanced to `8db93e2d0ec91514753faeb92732bb3bb2dc253c` via #1541. This supersedes the prior head SHA for merge/sign purposes; earlier evidence remains retained as audit history but military SIGN must bind the current head.

Current head: `f783e5d308015fbbe4abc59c4326f0b12f54ca3a`

Rebased commits:

- Red: `4a65f905 test(deploy): require pnpm native build allowlist`
- Green: `f783e5d3 fix(deploy): allow better-sqlite3 pnpm native build`

Rebase evidence:

- `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/deploy-native-build-allowlist-rebase-20260707T0000-0700/`
- `red-pnpm-native-build-allowlist-rebased.exit=1`
- `green-pnpm-native-build-allowlist-rebased.exit=0`
- `green-package-json-parse-rebased.exit=0`
- `green-diff-check-rebased.exit=0`
- `revert-red-pnpm-native-build-allowlist-rebased.exit=1`
- `sha256sums.verify.exit=0`

Skipped jobs remain non-counted. Expected red/revert-red failures are discrimination evidence only. Builder still must not merge; this remains queued for military/advisor SIGN under §27 v8.



## Superseding born-current rebase update — 2026-07-06 22:53 PT

Rebased again after `origin/main` advanced to `43812330f03193648dcfc9950cae9c8e1357fed1` via #1540. This supersedes prior head `f783e5d308015fbbe4abc59c4326f0b12f54ca3a`; military SIGN must bind the current head.

Current head: `cdc7ee160f6d28f48decaca39e24410c4bf4be73`

Rebased commits:

- Red: `3d4efcdf test(deploy): require pnpm native build allowlist`
- Green: `cdc7ee16 fix(deploy): allow better-sqlite3 pnpm native build`

Current rebase evidence:

- `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/deploy-native-build-allowlist-rebase-current-20260707T2253-0700/`
- `red-pnpm-native-build-allowlist.exit=1`
- `green-pnpm-native-build-allowlist.exit=0`
- `green-package-json-parse.exit=0`
- `green-diff-check.exit=0`
- `revert-green-apply.exit=0`
- `revert-red-pnpm-native-build-allowlist.exit=1`
- `sha256sums.verify.exit=0`

PR-CI is restarted for the new head and is not terminal green yet. Skipped jobs remain non-counted. Expected red/revert-red failures are discrimination evidence only. Builder still must not merge; this remains queued for military/advisor SIGN under §27 v8.
