### PR TITLE
Align shell rail tokens

### DIFF
--- a/test/unit/ui/ui-w2-shell-rail-token-contract.test.ts
+++ b/test/unit/ui/ui-w2-shell-rail-token-contract.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readRepoFile = (path: string) => readFileSync(resolve(process.cwd(), path), "utf8");
+
+describe("UI-W2 shell rail token contract", () => {
+  it("keeps desktop and mobile shell rails on selected color tokens", () => {
+    const source = readRepoFile("ui/src/components/console/shell/rail.tsx");
+
+    const bannedFragments = [
+      "var(--surface-1)",
+      "var(--surface-border)",
+      "var(--ink-900)",
+      "var(--ink-700)",
+      "var(--ink-500)",
+      "var(--ink-300)",
+      "var(--accent-soft)",
+      "rgba(18, 40, 45, 0.10)",
+    ];
+
+    for (const fragment of bannedFragments) {
+      expect(source, `shell rail should not use stale token fragment ${fragment}`).not.toContain(fragment);
+    }
+
+    const requiredFragments = [
+      "var(--color-bg-chrome)",
+      "var(--color-border-soft)",
+      "var(--color-text-primary)",
+      "var(--color-text-secondary)",
+      "var(--color-text-tertiary)",
+      "var(--color-text-faint)",
+      "var(--color-accent-soft)",
+    ];
+
+    for (const fragment of requiredFragments) {
+      expect(source, `shell rail should use selected token fragment ${fragment}`).toContain(fragment);
+    }
+  });
+});

