### PR TITLE
Align workflow builder edge tokens

### DIFF
--- a/test/unit/ui/ui-w2-workflow-builder-token-drift-contract.test.ts
+++ b/test/unit/ui/ui-w2-workflow-builder-token-drift-contract.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const WORKFLOW_BUILDER_SOURCE = resolve(
+  process.cwd(),
+  "ui/src/components/workflows/workflow-builder-workspace.tsx",
+);
+
+describe("UI-W2 workflow builder token contract", () => {
+  it("uses Friday tokens for workflow canvas edge colors", () => {
+    const source = readFileSync(WORKFLOW_BUILDER_SOURCE, "utf8");
+
+    expect(source).not.toContain("rgba(251, 113, 133");
+    expect(source).not.toContain("rgba(251, 191, 36");
+    expect(source).not.toContain("rgba(110, 231, 183");
+    expect(source).not.toContain("rgba(125, 211, 252");
+    expect(source).not.toContain("rgba(236, 245, 255");
+
+    expect(source).toContain("WORKFLOW_BUILDER_EDGE_COLORS");
+    expect(source).toContain("var(--color-text-danger)");
+    expect(source).toContain("var(--color-text-warning)");
+    expect(source).toContain("var(--color-accent)");
+    expect(source).toContain("var(--color-border-soft)");
+  });
+});

--- a/ui/src/components/workflows/workflow-builder-workspace.tsx
+++ b/ui/src/components/workflows/workflow-builder-workspace.tsx
@@ -163,6 +163,13 @@ const INTEGRATION_MODE_OPTIONS = [
 const NODE_LIBRARY_DND_MIME = "application/friday-workflow-node-type";
 
 const CANVAS_GRID_SIZE = 28;
+const WORKFLOW_BUILDER_EDGE_COLORS = {
+  active: "var(--color-accent)",
+  danger: "var(--color-text-danger)",
+  neutral: "var(--color-border-soft)",
+  selected: "var(--color-accent)",
+  warning: "var(--color-text-warning)",
+} as const;
 
 function describePaletteEntry(type: Exclude<WorkflowNodeType, "trigger">) {
   return BUILDER_NODE_PALETTE.find((entry) => entry.type === type) ?? null;
@@ -322,8 +329,8 @@ function toFlowEdges(edges: FridayWorkflowEditorEdge[], selectedEdgeIds: string[
     ...edge,
     type: "workflow_edge",
     selected: selected.has(edge.id),
-    markerEnd: { type: MarkerType.ArrowClosed, color: "rgba(236, 245, 255, 0.8)" },
-    style: { stroke: "rgba(236, 245, 255, 0.65)", strokeWidth: 1.6 },
+    markerEnd: { type: MarkerType.ArrowClosed, color: WORKFLOW_BUILDER_EDGE_COLORS.neutral },
+    style: { stroke: WORKFLOW_BUILDER_EDGE_COLORS.neutral, strokeWidth: 1.6 },
   }));
 }
 
@@ -474,10 +481,10 @@ function issueToneToStatusTone(tone?: BuilderValidationTone): "warning" | "dange
 }
 
 function issueToneToEdgeStroke(tone?: BuilderValidationTone, selected?: boolean): string {
-  if (tone === "danger") return "rgba(251, 113, 133, 0.9)";
-  if (tone === "warning") return "rgba(251, 191, 36, 0.9)";
-  if (selected) return "rgba(110, 231, 183, 0.92)";
-  return "rgba(236, 245, 255, 0.65)";
+  if (tone === "danger") return WORKFLOW_BUILDER_EDGE_COLORS.danger;
+  if (tone === "warning") return WORKFLOW_BUILDER_EDGE_COLORS.warning;
+  if (selected) return WORKFLOW_BUILDER_EDGE_COLORS.selected;
+  return WORKFLOW_BUILDER_EDGE_COLORS.neutral;
 }
 
 function createCompactCanvasNode(node: FlowNode): FlowNode {
@@ -716,7 +723,7 @@ function WorkflowCanvasEdgeInner(props: EdgeProps<FlowEdge>) {
     targetPosition,
   });
   const edgeStroke = isActiveIssue
