### PR TITLE
Harden signed prod advance sequencing

### DIFF
--- a/scripts/ops/friday-advance-prod-hub-to-main.sh
+++ b/scripts/ops/friday-advance-prod-hub-to-main.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DRY_RUN=0
+SIGNED_SHA="${FRIDAY_ADVANCE_SIGNED_SHA:-}"
+TS_HUB_HEALTH_URL="${FRIDAY_ADVANCE_TS_HUB_HEALTH_URL:-http://127.0.0.1:3141/v1/health}"
+HEALTH_TIMEOUT_SECONDS="${FRIDAY_ADVANCE_HEALTH_TIMEOUT_SECONDS:-180}"
+RUST_WS_LABEL="${FRIDAY_ADVANCE_RUST_WS_LABEL:-com.friday.rust-agent-run-ws-server}"
+READ_PROJECTION_LABEL="${FRIDAY_ADVANCE_READ_PROJECTION_LABEL:-com.friday.read-projection-server}"
+TS_HUB_LABEL="${FRIDAY_ADVANCE_TS_HUB_LABEL:-com.friday.hub}"
+
+# Deployment order manifest for reviewers/tests. Keep this sequence aligned with
+# the executable block below; recovery text later in this file intentionally
+# repeats some commands but must not define the deployment order.
+# git -C "${REPO_DIR}" fetch origin main
+# git -C "${REPO_DIR}" switch main
+# git -C "${REPO_DIR}" checkout "${SIGNED_SHA}"
+# pnpm install --frozen-lockfile
+# verify_better_sqlite3_native_binding
+# --bin hub_agent_run_server --bin hub_read_projection_server
+# kickstart_launch_agent "${RUST_WS_LABEL}"
+# kickstart_launch_agent "${READ_PROJECTION_LABEL}"
+# kickstart_launch_agent "${TS_HUB_LABEL}"
+# wait_for_http "${TS_HUB_HEALTH_URL}"
+# verify_schema_handshake
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  friday-advance-prod-hub-to-main.sh --signed-sha <military-signed-main-sha> [--repo <path>] [--dry-run]
+
+This operator-run script advances the production checkout only to an explicit
+military SIGN target SHA. It refuses a blind origin/main deployment because the
+operator must compare this SHA to the military SIGN report before prod moves.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --repo)
+      REPO_DIR="${2:-}"
+      if [[ -z "${REPO_DIR}" ]]; then
+        echo "FATAL: --repo requires a path." >&2
+        exit 64
+      fi
+      shift 2
+      ;;
+    --signed-sha)
+      SIGNED_SHA="${2:-}"
+      if [[ -z "${SIGNED_SHA}" ]]; then
+        echo "FATAL: --signed-sha requires a commit SHA." >&2
+        exit 64
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "FATAL: unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [[ -z "${SIGNED_SHA}" ]]; then
+  echo "FATAL: Refusing to deploy without an explicit military SIGN target SHA." >&2
+  echo "Pass --signed-sha <sha> or set FRIDAY_ADVANCE_SIGNED_SHA." >&2
+  exit 64
+fi
+
+if [[ ! "${SIGNED_SHA}" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+  echo "FATAL: signed SHA must be a 7-40 character hexadecimal git revision." >&2
+  exit 64
+fi
+
+if [[ ! -e "${REPO_DIR}/.git" ]]; then
+  echo "FATAL: repo path is not a git checkout: ${REPO_DIR}" >&2
+  exit 66
+fi
+
+print_recovery_steps() {
+  local status="$1"
+  cat >&2 <<RECOVERY
+
+[advance] FAILED with exit ${status}.
+[advance] Recovery checklist:
+[advance]   1. Do not rely on git rollback alone: lockfile/schema changed, so git rollback is not sufficient when native modules or Rust schema are out of sync.
+[advance]   2. Re-run: pnpm install --frozen-lockfile, then verify node_modules contains better_sqlite3.node.
+[advance]   3. Re-run: cargo build --release --manifest-path rust-core/Cargo.toml --bin hub_agent_run_server --bin hub_read_projection_server.
+[advance]   4. Kickstart in dependency order: ${RUST_WS_LABEL} -> ${READ_PROJECTION_LABEL} -> ${TS_HUB_LABEL}.
+[advance]   5. Check launchctl print and ~/.friday/launchd logs before retrying the signed advance.
+RECOVERY
+}
+
+on_error() {
+  local status="$?"
+  print_recovery_steps "${status}"
+  exit "${status}"
+}
+trap on_error ERR
+
+log() {
+  echo "[advance] $*"
+}
+
+run_cmd() {
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "[advance] DRY-RUN: $*"
+  else
+    "$@"
+  fi
+}
+
+run_in_repo() {
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "[advance] DRY-RUN: $*"
+  else
+    (cd "${REPO_DIR}" && "$@")
+  fi
+}
+
+verify_better_sqlite3_native_binding() {
+  log "verify better_sqlite3.node"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "[advance] DRY-RUN: find node_modules -path '*better-sqlite3*better_sqlite3.node'"
+    return 0
+  fi
+
+  local binding
+  binding="$(
+    find "${REPO_DIR}/node_modules" \
+      -path '*better-sqlite3*better_sqlite3.node' \
+      -type f \
+      -print \
+      -quit 2>/dev/null || true
+  )"
+  if [[ -z "${binding}" ]]; then
+    echo "FATAL: better_sqlite3.node was not found after pnpm install --frozen-lockfile." >&2
+    echo "FATAL: pnpm may have ignored native build scripts; approve/build better-sqlite3 before deployment." >&2
+    exit 70
+  fi
+  log "found native binding: ${binding}"
+}
+
+kickstart_launch_agent() {
+  local label="$1"
+  log "kickstart ${label}"
+  run_cmd launchctl kickstart -k "gui/${UID}/${label}"
+}
+
+wait_for_http() {
+  local url="$1"
+  local deadline=$((SECONDS + HEALTH_TIMEOUT_SECONDS))
+  log "GET ${url}"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "[advance] DRY-RUN: curl --fail --silent --show-error --max-time 5 ${url}"
+    return 0
+  fi
+  if [[ "${FRIDAY_ADVANCE_SKIP_NETWORK_HEALTH:-}" == "1" ]]; then
+    log "network health skipped by FRIDAY_ADVANCE_SKIP_NETWORK_HEALTH=1"
+    return 0
+  fi
+
+  until curl --fail --silent --show-error --max-time 5 "${url}" >/dev/null; do
+    if (( SECONDS >= deadline )); then
+      echo "FATAL: timed out waiting for ${url} after ${HEALTH_TIMEOUT_SECONDS}s." >&2
+      exit 71
+    fi
+    sleep 2
+  done
+}
+
+verify_schema_handshake() {
+  log "schema handshake"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "[advance] DRY-RUN: verify CURRENT_SCHEMA_VERSION and Rust protocol handshake"
+    return 0
+  fi
+
+  local protocol_file="${REPO_DIR}/rust-core/crates/friday-protocol/src/lib.rs"
+  local ffi_file="${REPO_DIR}/rust-core/crates/friday-ffi/src/lib.rs"
+  local schema_version
+
+  schema_version="$(
+    sed -nE 's/^pub const CURRENT_SCHEMA_VERSION: u16 = ([0-9]+);$/\1/p' "${protocol_file}" | head -n 1
+  )"
+  if [[ -z "${schema_version}" ]]; then
+    echo "FATAL: could not read CURRENT_SCHEMA_VERSION from ${protocol_file}." >&2
+    exit 72
+  fi
+  if ! grep -q "CURRENT_SCHEMA_VERSION" "${ffi_file}"; then
+    echo "FATAL: Rust FFI does not reference CURRENT_SCHEMA_VERSION; schema handshake may be stale." >&2
+    exit 72
+  fi
+  log "CURRENT_SCHEMA_VERSION=${schema_version}; Rust bins were rebuilt before hub restart."
+}
+
+announce_signed_target() {
+  log "signed target SHA: ${SIGNED_SHA}"
+  log "operator must compare this SHA to the military SIGN report before continuing."
+}
+
+verify_signed_main_target() {
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    return 0
+  fi
+
+  git -C "${REPO_DIR}" rev-parse --verify "${SIGNED_SHA}^{commit}" >/dev/null
+  local origin_main
+  origin_main="$(git -C "${REPO_DIR}" rev-parse origin/main)"
+  local signed_full
+  signed_full="$(git -C "${REPO_DIR}" rev-parse "${SIGNED_SHA}^{commit}")"
+  if [[ "${origin_main}" != "${signed_full}" ]]; then
+    echo "FATAL: signed SHA ${signed_full} does not equal current origin/main ${origin_main}." >&2
+    echo "FATAL: refusing to deploy an unsigned newer HEAD or a stale signed target." >&2
+    exit 73
+  fi
+}
+
+log "starting signed production advance"
+if [[ "${DRY_RUN}" == "1" ]]; then
+  log "DRY-RUN mode: no checkout, install, cargo build, launchctl, or health mutation will run."
+fi
+
+announce_signed_target
+
+log "git fetch origin main"
+if [[ "${DRY_RUN}" == "1" ]]; then
+  echo "[advance] DRY-RUN: git fetch origin main"
+else
+  git -C "${REPO_DIR}" fetch origin main
+fi
+
+verify_signed_main_target
+
+log "git switch main"
+if [[ "${DRY_RUN}" == "1" ]]; then
+  echo "[advance] DRY-RUN: git switch main"
+else
+  git -C "${REPO_DIR}" switch main
+fi
+
+log "git pull --ff-only origin main"
+if [[ "${DRY_RUN}" == "1" ]]; then
+  echo "[advance] DRY-RUN: git pull --ff-only origin main"
+else
+  git -C "${REPO_DIR}" pull --ff-only origin main
+fi
+
+log "git checkout ${SIGNED_SHA}"
+if [[ "${DRY_RUN}" == "1" ]]; then
+  echo "[advance] DRY-RUN: git checkout ${SIGNED_SHA}"
+else
+  git -C "${REPO_DIR}" checkout "${SIGNED_SHA}"
+fi
+
+run_in_repo pnpm install --frozen-lockfile
+verify_better_sqlite3_native_binding
+
+run_in_repo cargo build --release --manifest-path rust-core/Cargo.toml --bin hub_agent_run_server --bin hub_read_projection_server
+
+kickstart_launch_agent "${RUST_WS_LABEL}"
+kickstart_launch_agent "${READ_PROJECTION_LABEL}"
+kickstart_launch_agent "${TS_HUB_LABEL}"
+
+wait_for_http "${TS_HUB_HEALTH_URL}"
+verify_schema_handshake
+
+log "signed production advance completed for ${SIGNED_SHA}"

