### PR TITLE
Fail-close satellite revoke misses

### DIFF
--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -3952,9 +3952,19 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     },
     revokeSatellite: (satelliteId, reason) => {
       deps.db.withWriteTransaction((db) => {
-        db.prepare(
+        const satelliteUpdate = db.prepare(
           "UPDATE satellites SET pairing_status = 'revoked', updated_at = ? WHERE id = ?",
         ).run(deps.nowIso(), satelliteId);
+        if (satelliteUpdate.changes === 0) {
+          throw new FridayDomainError(
+            "SATELLITE_NOT_FOUND",
+            "Security satellite revoke did not match any satellite",
+            {
+              httpStatus: 404,
+              details: { satelliteId },
+            },
+          );
+        }
       });
       return { revoked: true, satelliteId };
     },

--- a/test/unit/api/runtime/friday-security-runtime-revoke-satellite-source.test.ts
+++ b/test/unit/api/runtime/friday-security-runtime-revoke-satellite-source.test.ts
@@ -9,6 +9,11 @@ describe("Friday API runtime security satellite revoke truth", () => {
     expect(source).toContain("satelliteUpdate.changes === 0");
     expect(source).toContain("SATELLITE_NOT_FOUND");
     expect(source).toContain("Security satellite revoke did not match any satellite");
-    expect(source).not.toContain("return { revoked: true, satelliteId };\n    },\n  }))");
+    const updateIndex = source.indexOf("const satelliteUpdate = db.prepare");
+    const guardIndex = source.indexOf("satelliteUpdate.changes === 0");
+    const successIndex = source.indexOf("return { revoked: true, satelliteId };", guardIndex);
+    expect(updateIndex).toBeGreaterThan(-1);
+    expect(guardIndex).toBeGreaterThan(updateIndex);
+    expect(successIndex).toBeGreaterThan(guardIndex);
   });
 });

--- a/test/unit/api/runtime/friday-security-runtime-revoke-satellite-source.test.ts
+++ b/test/unit/api/runtime/friday-security-runtime-revoke-satellite-source.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("Friday API runtime security satellite revoke truth", () => {
+  it("fails closed when the security satellite revoke update touches zero rows", () => {
+    const source = readFileSync("src/api/runtime/friday-api-runtime.ts", "utf8");
+
+    expect(source).toContain("const satelliteUpdate = db.prepare");
+    expect(source).toContain("satelliteUpdate.changes === 0");
+    expect(source).toContain("SATELLITE_NOT_FOUND");
+    expect(source).toContain("Security satellite revoke did not match any satellite");
+    expect(source).not.toContain("return { revoked: true, satelliteId };\n    },\n  }))");
+  });
+});


### PR DESCRIPTION
## Scope

NEW-77 satellite revoke truth, scoped to the runtime revoke path only:

- `src/api/runtime/friday-api-runtime.ts`
- `test/unit/api/runtime/friday-security-runtime-revoke-satellite-source.test.ts`

This PR fail-closes a revoke miss: if `UPDATE satellites ... WHERE id = ?` affects zero rows, `revokeSatellite` throws `SATELLITE_NOT_FOUND` (404) before the success return.

## Current HEAD / Base

- Base: `origin/main=43812330f03193648dcfc9950cae9c8e1357fed1`
- Head: `4e55b138ffc221b01783df604ed8406a1eddbefe`
- Branch: `codex/new77-satellite-revoke-truth-20260707`

## Red-First Evidence

Evidence directory:

`/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new77-satellite-revoke-truth-rebase-after-uiw1-20260706T2302-0700/`

Commits:

- Red: `3f57b465 test(security): require satellite revoke truth`
- Red/order guard: `e7022dbb test(security): require ordered satellite revoke guard`
- Green: `4e55b138 fix(security): fail-close satellite revoke misses`

Counted exits:

- `red-new77-satellite-revoke-truth.exit=1`
- `green-new77-satellite-revoke-truth.exit=0`
- `green-typecheck-src.exit=0`
- `green-diff-check.exit=0`
- `revert-red-new77-satellite-revoke-truth.exit=1`
- `sha256sums.verify.exit=0`

Non-counted setup failures retained:

- `noncounted-red-vitest-missing.exit=254`
- `noncounted-revert-red-vitest-missing.exit=254`

Those two failed because the temporary worktree did not have `vitest`; they are not counted as product red evidence. Counted red/revert-red were rerun with the main worktree `node_modules` linked and fail on the target missing-guard assertion.

## Reviewers

- Reviewer A Heisenberg `019f3b2b-77c4-79a1-a0f6-b954bb42e704`: PASS, `reviewer-a-new77-satellite-revoke-truth-rebase.md`
- Reviewer B Feynman `019f3b2b-cca9-7a43-90f8-f093bed1c270`: PASS, `reviewer-b-new77-satellite-revoke-truth-rebase.md`

Both reviewers confirmed the diff is two files only, does not overlap open PR #1542/#1543, and must still wait for military/advisor SIGN because it touches security behavior.

## Boundaries

- `military-sign-required`: this PR must wait for military/advisor SIGN.
- Builder must not merge.
- No auto-merge, no `--admin`, no prod/main direct push.
- This does not claim END-BAR, prod deploy/currentness, release/latest-install, organic adoption, route-level HTTP coverage, broader authz coverage, or operator terminal attestation.
---

### 2026-07-06 23:24 PT superseding update: born-current rebase after #1542

Rebased after `origin/main` advanced to `0bf3121d59130d998de38cdf6790f9f65969051e` via #1542. This supersedes prior head `4e55b138ffc221b01783df604ed8406a1eddbefe`; military/advisor SIGN must bind the current head.

Current head: `c14da6791b0c06f5e48ce7993fb01be5832ad38f`

Current rebase evidence:

- `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new77-satellite-revoke-truth-rebase-after-native-20260706T2318-0700/`
- `red-new77-satellite-revoke-truth.exit=1`
- `green-new77-satellite-revoke-truth.exit=0`
- `green-typecheck-src.exit=0`
- `green-diff-check.exit=0`
- `revert-red-new77-satellite-revoke-truth.exit=1`
- `sha256sums.verify.exit=0`

Current-head reviewers:

- Reviewer C Gauss `019f3b3b-a969-7170-a3f9-7fcb31bd70a1`: PASS, `reviewer-c-new77-satellite-revoke-truth-rebase-after-native.md`
- Reviewer D Sartre `019f3b3b-ce45-7a21-be1a-57e7e73991e2`: PASS, `reviewer-d-new77-satellite-revoke-truth-rebase-after-native.md`

PR-CI is restarted for current head and is not terminal green yet. Skipped jobs remain non-counted. Expected red/revert-red failures are discrimination evidence only. Builder still must not merge; this remains queued for military/advisor SIGN under §27 v8.
---

### 2026-07-06 23:43 PT update: final current-head reviewers PASS

Current head remains `a7486a89b086052cce2827a2b878b18694e0d58d`, based on `ec82995f9bdd1eeacf45c91f44ac0b4d2daa5a58`.

Final current-head reviewers:

- Reviewer E Pasteur `019f3b4d-4f5c-7e70-a67c-59ceff53ce7e`: PASS, `reviewer-e-new77-satellite-revoke-truth-rebase-after-advance.md`
- Reviewer F Mill `019f3b4d-81a7-7103-bd22-14d890be4720`: PASS, `reviewer-f-new77-satellite-revoke-truth-rebase-after-advance.md`

Evidence checksum was regenerated after adding reviewer files and remains `sha256sums.verify.exit=0`.

Reviewer F caveat retained: the source-order test is discriminating for the missing `satelliteUpdate.changes` guard in this patch, but it is still a source-text assertion rather than a DB behavior test. This remains security-touching and must wait for military/advisor SIGN; builder will not merge.