### PR TITLE
Bridge retired session lifecycle writes to Rust seam

### DIFF
--- a/src/api/http/routes/friday-session-routes.ts
+++ b/src/api/http/routes/friday-session-routes.ts
@@ -60,6 +60,8 @@ export interface FridaySessionRoutesDeps {
   extractionService?: FridaySessionMemoryExtractionService;
   channelRegistry?: FridayChannelRegistry;
   nowIso?: () => string;
+  routeSessionsViaRust?: boolean;
+  rustSessionLifecycleBridge?: FridayRustSessionLifecycleBridge;
   runSession?: (input: {
     sessionKey: string;
     task: string;
@@ -99,6 +101,28 @@ export interface FridaySessionRoutesDeps {
    * the session memory extraction entrypoint.
    */
   allowTestOnlySessionMemoryExtractionExecution?: boolean;
+}
+
+export interface FridayRustSessionLifecycleBridge {
+  createSession(input: {
+    channel: string;
+    chatId: string;
+    userId?: string;
+    accountId?: string;
+    chatKind?: FridaySessionChatKind;
+    principal?: FridayAuthPrincipal | null;
+  }): Promise<FridaySessionCreateResponse>;
+  appendMessage(input: {
+    sessionKey: string;
+    role: FridaySessionMessageRecord["role"];
+    content: string;
+    metadata?: Record<string, unknown>;
+    principal?: FridayAuthPrincipal | null;
+  }): Promise<FridaySessionMessageCreateResponse>;
+  getMemoryNamespace(input: {
+    sessionKey: string;
+    principal: FridayAuthPrincipal;
+  }): Promise<FridaySessionMemoryNamespaceResponse>;
 }
 
 // ─── Metadata sanitization (VULN-1: Prototype Pollution DoS) ───
@@ -773,6 +797,19 @@ function assertSessionTestOracleAllowed(deps: FridaySessionRoutesDeps): void {
   }
 }
 
+function rustSessionLifecycleBridgeOrRetired(
+  deps: FridaySessionRoutesDeps,
+): FridayRustSessionLifecycleBridge {
+  if (deps.routeSessionsViaRust === true && deps.rustSessionLifecycleBridge) {
+    return deps.rustSessionLifecycleBridge;
+  }
+  throwRetiredSession(
+    "TS_RUNTIME_SESSION_RETIRED",
+    "TypeScript session execution",
+    "session_lifecycle",
+  );
+}
+
 function assertSessionRunTestOracleAllowed(deps: FridaySessionRoutesDeps): void {
   if (deps.allowTestOnlySessionRunExecution !== true) {
     throwRetiredSession(
@@ -859,6 +896,16 @@ export function createFridaySessionRoutes(
         validateCreateSessionBody(ctx.body);
         const body = ctx.body;
         const metadata = sanitizeMetadata(body.metadata);
+        if (deps.routeSessionsViaRust === true) {
+          return rustSessionLifecycleBridgeOrRetired(deps).createSession({
+            channel: body.channel,
+            chatId: body.chatId,
+            userId: body.userId,
+            accountId: body.accountId,
+            chatKind: body.chatKind,
+            principal: (ctx.principal as FridayAuthPrincipal | null | undefined) ?? null,
+          });
+        }
         assertSessionTestOracleAllowed(deps);
         let session = await deps.sessionService.createSession({
           channel: body.channel,
@@ -1087,6 +1134,15 @@ export function createFridaySessionRoutes(
         const key = decodeSessionKeyParam(sessionKey);
         validateCreateMessageBody(ctx.body);
         const body = ctx.body;
+        if (deps.routeSessionsViaRust === true) {
+          return rustSessionLifecycleBridgeOrRetired(deps).appendMessage({
+            sessionKey: key,
+            role: body.role,
+            content: body.content,
+            metadata: sanitizeMetadata(body.metadata),
+            principal: (ctx.principal as FridayAuthPrincipal | null | undefined) ?? null,
+          });
+        }
         assertSessionTestOracleAllowed(deps);
         await deps.sessionService.getOrCreateSession(key).catch(() => undefined);
         await alignSessionWithPrincipalContext(deps.sessionService, key, ctx.principal).catch(() => undefined);
@@ -1295,6 +1351,12 @@ export function createFridaySessionRoutes(
         const { sessionKey } = ctx.params as { sessionKey: string };
         const key = decodeSessionKeyParam(sessionKey);
         const principal = assertSessionReadPrincipal(ctx.principal ?? null, "sessions.memory.namespace.get");
+        if (deps.routeSessionsViaRust === true) {
+          return rustSessionLifecycleBridgeOrRetired(deps).getMemoryNamespace({
+            sessionKey: key,
+            principal,
+          });
+        }
         await assertSessionReadableIfPresent(deps.sessionService, key, principal, "sessions.memory.namespace.get");
         const namespace = await deps.sessionService.getSessionMemoryNamespace(key);
         return { namespace };

--- a/src/api/http/routes/friday-session-routes.ts
+++ b/src/api/http/routes/friday-session-routes.ts
@@ -115,7 +115,7 @@ export interface FridayRustSessionLifecycleBridge {
   appendMessage(input: {
     sessionKey: string;
     role: FridaySessionMessageRecord["role"];
-    content: string;
+    content: unknown;
     metadata?: Record<string, unknown>;
     principal?: FridayAuthPrincipal | null;
   }): Promise<FridaySessionMessageCreateResponse>;

--- a/src/api/http/routes/friday-session-routes.ts
+++ b/src/api/http/routes/friday-session-routes.ts
@@ -50,7 +50,10 @@ import type { FridayProviderTenantContext } from "#providers";
 import type { FridayChannelRegistry } from "#channels";
 import type { FridayAgentRunConstraints } from "../../../agent/model/friday-agent.types.js";
 import type { FridayAuthPrincipal } from "../../model/friday-api-auth.types.js";
-import { isUnauthenticatedPublicPrincipal } from "../../../security/friday-owner-session-channel-capability.js";
+import {
+  assertBoundPrincipalAuthorityForOperation,
+  isUnauthenticatedPublicPrincipal,
+} from "../../../security/friday-owner-session-channel-capability.js";
 import { buildPublicV1AgentRunIsolation } from "./friday-public-v1-agent-isolation.js";
 
 // ─── Dependencies ───
@@ -110,14 +113,21 @@ export interface FridayRustSessionLifecycleBridge {
     userId?: string;
     accountId?: string;
     chatKind?: FridaySessionChatKind;
-    principal?: FridayAuthPrincipal | null;
+    metadata?: Record<string, unknown>;
+    principal: FridayAuthPrincipal;
   }): Promise<FridaySessionCreateResponse>;
   appendMessage(input: {
     sessionKey: string;
     role: FridaySessionMessageRecord["role"];
     content: unknown;
+    contentText?: string;
+    toolCalls?: unknown[];
+    tokenCount?: number;
+    idempotencyKey?: string;
+    parentMessageId?: string;
     metadata?: Record<string, unknown>;
-    principal?: FridayAuthPrincipal | null;
+    timestamp?: string;
+    principal: FridayAuthPrincipal;
   }): Promise<FridaySessionMessageCreateResponse>;
   getMemoryNamespace(input: {
     sessionKey: string;
@@ -810,6 +820,17 @@ function rustSessionLifecycleBridgeOrRetired(
   );
 }
 
+function assertSessionWritePrincipal(
+  principal: FridayAuthPrincipal | null | undefined,
+  operation: Parameters<typeof assertBoundPrincipalAuthorityForOperation>[1],
+): FridayAuthPrincipal {
+  assertBoundPrincipalAuthorityForOperation(principal, operation, "api", {
+    anyOfScopes: ["hub.admin", "session.write"],
+    anyOfRoles: ["owner", "admin", "operator"],
+  });
+  return principal as FridayAuthPrincipal;
+}
+
 function assertSessionRunTestOracleAllowed(deps: FridaySessionRoutesDeps): void {
   if (deps.allowTestOnlySessionRunExecution !== true) {
     throwRetiredSession(
@@ -897,13 +918,15 @@ export function createFridaySessionRoutes(
         const body = ctx.body;
         const metadata = sanitizeMetadata(body.metadata);
         if (deps.routeSessionsViaRust === true) {
+          const principal = assertSessionWritePrincipal(ctx.principal ?? null, "sessions.create");
           return rustSessionLifecycleBridgeOrRetired(deps).createSession({
             channel: body.channel,
             chatId: body.chatId,
             userId: body.userId,
             accountId: body.accountId,
             chatKind: body.chatKind,
-            principal: (ctx.principal as FridayAuthPrincipal | null | undefined) ?? null,
+            metadata,
+            principal,
           });
         }
         assertSessionTestOracleAllowed(deps);
@@ -1135,12 +1158,19 @@ export function createFridaySessionRoutes(
         validateCreateMessageBody(ctx.body);
         const body = ctx.body;
         if (deps.routeSessionsViaRust === true) {
+          const principal = assertSessionWritePrincipal(ctx.principal ?? null, "sessions.messages.create");
           return rustSessionLifecycleBridgeOrRetired(deps).appendMessage({
             sessionKey: key,
             role: body.role,
             content: body.content,
+            contentText: body.contentText,
+            toolCalls: body.toolCalls,
+            tokenCount: body.tokenCount,
+            idempotencyKey: body.idempotencyKey,
+            parentMessageId: body.parentMessageId,
             metadata: sanitizeMetadata(body.metadata),
-            principal: (ctx.principal as FridayAuthPrincipal | null | undefined) ?? null,
+            timestamp: body.timestamp,
+            principal,
           });
         }
         assertSessionTestOracleAllowed(deps);

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -15,6 +15,8 @@ import type { FridayAuthPrincipal, FridayRole, FridayScope } from "../api/model/
 
 export type FridayPublicMutationOperation =
   | "capability.grant.revoke"
+  | "sessions.create"
+  | "sessions.messages.create"
   | "workflow.create"
   | "workflow.update"
   | "workflow.archive"

--- a/test/unit/api/http/routes/friday-session-routes.test.ts
+++ b/test/unit/api/http/routes/friday-session-routes.test.ts
@@ -2649,12 +2649,22 @@ describe("Rust session lifecycle bridge", () => {
     const create = routes.find((r) => r.operationId === "sessions.create")!;
     const createResult = await create.handler(
       makeMockCtx({
-        body: { channel: "closure", chatId: "closure-chat" },
+        body: {
+          channel: "closure",
+          chatId: "closure-chat",
+          metadata: { source: "new79-reviewer-refute" },
+        },
         principal: makeBoundPrincipal(),
       }) as never,
     );
     expect((createResult as { session: { key: string } }).session.key).toBe(
       "closure:default:closure-chat",
+    );
+    expect(rustSessionLifecycleBridge.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { source: "new79-reviewer-refute" },
+        principal: expect.objectContaining({ principalId: "user:bound-1" }),
+      }),
     );
     expect(sessionService.createSession).not.toHaveBeenCalled();
 
@@ -2662,7 +2672,17 @@ describe("Rust session lifecycle bridge", () => {
     await message.handler(
       makeMockCtx({
         params: { sessionKey: "closure:default:closure-chat" },
-        body: { role: "user", content: "Remember that my favorite color is teal." },
+        body: {
+          role: "user",
+          content: { text: "Remember that my favorite color is teal." },
+          contentText: "Remember that my favorite color is teal.",
+          toolCalls: [{ name: "memory.remember", arguments: { color: "teal" } }],
+          tokenCount: 8,
+          idempotencyKey: "idem-new79",
+          parentMessageId: "msg-parent",
+          metadata: { reviewer: "linnaeus" },
+          timestamp: "2026-07-07T10:10:00.000Z",
+        },
         principal: makeBoundPrincipal(),
       }) as never,
     );
@@ -2670,6 +2690,15 @@ describe("Rust session lifecycle bridge", () => {
       expect.objectContaining({
         sessionKey: "closure:default:closure-chat",
         role: "user",
+        content: { text: "Remember that my favorite color is teal." },
+        contentText: "Remember that my favorite color is teal.",
+        toolCalls: [{ name: "memory.remember", arguments: { color: "teal" } }],
+        tokenCount: 8,
+        idempotencyKey: "idem-new79",
+        parentMessageId: "msg-parent",
+        metadata: { reviewer: "linnaeus" },
+        timestamp: "2026-07-07T10:10:00.000Z",
+        principal: expect.objectContaining({ principalId: "user:bound-1" }),
       }),
     );
     expect(sessionService.addMessage).not.toHaveBeenCalled();
@@ -2686,5 +2715,46 @@ describe("Rust session lifecycle bridge", () => {
         "tenant.00000000-0000-0000-0000-000000000101.channel.closure.user.00000000-0000-0000-0000-000000000102.shared",
     });
     expect(sessionService.getSessionMemoryNamespace).not.toHaveBeenCalled();
+  });
+
+  it("rejects Rust bridge writes without a bound session.write principal", async () => {
+    const sessionService = createMockService();
+    const rustSessionLifecycleBridge = {
+      createSession: vi.fn(),
+      appendMessage: vi.fn(),
+      getMemoryNamespace: vi.fn(),
+    };
+
+    const routes = createFridaySessionRoutes({
+      sessionService,
+      routeSessionsViaRust: true,
+      rustSessionLifecycleBridge,
+      allowTestOnlySessionExecution: false,
+    });
+
+    const create = routes.find((r) => r.operationId === "sessions.create")!;
+    await expectRouteError(
+      create.handler(
+        makeMockCtx({
+          body: { channel: "closure", chatId: "closure-chat" },
+          principal: null,
+        }) as never,
+      ),
+      "OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED",
+    );
+    expect(rustSessionLifecycleBridge.createSession).not.toHaveBeenCalled();
+
+    const message = routes.find((r) => r.operationId === "sessions.messages.create")!;
+    await expectRouteError(
+      message.handler(
+        makeMockCtx({
+          params: { sessionKey: "closure:default:closure-chat" },
+          body: { role: "user", content: "hello" },
+          principal: makeBoundPrincipal({ scopes: ["session.read"], role: "viewer" }),
+        }) as never,
+      ),
+      "OWNER_SESSION_CHANNEL_AUTHORITY_REQUIRED",
+    );
+    expect(rustSessionLifecycleBridge.appendMessage).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/api/http/routes/friday-session-routes.test.ts
+++ b/test/unit/api/http/routes/friday-session-routes.test.ts
@@ -2611,3 +2611,80 @@ describe("TS runtime retirement — session mutations fail-close by default", ()
     expect(result).toHaveProperty("delivery");
   });
 });
+
+describe("Rust session lifecycle bridge", () => {
+  it("routes create/message/namespace through the Rust-owned bridge when enabled", async () => {
+    const sessionService = createMockService();
+    const rustSessionLifecycleBridge = {
+      createSession: vi.fn().mockResolvedValue({
+        session: makeMockSession({
+          key: "closure:default:closure-chat",
+          channel: "closure",
+          accountId: "00000000-0000-0000-0000-000000000101",
+          userId: "00000000-0000-0000-0000-000000000102",
+          chatId: "closure-chat",
+        }),
+      }),
+      appendMessage: vi.fn().mockResolvedValue({
+        message: makeMockMessage({
+          sessionKey: "closure:default:closure-chat",
+          role: "user",
+          content: "Remember that my favorite color is teal.",
+          contentText: "Remember that my favorite color is teal.",
+        }),
+      }),
+      getMemoryNamespace: vi.fn().mockResolvedValue({
+        namespace:
+          "tenant.00000000-0000-0000-0000-000000000101.channel.closure.user.00000000-0000-0000-0000-000000000102.shared",
+      }),
+    };
+
+    const routes = createFridaySessionRoutes({
+      sessionService,
+      routeSessionsViaRust: true,
+      rustSessionLifecycleBridge,
+      allowTestOnlySessionExecution: false,
+    });
+
+    const create = routes.find((r) => r.operationId === "sessions.create")!;
+    const createResult = await create.handler(
+      makeMockCtx({
+        body: { channel: "closure", chatId: "closure-chat" },
+        principal: makeBoundPrincipal(),
+      }) as never,
+    );
+    expect((createResult as { session: { key: string } }).session.key).toBe(
+      "closure:default:closure-chat",
+    );
+    expect(sessionService.createSession).not.toHaveBeenCalled();
+
+    const message = routes.find((r) => r.operationId === "sessions.messages.create")!;
+    await message.handler(
+      makeMockCtx({
+        params: { sessionKey: "closure:default:closure-chat" },
+        body: { role: "user", content: "Remember that my favorite color is teal." },
+        principal: makeBoundPrincipal(),
+      }) as never,
+    );
+    expect(rustSessionLifecycleBridge.appendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "closure:default:closure-chat",
+        role: "user",
+      }),
+    );
+    expect(sessionService.addMessage).not.toHaveBeenCalled();
+
+    const namespace = routes.find((r) => r.operationId === "sessions.memory.namespace.get")!;
+    const namespaceResult = await namespace.handler(
+      makeMockCtx({
+        params: { sessionKey: "closure:default:closure-chat" },
+        principal: makeBoundPrincipal(),
+      }) as never,
+    );
+    expect(namespaceResult).toEqual({
+      namespace:
+        "tenant.00000000-0000-0000-0000-000000000101.channel.closure.user.00000000-0000-0000-0000-000000000102.shared",
+    });
+    expect(sessionService.getSessionMemoryNamespace).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Scope
NEW-79 / `local.sessions-agent-memory` partial closure: add an opt-in Rust-owned session lifecycle bridge seam for `sessions.create`, `sessions.messages.create`, and `sessions.memory.namespace.get` while preserving default/live fail-close for retired TypeScript session execution.

Touched files:
- `src/api/http/routes/friday-session-routes.ts`
- `src/security/friday-owner-session-channel-capability.ts`
- `test/unit/api/http/routes/friday-session-routes.test.ts`

This does not reopen legacy TS session runtime. `routeSessionsViaRust` is opt-in; default/live without the Rust bridge still throws `TS_RUNTIME_SESSION_RETIRED`.

## Red-first / Evidence
Evidence directory: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new79-session-closure-current-20260707T030749-0700/`

Commit chain from `origin/main=25329515e417a5f938e2e83b049a31bb3ebeee83`:
- `3b860c60` red test-only: captures Rust session lifecycle bridge contract.
- `10687db9` green: adds Rust bridge seam.
- `b9e71d30` green type-contract repair: preserves `content: unknown`.
- `9f6ed04a` reviewer-refute red test-only: captures metadata passthrough, full message payload, and write-principal gates.
- `1fd7c120` green: preserves auth and payload for the bridge.

Counted evidence:
- `red-reviewer-refutes.exit=1`
- `green-reviewer-refutes-v2.exit=0` (`107 tests passed`)
- `green-typecheck-after-refutes-v2.exit=0`
- `green-diff-check-after-refutes-v2.exit=0`
- `green-ts-runtime-retirement.exit=0`
- `revert-red-current-v3.exit=1`
- `sha256sums.verify.exit=0`

Non-counted retained logs: earlier zsh/PIPESTATUS and missing-vitest/symlink mistakes are retained in the evidence directory but superseded by the v2/v3 counted logs; they are not used as proof. No skipped job is counted as functional proof.

## Reviewers / Refutes
- Faraday `019f3c0e-6848-7141-8cbe-fdf84925da07`: initial NEEDS-CHANGES for metadata/message no-degrade, final PASS in `reviewer-a-faraday-final.md`.
- Linnaeus `019f3c0e-805a-7f63-9dcc-411b8ba0566e`: initial NEEDS-CHANGES for null principal, metadata loss, message narrowing; final PASS in `reviewer-b-linnaeus-final.md`.

All prior refutes are disclosed and closed by `9f6ed04a` / `1fd7c120`.

## No-degrade
- Default session mutation fail-close remains intact when `routeSessionsViaRust !== true`.
- Rust bridge writes require a bound principal with `hub.admin` or `session.write`, or owner/admin/operator role.
- Create metadata remains sanitized and is passed to the bridge.
- Message payload preserves existing `FridaySessionMessageInput` fields: `content`, `contentText`, `toolCalls`, `tokenCount`, `idempotencyKey`, `parentMessageId`, `metadata`, and `timestamp`.
- `sessions.memory.namespace.get` still requires `session.read` via `assertSessionReadPrincipal`.
- `npm run check:ts-runtime-retirement` passes with `failures=[]`.
- Open PR overlap check against #1547/#1549 returned empty before push.

## Boundaries
This is not END-BAR, prod deploy/currentness, release/latest-install, organic adoption, operator terminal attestation, real channel/device proof, or final frozen-set completeness. Builder must not merge. Await military/advisor SIGN under §27 v8.