### PR TITLE
Align usage page progress tokens

### DIFF
--- a/test/unit/ui/ui-w2-usage-token-drift-contract.test.ts
+++ b/test/unit/ui/ui-w2-usage-token-drift-contract.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const usagePageSource = () => readFileSync("ui/src/routes/usage-page.tsx", "utf8");
+
+describe("UI-W2 usage page token drift", () => {
+  it("keeps token usage bars on selected Friday color tokens", () => {
+    const source = usagePageSource();
+    const forbiddenLegacyProgressColors = ["#6366f1", "#8b5cf6"];
+
+    expect(forbiddenLegacyProgressColors.filter((fragment) => source.includes(fragment))).toEqual([]);
+    expect(source).toContain('const USAGE_INPUT_BAR_COLOR = "var(--color-accent)"');
+    expect(source).toContain('const USAGE_OUTPUT_BAR_COLOR = "var(--color-coral)"');
+    expect(source).toContain('const USAGE_PROVIDER_BAR_COLOR = "var(--color-accent)"');
+  });
+});

--- a/test/unit/ui/ui-w2-usage-token-drift-contract.test.ts
+++ b/test/unit/ui/ui-w2-usage-token-drift-contract.test.ts
@@ -10,7 +10,7 @@ describe("UI-W2 usage page token drift", () => {
 
     expect(forbiddenLegacyProgressColors.filter((fragment) => source.includes(fragment))).toEqual([]);
     expect(source).toContain('const USAGE_INPUT_BAR_COLOR = "var(--color-accent)"');
-    expect(source).toContain('const USAGE_OUTPUT_BAR_COLOR = "var(--color-coral)"');
+    expect(source).toContain('const USAGE_OUTPUT_BAR_COLOR = "var(--coral)"');
     expect(source).toContain('const USAGE_PROVIDER_BAR_COLOR = "var(--color-accent)"');
   });
 });

--- a/ui/src/routes/usage-page.tsx
+++ b/ui/src/routes/usage-page.tsx
@@ -12,6 +12,10 @@ import type {
   FridayProviderUsageSummary,
 } from "@/lib/api/types";
 
