### PR TITLE
Stabilize release verify CLI backstops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -451,7 +451,7 @@
         "filename": "test/integration/providers/friday-provider-service-lifecycle.test.ts",
         "hashed_secret": "b442e3565a2e01950b68b938201e59ac8c43569c",
         "is_verified": false,
-        "line_number": 93
+        "line_number": 94
       }
     ],
     "test/unit/agent/runtime/friday-agent-llm-client.test.ts": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-06T18:46:27Z"
+  "generated_at": "2026-07-07T09:14:15Z"
 }

--- a/test/integration/providers/friday-provider-service-lifecycle-env-contract.test.ts
+++ b/test/integration/providers/friday-provider-service-lifecycle-env-contract.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("FridayProviderService lifecycle env-ref contract", () => {
+  it("keeps the env-ref create-provider test independent of ambient API keys", () => {
+    const source = readFileSync("test/integration/providers/friday-provider-service-lifecycle.test.ts", "utf8");
+
+    expect(source).toMatch(/apiKey:\s*"\$OPENAI_API_KEY",\s*[\r\n]+\s*preserveEnvRef:\s*true,/);
+  });
+});

--- a/test/integration/providers/friday-provider-service-lifecycle.test.ts
+++ b/test/integration/providers/friday-provider-service-lifecycle.test.ts
@@ -68,6 +68,7 @@ describe("FridayProviderService Lifecycle (Integration)", () => {
         authMode: "api-key",
         api: "openai-completions",
         apiKey: "$OPENAI_API_KEY",
+        preserveEnvRef: true,
         supportedModels: ["gpt-4o"],
         defaultModel: "gpt-4o",
         validateOnSave: false,

--- a/test/unit/qa/friday-served-ui-design-fidelity-cli-timeout-contract.test.ts
+++ b/test/unit/qa/friday-served-ui-design-fidelity-cli-timeout-contract.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("friday-served-ui-design-fidelity CLI timeout contract", () => {
+  it("pins shell-executing fidelity CLI cases to an explicit extended timeout", () => {
+    const source = readFileSync("test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts", "utf8");
+    const timeoutConstPattern = new RegExp([
+      "const\\s+SERVED_UI_DESIGN_FIDELITY_CLI_TEST_TIMEOUT_MS",
+      "\\s*=\\s*60_000\\s*;",
+    ].join(""));
+
+    expect(source).toMatch(timeoutConstPattern);
+    expect(source).toContain("function servedUiDesignFidelityCliIt(");
+
+    const helperCalls = source.match(/^\s*servedUiDesignFidelityCliIt\(/gm) ?? [];
+    expect(helperCalls.length).toBeGreaterThanOrEqual(15);
+
+    expect(source).not.toMatch(/^\s*it\("fails Gate D .*run\(/ms);
+    expect(source).not.toMatch(/^\s*it\("writes and parses .*run\(/ms);
+    expect(source).not.toMatch(/^\s*it\("fails an explicitly supplied .*run\(/ms);
+  });
+});

--- a/test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts
+++ b/test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts
@@ -301,8 +301,14 @@ function run(root: string, designRoot: string, distRoot: string, iosRoot: string
   ], { cwd: process.cwd(), encoding: "utf8" });
 }
 
+const SERVED_UI_DESIGN_FIDELITY_CLI_TEST_TIMEOUT_MS = 60_000;
+
+function servedUiDesignFidelityCliIt(name: string, fn: () => void) {
+  it(name, fn, SERVED_UI_DESIGN_FIDELITY_CLI_TEST_TIMEOUT_MS);
+}
+
 describe("check-friday-served-ui-design-fidelity", () => {
-  it("passes a minimal selected desktop+iOS fixture that applies locked tokens, right dock, subtle pet, and design-system controls", () => {
+  servedUiDesignFidelityCliIt("passes a minimal selected desktop+iOS fixture that applies locked tokens, right dock, subtle pet, and design-system controls", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-good-"));
     try {
       const result = run(root, writeSelections(root), writeGoodDist(root), writeGoodIos(root));
@@ -332,7 +338,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("fails Gate A when selected desktop and pet reference HTML cannot be rendered into oracle artifacts", () => {
+  servedUiDesignFidelityCliIt("fails Gate A when selected desktop and pet reference HTML cannot be rendered into oracle artifacts", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-gate-a-missing-"));
     try {
       const result = run(root, writeSelections(root, { referenceHtml: false }), writeGoodDist(root), writeGoodIos(root));
@@ -348,7 +354,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("fails Gate C2 when the selected pet v9 reference is static or blank", () => {
+  servedUiDesignFidelityCliIt("fails Gate C2 when the selected pet v9 reference is static or blank", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-gate-c2-static-pet-"));
     try {
       const result = run(root, writeSelections(root, { petInteractive: false }), writeGoodDist(root), writeGoodIos(root));
@@ -365,7 +371,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("accepts the legacy selected pet reference click/step hook as an interactive Gate C2 oracle", () => {
+  servedUiDesignFidelityCliIt("accepts the legacy selected pet reference click/step hook as an interactive Gate C2 oracle", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-gate-c2-legacy-pet-"));
     try {
       const result = run(root, writeLegacyPetReference(root), writeGoodDist(root), writeGoodIos(root));
@@ -390,7 +396,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("fails Gate D when the healthy served desktop normal path still renders fallback, demo, or internal readiness copy", () => {
+  servedUiDesignFidelityCliIt("fails Gate D when the healthy served desktop normal path still renders fallback, demo, or internal readiness copy", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-gate-d-fallback-copy-"));
     try {
       const result = run(root, writeSelections(root), writeFallbackTextDist(root), writeGoodIos(root));
@@ -407,7 +413,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("fails Gate D when disabled or unavailable copy lacks machine-readable ineligibility evidence", () => {
+  servedUiDesignFidelityCliIt("fails Gate D when disabled or unavailable copy lacks machine-readable ineligibility evidence", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-gate-d-disabled-copy-"));
     try {
       const result = run(root, writeSelections(root), writeDisabledUnavailableDist(root), writeGoodIos(root));
@@ -422,7 +428,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("passes Gate D disabled or unavailable copy when local machine-readable ineligibility evidence is present", () => {
+  servedUiDesignFidelityCliIt("passes Gate D disabled or unavailable copy when local machine-readable ineligibility evidence is present", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-gate-d-ineligible-copy-"));
     try {
       const result = run(root, writeSelections(root), writeIneligibleUnavailableDist(root), writeGoodIos(root));
@@ -432,7 +438,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("fails Gate D when disabled or unavailable copy has an empty ineligibility marker", () => {
+  servedUiDesignFidelityCliIt("fails Gate D when disabled or unavailable copy has an empty ineligibility marker", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-gate-d-empty-ineligible-"));
     try {
       const result = run(root, writeSelections(root), writeIneligibleUnavailableDist(root, ""), writeGoodIos(root));
@@ -447,7 +453,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("does not turn ordinary navigation and chrome buttons into Gate E failures in default CI mode", () => {
+  servedUiDesignFidelityCliIt("does not turn ordinary navigation and chrome buttons into Gate E failures in default CI mode", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-gate-e-default-nav-"));
     try {
       const result = run(root, writeSelections(root), writeNavigationHeavyDist(root), writeGoodIos(root));
@@ -472,7 +478,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("fails Gate E in strict mode when a visible action has no closed-loop contract evidence", () => {
+  servedUiDesignFidelityCliIt("fails Gate E in strict mode when a visible action has no closed-loop contract evidence", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-gate-e-open-action-"));
     try {
       const result = run(root, writeSelections(root), writeOpenActionDist(root), writeGoodIos(root), [
@@ -489,7 +495,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("writes and parses the Gate F proof manifest with all required linked artifact reports", () => {
+  servedUiDesignFidelityCliIt("writes and parses the Gate F proof manifest with all required linked artifact reports", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-proof-"));
     try {
       const artifactsRoot = join(root, "proof-artifacts");
@@ -530,7 +536,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("fails an explicitly supplied Gate F proof manifest that is stale and disconnected from required artifact reports", () => {
+  servedUiDesignFidelityCliIt("fails an explicitly supplied Gate F proof manifest that is stale and disconnected from required artifact reports", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-stale-proof-"));
     try {
       const staleManifest = writeFile(root, "proof/manifest.json", JSON.stringify({
@@ -563,7 +569,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("fails a current-HEAD Gate F proof manifest whose artifact identifiers are self-consistent but disconnected from the live run", () => {
+  servedUiDesignFidelityCliIt("fails a current-HEAD Gate F proof manifest whose artifact identifiers are self-consistent but disconnected from the live run", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-forged-proof-"));
     try {
       const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: process.cwd(), encoding: "utf8" }).stdout.trim();
@@ -616,7 +622,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("fails a Gate F actionClosure artifact that claims closed-loop while carrying unresolved actions", () => {
+  servedUiDesignFidelityCliIt("fails a Gate F actionClosure artifact that claims closed-loop while carrying unresolved actions", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-inconsistent-action-closure-"));
     try {
       const artifactsRoot = join(root, "proof-artifacts");
@@ -655,7 +661,7 @@ describe("check-friday-served-ui-design-fidelity", () => {
     }
   });
 
-  it("fails red-first for the old amber/jade desktop, bottom proof dock, hero pet, missing design-system controls, and stock iOS user path", () => {
+  servedUiDesignFidelityCliIt("fails red-first for the old amber/jade desktop, bottom proof dock, hero pet, missing design-system controls, and stock iOS user path", () => {
     const root = mkdtempSync(join(tmpdir(), "friday-served-ui-bad-"));
     try {
       const result = run(root, writeSelections(root), writeBadDist(root), writeBadIos(root));

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli-timeout-contract.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli-timeout-contract.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("friday-ui-device-proof-readiness CLI timeout contract", () => {
+  it("pins shell-executing readiness CLI cases to an explicit extended timeout", () => {
+    const source = readFileSync("test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts", "utf8");
+    const timeoutConstPattern = new RegExp([
+      "const\\s+UI_DEVICE_READINESS_CLI_TEST_TIMEOUT_MS",
+      "\\s*=\\s*60_000\\s*;",
+    ].join(""));
+
+    expect(source).toMatch(timeoutConstPattern);
+    expect(source).toContain("function readinessCliIt(");
+
+    const helperCalls = source.match(/^\s*readinessCliIt\(/gm) ?? [];
+    expect(helperCalls.length).toBeGreaterThanOrEqual(19);
+
+    expect(source).not.toMatch(/^\s*it\("discovers .*execFileSync\("bash"/ms);
+    expect(source).not.toMatch(/^\s*it\("reports blocked .*execFileSync\("bash"/ms);
+    expect(source).not.toMatch(/^\s*it\("can derive .*execFileSync\("bash"/ms);
+  });
+});

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -537,6 +537,12 @@ function makeManifest(files: ReturnType<typeof writeEvidenceDir>) {
   };
 }
 
+const UI_DEVICE_READINESS_CLI_TEST_TIMEOUT_MS = 60_000;
+
+function readinessCliIt(name: string, fn: () => void) {
+  it(name, fn, UI_DEVICE_READINESS_CLI_TEST_TIMEOUT_MS);
+}
+
 describe("friday-ui-device-proof-readiness", () => {
   it("does not require final proof mode to be not-ready", () => {
     const source = readFileSync("scripts/ops/friday-ui-device-proof-readiness.sh", "utf8");
@@ -548,7 +554,7 @@ describe("friday-ui-device-proof-readiness", () => {
     expect(source).not.toContain("check-mission-workbench-live-readiness.mjs\" --expect-not-ready");
   });
 
-  it("discovers a complete evidence dir and delegates to the strict assembler", () => {
+  readinessCliIt("discovers a complete evidence dir and delegates to the strict assembler", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-"));
     try {
       const files = writeEvidenceDir(tempDir);
@@ -576,7 +582,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("reports blocked instead of assembling when the evidence dir is incomplete", () => {
+  readinessCliIt("reports blocked instead of assembling when the evidence dir is incomplete", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-missing-"));
     try {
       writeFileSync(join(tempDir, "mission-id.txt"), `${missionId}\n`);
@@ -604,7 +610,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("discovers desktop live write-read capture artifacts without hand-written evidence aliases", () => {
+  readinessCliIt("discovers desktop live write-read capture artifacts without hand-written evidence aliases", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-desktop-live-"));
     try {
       const files = writeDesktopLiveCaptureDir(tempDir);
@@ -635,7 +641,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("discovers live write-read bundle missionId and prefers combined same-run events", () => {
+  readinessCliIt("discovers live write-read bundle missionId and prefers combined same-run events", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-bundle-"));
     try {
       const files = writeLiveWriteReadBundleDir(tempDir);
@@ -667,7 +673,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("discovers live write-read bundle files when the bundle directory is passed directly", () => {
+  readinessCliIt("discovers live write-read bundle files when the bundle directory is passed directly", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-direct-bundle-"));
     try {
       const files = writeLiveWriteReadBundleDir(tempDir);
@@ -700,7 +706,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("writes a gap report from discovered same-run events without treating it as proof", () => {
+  readinessCliIt("writes a gap report from discovered same-run events without treating it as proof", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-gap-"));
     try {
       writePartialEvidenceDir(tempDir);
@@ -742,7 +748,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("can defer channel proof in report-only mode without satisfying UI proof", () => {
+  readinessCliIt("can defer channel proof in report-only mode without satisfying UI proof", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-defer-channel-"));
     try {
       const files = writePartialEvidenceDir(tempDir);
@@ -810,7 +816,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("discovers indexed channel and timeline evidence without satisfying UI proof", () => {
+  readinessCliIt("discovers indexed channel and timeline evidence without satisfying UI proof", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-indexed-roles-"));
     try {
       const files = writeIndexedChannelTimelineEvidenceDir(tempDir);
@@ -842,7 +848,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("discovers design action runtime evidence bundle indexes without downgrading UI proof truth", () => {
+  readinessCliIt("discovers design action runtime evidence bundle indexes without downgrading UI proof truth", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-action-bundle-"));
     try {
       writePartialEvidenceDir(tempDir);
@@ -893,7 +899,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("accumulates repeated explicit design action runtime evidence paths", () => {
+  readinessCliIt("accumulates repeated explicit design action runtime evidence paths", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-action-explicit-"));
     try {
       writePartialEvidenceDir(tempDir);
@@ -946,7 +952,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("passes supporting proofs into the gap report without satisfying UI device proof", () => {
+  readinessCliIt("passes supporting proofs into the gap report without satisfying UI device proof", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-supporting-"));
     try {
       writePartialEvidenceDir(tempDir);
@@ -997,7 +1003,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("auto-discovers supporting proof artifacts from the evidence dir without counting them as UI proof", () => {
+  readinessCliIt("auto-discovers supporting proof artifacts from the evidence dir without counting them as UI proof", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-supporting-auto-"));
     try {
       writePartialEvidenceDir(tempDir);
@@ -1050,7 +1056,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("bridges redacted channel proof into same-run events without treating it as UI proof", () => {
+  readinessCliIt("bridges redacted channel proof into same-run events without treating it as UI proof", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-channel-bridge-"));
     try {
       const files = writePartialEvidenceDir(tempDir);
@@ -1098,7 +1104,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("derives diagnostic events from a preflighted workbench snapshot without assembling proof", () => {
+  readinessCliIt("derives diagnostic events from a preflighted workbench snapshot without assembling proof", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-workbench-"));
     try {
       writeWorkbenchSnapshotEvidenceDir(tempDir);
@@ -1140,7 +1146,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("merges workbench-derived events with discovered same-run events instead of replacing them", () => {
+  readinessCliIt("merges workbench-derived events with discovered same-run events instead of replacing them", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-merge-"));
     try {
       writePartialEvidenceDir(tempDir);
@@ -1173,7 +1179,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("blocks workbench-derived rows when negative-control status labels are absent", () => {
+  readinessCliIt("blocks workbench-derived rows when negative-control status labels are absent", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-partial-workbench-"));
     try {
       writePartialEvidenceDir(tempDir);
@@ -1236,7 +1242,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("treats non-ready workbench bridge status as a hard blocker in final proof mode", () => {
+  readinessCliIt("treats non-ready workbench bridge status as a hard blocker in final proof mode", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-workbench-proof-blocker-"));
     try {
       writePartialEvidenceDir(tempDir);
@@ -1275,7 +1281,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("keeps discovered same-run events when the workbench diagnostic bridge emits no derived events", () => {
+  readinessCliIt("keeps discovered same-run events when the workbench diagnostic bridge emits no derived events", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-empty-workbench-"));
     try {
       const files = writePartialEvidenceDir(tempDir);
@@ -1318,7 +1324,7 @@ describe("friday-ui-device-proof-readiness", () => {
     }
   });
 
-  it("can derive a workbench snapshot from an explicit read-only Rust DB path", () => {
+  readinessCliIt("can derive a workbench snapshot from an explicit read-only Rust DB path", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-workbench-db-"));
     try {
       writePartialEvidenceDir(tempDir);


### PR DESCRIPTION
## Scope

NEW-78: stabilize the local `release:verify:repo` backstop after the post-#1546 END-BAR local closure rerun exposed timeout/env-coupling failures.

This PR changes tests plus secrets-baseline metadata only:

- `.secrets.baseline` (line-number/generated metadata refresh for an already-baselined provider lifecycle false-positive hash)
- `test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts`
- `test/unit/qa/friday-ui-device-proof-readiness-cli-timeout-contract.test.ts`
- `test/unit/qa/friday-served-ui-design-fidelity-cli.test.ts`
- `test/unit/qa/friday-served-ui-design-fidelity-cli-timeout-contract.test.ts`
- `test/integration/providers/friday-provider-service-lifecycle.test.ts`
- `test/integration/providers/friday-provider-service-lifecycle-env-contract.test.ts`

It does not change product runtime, proof gate scripts, provider secret implementation, deployment scripts, UI source, or CI workflows.

Current SIGN target candidate: `9cbb90d4f8b67f725f65e1e03be2b77e29f40f0e`.
Previous head `d2b58d0491524171969a69ab4f35b0b41a08fa5d` had counted PR-CI `secrets` failure and is not signable.

## Red-first evidence

Evidence directory:
`/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/endbar-release-verify-ui-device-timeout-20260707T0140-0700/`

Commit chain:

- Red `23f62082` adds `friday-ui-device-proof-readiness-cli-timeout-contract.test.ts`; `red-timeout-contract-v2.exit=1` because the shell-heavy readiness CLI tests had no explicit extended timeout helper.
- Green `5dafc30c` adds `UI_DEVICE_READINESS_CLI_TEST_TIMEOUT_MS=60_000` and `readinessCliIt(...)`; `green-timeout-contract.exit=0`, `green-readiness-file.exit=0`.
- Red `be8b9c02` adds residual contracts; `red-release-verify-residual-contracts.exit=1` because served UI fidelity CLI tests lacked a timeout helper and the provider env-ref fixture could be polluted by ambient `OPENAI_API_KEY`.
- Green `d2b58d04` adds `SERVED_UI_DESIGN_FIDELITY_CLI_TEST_TIMEOUT_MS=60_000`, `servedUiDesignFidelityCliIt(...)`, and `preserveEnvRef: true` for the env-ref fixture; `green-release-verify-residual-contracts.exit=0`, `green-provider-env-ref-after-contract.exit=0`, `green-served-ui-fidelity-file.exit=0`.
- CI hygiene `9cbb90d4` refreshes only `.secrets.baseline` after the previous head exposed a counted `secrets` failure from provider lifecycle baseline line-number drift; evidence `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/pr1547-secrets-baseline-ci-fix-20260707T0212-0700/` records local red `red-secrets-hook.exit=1`, green `green-secrets-hook-staged.exit=0`, and `sha256sums.verify.exit=0`.

Revert-red:

- `revert-red-ui-device-timeout-contract.exit=1` after temporarily reverting `5dafc30c`.
- `revert-red-residual-contracts.exit=1` after temporarily reverting `d2b58d04`.

Full local gate:

- First full `release:verify:repo` after the first green still failed honestly: `green-release-verify-repo.exit=1`, exposing the provider env-ref and served UI fidelity residuals.
- Final full `release:verify:repo` passed: `green-release-verify-repo-v2.exit=0`.
- `green-diff-check.exit=0`.
- `sha256sums.verify.exit=0`.

## PR-CI / required contexts

Current-head PR-CI is terminal green on `9cbb90d4f8b67f725f65e1e03be2b77e29f40f0e`.

Evidence:
`/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/pr1547-terminal-ci-green-current-20260707T0248-0700/`

Branch-protection required contexts were enumerated from GitHub API and all are present with success (`required-contexts-summary.exit=0`): `build`, `test`, `migrations`, `security`, `contracts`, `ssd-lint`, `alignment-guard`, `agent-parity`, `secrets`, and `quality-gate`.

Workflow-condition phase/live/channel skips remain non-counted and are not functional proof.

## Independent reviewers

- Reviewer A Pauli session `019f3bce-b86e-7161-9eea-03c3e7c9d011`: `reviewer-a-new78-release-verify-stability.md`, verdict `PASS`.
- Reviewer B Popper session `019f3bce-f5b8-76b0-b478-f1159c86a6eb`: `reviewer-b-new78-release-verify-stability.md`, verdict `PASS`.
- Additional scope sanity: Hegel `019f3bcf-d29f-7273-bdcb-a5bd3e0472ae` PASS, confirmed only tests/proof metadata changed and no product runtime/gate scripts changed.
- Additional evidence sanity: Dalton `019f3bd0-1875-7a43-9e24-d8630f31e954` PASS, confirmed green/revert-red/checksum exit values.

## No-degrade / proof boundary

- UI/device proof and served UI fidelity scripts still run; this PR does not skip them or alter their proof predicates.
- The 60s timeout is a Vitest case budget for shell-heavy CLI tests under full-suite load, not a proof shortcut and not a substitute for real UI/device evidence.
- `preserveEnvRef: true` is limited to the env-ref fixture so the test remains independent of ambient machine `OPENAI_API_KEY`; raw-key encryption still goes through product `secret-ref` and strict master-key fail-close paths.
- `.secrets.baseline` only moves the existing provider lifecycle false-positive line from 93 to 94 and refreshes generated metadata; no provider secret implementation or denylist behavior is weakened.
- Skipped tests/jobs remain non-counted and are not claimed as functional proof.
- This PR makes `local.backstop.release-verify` green on this branch only. It does not claim END-BAR, prod deploy/currentness, release/latest-install, organic adoption, terminal channel/device proof, operator visual attestation, or final frozen-set completeness.

## Military SIGN queue

Label: `military-sign-required`. Builder must not merge. Await military/advisor SIGN and external merge under §27 v8.
