### PR TITLE
Align Android tokens and v9 dog hero

### DIFF
--- a/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
+++ b/apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt
@@ -1,7 +1,7 @@
 // Friday — native Android app, operator-selected design baseline (file 17 §3 / 06).
 //
 // Native Cousin of the iOS baseline (not pixel-perfect): Cyan+Coral palette,
-// Glass-ish rounded cards, Retro-LCD Hero Pet (custom Canvas view), Command-Sheet
+// Glass-ish rounded cards, v9 dog Hero Pet (custom Canvas view), Command-Sheet
 // menu (Friday/Platform/Workflows/Activity/Settings), Friday-first launch,
 // Friday Home = Hero Pet + Status + Needs-Me, Platform = Cards+Queues, Activity
 // urgency-first with the REAL mark-done write, Workflows = Memory Review, Settings
@@ -34,36 +34,46 @@ import uniffi.friday_ffi.sampleActivityInbox
 import uniffi.friday_ffi.sampleMemoryReview
 
 private object Palette {
-    val cyan = Color.rgb(26, 176, 194)
-    val coral = Color.rgb(242, 115, 91)
-    val lcd = Color.rgb(140, 242, 178)
-    val lcdBg = Color.rgb(15, 26, 23)
+    val cyan = Color.rgb(15, 125, 140)
+    val coral = Color.rgb(216, 99, 77)
+    val warn = Color.rgb(168, 106, 29)
+    val ok = Color.rgb(39, 122, 93)
+    val dogStage = Color.rgb(238, 243, 232)
+    val dogFur = Color.rgb(246, 213, 166)
+    val dogShadow = Color.rgb(139, 82, 46)
     val ink = Color.rgb(28, 30, 34)
     val sub = Color.rgb(120, 128, 134)
     val bg = Color.rgb(247, 248, 247)
     val card = Color.WHITE
     fun risk(s: String) = when (s) {
-        "done", "direct", "success" -> cyan
-        "running", "pending", "warning" -> Color.rgb(230, 150, 30)
+        "done", "success" -> ok
+        "direct" -> cyan
+        "running", "pending", "warning" -> warn
         "failed", "fallback", "danger" -> coral
         else -> sub
     }
 }
 