-    ? "rgba(125, 211, 252, 0.96)"
+    ? WORKFLOW_BUILDER_EDGE_COLORS.active
     : issueToneToEdgeStroke(data?.issueTone, selected);
   const compactMode = interaction?.compactMode === true && !selected && !isActiveIssue && !data?.primaryIssueMessage;
 
@@ -2351,8 +2358,8 @@ function WorkflowBuilderEditor() {
           branch,
         }),
       },
-      markerEnd: { type: MarkerType.ArrowClosed, color: "rgba(236, 245, 255, 0.8)" },
-      style: { stroke: "rgba(236, 245, 255, 0.65)", strokeWidth: 1.6 },
+      markerEnd: { type: MarkerType.ArrowClosed, color: WORKFLOW_BUILDER_EDGE_COLORS.neutral },
+      style: { stroke: WORKFLOW_BUILDER_EDGE_COLORS.neutral, strokeWidth: 1.6 },
     } satisfies FlowEdge;
     const nextEdges = [...edges, nextEdge];
     updateGraph({


### PR DESCRIPTION
## Scope

UI-W2 workflow builder token alignment. This PR only aligns the workflow builder canvas edge colors with Friday token variables.

Touched files:

- `test/unit/ui/ui-w2-workflow-builder-token-drift-contract.test.ts`
- `ui/src/components/workflows/workflow-builder-workspace.tsx`

No workflow graph behavior, save, compile, publish, external review, approval, permission, provider, deploy, or security logic is changed.

## Red / Green

Base: `origin/main=25329515e417a5f938e2e83b049a31bb3ebeee83`
Current head: `24c99608d7df15ddfa68583ef4851badfc20030a`

Evidence: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-workflow-builder-token-20260707T044506-0700/`

- Red commit: `4379c8df84d97e41f9a19e73f850baaf3f61ae97` adds only the workflow builder token contract test.
- Counted red: `red-workflow-builder-token.exit=1`; Vitest starts successfully and fails on the stale `rgba(251, 113, 133` source assertion.
- Non-counted setup attempt retained: `noncounted-red-missing-vitest.log`; dependency executable was missing before `pnpm install --frozen-lockfile`, so it is not counted as red evidence.
- Green commit: `24c99608d7df15ddfa68583ef4851badfc20030a` adds `WORKFLOW_BUILDER_EDGE_COLORS` and replaces hardcoded edge rgba palette values with `var(--color-...)` token variables.
- Counted green: `green-workflow-builder-token-related.exit=0`, `green-typecheck-src.exit=0`, `green-diff-check.exit=0`.
- Revert-red: `revert-red-workflow-builder-token.exit=1`; temporarily reverting the green commit makes the same source assertion fail again.
- Current head reruns: `current-green-workflow-builder-token-related.exit=0`, `current-green-typecheck-src.exit=0`, `current-diff-check.exit=0`.
- Open PR overlap: `current-open-pr-overlap.json` reports `overlaps: []`.
- SHA verification: `sha256sums.verify.exit=0`.

## Reviewers

- Reviewer A Hooke `019f3c67-7850-79f3-9cde-7ef3f32ed43e`: PASS, `reviewer-a-hooke-workflow-builder-token.md`.
- Reviewer B Parfit `019f3c67-ab27-7501-869e-777b699b918e`: PASS, `reviewer-b-parfit-workflow-builder-token.md`.

## Refutes

No reviewer/advisor refutes were raised for this PR. Reviewer B caveat retained: read-only review did not rerun tests; counted builder evidence includes the actual green/typecheck/revert-red logs.

## Boundaries

This PR is not END-BAR, not HR13/operator visual attestation, not rendered screenshot parity, not prod deploy/currentness, not release/latest-install, not organic adoption, and not terminal channel/device proof.

Per §27 v8 this remains `military-sign-required`: builder must not merge. Military/advisor SIGN and any merge are external only, after current-head PR-CI required contexts are all present and success.
