### PR TITLE
Align settings guide avatar tokens

### DIFF
--- a/test/unit/ui/ui-w2-settings-avatar-token-drift-contract.test.ts
+++ b/test/unit/ui/ui-w2-settings-avatar-token-drift-contract.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const settingsPageSource = () => readFileSync("ui/src/routes/settings-page.tsx", "utf8");
+
+describe("UI-W2 settings guide avatar token drift", () => {
+  it("keeps the guide avatar on selected neutral surface tokens", () => {
+    const source = settingsPageSource();
+
+    expect(source).not.toContain("bg-[#c4c7c5]");
+    expect(source).toContain("bg-[color:var(--color-bg-surface-strong)]");
+    expect(source).toContain("text-[color:var(--color-accent)]");
+  });
+});

--- a/ui/src/routes/settings-page.tsx
+++ b/ui/src/routes/settings-page.tsx
@@ -1095,7 +1095,7 @@ export function SettingsPage() {
           {guideLensState ? (
             <div className="space-y-4 text-sm text-[color:var(--color-text-secondary)]">
               <div className="flex items-center gap-4 rounded-[18px] border border-[color:var(--color-border-soft)] bg-[color:var(--color-bg-subtle)] p-4">
-                <div className="grid h-14 w-14 shrink-0 place-items-center rounded-full bg-[#c4c7c5] text-xl font-semibold text-white">
+                <div className="grid h-14 w-14 shrink-0 place-items-center rounded-full bg-[color:var(--color-bg-surface-strong)] text-xl font-semibold text-[color:var(--color-accent)]">
                   {guideLensState.preferences.avatar.kind === "default_f" ? (guideLensState.preferences.avatar.initials ?? "F") : "F"}
                 </div>
                 <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Scope

Narrow UI-W2 token drift fix for the Settings guide avatar.

Changed files:
- `test/unit/ui/ui-w2-settings-avatar-token-drift-contract.test.ts`
- `ui/src/routes/settings-page.tsx`

This replaces the stale hard-coded gray avatar class `bg-[#c4c7c5] text-white` with selected Friday token classes:
- `bg-[color:var(--color-bg-surface-strong)]`
- `text-[color:var(--color-accent)]`

No route, API, state, security, runtime, provider, deployment, CI, or approval behavior is changed.

## Red-first evidence

Evidence directory:
`/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-settings-avatar-token-20260707T0443-0700/`

- Red commit: `74229a6e` (`test(ui): capture settings avatar token drift`), test-only.
- Counted red: `red-settings-avatar-token.exit=1`, failing on `bg-[#c4c7c5]` assertion, not setup/import failure.
- Green commit/current head: `e5647298` (`fix(ui): align settings guide avatar tokens`).
- Green logs: `green-settings-avatar-related.exit=0`, `green-typecheck.exit=0`, `green-diff-check.exit=0`.
- Revert-red: `revert-red-settings-avatar-token.exit=1`, same stale-avatar assertion returns when the green hunk is reverted.
- Born-current rerun after `git fetch origin main && git rebase origin/main`: `current-green-settings-avatar-related.exit=0`, `current-green-typecheck.exit=0`, `current-diff-check.exit=0`.
- Open PR overlap: `current-open-pr-overlap.exit=0`, `overlaps=[]`.
- Evidence integrity: `sha256sums.verify.exit=0`.

## Independent review

- Reviewer A Pauli: `reviewer-a-settings-avatar-token.md`, verdict PASS.
- Reviewer B Planck: `reviewer-b-settings-avatar-token.md`, verdict PASS.

No reviewer NEEDS-CHANGES/refute remains open.

## Boundaries

Per §27 v8 this PR is queued for military/advisor SIGN and external merge only. Builder must not merge.

This PR is not END-BAR, not HR13/operator visual attestation, not prod deploy/currentness, not release/latest-install, not organic adoption, not terminal channel/device proof, and not final UI matrix completion.