-// Retro-LCD Hero Pet: a pixel cat face on an LCD panel (mood companion).
-private class LcdPet(ctx: Activity) : View(ctx) {
-    private val face = listOf(
-        "X..XX..X", ".XXXXXX.", "X.XOXO.X", "X.XXXX.X", "X.X..X.X", ".XXXXXX."
-    )
-    private val on = Paint().apply { color = Palette.lcd; isAntiAlias = true }
-    private val dim = Paint().apply { color = Color.argb(90, 140, 242, 178); isAntiAlias = true }
+// v9 dog Hero Pet: a small friendly companion; decorative only, never truth state.
+private class V9DogPet(ctx: Activity) : View(ctx) {
+    private val fur = Paint().apply { color = Palette.dogFur; isAntiAlias = true }
+    private val shadow = Paint().apply { color = Palette.dogShadow; isAntiAlias = true }
+    private val ink = Paint().apply { color = Palette.ink; isAntiAlias = true }
+    private val blush = Paint().apply { color = Color.argb(90, 216, 99, 77); isAntiAlias = true }
     override fun onDraw(c: Canvas) {
-        val cell = minOf(width / 8f, height / face.size.toFloat())
-        for ((r, line) in face.withIndex()) for ((col, ch) in line.withIndex()) {
-            if (ch == '.') continue
-            val p = if (ch == 'X') on else dim
-            c.drawRoundRect(col * cell + 2, r * cell + 2, (col + 1) * cell - 2, (r + 1) * cell - 2, 2f, 2f, p)
-        }
+        val cx = width / 2f
+        val cy = height / 2f
+        val s = minOf(width, height) / 120f
+        c.drawOval(cx - 44 * s, cy - 18 * s, cx - 18 * s, cy + 32 * s, fur)
+        c.drawOval(cx + 18 * s, cy - 18 * s, cx + 44 * s, cy + 32 * s, fur)
+        c.drawOval(cx - 36 * s, cy - 30 * s, cx + 36 * s, cy + 38 * s, fur)
+        c.drawOval(cx - 25 * s, cy - 4 * s, cx - 15 * s, cy + 6 * s, ink)
+        c.drawOval(cx + 15 * s, cy - 4 * s, cx + 25 * s, cy + 6 * s, ink)
+        c.drawOval(cx - 8 * s, cy + 8 * s, cx + 8 * s, cy + 20 * s, shadow)
+        c.drawCircle(cx - 26 * s, cy + 16 * s, 6 * s, blush)
+        c.drawCircle(cx + 26 * s, cy + 16 * s, 6 * s, blush)
+        c.drawOval(cx - 28 * s, cy + 36 * s, cx - 8 * s, cy + 62 * s, fur)
+        c.drawOval(cx + 8 * s, cy + 36 * s, cx + 28 * s, cy + 62 * s, fur)
     }
 }
 
@@ -146,8 +156,8 @@ class MainActivity : Activity() {
         // Hero Pet
         content.addView(LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL; gravity = Gravity.CENTER_HORIZONTAL
-            addView(LcdPet(this@MainActivity).apply {
-                background = rounded(Palette.lcdBg, Palette.lcd, 14)
+            addView(V9DogPet(this@MainActivity).apply {
+                background = rounded(Palette.dogStage, Color.argb(45, 15, 125, 140), 14)
                 layoutParams = LinearLayout.LayoutParams(360, 260).apply { topMargin = 8 }
                 setPadding(16, 16, 16, 16)
             })

--- a/apps/friday-android/mock/src/main/kotlin/com/friday/mock/MainActivity.kt
+++ b/apps/friday-android/mock/src/main/kotlin/com/friday/mock/MainActivity.kt
@@ -3,7 +3,7 @@
 // Goal: prove the device-pairing + Hub<->phone sync FLOW runs on the Android
 // emulator. It mirrors the design intent of apps/friday-ios at a MINIMAL level:
 // Cyan+Coral palette, warm off-white bg, glass cards, light theme, a small
-// retro-LCD pet, Home = Status + a chat-entry affordance.
+// v9 dog pet, Home = Status + a chat-entry affordance.
 //
 // HONEST SCOPE (do not mistake this for the real app):
 //  - Pairing (QR/passkey) and Hub<->phone sync are MOCKED — a deterministic
@@ -411,8 +411,7 @@ private fun DrawScope.drawRectAt(r: Int, c: Int, cell: Float) {
     )
 }
 
-// Retro-LCD Hero Pet — minimal pixel cat face on an LCD panel (mood companion,
-// not a status source of truth). Mirrors the iOS HeroPet at a minimal level.
+// v9 dog Hero Pet — decorative companion, not a status source of truth.
 @Composable
 private fun HeroPet(online: Boolean) {
     Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
@@ -421,36 +420,31 @@ private fun HeroPet(online: Boolean) {
                 .padding(top = 6.dp)
                 .size(width = 150.dp, height = 110.dp)
                 .clip(RoundedCornerShape(14.dp))
-                .background(Theme.lcdBg)
-                .border(1.dp, Theme.lcd.copy(alpha = 0.25f), RoundedCornerShape(14.dp))
+                .background(Theme.dogStage)
+                .border(1.dp, Theme.cyan.copy(alpha = 0.18f), RoundedCornerShape(14.dp))
                 .padding(12.dp),
         ) {
-            Canvas(Modifier.fillMaxSize()) { drawPet() }
+            Canvas(Modifier.fillMaxSize()) { drawV9Dog() }
         }
         Spacer(Modifier.height(6.dp))
         Text(if (online) "Friday is here" else "Friday is offline", color = Theme.sub, fontSize = 12.sp)
     }
 }
 
-private val petFace = listOf(
-    "X..XX..X", ".XXXXXX.", "X.XOXO.X", "X.XXXX.X", "X.X..X.X", ".XXXXXX.",
-)
-
-private fun DrawScope.drawPet() {
-    val cols = 8
-    val rows = petFace.size
-    val cell = minOf(size.width / cols, size.height / rows)
-    petFace.forEachIndexed { r, line ->
-        line.forEachIndexed { c, ch ->
-            if (ch == '.') return@forEachIndexed
-            val on = ch == 'X'
-            drawRect(
-                color = if (on) Theme.lcd else Theme.lcd.copy(alpha = 0.35f),
-                topLeft = Offset(c * cell + 1f, r * cell + 1f),
-                size = Size(cell - 2f, cell - 2f),
-            )
-        }
-    }
+private fun DrawScope.drawV9Dog() {
+    val cx = size.width / 2f
+    val cy = size.height / 2f
+    val s = size.minDimension / 100f
+    drawOval(color = Theme.dogFur, topLeft = Offset(cx - 38 * s, cy - 16 * s), size = Size(24 * s, 42 * s))
+    drawOval(color = Theme.dogFur, topLeft = Offset(cx + 14 * s, cy - 16 * s), size = Size(24 * s, 42 * s))
+    drawOval(color = Theme.dogFur, topLeft = Offset(cx - 32 * s, cy - 28 * s), size = Size(64 * s, 58 * s))
+    drawCircle(color = Theme.ink, radius = 4 * s, center = Offset(cx - 16 * s, cy - 5 * s))
+    drawCircle(color = Theme.ink, radius = 4 * s, center = Offset(cx + 16 * s, cy - 5 * s))
+    drawOval(color = Theme.dogShadow, topLeft = Offset(cx - 7 * s, cy + 6 * s), size = Size(14 * s, 10 * s))
+    drawCircle(color = Theme.coral.copy(alpha = 0.30f), radius = 5 * s, center = Offset(cx - 24 * s, cy + 12 * s))
+    drawCircle(color = Theme.coral.copy(alpha = 0.30f), radius = 5 * s, center = Offset(cx + 24 * s, cy + 12 * s))
+    drawOval(color = Theme.dogFur, topLeft = Offset(cx - 22 * s, cy + 28 * s), size = Size(18 * s, 24 * s))
+    drawOval(color = Theme.dogFur, topLeft = Offset(cx + 4 * s, cy + 28 * s), size = Size(18 * s, 24 * s))
 }
 
 // A tiny no-ripple clickable for the top-bar tabs (keeps deps minimal).

--- a/apps/friday-android/mock/src/main/kotlin/com/friday/mock/Theme.kt
+++ b/apps/friday-android/mock/src/main/kotlin/com/friday/mock/Theme.kt
@@ -1,7 +1,7 @@
 // Friday mobile design tokens — minimal Compose port of the operator-locked
 // baseline (friday-design-handoff-20260602/saved/mobile-selection.json):
 // palette = Cyan + Coral (locked), background = Warm off-white, theme = Light,
-// form = Glass Native (translucent rounded panels), pet = Retro LCD.
+// form = Glass Native (translucent rounded panels), pet = v9 dog.
 //
 // This is the Android mirror of apps/friday-ios Theme; applied at a MINIMAL
 // level (a glass-ish card + the two brand colors + warm bg), not pixel-perfect.
@@ -23,10 +23,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 object Theme {
-    val cyan = Color(0xFF1AB0C2)    // action / online / direct (locked)
-    val coral = Color(0xFFF2735B)   // urgency / accent / danger (locked)
-    val lcd = Color(0xFF8CF2B2)     // retro-LCD phosphor
-    val lcdBg = Color(0xFF0F1A17)
+    val cyan = Color(0xFF0F7D8C)    // action / online / direct (locked)
+    val coral = Color(0xFFD8634D)   // urgency / accent / danger (locked)
+    val warn = Color(0xFFA86A1D)    // review / pending attention
+    val ok = Color(0xFF277A5D)      // semantic success only
+    val dogStage = Color(0xFFEEF3E8)
+    val dogFur = Color(0xFFF6D5A6)
+    val dogShadow = Color(0xFF8B522E)
     val ink = Color(0xFF1C1E22)
     val sub = Color(0xFF788086)
     val bg = Color(0xFFF7F6F2)      // warm off-white (locked)
@@ -34,8 +37,9 @@ object Theme {
 
     // Risk semantics via color (mirrors iOS Theme.risk): success/warning/danger.
     fun risk(kind: String): Color = when (kind) {
-        "online", "paired", "success", "synced", "direct" -> cyan
-        "syncing", "pairing", "stale", "warning", "pending" -> Color(0xFFE6961E)
+        "online", "paired", "synced", "direct" -> cyan
+        "success" -> ok
+        "syncing", "pairing", "stale", "warning", "pending" -> warn
         "offline", "failed", "danger", "fallback" -> coral
         else -> sub
     }

--- a/test/unit/ui/ui-w2-android-token-dog-contract.test.ts
+++ b/test/unit/ui/ui-w2-android-token-dog-contract.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const ANDROID_APP = "apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt";
+const ANDROID_MOCK_THEME = "apps/friday-android/mock/src/main/kotlin/com/friday/mock/Theme.kt";
+const ANDROID_MOCK_MAIN = "apps/friday-android/mock/src/main/kotlin/com/friday/mock/MainActivity.kt";
+
+const selectedAndroidTokens = [
+  "Color.rgb(15, 125, 140)",
+  "Color.rgb(216, 99, 77)",
+  "Color.rgb(168, 106, 29)",
+  "Color.rgb(39, 122, 93)",
+] as const;
+
+const selectedComposeTokens = [
+  "Color(0xFF0F7D8C)",
+  "Color(0xFFD8634D)",
+  "Color(0xFFA86A1D)",
+  "Color(0xFF277A5D)",
+] as const;
+
+const staleFragments = [
+  "Retro-LCD",
+  "retro-LCD",
+  "pixel cat",
+  "pet = Retro LCD",
+  "Color.rgb(26, 176, 194)",
+  "Color.rgb(242, 115, 91)",
+  "Color.rgb(230, 150, 30)",
+  "Color(0xFF1AB0C2)",
+  "Color(0xFFF2735B)",
+  "Color(0xFFE6961E)",
+  "Color(0xFF8CF2B2)",
+] as const;
+
+describe("UI-W2 Android selected token and v9 dog contract", () => {
+  it("keeps the real Android shell on selected design tokens and the v9 dog hero", () => {
+    const source = readFileSync(ANDROID_APP, "utf8");
+
+    expect(selectedAndroidTokens.filter((token) => !source.includes(token))).toEqual([]);
+    expect(staleFragments.filter((fragment) => source.includes(fragment))).toEqual([]);
+    expect(source).toContain("V9DogPet");
+    expect(source).toContain("v9 dog");
+  });
+
+  it("keeps the Android mock shell on selected design tokens and the v9 dog hero", () => {
+    const theme = readFileSync(ANDROID_MOCK_THEME, "utf8");
+    const main = readFileSync(ANDROID_MOCK_MAIN, "utf8");
+    const corpus = `${theme}\n${main}`;
+
+    expect(selectedComposeTokens.filter((token) => !corpus.includes(token))).toEqual([]);
+    expect(staleFragments.filter((fragment) => corpus.includes(fragment))).toEqual([]);
+    expect(corpus).toContain("drawV9Dog");
+    expect(corpus).toContain("v9 dog");
+  });
+});


### PR DESCRIPTION
## Scope

UI-W2 Android selected-token + v9 dog drift repair. This PR is intentionally narrow and touches only:

- `test/unit/ui/ui-w2-android-token-dog-contract.test.ts`
- `apps/friday-android/app/src/main/kotlin/com/friday/shell/MainActivity.kt`
- `apps/friday-android/mock/src/main/kotlin/com/friday/mock/Theme.kt`
- `apps/friday-android/mock/src/main/kotlin/com/friday/mock/MainActivity.kt`

No runtime auth/security, CI, deploy, provider, prod, or approval files are changed.

## Red-first

Evidence dir: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-android-token-dog-20260707T0318-0700/`

- Red commit: `c64bdfa8` (`test(ui): capture Android token and dog drift`), test-only.
- Green commit / current head: `07520a28afce84e7707bf87d1229e5f87854a62a` (`fix(ui): align Android tokens and v9 dog hero`).
- Red: `red-ui-w2-android-token-dog.exit=1`.
- Green: `green-ui-w2-android-token-dog.exit=0`, `green-typecheck.exit=0`, `green-android-mock-assemble.exit=0`.
- Revert-red: `revert-red-ui-w2-android-token-dog.exit=1`.
- Current-head after fetch/rebase: `green-current-contract-after-rebase.exit=0`, `green-current-typecheck-after-rebase.exit=0`, `green-current-android-mock-assemble-after-rebase.exit=0`, `rebase-current.exit=0`.
- Open PR overlap: `open-pr-overlap.exit=0`, `open-pr-overlap.json` has no overlaps.
- Checksums: `sha256sums.verify.exit=0`.

## What Changed

- Real Android shell selected tokens now match the selected palette: cyan `Color.rgb(15, 125, 140)`, coral `Color.rgb(216, 99, 77)`, warn `Color.rgb(168, 106, 29)`, success `Color.rgb(39, 122, 93)`.
- Real Android shell replaces Retro-LCD/pixel-cat pet with `V9DogPet`, a Canvas-based v9 dog companion.
- Mock Compose shell uses selected tokens and `drawV9Dog()` instead of stale retro-LCD/pixel-cat fragments.
- Contract rejects stale Retro-LCD/pixel-cat and old token fragments.

## Independent Reviewers

- Nash `019f3c0a-2580-7253-a8d2-918b6c2cf888`: PASS, `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-android-token-dog-20260707T0318-0700/reviewer-a-nash-android-token-dog.md`.
- Goodall `019f3c0a-2601-7890-973e-a42e8394adf0`: PASS, `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-android-token-dog-20260707T0318-0700/reviewer-b-goodall-android-token-dog.md`.

Both reviewers independently reran the focused contract, typecheck, Android mock assemble, and revert-red discrimination in scratch worktrees. Both explicitly require the emulator screenshot caveat below.

## Failed/Skipped Handling

Android real emulator install/screenshot attempts are retained as failed/non-counted evidence, not proof:

- `green-android-real-build-emu.exit=1`: Rust/UniFFI + `:app:assembleDebug` reached `BUILD SUCCESSFUL`, then install/screenshot failed with `adb: no devices/emulators found`.
- `green-android-real-install-screenshot.exit=1`.
- `green-android-real-install-screenshot-headless.exit=1`.
- `green-android-real-emu-headless.png` is empty and must not be counted.

This PR does not claim Android real emulator screenshot proof, real-device proof, operator visual attestation, END-BAR, release/latest-install, prod deploy/currentness, organic adoption, or terminal channel/device proof.

## Refutes

No unresolved reviewer refutes. Reviewer caveat about missing real emulator screenshot is disclosed above and limits the claim scope.

## Release Discipline

Label: `military-sign-required`.

Builder must not merge this PR under §27 v8. Military/advisor SIGN and external merge are required.
