### PR TITLE
Align deeplink dialog tokens

### DIFF
--- a/test/unit/ui/deeplink-preview-dialog.test.ts
+++ b/test/unit/ui/deeplink-preview-dialog.test.ts
@@ -1,11 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { parseHTML } from "linkedom";
+import { readFileSync } from "node:fs";
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DeepLinkPreviewDialog } from "../../../ui/src/components/deeplink/deeplink-preview-dialog";
+
+const DEEPLINK_DIALOG_SOURCE = "ui/src/components/deeplink/deeplink-preview-dialog.tsx";
 
 const mocks = vi.hoisted(() => ({
   post: vi.fn(),
@@ -135,6 +138,18 @@ describe("DeepLinkPreviewDialog", () => {
     defineGlobal("navigator", previousNavigator as typeof globalThis.navigator);
     defineGlobal("HTMLElement", previousHTMLElement as typeof globalThis.HTMLElement);
     defineGlobal("Event", previousEvent as typeof globalThis.Event);
+  });
+
+  it("keeps advisory and inline-code chrome on selected Friday tokens", () => {
+    const source = readFileSync(DEEPLINK_DIALOG_SOURCE, "utf8");
+
+    expect(source).not.toContain("bg-blue-100");
+    expect(source).not.toContain("text-blue-600");
+    expect(source).not.toContain("bg-zinc-100");
+
+    expect(source).toContain("bg-[color:var(--color-accent-soft)]");
+    expect(source).toContain("text-[color:var(--color-accent)]");
+    expect(source).toContain("bg-[color:var(--color-bg-subtle)]");
   });
 
   it("imports a workflow-template draft and navigates to the returned builder route", async () => {

--- a/ui/src/components/deeplink/deeplink-preview-dialog.tsx
+++ b/ui/src/components/deeplink/deeplink-preview-dialog.tsx
@@ -55,7 +55,7 @@ function checkLevelBadge(level: string) {
     case "warning":
       return <span className="rounded-full bg-[color:var(--warn-soft)] px-2 py-0.5 text-xs font-medium text-[color:var(--warn)]">Warning</span>;
     default:
-      return <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-600 ">Advisory</span>;
+      return <span className="rounded-full bg-[color:var(--color-accent-soft)] px-2 py-0.5 text-xs font-medium text-[color:var(--color-accent)]">Advisory</span>;
   }
 }
 
@@ -99,7 +99,7 @@ export function DeepLinkPreviewDialog(props: { onClose: () => void; onApplied?: 
       >
         <h2 className="text-lg font-semibold text-[color:var(--color-text-primary)]">Import from URL</h2>
         <p className="mt-1 text-sm text-[color:var(--color-text-secondary)]">
-          Paste a <code className="rounded bg-zinc-100 px-1 ">friday://</code> deep link or a JSON payload to preview it before importing.
+          Paste a <code className="rounded bg-[color:var(--color-bg-subtle)] px-1 text-[color:var(--color-text-primary)]">friday://</code> deep link or a JSON payload to preview it before importing.
         </p>
 
         <textarea


### PR DESCRIPTION
## Scope

Narrow UI-W2 token drift fix for the deeplink preview dialog.

Changed files:
- `test/unit/ui/deeplink-preview-dialog.test.ts`
- `ui/src/components/deeplink/deeplink-preview-dialog.tsx`

This replaces stale Tailwind color literals in the dialog chrome:
- Advisory badge: `bg-blue-100 text-blue-600` -> Friday accent tokens.
- Inline `friday://` code chip: `bg-zinc-100` -> Friday neutral token classes.

No deeplink parser, preview/apply API path, mutation behavior, navigation, approval, auth, runtime, deployment, CI, provider, or persistence behavior is changed.

## Red-first evidence

Evidence directory:
`/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-deeplink-dialog-token-20260707T042502-0700`

- Red commit: `9c1a3332a1bcf596ecf54407a1824fefea78b7a5` (test-only).
- Counted red: `red-deeplink-dialog-token.v2.exit=1`, failing on the stale `bg-blue-100` token assertion, not setup/import failure.
- Green/current head: `f5cd6dfd21a59f08ad8162fd944d21845ec90a04` (`fix(ui): align deeplink dialog tokens`).
- Green logs: `green-deeplink-dialog-token.exit=0`, `green-typecheck-src.exit=0`, `green-diff-check.exit=0`.
- Revert-red: `revert-red-deeplink-dialog-token.exit=1` after temporarily reverting the green commit.
- Born-current/current-head reruns after `git fetch origin main && git rebase origin/main`: `current-green-deeplink-dialog-token.exit=0`, `current-green-typecheck-src.exit=0`, `current-diff-check.exit=0`.
- Open PR overlap: `open-pr-overlap.exit=0`, `overlaps=[]`.
- Evidence integrity: `sha256sums.verify.exit=0`.

## Independent review

- Reviewer A Laplace `019f3c54-4382-7860-a4f5-7e6812564d7f`: `reviewer-a-laplace-deeplink-dialog-token.md`, verdict PASS.
- Reviewer B Pauli `019f3bce-b86e-7161-9eea-03c3e7c9d011`: `reviewer-b-pauli-deeplink-dialog-token.md`, verdict PASS.

No reviewer NEEDS-CHANGES/refute remains open.

## Boundaries

Per §27 v8 this PR is queued for military/advisor SIGN and external merge only. Builder must not merge.

This PR is not END-BAR, not HR13/operator visual attestation, not rendered visual proof, not prod deploy/currentness, not release/latest-install, not organic adoption, not terminal channel/device proof, and not final UI matrix completion.
