### PR TITLE
Align shell splash tokens

### DIFF
--- a/test/unit/ui/ui-w2-shell-splash-token-contract.test.ts
+++ b/test/unit/ui/ui-w2-shell-splash-token-contract.test.ts
@@ -9,7 +9,9 @@ describe("UI-W2 shell splash token contract", () => {
     const files = [
       "ui/src/components/console/shell/splash/shell.tsx",
       "ui/src/components/console/shell/splash/auth-error.tsx",
+      "ui/src/components/console/shell/splash/loading.tsx",
       "ui/src/components/console/shell/splash/network-error.tsx",
+      "ui/src/components/console/shell/splash/setup-gate.tsx",
     ];
     const source = files.map((file) => readRepoFile(file)).join("\n");
 
@@ -20,6 +22,8 @@ describe("UI-W2 shell splash token contract", () => {
       "var(--ink-700)",
       "var(--ink-500)",
       "var(--ink-300)",
+      "var(--accent)",
+      "var(--accent-soft)",
       "var(--rust-500)",
       "rgba(176, 80, 58, 0.14)",
       "rgba(15, 125, 140, 0.22)",
@@ -38,6 +42,8 @@ describe("UI-W2 shell splash token contract", () => {
       "var(--color-text-faint)",
       "var(--color-text-danger)",
       "var(--color-bg-danger-subtle)",
+      "var(--color-accent)",
+      "var(--color-accent-soft)",
       "var(--color-border-strong)",
     ];
 

--- a/test/unit/ui/ui-w2-shell-splash-token-contract.test.ts
+++ b/test/unit/ui/ui-w2-shell-splash-token-contract.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readRepoFile = (path: string) => readFileSync(resolve(process.cwd(), path), "utf8");
+
+describe("UI-W2 shell splash token contract", () => {
+  it("keeps splash shell surfaces and error accents on selected color tokens", () => {
+    const files = [
+      "ui/src/components/console/shell/splash/shell.tsx",
+      "ui/src/components/console/shell/splash/auth-error.tsx",
+      "ui/src/components/console/shell/splash/network-error.tsx",
+    ];
+    const source = files.map((file) => readRepoFile(file)).join("\n");
+
+    const bannedFragments = [
+      "var(--surface-0)",
+      "var(--surface-2)",
+      "var(--ink-900)",
+      "var(--ink-700)",
+      "var(--ink-500)",
+      "var(--ink-300)",
+      "var(--rust-500)",
+      "rgba(176, 80, 58, 0.14)",
+      "rgba(15, 125, 140, 0.22)",
+    ];
+
+    for (const fragment of bannedFragments) {
+      expect(source, `splash shell should not use stale token fragment ${fragment}`).not.toContain(fragment);
+    }
+
+    const requiredFragments = [
+      "var(--color-bg-base)",
+      "var(--color-bg-surface-strong)",
+      "var(--color-text-primary)",
+      "var(--color-text-secondary)",
+      "var(--color-text-tertiary)",
+      "var(--color-text-faint)",
+      "var(--color-text-danger)",
+      "var(--color-bg-danger-subtle)",
+      "var(--color-border-strong)",
+    ];
+
+    for (const fragment of requiredFragments) {
+      expect(source, `splash shell should use selected token fragment ${fragment}`).toContain(fragment);
+    }
+  });
+});

--- a/ui/src/components/console/shell/splash/auth-error.tsx
+++ b/ui/src/components/console/shell/splash/auth-error.tsx
@@ -9,12 +9,12 @@ import { SplashShell, type SplashShellProps } from "./shell";
 export function AuthErrorSplash(props: Omit<SplashShellProps, "visual">) {
   return (
     <SplashShell
-      accentColor="var(--rust-500)"
+      accentColor="var(--color-text-danger)"
       visual={
         <span
           aria-hidden="true"
           className="inline-flex h-10 w-10 items-center justify-center rounded-full"
-          style={{ background: "rgba(176, 80, 58, 0.14)", color: "var(--rust-500)" }}
+          style={{ background: "var(--color-bg-danger-subtle)", color: "var(--color-text-danger)" }}
         >
           <ShieldAlert className="h-5 w-5" />
         </span>

--- a/ui/src/components/console/shell/splash/loading.tsx
+++ b/ui/src/components/console/shell/splash/loading.tsx
@@ -15,7 +15,7 @@ export function LoadingSplash(props: Omit<SplashShellProps, "visual"> & { eyebro
         <span
           aria-hidden="true"
           className="inline-flex h-10 w-10 items-center justify-center rounded-full"
-          style={{ background: "var(--accent-soft)", color: "var(--accent)" }}
+          style={{ background: "var(--color-accent-soft)", color: "var(--color-accent)" }}
         >
           <Loader2 className="h-5 w-5 animate-spin" />
         </span>

--- a/ui/src/components/console/shell/splash/network-error.tsx
+++ b/ui/src/components/console/shell/splash/network-error.tsx
@@ -7,12 +7,12 @@ import { SplashShell, type SplashShellProps } from "./shell";
 export function NetworkErrorSplash(props: Omit<SplashShellProps, "visual">) {
   return (
     <SplashShell
-      accentColor="var(--rust-500)"
+      accentColor="var(--color-text-danger)"
       visual={
         <span
           aria-hidden="true"
           className="inline-flex h-10 w-10 items-center justify-center rounded-full"
-          style={{ background: "rgba(176, 80, 58, 0.14)", color: "var(--rust-500)" }}
+          style={{ background: "var(--color-bg-danger-subtle)", color: "var(--color-text-danger)" }}
         >
           <WifiOff className="h-5 w-5" />
         </span>

--- a/ui/src/components/console/shell/splash/setup-gate.tsx
+++ b/ui/src/components/console/shell/splash/setup-gate.tsx
@@ -9,12 +9,12 @@ import { SplashShell, type SplashShellProps } from "./shell";
 export function SetupGateSplash(props: Omit<SplashShellProps, "visual">) {
   return (
     <SplashShell
-      accentColor="var(--accent)"
+      accentColor="var(--color-accent)"
       visual={
         <span
           aria-hidden="true"
           className="inline-flex h-10 w-10 items-center justify-center rounded-full"
-          style={{ background: "var(--accent-soft)", color: "var(--accent)" }}
+          style={{ background: "var(--color-accent-soft)", color: "var(--color-accent)" }}
         >
           <Wrench className="h-5 w-5" />
         </span>

--- a/ui/src/components/console/shell/splash/shell.tsx
+++ b/ui/src/components/console/shell/splash/shell.tsx
@@ -31,16 +31,16 @@ export interface SplashShellProps {
 }
 
 const PILL_STYLE: Record<NonNullable<SplashPill["tone"]>, { background: string; color: string }> = {
-  neutral: { background: "var(--surface-2)", color: "var(--ink-700)" },
-  warn: { background: "var(--warn-soft)", color: "var(--warn)" },
-  ok: { background: "var(--ok-soft)", color: "var(--ok)" },
-  danger: { background: "var(--danger-soft)", color: "var(--danger)" },
+  neutral: { background: "var(--color-bg-surface-strong)", color: "var(--color-text-secondary)" },
+  warn: { background: "var(--color-bg-warning-subtle)", color: "var(--color-text-warning)" },
+  ok: { background: "var(--color-bg-success-subtle)", color: "var(--color-text-success)" },
+  danger: { background: "var(--color-bg-danger-subtle)", color: "var(--color-text-danger)" },
 };
 
 const STEP_DOT: Record<NonNullable<SplashStep["status"]>, string> = {
-  done: "var(--ok)",
-  active: "var(--accent)",
-  todo: "var(--ink-300)",
+  done: "var(--color-text-success)",
+  active: "var(--color-accent)",
+  todo: "var(--color-text-faint)",
 };
 
 export function SplashShell(props: SplashShellProps) {
@@ -49,7 +49,7 @@ export function SplashShell(props: SplashShellProps) {
   return (
     <div
       className="flex min-h-screen items-center justify-center px-6"
-      style={{ background: "var(--surface-0)" }}
+      style={{ background: "var(--color-bg-base)" }}
     >
       <div className="w-full max-w-xl text-center">
         {visual ? <div className="mb-4 flex justify-center">{visual}</div> : null}
@@ -65,13 +65,13 @@ export function SplashShell(props: SplashShellProps) {
 
         <h1
           className="mt-3 text-2xl font-semibold tracking-tight"
-          style={{ color: "var(--ink-900)", fontFamily: "var(--font-serif-sc)" }}
+          style={{ color: "var(--color-text-primary)", fontFamily: "var(--font-serif-sc)" }}
         >
           {title}
         </h1>
 
         {body ? (
-          <p className="mt-3 text-sm leading-6" style={{ color: "var(--ink-500)" }}>
+          <p className="mt-3 text-sm leading-6" style={{ color: "var(--color-text-tertiary)" }}>
             {body}
           </p>
         ) : null}
@@ -96,7 +96,7 @@ export function SplashShell(props: SplashShellProps) {
         {steps && steps.length > 0 ? (
           <ol className="mt-6 flex flex-col items-start gap-3 text-left">
             {steps.map((step) => (
-              <li key={step.label} className="flex items-start gap-3 text-sm" style={{ color: "var(--ink-700)" }}>
+              <li key={step.label} className="flex items-start gap-3 text-sm" style={{ color: "var(--color-text-secondary)" }}>
                 <span
                   aria-hidden="true"
                   className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
@@ -115,11 +115,11 @@ export function SplashShell(props: SplashShellProps) {
             {actions.map((action) => {
               const isPrimary = action.tone !== "secondary";
               const style = isPrimary
-                ? { background: accentColor ?? "var(--accent)", color: "var(--surface-2)" }
+                ? { background: accentColor ?? "var(--color-accent)", color: "var(--color-bg-surface-strong)" }
                 : {
                     background: "transparent",
-                    color: "var(--ink-700)",
-                    border: "1px solid rgba(15, 125, 140, 0.22)",
+                    color: "var(--color-text-secondary)",
+                    border: "1px solid var(--color-border-strong)",
                   };
               const className = "inline-flex min-h-[40px] items-center gap-2 rounded-[var(--radius-md)] px-4 text-sm font-medium transition-opacity hover:opacity-90";
               if (action.href) {

--- a/ui/src/components/console/shell/splash/shell.tsx
+++ b/ui/src/components/console/shell/splash/shell.tsx
@@ -57,7 +57,7 @@ export function SplashShell(props: SplashShellProps) {
         {eyebrow ? (
           <p
             className="text-[11px] font-semibold uppercase tracking-[0.18em]"
-            style={{ color: accentColor ?? "var(--accent)" }}
+            style={{ color: accentColor ?? "var(--color-accent)" }}
           >
             {eyebrow}
           </p>


### PR DESCRIPTION
## Summary
- Adds a UI-W2 source-token contract for the console shell splash surface.
- Moves all five splash files off stale compatibility aliases and hardcoded rgba fragments onto selected `--color-*` tokens.
- Closes reviewer-discovered coverage gap for `loading.tsx`, `setup-gate.tsx`, and the shell eyebrow fallback.

## Scope / touched files
- `test/unit/ui/ui-w2-shell-splash-token-contract.test.ts`
- `ui/src/components/console/shell/splash/shell.tsx`
- `ui/src/components/console/shell/splash/auth-error.tsx`
- `ui/src/components/console/shell/splash/network-error.tsx`
- `ui/src/components/console/shell/splash/loading.tsx`
- `ui/src/components/console/shell/splash/setup-gate.tsx`

No API, routing, auth, provider, runtime, deployment, security, package, lockfile, or approval logic changes. `toSafeHref`, `href`, and `onClick` behavior remain unchanged.

## Red-first / evidence
Evidence directory: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-shell-splash-token-20260707T0502-0700/`

- Base: `25329515e417a5f938e2e83b049a31bb3ebeee83`
- Head / SIGN target candidate: `1c4853d8218bd15abcf72975f0465132e8f5c7b4`
- Initial red commit: `84eca826` (`test: catch shell splash token drift`), test-only. Counted red: `logs/red-shell-splash-token.v2.exit=1`; failure was a Vitest assertion on old splash token fragments; Type Errors reported no errors. `logs/red-shell-splash-token.log` is retained as non-counted setup/install failure.
- Initial green commit: `68866324` (`fix: align shell splash tokens`). Green: `logs/green-shell-splash-token.exit=0`, `logs/green-typecheck-src.exit=0`, `logs/green-diff-check.exit=0`.
- Reviewer refute red commit: `985a1a63` (`test: cover all shell splash token aliases`), test-only. Counted red: `logs/red-reviewer-refute-shell-splash-complete-scope.exit=1`; it failed on remaining `var(--accent)` / `var(--accent-soft)` in 5/5 splash coverage.
- Reviewer refute green commit: `1c4853d8` (`fix: finish shell splash token aliases`). Green: `logs/green-reviewer-refute-shell-splash-complete-scope.exit=0`, `logs/green-reviewer-refute-typecheck-src.exit=0`, `logs/green-reviewer-refute-diff-check.exit=0`.
- Final current-head evidence: `logs/final-green-shell-splash-token.exit=0`, `logs/final-green-typecheck-src.exit=0`, `logs/final-diff-check.exit=0`, `logs/revert-red-refute-shell-splash-complete-scope.exit=1`, `open-pr-overlap-current.exit=0`, `sha256sums.verify.exit=0`.
- Stale-token scan: `logs/final-stale-token-scan.exit=1` with empty log; this is expected `rg` no-match semantics and proves no old splash token hits remain for the banned pattern.

## Advisory reviewers
- Reviewer C Aristotle `019f3c7b-823c-73a2-903c-cc243fabeb48`: PASS. File: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-shell-splash-token-20260707T0502-0700/reviewer-c-aristotle-shell-splash-token.md`.
- Reviewer D Gauss `019f3c7b-99fe-7f40-acb1-01b04e7e6da0`: PASS. File: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-shell-splash-token-20260707T0502-0700/reviewer-d-gauss-shell-splash-token.md`.

## Refute disclosure
Reviewer B Descartes `019f3c76-38c7-73d1-80ab-65a908676131` initially returned NEEDS-CHANGES:

> main blocker: the test covered only 3 of the 5 splash files; remaining legacy token uses were `shell.tsx` eyebrow fallback `accentColor ?? "var(--accent)"`, `setup-gate.tsx` `accentColor="var(--accent)"`, `setup-gate.tsx` visual `var(--accent-soft)` / `var(--accent)`, and `loading.tsx` visual `var(--accent-soft)` / `var(--accent)`.

Resolution: commit `985a1a63` expanded the contract to 5/5 splash files and made the remaining aliases fail red; commit `1c4853d8` replaced the remaining aliases with `var(--color-accent)` / `var(--color-accent-soft)`. Aristotle and Gauss both re-reviewed the current head and returned PASS. Caveat retained: this is source-token/typecheck evidence, not a browser screenshot visual proof.

## No-degrade
- Product diffs are inline style token replacements only.
- `toSafeHref(action.href, { allowRelative: true })`, link/button branching, auth error/network error setup semantics, routing, APIs, security gates, runtime, deployment, provider behavior, and persistence were not changed.
- Open PR exact-file overlap check reports `overlaps=[]`.

## §27 v8 boundary
This PR is queued for military/advisor SIGN. Builder must not merge. This is not END-BAR, not HR13/operator visual attestation, not prod deploy/currentness, not release/latest-install, not organic adoption, not terminal channel/device proof, and not final UI matrix completion.