--- a/ui/src/components/console/shell/rail.tsx
+++ b/ui/src/components/console/shell/rail.tsx
@@ -94,28 +94,28 @@ export function Rail({ collapsed, onToggleCollapse }: RailProps) {
       <div
         className="flex h-full flex-col border-r px-3 py-4"
         style={{
-          background: "var(--surface-1)",
-          borderColor: "var(--ink-300)",
-          borderRightColor: "rgba(18, 40, 45, 0.10)",
+          background: "var(--color-bg-chrome)",
+          borderColor: "var(--color-text-faint)",
+          borderRightColor: "var(--color-border-soft)",
         }}
       >
         <div className={cn("flex items-center gap-2 px-1 pb-3", collapsed ? "justify-center" : "justify-between")}>
           {collapsed ? (
             <p
               className="text-base font-semibold tracking-tight"
-              style={{ color: "var(--ink-900)" }}
+              style={{ color: "var(--color-text-primary)" }}
               aria-label="Friday"
             >
               F
             </p>
           ) : (
             <div className="min-w-0">
-              <p className="text-base font-semibold tracking-tight" style={{ color: "var(--ink-900)" }}>
+              <p className="text-base font-semibold tracking-tight" style={{ color: "var(--color-text-primary)" }}>
                 Friday
               </p>
               <p
                 className="mt-0.5 text-xs italic"
-                style={{ fontFamily: "var(--font-serif-sc)", color: "var(--ink-500)" }}
+                style={{ fontFamily: "var(--font-serif-sc)", color: "var(--color-text-tertiary)" }}
               >
                 Console
               </p>
@@ -126,8 +126,8 @@ export function Rail({ collapsed, onToggleCollapse }: RailProps) {
             onClick={onToggleCollapse}
             aria-label={localize(locale, collapsed ? "展开导航" : "收起导航", collapsed ? "Expand rail" : "Collapse rail")}
             aria-pressed={collapsed}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] transition-colors hover:bg-[color:var(--accent-soft)]"
-            style={{ color: "var(--ink-500)" }}
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)] transition-colors hover:bg-[color:var(--color-accent-soft)]"
+            style={{ color: "var(--color-text-tertiary)" }}
           >
             {collapsed ? <ChevronsRight className="h-4 w-4" /> : <ChevronsLeft className="h-4 w-4" />}
           </button>
@@ -141,7 +141,7 @@ export function Rail({ collapsed, onToggleCollapse }: RailProps) {
 
         <div
           className="mt-4 border-t pt-3"
-          style={{ borderColor: "var(--surface-border)" }}
+          style={{ borderColor: "var(--color-border-soft)" }}
           aria-label="Advanced surfaces"
         >
           <nav className="space-y-1">
@@ -153,7 +153,7 @@ export function Rail({ collapsed, onToggleCollapse }: RailProps) {
 
         <div
           className="mt-auto border-t pt-3"
-          style={{ borderColor: "var(--surface-border)" }}
+          style={{ borderColor: "var(--color-border-soft)" }}
         >
           <RailNavItem
             item={{
@@ -170,7 +170,7 @@ export function Rail({ collapsed, onToggleCollapse }: RailProps) {
             onClick={() => setLocale(locale === "zh" ? "en" : "zh")}
             className="mt-2 flex w-full items-center gap-2 rounded-[var(--radius-md)] px-3 py-2 text-sm transition-colors"
             style={{
-              color: "var(--ink-700)",
+              color: "var(--color-text-secondary)",
               background: "transparent",
             }}
             aria-label={localize(locale, "切换语言", "Toggle language")}
@@ -203,8 +203,8 @@ function RailNavItem(props: {
         collapsed ? "justify-center" : "",
       )}
       style={({ isActive }) => ({
-        color: isActive ? "var(--ink-900)" : "var(--ink-700)",
-        background: isActive ? "var(--accent-soft)" : "transparent",
+        color: isActive ? "var(--color-text-primary)" : "var(--color-text-secondary)",
+        background: isActive ? "var(--color-accent-soft)" : "transparent",
       })}
     >
       <Icon className="h-4 w-4 shrink-0" />
@@ -229,8 +229,8 @@ export function MobileNav(props: { onOpenMore: () => void }) {
       aria-label="Mobile navigation"
       className="fixed inset-x-0 bottom-0 z-30 border-t lg:hidden"
       style={{
-        background: "var(--surface-1)",
-        borderColor: "var(--surface-border)",
+        background: "var(--color-bg-chrome)",
+        borderColor: "var(--color-border-soft)",
         height: "var(--shell-mobile-nav-h)",
       }}
     >
@@ -241,8 +241,8 @@ export function MobileNav(props: { onOpenMore: () => void }) {
             to={item.path}
             className="flex flex-col items-center justify-center rounded-[var(--radius-md)] text-[11px] font-medium transition-colors"
             style={({ isActive }) => ({
-              color: isActive ? "var(--ink-900)" : "var(--ink-500)",
-              background: isActive ? "var(--accent-soft)" : "transparent",
+              color: isActive ? "var(--color-text-primary)" : "var(--color-text-tertiary)",
+              background: isActive ? "var(--color-accent-soft)" : "transparent",
             })}
           >
             <item.Icon className="mb-1 h-4 w-4" />
@@ -253,7 +253,7 @@ export function MobileNav(props: { onOpenMore: () => void }) {
           type="button"
           onClick={props.onOpenMore}
           className="flex flex-col items-center justify-center rounded-[var(--radius-md)] text-[11px] font-medium"
-          style={{ color: "var(--ink-500)" }}
+          style={{ color: "var(--color-text-tertiary)" }}
           aria-label={localize(locale, "更多", "More")}
         >
           <BarChart3 className="mb-1 h-4 w-4" />


### PR DESCRIPTION
## Summary
- Adds a UI-W2 source-token contract for the shell navigation rails.
- Replaces stale `--surface-*`, `--ink-*`, `--accent-soft`, and hardcoded rail border rgba usage in `rail.tsx` with selected `--color-*` tokens.
- Keeps navigation, locale, collapse, route, and mobile More behavior unchanged.

## Scope / touched files
- `test/unit/ui/ui-w2-shell-rail-token-contract.test.ts`
- `ui/src/components/console/shell/rail.tsx`

No API, routing definitions, auth, provider, runtime, deployment, security, package, lockfile, pet, capability, approval, or permission logic changes.

## Red-first / evidence
Evidence directory: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-shell-rail-token-20260707T0520-0700/`

- Base: `25329515e417a5f938e2e83b049a31bb3ebeee83`
- Head / SIGN target candidate: `024182ec846055ba178a773c91ee529bc23af437`
- Red commit: `0781decb` (`test: catch shell rail token drift`), test-only. Counted red: `logs/red-shell-rail-token.v3.exit=1`; failure is a Vitest assertion on old rail token fragments; Type Errors reported no errors. Earlier `logs/red-shell-rail-token.exit=127` and `logs/red-shell-rail-token.v2.exit=1` are retained as non-counted setup failures before the worktree had resolvable dependencies.
- Green commit: `024182ec` (`fix: align shell rail tokens`). Green: `logs/green-shell-rail-token.exit=0`, `logs/green-typecheck-src.exit=0`, `logs/green-diff-check.exit=0`.
- Final current-head evidence: `logs/final-green-shell-rail-token.exit=0`, `logs/final-green-typecheck-src.exit=0`, `logs/final-diff-check.exit=0`, `logs/revert-red-shell-rail-token.exit=1`, `open-pr-overlap-current.exit=0`, `sha256sums.verify.exit=0`.
- Stale-token scan: `logs/final-stale-token-scan.exit=1` with empty log; this is expected `rg` no-match semantics and proves no banned rail token hits remain.

## Advisory reviewers
- Reviewer A Confucius `019f3c86-2694-78d0-96e6-61ff566a13dc`: PASS. File: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-shell-rail-token-20260707T0520-0700/reviewer-a-confucius-shell-rail-token.md`.
- Reviewer B Newton `019f3c86-4a05-7571-bfd2-f2ea251c2de5`: PASS. File: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-shell-rail-token-20260707T0520-0700/reviewer-b-newton-shell-rail-token.md`.

## No-degrade
- Product diff is inline style token replacement only.
- `AGENT_OS_NAV_*` data, adaptive nav ordering, `NavLink` paths/end behavior, collapse toggle, locale toggle, mobile More `onOpenMore`, and route behavior are unchanged.
- Open PR exact-file overlap reports `overlaps=[]`.

## §27 v8 boundary
This PR is queued for military/advisor SIGN. Builder must not merge. This is not END-BAR, not HR13/operator visual attestation, not prod deploy/currentness, not release/latest-install, not organic adoption, not terminal channel/device proof, and not final UI matrix completion.