+const USAGE_INPUT_BAR_COLOR = "var(--color-accent)";
+const USAGE_OUTPUT_BAR_COLOR = "var(--color-coral)";
+const USAGE_PROVIDER_BAR_COLOR = "var(--color-accent)";
+
 // ─── Types ───
 
 interface ProviderHealthItem {
@@ -414,7 +418,7 @@ export function UsagePage() {
               <div className="flex items-center gap-3">
                 <span className="w-14 text-xs text-[color:var(--color-text-secondary)]">{localize(locale, "输入", "Input")}</span>
                 <div className="flex-1">
-                  <PercentBar value={estimatedInputTokens} max={estimatedTotalTokens} color="#6366f1" />
+                  <PercentBar value={estimatedInputTokens} max={estimatedTotalTokens} color={USAGE_INPUT_BAR_COLOR} />
                 </div>
                 <span className="w-10 text-right text-xs text-[color:var(--color-text-secondary)]">
                   {formatTokenSharePercent(estimatedInputTokens, estimatedTotalTokens)}
@@ -423,7 +427,7 @@ export function UsagePage() {
               <div className="flex items-center gap-3">
                 <span className="w-14 text-xs text-[color:var(--color-text-secondary)]">{localize(locale, "输出", "Output")}</span>
                 <div className="flex-1">
-                  <PercentBar value={estimatedOutputTokens} max={estimatedTotalTokens} color="#8b5cf6" />
+                  <PercentBar value={estimatedOutputTokens} max={estimatedTotalTokens} color={USAGE_OUTPUT_BAR_COLOR} />
                 </div>
                 <span className="w-10 text-right text-xs text-[color:var(--color-text-secondary)]">
                   {formatTokenSharePercent(estimatedOutputTokens, estimatedTotalTokens)}
@@ -504,7 +508,7 @@ export function UsagePage() {
                           {formatNumber(row.tokens)}
                         </td>
                         <td className="w-32 py-2.5 pr-4">
-                          <PercentBar value={row.tokens} max={maxTokensInRow} color="#6366f1" />
+                          <PercentBar value={row.tokens} max={maxTokensInRow} color={USAGE_PROVIDER_BAR_COLOR} />
                         </td>
                         <td className="py-2.5 text-right font-medium text-[color:var(--color-text-primary)]">
                           {formatUsd(row.costUsd)}

--- a/ui/src/routes/usage-page.tsx
+++ b/ui/src/routes/usage-page.tsx
@@ -13,7 +13,7 @@ import type {
 } from "@/lib/api/types";
 
 const USAGE_INPUT_BAR_COLOR = "var(--color-accent)";
-const USAGE_OUTPUT_BAR_COLOR = "var(--color-coral)";
+const USAGE_OUTPUT_BAR_COLOR = "var(--coral)";
 const USAGE_PROVIDER_BAR_COLOR = "var(--color-accent)";
 
 // ─── Types ───


### PR DESCRIPTION
## Scope

Narrow UI-W2 usage page progress-token drift repair.

Changed files:
- `test/unit/ui/ui-w2-usage-token-drift-contract.test.ts`
- `ui/src/routes/usage-page.tsx`

This replaces stale progress bar colors (`#6366f1`, `#8b5cf6`) with selected Friday tokens:
- input/provider bars: `var(--color-accent)`
- output bar: `var(--coral)` (canonical selected coral token defined in `ui/src/styles/tokens.css`)

No route, API, auth, approval, persistence, deployment, CI, or runtime behavior is changed.

## Red-first evidence

Evidence directory:
`/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-usage-token-20260707T0416-0700/`

- Initial red commit: `3cfaf0b8` (`test(ui): capture usage page token drift`), test-only.
- Initial red log: `red-usage-token.exit=1`, failing on legacy `#6366f1/#8b5cf6` assertion, not setup/import failure.
- Initial green commit: `7b2b1bed` (`fix(ui): align usage page progress tokens`).
- Reviewer-refute red commit: `886a2641` (`test(ui): require defined usage output token`), test-only, fails with `red-reviewer-token-name.exit=1` while the product still used undefined `var(--color-coral)`.
- Reviewer-refute green/current head: `f222f1dc` (`fix(ui): use defined usage output token`).
- Current green logs: `green-reviewer-token-name.exit=0`, `green-typecheck-after-refute.exit=0`, `diff-check-after-refute.exit=0`.
- Valid revert-red: `revert-red-valid-usage-token.exit=1`, failing on the `var(--coral)` assertion after reverting `f222f1dc` in a scratch worktree with dependencies linked.
- Non-counted evidence retained: missing-vitest startup errors and wrong-worktree revert-red are not counted.
- Evidence integrity: `sha256sums.verify.exit=0` after refreshing `SHA256SUMS`.

## Independent reviewers / refutes

- Lagrange `019f3c36-0942-7600-8a08-c27a3dc2cb97`: NEEDS-CHANGES. Refutes: `var(--color-coral)` was undefined; prior revert-red v2 was startup failure, not assertion failure; checksum was stale.
- Feynman `019f3c36-2ad9-79e0-af6c-4f4fcd85abdf`: NEEDS-CHANGES with the same issues.

Disposition:
- Closed by `886a2641` + `f222f1dc`.
- Output bar now uses `var(--coral)`, the selected coral token defined in `ui/src/styles/tokens.css`.
- Valid revert-red is now `revert-red-valid-usage-token.exit=1` with a substantive assertion failure.
- `SHA256SUMS` and `sha256sums.verify.*` were regenerated after the new evidence files.

A final read-only reviewer is being run for the current head; this PR remains queued for military/advisor SIGN regardless of advisory PASS.

## Boundaries

Per §27 v8 this PR is queued for military/advisor SIGN and external merge only. Builder must not merge.

This PR is not END-BAR, not HR13/operator visual attestation, not prod deploy/currentness, not release/latest-install, not organic adoption, not terminal channel/device proof, and not final UI matrix completion.
