### PR TITLE
Fail-close release verify backstop self-test churn

### DIFF
--- a/scripts/ops/friday-ui-device-proof-readiness.sh
+++ b/scripts/ops/friday-ui-device-proof-readiness.sh
@@ -30,6 +30,7 @@ DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS=()
 if [ -n "${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS:-}" ]; then
   IFS=':' read -r -a DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS <<<"${FRIDAY_DESIGN_ACTION_RUNTIME_EVIDENCE_DIRS}"
 fi
+SKIP_GATE_SELF_TEST_FOR_TESTS="${FRIDAY_UI_DEVICE_READINESS_SKIP_SELF_TEST_FOR_TESTS:-0}"
 
 usage() {
   cat <<'EOF'
@@ -1009,21 +1010,25 @@ if [ "${MODE}" = "require-proof" ]; then
   EXPECT_NOT_READY_ARGS=()
 fi
 
-run_note_step "ui_device_gate_self_test" env \
-  -u MISSION_ID \
-  -u MOBILE_EVIDENCE \
-  -u DESKTOP_EVIDENCE \
-  -u CHANNEL_EVIDENCE \
-  -u TIMELINE_EVIDENCE \
-  -u OBSERVATIONS_MANIFEST \
-  -u MISSION_SPINE_UI_DEVICE_PROOF \
-  -u MOBILE_EXTRA_EVIDENCE \
-  -u DESKTOP_EXTRA_EVIDENCE \
-  -u CHANNEL_EXTRA_EVIDENCE \
-  -u TIMELINE_EXTRA_EVIDENCE \
-  -u SHARED_EXTRA_EVIDENCE \
-  -u NEGATIVE_CONTROL_EVIDENCE_FILES \
-  bash "${RUST_SCRIPTS_DIR}/mission-spine-ui-device-proof-gate-self-test.sh"
+if [ "${SKIP_GATE_SELF_TEST_FOR_TESTS}" = "1" ]; then
+  notes+=("ui_device_gate_self_test:skipped_explicit_for_tests")
+else
+  run_note_step "ui_device_gate_self_test" env \
+    -u MISSION_ID \
+    -u MOBILE_EVIDENCE \
+    -u DESKTOP_EVIDENCE \
+    -u CHANNEL_EVIDENCE \
+    -u TIMELINE_EVIDENCE \
+    -u OBSERVATIONS_MANIFEST \
+    -u MISSION_SPINE_UI_DEVICE_PROOF \
+    -u MOBILE_EXTRA_EVIDENCE \
+    -u DESKTOP_EXTRA_EVIDENCE \
+    -u CHANNEL_EXTRA_EVIDENCE \
+    -u TIMELINE_EXTRA_EVIDENCE \
+    -u SHARED_EXTRA_EVIDENCE \
+    -u NEGATIVE_CONTROL_EVIDENCE_FILES \
+    bash "${RUST_SCRIPTS_DIR}/mission-spine-ui-device-proof-gate-self-test.sh"
+fi
 
 if [ "${RUN_LIVE_READINESS}" = "1" ]; then
   run_step "mission_workbench_live_readiness" \

--- a/test/integration/providers/friday-provider-service-lifecycle.test.ts
+++ b/test/integration/providers/friday-provider-service-lifecycle.test.ts
@@ -61,25 +61,35 @@ describe("FridayProviderService Lifecycle (Integration)", () => {
 
   describe("create provider", () => {
     it("creates a provider with env-ref key", async () => {
-      const profile = await service.createProvider({
-        kind: "openai",
-        name: "OpenAI",
-        baseUrl: "https://api.openai.com",
-        authMode: "api-key",
-        api: "openai-completions",
-        apiKey: "$OPENAI_API_KEY",
-        supportedModels: ["gpt-4o"],
-        defaultModel: "gpt-4o",
-        validateOnSave: false,
-      });
+      const previousOpenAiApiKey = process.env.OPENAI_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+      try {
+        const profile = await service.createProvider({
+          kind: "openai",
+          name: "OpenAI",
+          baseUrl: "https://api.openai.com",
+          authMode: "api-key",
+          api: "openai-completions",
+          apiKey: "$OPENAI_API_KEY",
+          supportedModels: ["gpt-4o"],
+          defaultModel: "gpt-4o",
+          validateOnSave: false,
+        });
 
-      expect(profile.id).toBeTruthy();
-      expect(profile.kind).toBe("openai");
-      expect(profile.name).toBe("OpenAI");
-      expect(profile.config.keySource).toEqual({
-        kind: "env-ref",
-        envVar: "OPENAI_API_KEY",
-      });
+        expect(profile.id).toBeTruthy();
+        expect(profile.kind).toBe("openai");
+        expect(profile.name).toBe("OpenAI");
+        expect(profile.config.keySource).toEqual({
+          kind: "env-ref",
+          envVar: "OPENAI_API_KEY",
+        });
+      } finally {
+        if (previousOpenAiApiKey === undefined) {
+          delete process.env.OPENAI_API_KEY;
+        } else {
+          process.env.OPENAI_API_KEY = previousOpenAiApiKey;
+        }
+      }
     });
 
     it("creates a provider with raw key (encrypted secret)", async () => {

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const missionId = "mission_cli_ui_device_readiness";
+process.env.FRIDAY_UI_DEVICE_READINESS_SKIP_SELF_TEST_FOR_TESTS = "1";
 
 function currentGitHead() {
   return execFileSync("git", ["rev-parse", "HEAD"], { cwd: process.cwd(), encoding: "utf8" }).trim();

--- a/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
+++ b/test/unit/qa/friday-ui-device-proof-readiness-cli.test.ts
@@ -548,6 +548,31 @@ describe("friday-ui-device-proof-readiness", () => {
     expect(source).not.toContain("check-mission-workbench-live-readiness.mjs\" --expect-not-ready");
   });
 
+  it("can explicitly skip repeated gate self-tests for unit-test wrapper invocations", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-skip-self-test-"));
+    try {
+      const stdout = execFileSync("bash", [
+        "scripts/ops/friday-ui-device-proof-readiness.sh",
+        "--evidence-dir",
+        tempDir,
+      ], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          FRIDAY_UI_DEVICE_READINESS_SKIP_SELF_TEST_FOR_TESTS: "1",
+        },
+        encoding: "utf8",
+      });
+      const result = JSON.parse(stdout.slice(stdout.indexOf("{"))) as {
+        notes?: string[];
+      };
+
+      expect(result.notes).toContain("ui_device_gate_self_test:skipped_explicit_for_tests");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("discovers a complete evidence dir and delegates to the strict assembler", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "friday-ui-device-readiness-"));
     try {


### PR DESCRIPTION
## Scope

NEW-78: repair the current-main END-BAR `local.backstop.release-verify` failure caused by repeated UI device readiness self-tests and a provider env-ref test polluted by operator shell credentials.

This PR only claims the `local.backstop.release-verify` delta. It does not claim END-BAR, prod deploy, release/latest-install, organic adoption, channel proof, or closure of the remaining END-BAR failures/blocker.

## Born-current

- Base/origin main at branch creation and push: `25329515e417a5f938e2e83b049a31bb3ebeee83`
- Head: `3225a03cbc2e82eba23d52bba5f32de6da19f6ec`
- `origin/main` is an ancestor of the branch head at push time.

## Red-first chain

- Red commit: `a544c19e test(qa): capture repeated readiness self-test cost`
  - Evidence: `evidence/new78-ui-device-readiness-timeout-redfirst-20260707T013320-0700/red-skip-self-test-contract.exit=1`
- Green commit: `cfbe0fad test(qa): avoid repeated UI readiness self-tests`
  - Evidence:
    - `green-skip-self-test-contract.exit=0`
    - `green-full-readiness-file.exit=0`
    - `green-default-self-test.exit=0`
  - Default product path still runs the readiness self-test and records `ui_device_gate_self_test:pass`.
- Existing provider red exposed during full release verify:
  - Evidence: `red-provider-env-ref-master-key.exit=1`
- Non-counted wrong direction retained for audit:
  - Evidence: `green-provider-env-ref-master-key.exit=1`
- Final provider green commit: `3225a03c test(providers): isolate env-ref lifecycle credentials`
  - Evidence:
    - `green-provider-env-ref-isolated-env.exit=0`
    - `green-provider-lifecycle-file-isolated-env.exit=0`
- Final backstop:
  - Evidence: `green-release-verify-repo-after-provider.exit=0`

## Independent review

- Reviewer A: Lovelace the 5th, session `019f3bc8-d33e-7b60-9b7c-1c7fe9e48de0`, verdict PASS.
  - File: `evidence/new78-ui-device-readiness-timeout-redfirst-20260707T013320-0700/reviewer-a-lovelace-new78.md`
- Reviewer B: Helmholtz the 5th, session `019f3bc9-0fb4-7d93-842a-0ddfc1044dc4`, verdict PASS.
  - File: `evidence/new78-ui-device-readiness-timeout-redfirst-20260707T013320-0700/reviewer-b-helmholtz-new78.md`
  - Residual risk noted by reviewer: low. The no-skip production path is smoke-confirmed; a dedicated no-skip automated wrapper regression could make that permanent later.

## Closure delta

Before this branch, current-main local closure after #1546 was:

- Evidence: `evidence/endbar-local-closure-current-after-pr1546-20260707T012200-0700/`
- `run-friday-closure.exit=1`
- Verdict: `Product Ready (Local): NO-GO`
- Summary: `pass=12 fail=11 blocker=1`
- Included FAIL: `local.backstop.release-verify`

After this branch:

- Evidence: `evidence/new78-closure-after-release-verify-fix-20260707T015443-0700/`
- `run-friday-closure.exit=1`
- Verdict: `Product Ready (Local): NO-GO`
- Summary: `pass=13 fail=10 blocker=1`
- `local.backstop.release-verify` is no longer a FAIL.

Remaining FAILs intentionally not fixed or claimed by this PR:

- `local.providers.lifecycle`
- `local.uix.templates`
- `local.skills.generator`
- `local.uix.deploy-export`
- `local.sessions-agent-memory`
- `local.realtime`
- `local.workflows.builder-templates`
- `local.fleet-security`
- `local.rules-acceptance`
- `local.self-healing`

Remaining BLOCKER intentionally not fixed or claimed by this PR:

- `local.deep-proof.live` missing `FRIDAY_DEEPSEEK_API_KEY` / `DEEPSEEK_API_KEY`

## Failed/skipped handling

- Failed required checks stay RED/NO-GO.
- Skipped jobs/tests are non-counted and are not treated as green.
- The explicit test-only skip knob only applies when `FRIDAY_UI_DEVICE_READINESS_SKIP_SELF_TEST_FOR_TESTS=1` is set by the test harness; default wrapper execution still runs the self-test.

## Queue state

Per the 2026-07-06 override and §27 v8, this PR requires military SIGN before merge. Builder must not auto-merge.