--- a/scripts/ops/friday-advance-prod-hub-to-main.sh
+++ b/scripts/ops/friday-advance-prod-hub-to-main.sh
@@ -10,21 +10,8 @@ HEALTH_TIMEOUT_SECONDS="${FRIDAY_ADVANCE_HEALTH_TIMEOUT_SECONDS:-180}"
 RUST_WS_LABEL="${FRIDAY_ADVANCE_RUST_WS_LABEL:-com.friday.rust-agent-run-ws-server}"
 READ_PROJECTION_LABEL="${FRIDAY_ADVANCE_READ_PROJECTION_LABEL:-com.friday.read-projection-server}"
 TS_HUB_LABEL="${FRIDAY_ADVANCE_TS_HUB_LABEL:-com.friday.hub}"
-
-# Deployment order manifest for reviewers/tests. Keep this sequence aligned with
-# the executable block below; recovery text later in this file intentionally
-# repeats some commands but must not define the deployment order.
-# git -C "${REPO_DIR}" fetch origin main
-# git -C "${REPO_DIR}" switch main
-# git -C "${REPO_DIR}" checkout "${SIGNED_SHA}"
-# pnpm install --frozen-lockfile
-# verify_better_sqlite3_native_binding
-# --bin hub_agent_run_server --bin hub_read_projection_server
-# kickstart_launch_agent "${RUST_WS_LABEL}"
-# kickstart_launch_agent "${READ_PROJECTION_LABEL}"
-# kickstart_launch_agent "${TS_HUB_LABEL}"
-# wait_for_http "${TS_HUB_HEALTH_URL}"
-# verify_schema_handshake
+RUST_WS_PORT="${FRIDAY_ADVANCE_RUST_WS_PORT:-48750}"
+READ_PROJECTION_PORT="${FRIDAY_ADVANCE_READ_PROJECTION_PORT:-48751}"
 
 usage() {
   cat <<'USAGE'
@@ -71,22 +58,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "${SIGNED_SHA}" ]]; then
-  echo "FATAL: Refusing to deploy without an explicit military SIGN target SHA." >&2
-  echo "Pass --signed-sha <sha> or set FRIDAY_ADVANCE_SIGNED_SHA." >&2
-  exit 64
-fi
-
-if [[ ! "${SIGNED_SHA}" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
-  echo "FATAL: signed SHA must be a 7-40 character hexadecimal git revision." >&2
-  exit 64
-fi
-
-if [[ ! -e "${REPO_DIR}/.git" ]]; then
-  echo "FATAL: repo path is not a git checkout: ${REPO_DIR}" >&2
-  exit 66
-fi
-
 print_recovery_steps() {
   local status="$1"
   cat >&2 <<RECOVERY
@@ -101,12 +72,32 @@ print_recovery_steps() {
 RECOVERY
 }
 
+fatal() {
+  local status="$1"
+  shift
+  echo "FATAL: $*" >&2
+  print_recovery_steps "${status}"
+  exit "${status}"
+}
+
 on_error() {
   local status="$?"
   print_recovery_steps "${status}"
   exit "${status}"
 }
 trap on_error ERR
+
+if [[ -z "${SIGNED_SHA}" ]]; then
+  fatal 64 "Refusing to deploy without an explicit military SIGN target SHA. Pass --signed-sha <sha> or set FRIDAY_ADVANCE_SIGNED_SHA."
+fi
+
+if [[ ! "${SIGNED_SHA}" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+  fatal 64 "signed SHA must be a 7-40 character hexadecimal git revision."
+fi
+
+if [[ ! -e "${REPO_DIR}/.git" ]]; then
+  fatal 66 "repo path is not a git checkout: ${REPO_DIR}"
+fi
 
 log() {
   echo "[advance] $*"
@@ -144,10 +135,9 @@ verify_better_sqlite3_native_binding() {
       -quit 2>/dev/null || true
   )"
   if [[ -z "${binding}" ]]; then
-    echo "FATAL: better_sqlite3.node was not found after pnpm install --frozen-lockfile." >&2
-    echo "FATAL: pnpm may have ignored native build scripts; approve/build better-sqlite3 before deployment." >&2
-    exit 70
+    fatal 70 "better_sqlite3.node was not found after pnpm install --frozen-lockfile; pnpm may have ignored native build scripts."
   fi
+  run_in_repo node -e 'require("better-sqlite3");'
   log "found native binding: ${binding}"
 }
 
@@ -155,6 +145,39 @@ kickstart_launch_agent() {
   local label="$1"
   log "kickstart ${label}"
   run_cmd launchctl kickstart -k "gui/${UID}/${label}"
+}
+
+wait_for_launch_agent_running() {
+  local label="$1"
+  local deadline=$((SECONDS + HEALTH_TIMEOUT_SECONDS))
+  log "launchctl print gui/${UID}/${label}"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "[advance] DRY-RUN: launchctl print gui/${UID}/${label} | grep pid"
+    return 0
+  fi
+  until launchctl print "gui/${UID}/${label}" 2>/dev/null | grep -Eq 'pid = [0-9]+'; do
+    if (( SECONDS >= deadline )); then
+      fatal 71 "timed out waiting for launch agent ${label} to report a running pid."
+    fi
+    sleep 2
+  done
+}
+
+wait_for_tcp() {
+  local port="$1"
+  local name="$2"
+  local deadline=$((SECONDS + HEALTH_TIMEOUT_SECONDS))
+  log "tcp ${name} 127.0.0.1:${port}"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "[advance] DRY-RUN: lsof -nP -iTCP:${port} -sTCP:LISTEN"
+    return 0
+  fi
+  until lsof -nP "-iTCP:${port}" -sTCP:LISTEN >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      fatal 71 "timed out waiting for ${name} to listen on 127.0.0.1:${port}."
+    fi
+    sleep 2
+  done
 }
 
 wait_for_http() {
@@ -165,15 +188,10 @@ wait_for_http() {
     echo "[advance] DRY-RUN: curl --fail --silent --show-error --max-time 5 ${url}"
     return 0
   fi
-  if [[ "${FRIDAY_ADVANCE_SKIP_NETWORK_HEALTH:-}" == "1" ]]; then
-    log "network health skipped by FRIDAY_ADVANCE_SKIP_NETWORK_HEALTH=1"
-    return 0
-  fi
 
   until curl --fail --silent --show-error --max-time 5 "${url}" >/dev/null; do
     if (( SECONDS >= deadline )); then
-      echo "FATAL: timed out waiting for ${url} after ${HEALTH_TIMEOUT_SECONDS}s." >&2
-      exit 71
+      fatal 71 "timed out waiting for ${url} after ${HEALTH_TIMEOUT_SECONDS}s."
     fi
     sleep 2
   done
@@ -182,25 +200,20 @@ wait_for_http() {
 verify_schema_handshake() {
   log "schema handshake"
   if [[ "${DRY_RUN}" == "1" ]]; then
-    echo "[advance] DRY-RUN: verify CURRENT_SCHEMA_VERSION and Rust protocol handshake"
+    echo "[advance] DRY-RUN: node scripts/ops/check-read-projection-runtime-freshness.mjs --repo-dir ${REPO_DIR} --require-current-schema --require-running-current"
     return 0
   fi
 
   local protocol_file="${REPO_DIR}/rust-core/crates/friday-protocol/src/lib.rs"
-  local ffi_file="${REPO_DIR}/rust-core/crates/friday-ffi/src/lib.rs"
   local schema_version
 
   schema_version="$(
     sed -nE 's/^pub const CURRENT_SCHEMA_VERSION: u16 = ([0-9]+);$/\1/p' "${protocol_file}" | head -n 1
   )"
   if [[ -z "${schema_version}" ]]; then
-    echo "FATAL: could not read CURRENT_SCHEMA_VERSION from ${protocol_file}." >&2
-    exit 72
+    fatal 72 "could not read CURRENT_SCHEMA_VERSION from ${protocol_file}."
   fi
-  if ! grep -q "CURRENT_SCHEMA_VERSION" "${ffi_file}"; then
-    echo "FATAL: Rust FFI does not reference CURRENT_SCHEMA_VERSION; schema handshake may be stale." >&2
-    exit 72
-  fi
+  run_in_repo node scripts/ops/check-read-projection-runtime-freshness.mjs --repo-dir "${REPO_DIR}" --require-current-schema --require-running-current
   log "CURRENT_SCHEMA_VERSION=${schema_version}; Rust bins were rebuilt before hub restart."
 }
 
@@ -210,19 +223,30 @@ announce_signed_target() {
 }
 
 verify_signed_main_target() {
-  if [[ "${DRY_RUN}" == "1" ]]; then
-    return 0
+  if ! git -C "${REPO_DIR}" rev-parse --verify "${SIGNED_SHA}^{commit}" >/dev/null 2>&1; then
+    fatal 73 "signed SHA ${SIGNED_SHA} is not present in the production checkout."
   fi
-
-  git -C "${REPO_DIR}" rev-parse --verify "${SIGNED_SHA}^{commit}" >/dev/null
   local origin_main
   origin_main="$(git -C "${REPO_DIR}" rev-parse origin/main)"
   local signed_full
   signed_full="$(git -C "${REPO_DIR}" rev-parse "${SIGNED_SHA}^{commit}")"
   if [[ "${origin_main}" != "${signed_full}" ]]; then
-    echo "FATAL: signed SHA ${signed_full} does not equal current origin/main ${origin_main}." >&2
-    echo "FATAL: refusing to deploy an unsigned newer HEAD or a stale signed target." >&2
-    exit 73
+    fatal 73 "signed SHA ${signed_full} does not equal current origin/main ${origin_main}; refusing to deploy an unsigned newer HEAD or a stale signed target."
+  fi
+}
+
+verify_checked_out_signed_target() {
+  log "verify checked out signed target"
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "[advance] DRY-RUN: git rev-parse HEAD == ${SIGNED_SHA}"
+    return 0
+  fi
+  local checked_out
+  checked_out="$(git -C "${REPO_DIR}" rev-parse HEAD)"
+  local signed_full
+  signed_full="$(git -C "${REPO_DIR}" rev-parse "${SIGNED_SHA}^{commit}")"
+  if [[ "${checked_out}" != "${signed_full}" ]]; then
+    fatal 73 "checked out HEAD ${checked_out} does not equal military signed SHA ${signed_full}."
   fi
 }
 
@@ -249,19 +273,13 @@ else
   git -C "${REPO_DIR}" switch main
 fi
 
-log "git pull --ff-only origin main"
-if [[ "${DRY_RUN}" == "1" ]]; then
-  echo "[advance] DRY-RUN: git pull --ff-only origin main"
-else
-  git -C "${REPO_DIR}" pull --ff-only origin main
-fi
-
 log "git checkout ${SIGNED_SHA}"
 if [[ "${DRY_RUN}" == "1" ]]; then
   echo "[advance] DRY-RUN: git checkout ${SIGNED_SHA}"
 else
   git -C "${REPO_DIR}" checkout "${SIGNED_SHA}"
 fi
+verify_checked_out_signed_target
 
 run_in_repo pnpm install --frozen-lockfile
 verify_better_sqlite3_native_binding
@@ -269,8 +287,13 @@ verify_better_sqlite3_native_binding
 run_in_repo cargo build --release --manifest-path rust-core/Cargo.toml --bin hub_agent_run_server --bin hub_read_projection_server
 
 kickstart_launch_agent "${RUST_WS_LABEL}"
+wait_for_launch_agent_running "${RUST_WS_LABEL}"
+wait_for_tcp "${RUST_WS_PORT}" "${RUST_WS_LABEL}"
 kickstart_launch_agent "${READ_PROJECTION_LABEL}"
+wait_for_launch_agent_running "${READ_PROJECTION_LABEL}"
+wait_for_tcp "${READ_PROJECTION_PORT}" "${READ_PROJECTION_LABEL}"
 kickstart_launch_agent "${TS_HUB_LABEL}"
+wait_for_launch_agent_running "${TS_HUB_LABEL}"
 
 wait_for_http "${TS_HUB_HEALTH_URL}"
 verify_schema_handshake

--- a/test/unit/scripts/ops/friday-advance-prod-hub-to-main.test.ts
+++ b/test/unit/scripts/ops/friday-advance-prod-hub-to-main.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const advanceScript = resolve(
+  repoRoot,
+  "scripts/ops/friday-advance-prod-hub-to-main.sh",
+);
+
+function orderedIndexes(haystack: string, needles: string[]): number[] {
+  return needles.map((needle) => {
+    const index = haystack.indexOf(needle);
+    expect(index, `missing ordered token: ${needle}`).toBeGreaterThanOrEqual(0);
+    return index;
+  });
+}
+
+describe("Friday production advance script", () => {
+  it("is shell-parseable", () => {
+    const result = spawnSync("bash", ["-n", advanceScript], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+  });
+
+  it("requires an explicit signed target SHA instead of blindly advancing origin/main", () => {
+    const source = readFileSync(advanceScript, "utf8");
+
+    expect(source).toContain("--signed-sha");
+    expect(source).toContain("FRIDAY_ADVANCE_SIGNED_SHA");
+    expect(source).toContain("Refusing to deploy without an explicit military SIGN target SHA");
+    expect(source).toContain("operator must compare this SHA to the military SIGN report");
+    expect(source).not.toContain('TARGET_REF="${TARGET_REF:-origin/main}"');
+    expect(source).not.toContain("git reset --hard origin/main");
+  });
+
+  it("hardens the deploy order from checkout through native, Rust, services, and health gates", () => {
+    const source = readFileSync(advanceScript, "utf8");
+
+    expect(source).toContain("pnpm install --frozen-lockfile");
+    expect(source).toContain("better_sqlite3.node");
+    expect(source).toContain("hub_agent_run_server");
+    expect(source).toContain("hub_read_projection_server");
+    expect(source).toContain("com.friday.rust-agent-run-ws-server");
+    expect(source).toContain("com.friday.read-projection-server");
+    expect(source).toContain("com.friday.hub");
+    expect(source).toContain("/v1/health");
+    expect(source).toContain("verify_schema_handshake");
+    expect(source).toContain("CURRENT_SCHEMA_VERSION");
+    expect(source).toContain("lockfile/schema changed");
+    expect(source).toContain("git rollback is not sufficient");
+
+    const indexes = orderedIndexes(source, [
+      "git -C \"${REPO_DIR}\" fetch origin main",
+      "git -C \"${REPO_DIR}\" switch main",
+      "git -C \"${REPO_DIR}\" checkout \"${SIGNED_SHA}\"",
+      "pnpm install --frozen-lockfile",
+      "verify_better_sqlite3_native_binding",
+      "--bin hub_agent_run_server --bin hub_read_projection_server",
+      "kickstart_launch_agent \"${RUST_WS_LABEL}\"",
+      "kickstart_launch_agent \"${READ_PROJECTION_LABEL}\"",
+      "kickstart_launch_agent \"${TS_HUB_LABEL}\"",
+      "wait_for_http \"${TS_HUB_HEALTH_URL}\"",
+      "verify_schema_handshake",
+    ]);
+
+    expect(indexes).toEqual([...indexes].sort((a, b) => a - b));
+  });
+
+  it("dry-runs the same signed deployment sequence without touching launchd or production state", () => {
+    const result = spawnSync(
+      "bash",
+      [
+        advanceScript,
+        "--dry-run",
+        "--repo",
+        repoRoot,
+        "--signed-sha",
+        "c47ab5e4a1662c3b02b68987953d34342aef938a",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FRIDAY_ADVANCE_SKIP_NETWORK_HEALTH: "1",
+        },
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("DRY-RUN");
+    expect(result.stdout).toContain("signed target SHA: c47ab5e4a1662c3b02b68987953d34342aef938a");
+
+    const indexes = orderedIndexes(result.stdout, [
+      "git fetch origin main",
+      "git switch main",
+      "git checkout c47ab5e4a1662c3b02b68987953d34342aef938a",
+      "pnpm install --frozen-lockfile",
+      "verify better_sqlite3.node",
+      "cargo build --release",
+      "kickstart com.friday.rust-agent-run-ws-server",
+      "kickstart com.friday.read-projection-server",
+      "kickstart com.friday.hub",
+      "GET http://127.0.0.1:3141/v1/health",
+      "schema handshake",
+    ]);
+
+    expect(indexes).toEqual([...indexes].sort((a, b) => a - b));
+  });
+});

--- a/test/unit/scripts/ops/friday-advance-prod-hub-to-main.test.ts
+++ b/test/unit/scripts/ops/friday-advance-prod-hub-to-main.test.ts
@@ -36,6 +36,8 @@ describe("Friday production advance script", () => {
     expect(source).toContain("operator must compare this SHA to the military SIGN report");
     expect(source).not.toContain('TARGET_REF="${TARGET_REF:-origin/main}"');
     expect(source).not.toContain("git reset --hard origin/main");
+    expect(source).not.toContain("git pull --ff-only origin main");
+    expect(source).toContain("verify_checked_out_signed_target");
   });
 
   it("hardens the deploy order from checkout through native, Rust, services, and health gates", () => {
@@ -51,13 +53,24 @@ describe("Friday production advance script", () => {
     expect(source).toContain("/v1/health");
     expect(source).toContain("verify_schema_handshake");
     expect(source).toContain("CURRENT_SCHEMA_VERSION");
+    expect(source).toContain("check-read-projection-runtime-freshness.mjs");
+    expect(source).toContain("--require-current-schema");
+    expect(source).toContain("--require-running-current");
     expect(source).toContain("lockfile/schema changed");
     expect(source).toContain("git rollback is not sufficient");
+    expect(source).not.toContain("Deployment order manifest");
+    expect(source).not.toContain("grep -q \"CURRENT_SCHEMA_VERSION\"");
 
-    const indexes = orderedIndexes(source, [
+    const executableSource = source
+      .split("\n")
+      .filter((line) => !line.trimStart().startsWith("#"))
+      .join("\n");
+
+    const indexes = orderedIndexes(executableSource, [
       "git -C \"${REPO_DIR}\" fetch origin main",
       "git -C \"${REPO_DIR}\" switch main",
       "git -C \"${REPO_DIR}\" checkout \"${SIGNED_SHA}\"",
+      "verify_checked_out_signed_target",
       "pnpm install --frozen-lockfile",
       "verify_better_sqlite3_native_binding",
       "--bin hub_agent_run_server --bin hub_read_projection_server",
@@ -69,6 +82,27 @@ describe("Friday production advance script", () => {
     ]);
 
     expect(indexes).toEqual([...indexes].sort((a, b) => a - b));
+  });
+
+  it("prints recovery steps on fail-closed deployment exits", () => {
+    const result = spawnSync(
+      "bash",
+      [
+        advanceScript,
+        "--repo",
+        repoRoot,
+        "--signed-sha",
+        "0000000",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(73);
+    expect(result.stderr).toContain("Recovery checklist");
+    expect(result.stderr).toContain("git rollback is not sufficient");
   });
 
   it("dry-runs the same signed deployment sequence without touching launchd or production state", () => {
@@ -100,6 +134,8 @@ describe("Friday production advance script", () => {
       "git fetch origin main",
       "git switch main",
       "git checkout c47ab5e4a1662c3b02b68987953d34342aef938a",
+      "verify checked out signed target",
+      "git checkout c47ab5e4a1662c3b02b68987953d34342aef938a",
       "pnpm install --frozen-lockfile",
       "verify better_sqlite3.node",
       "cargo build --release",
@@ -111,5 +147,6 @@ describe("Friday production advance script", () => {
     ]);
 
     expect(indexes).toEqual([...indexes].sort((a, b) => a - b));
+    expect(result.stdout).not.toContain("git pull --ff-only origin main");
   });
 });

--- a/test/unit/scripts/ops/friday-advance-prod-hub-to-main.test.ts
+++ b/test/unit/scripts/ops/friday-advance-prod-hub-to-main.test.ts
@@ -9,6 +9,15 @@ const advanceScript = resolve(
   "scripts/ops/friday-advance-prod-hub-to-main.sh",
 );
 
+function currentOriginMain(): string {
+  const result = spawnSync("git", ["rev-parse", "origin/main"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout.trim();
+}
+
 function orderedIndexes(haystack: string, needles: string[]): number[] {
   return needles.map((needle) => {
     const index = haystack.indexOf(needle);
@@ -106,6 +115,7 @@ describe("Friday production advance script", () => {
   });
 
   it("dry-runs the same signed deployment sequence without touching launchd or production state", () => {
+    const signedSha = currentOriginMain();
     const result = spawnSync(
       "bash",
       [
@@ -114,7 +124,7 @@ describe("Friday production advance script", () => {
         "--repo",
         repoRoot,
         "--signed-sha",
-        "c47ab5e4a1662c3b02b68987953d34342aef938a",
+        signedSha,
       ],
       {
         cwd: repoRoot,
@@ -128,14 +138,13 @@ describe("Friday production advance script", () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain("DRY-RUN");
-    expect(result.stdout).toContain("signed target SHA: c47ab5e4a1662c3b02b68987953d34342aef938a");
+    expect(result.stdout).toContain(`signed target SHA: ${signedSha}`);
 
     const indexes = orderedIndexes(result.stdout, [
       "git fetch origin main",
       "git switch main",
-      "git checkout c47ab5e4a1662c3b02b68987953d34342aef938a",
       "verify checked out signed target",
-      "git checkout c47ab5e4a1662c3b02b68987953d34342aef938a",
+      `git checkout ${signedSha}`,
       "pnpm install --frozen-lockfile",
       "verify better_sqlite3.node",
       "cargo build --release",

--- a/test/unit/scripts/ops/friday-advance-prod-hub-to-main.test.ts
+++ b/test/unit/scripts/ops/friday-advance-prod-hub-to-main.test.ts
@@ -70,7 +70,8 @@ describe("Friday production advance script", () => {
     expect(source).not.toContain("Deployment order manifest");
     expect(source).not.toContain("grep -q \"CURRENT_SCHEMA_VERSION\"");
 
-    const executableSource = source
+    const mainExecutionSource = source.slice(source.indexOf('log "starting signed production advance"'));
+    const executableSource = mainExecutionSource
       .split("\n")
       .filter((line) => !line.trimStart().startsWith("#"))
       .join("\n");
@@ -143,8 +144,8 @@ describe("Friday production advance script", () => {
     const indexes = orderedIndexes(result.stdout, [
       "git fetch origin main",
       "git switch main",
-      "verify checked out signed target",
       `git checkout ${signedSha}`,
+      "verify checked out signed target",
       "pnpm install --frozen-lockfile",
       "verify better_sqlite3.node",
       "cargo build --release",


### PR DESCRIPTION
## Scope

§26(2) deploy-chain hardening: add `scripts/ops/friday-advance-prod-hub-to-main.sh` and its unit contract for the operator-run production advance sequence.

This PR is queued under §27 v8. Builder must not merge. It requires full PR-CI green, born-current, `military-sign-required`, queue entry, and military/advisor SIGN before any external merge.

Touched files:

- `scripts/ops/friday-advance-prod-hub-to-main.sh`
- `test/unit/scripts/ops/friday-advance-prod-hub-to-main.test.ts`

## What changed

- Requires explicit `--signed-sha` / `FRIDAY_ADVANCE_SIGNED_SHA`; refuses blind `origin/main` deployment.
- Fetches `origin/main`, verifies signed SHA equals current `origin/main`, checks out the signed SHA, then verifies checked-out `HEAD` equals that signed SHA.
- Runs `pnpm install --frozen-lockfile`, verifies `better_sqlite3.node`, and loads `better-sqlite3`.
- Builds Rust release bins: `hub_agent_run_server` and `hub_read_projection_server`.
- Kickstarts in dependency order: Rust WS -> read-projection -> TS hub.
- Waits for launchd pid for all three services, TCP listeners for Rust WS/read-projection, TS hub `/v1/health`, and read-projection runtime/schema freshness via `check-read-projection-runtime-freshness.mjs --require-current-schema --require-running-current`.
- Prints real recovery steps on fail-closed fatal paths, including the warning that git rollback is not sufficient when lockfile/schema changed.

## Red-first evidence

Evidence directory:

`/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/deploy-advance-sequence-final-20260706T2227-0700/`

Commits:

- Initial red: `27ab5900 test(ops): require signed prod advance sequence`
- Initial green: `ec6b4af9 fix(ops): require signed prod advance sequence`
- Reviewer-gap red: `ddd65af2`, `7e9c6522`, `38d88907` test-only commits
- Final green: `8f192f5d0ed175c1019197516d2130d7acd25e33 fix(ops): close prod advance proof gaps`

Counted exits:

- `red1-test.exit=1`
- `red2-test.exit=1`
- `green-final-test.exit=0`
- `revert-final-red-test.exit=1`
- `dry-run.exit=0`
- `bash-n.exit=0`
- `sha256sums.verify.exit=0`

Failed red/revert-red logs are expected discrimination evidence only. Skipped jobs are not counted as functional proof.

## Reviewer evidence

- Reviewer A Sartre `019f3b03-8522-7a82-8c6a-584ba08b993d`: final PASS in `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/deploy-advance-sequence-final-20260706T2227-0700/reviewer-a-sartre-final.md`, bound to `8f192f5d0ed175c1019197516d2130d7acd25e33`.
- Reviewer B Avicenna `019f3b03-a118-7e03-8885-2bc215d03393`: final PASS in `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/deploy-advance-sequence-final-20260706T2227-0700/reviewer-b-avicenna-final.md`, bound to `8f192f5d0ed175c1019197516d2130d7acd25e33`.

## Refutes attached verbatim and disposition

### Reviewer A prior NEEDS-CHANGES

> verdict=NEEDS-CHANGES bound to `ec6b4af9`
>
> 1. `test/unit/scripts/ops/friday-advance-prod-hub-to-main.test.ts` is comment-spoofable. The order test uses `source.indexOf(...)`, while `scripts/ops/friday-advance-prod-hub-to-main.sh` contains a full “Deployment order manifest” comment before executable code. Failure scenario: the real executable order can regress or omit a step while the comment stays intact, and the test still passes.
>
> 2. `scripts/ops/friday-advance-prod-hub-to-main.sh` skips the signed-SHA/origin-main gate entirely in `--dry-run`, and the dry-run test still uses stale SHA `c47ab5e...` even though current `origin/main` is `8db93e2d`. Failure scenario: dry-run reports a successful signed sequence for a stale/unsigned SHA, so skipped validation can masquerade as proof.
>
> 3. `scripts/ops/friday-advance-prod-hub-to-main.sh` allows `FRIDAY_ADVANCE_SKIP_NETWORK_HEALTH=1` in real non-dry-run execution, then continues to final success. Failure scenario: TS hub never becomes healthy, but script exits 0 and says “signed production advance completed.”
>
> 4. `scripts/ops/friday-advance-prod-hub-to-main.sh` kickstarts the Rust WS, read-projection, and TS hub services, but only checks the TS hub HTTP health. Failure scenario: Rust WS or read-projection fails to start while TS hub `/v1/health` still passes; script claims completion without proving the three-service sequence is actually healthy.
>
> 5. `scripts/ops/friday-advance-prod-hub-to-main.sh` runs `git pull --ff-only origin main` after validating the signed SHA. Failure scenario: `origin/main` advances between the earlier fetch/validation and this pull; local `main` can be advanced to an unsigned newer commit.

Disposition: closed by `ddd65af2` / `7e9c6522` / `38d88907` red tests and final green `8f192f5d`; reviewer A final PASS bound to final head.

### Reviewer B prior NEEDS-CHANGES

> verdict=NEEDS-CHANGES，绑定 HEAD `ec6b4af9a0781cdaa67d831421029606e5feff1d`。
>
> 1. BLOCKING: stale/unsigned `origin/main` 仍有 race，不是完全 fail-close。先 `fetch`，随后验证 `SIGNED_SHA == origin/main`，但又执行 `git pull --ff-only origin main`，`pull` 会再次 fetch。若远端在验证后、pull 前前进，脚本不会重新比较签名 SHA。
>
> 2. BLOCKING: “schema handshake” 不是真实 handshake，只是静态 grep。`verify_schema_handshake` 只读取 `CURRENT_SCHEMA_VERSION` 并检查 FFI 文件是否包含字符串；这不能证明已启动 Rust bins 与 hub 的运行时 schema/protocol 真实兼容。
>
> 3. BLOCKING: recovery 不覆盖脚本自己的 fatal exits。只设置了 `trap on_error ERR`，但多处显式 `exit` 不会触发 `ERR` trap 打印 recovery checklist。
>
> 4. BLOCKING: 测试确实可被注释/字符串骗过。测试用 `source.indexOf(...)` 校验顺序；而脚本有 “Deployment order manifest” 注释，包含这些 ordered tokens，且出现在真实执行块之前。

Disposition: closed by test-only reds and final green `8f192f5d`; reviewer B final PASS bound to final head and confirms all four original blocking findings are cleared.

## Boundaries

This PR does not deploy prod, does not restart prod by itself, does not merge, does not claim END-BAR, release/latest-install, organic adoption, operator terminal attestation, or channel/device proof. It only prepares the §26(2) operator-run advance script and tests.


## Superseding born-current rebase update — 2026-07-06 22:58 PT

Rebased after `origin/main` advanced to `43812330f03193648dcfc9950cae9c8e1357fed1` via #1540. This supersedes prior head `8f192f5d0ed175c1019197516d2130d7acd25e33`; military SIGN must bind the current head.

Current head: `36532ce61904e7fba9d44e3271d4fbb8db004b66`

Rebased commits:

- Initial red: `c30ac85e test(ops): require signed prod advance sequence`
- Initial green: `94edb6cc fix(ops): require signed prod advance sequence`
- Reviewer-gap red commits: `41822b59`, `b421a6c1`, `00ca56c0`
- Final green: `36532ce6 fix(ops): close prod advance proof gaps`

Current rebase evidence:

- `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/deploy-advance-sequence-rebase-current-20260707T2258-0700/`
- `red-initial-test.exit=1`
- `green-final-test.exit=0`
- `dry-run.exit=0`
- `bash-n.exit=0`
- `green-diff-check.exit=0`
- `revert-final-green-apply.exit=0`
- `revert-final-red-test.exit=1`
- `sha256sums.verify.exit=0`

PR-CI is restarted/refreshing for the current head. Skipped jobs remain non-counted. Expected red/revert-red failures are discrimination evidence only. Builder still must not merge; this remains queued for military/advisor SIGN under §27 v8.
---

### 2026-07-06 22:58 PT superseding update: born-current rebase after #1540

Rebased after `origin/main` advanced to `43812330f03193648dcfc9950cae9c8e1357fed1` via #1540. This supersedes prior head `8f192f5d0ed175c1019197516d2130d7acd25e33`; military/advisor SIGN must bind the current head.

Current head: `36532ce61904e7fba9d44e3271d4fbb8db004b66`

Rebased commits:

- Red: `c30ac85e`, `41822b59`, `b421a6c1`, `00ca56c0`
- Green: `94edb6cc`, `36532ce6`

Current rebase evidence:

- `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/deploy-advance-sequence-rebase-after-uiw1-20260706T2255-0700/`
- `green-final-test.exit=0`
- `bash-n.exit=0`
- `dry-run.exit=0`
- `green-diff-check.exit=0`
- `revert-final-red-test.exit=254`
- `sha256sums.verify.exit=0`
- `noncounted-dry-run-wrong-invocation.exit=64` is retained as a non-counted wrong CLI invocation; the counted dry-run was rerun with `--signed-sha` and exited `0`.

PR-CI is restarted for the new head and is not terminal green yet. Skipped jobs remain non-counted. Expected red/revert-red failures are discrimination evidence only. Builder still must not merge; this remains queued for military/advisor SIGN under §27 v8.
---

### 2026-07-06 23:20 PT superseding update: current head after #1542 merge

Current GitHub head: `14fc85fff6c1337aed3e1c08f08212ec5b51ad8e` (`Merge branch 'main' into codex/deploy-advance-sequence-20260707`). This supersedes prior queued head `36532ce61904e7fba9d44e3271d4fbb8db004b66`; military/advisor SIGN must bind `14fc85ff...` if this PR is approved.

Base/current main at evidence time: `0bf3121d59130d998de38cdf6790f9f65969051e` (#1542 merged).

Current-head evidence:

- `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/deploy-advance-sequence-rebase-after-native-20260706T2318-0700/`
- `green-final-test.exit=0`
- `bash-n.exit=0`
- `dry-run.exit=0`
- `green-diff-check.exit=0`
- `revert-final-red-test.exit=1`
- `sha256sums.verify.exit=0`
- `noncounted-revert-current-merge-commit.exit=128` is retained as a non-counted wrong revert target; counted revert-red reverts final green `36532ce6` and exits `1`.

PR-CI is restarted for current head and is not terminal green yet. Skipped jobs remain non-counted. Expected red/revert-red failures are discrimination evidence only. Builder still must not merge; this remains queued for military/advisor SIGN under §27 v8.