### PR TITLE
Run plugin live proof with full runtime

### DIFF
--- a/test/e2e/live/friday-self-upgrade-plugin-live.e2e.test.ts
+++ b/test/e2e/live/friday-self-upgrade-plugin-live.e2e.test.ts
@@ -261,6 +261,8 @@ describe.skipIf(!FRIDAY_DEEP_PROOF_GATED)(`Friday Plugin Self Upgrade Live (${FR
     env = await createFridayDeepProofHubEnv({
       hubConfig: {
         tokenSecret: PLUGIN_LIFECYCLE_SIGNING_MATERIAL,
+        pluginRuntimeMode: "full",
+        allowTestOnlyPluginExecution: true,
       },
     });
     pluginRootDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-plugin-self-upgrade-"));

--- a/test/unit/e2e/friday-live-plugin-runtime-contract.test.ts
+++ b/test/unit/e2e/friday-live-plugin-runtime-contract.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const pluginLiveProofPath = path.join(
+  repoRoot,
+  "test/e2e/live/friday-self-upgrade-plugin-live.e2e.test.ts",
+);
+
+describe("Friday plugin self-upgrade live proof runtime config", () => {
+  it("starts the isolated hub with the full plugin runtime enabled", () => {
+    const source = readFileSync(pluginLiveProofPath, "utf8");
+
+    expect(source).toContain("pluginRuntimeMode: \"full\"");
+    expect(source).toContain("allowTestOnlyPluginExecution: true");
+  });
+});


### PR DESCRIPTION
## Summary

NEW-81 red-first repair for the live plugin self-upgrade proof: the isolated Deep Proof hub must opt into the full plugin runtime, otherwise `/v1/plugins/:id/install` runs against the standalone stub and returns 501.

This change is intentionally narrow: it only updates `test/e2e/live/friday-self-upgrade-plugin-live.e2e.test.ts` hubConfig with `pluginRuntimeMode: "full"` and `allowTestOnlyPluginExecution: true`, plus a source contract to keep that live proof from regressing.

## Scope

Files changed:
- `test/e2e/live/friday-self-upgrade-plugin-live.e2e.test.ts`
- `test/unit/e2e/friday-live-plugin-runtime-contract.test.ts`

No `src/`, auth, deploy, provider, plugin service, or production runtime source files are changed.

## Red-first evidence

Evidence: /Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new81-plugin-live-full-runtime-20260707T052330-0700

- Red commit: `ce37475a` (`test(new81): expose plugin live runtime stub gap`) adds only `test/unit/e2e/friday-live-plugin-runtime-contract.test.ts`.
- Counted red log: `logs/red-plugin-live-full-runtime-contract.counted.exit=1`; failure is missing `pluginRuntimeMode: "full"`.
- Green commit: `129033b6` (`fix(new81): run plugin live proof with full runtime`) adds the isolated live proof hubConfig repair.
- Green contract: `logs/green-plugin-live-full-runtime-contract.exit=0`.
- Live proof: `logs/green-live-plugin-self-upgrade.exit=0`, redacted log shows `1 passed (1)`.
- Hub bootstrap no-degrade: `logs/green-hub-bootstrap-env.exit=0` (`84 passed`).
- Typecheck: `logs/green-typecheck.exit=0`.
- Diff whitespace check: `logs/green-git-diff-check.exit=0`.
- Revert-red: `logs/revert-red-plugin-live-full-runtime-contract.exit=1` after temporarily removing the two green config lines.

Non-counted setup/wrong-command logs retained for audit:
- `logs/red-plugin-live-full-runtime-contract.exit=254`: fresh-worktree setup failure before `pnpm install`, `vitest` missing.
- `logs/noncounted-wrong-command-typecheck-src.exit=1`: obsolete command path `tsconfig.src.json` missing.
- `logs/noncounted-wrong-command-diff-check.exit=1`: obsolete command path `scripts/check-diff.mjs` missing.

## Independent reviewers

- Reviewer A Meitner `019f3c8a-f4c1-73c3-b26c-5a2dbfe26e61`: PASS, file `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new81-plugin-live-full-runtime-20260707T052330-0700/reviewer-a-meitner-new81.md`.
- Reviewer B Volta `019f3c8a-f54c-7ae1-9464-3a8edd4a7ced`: PASS, file `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/new81-plugin-live-full-runtime-20260707T052330-0700/reviewer-b-volta-new81.md`.

Reviewer caveat retained: the new contract is a source-string guard; diff review confirms the strings are in the intended isolated live proof hubConfig.

## No-degrade

- Production default remains fail-closed/stub: `src/hub/friday-hub-bootstrap.ts` still defaults plugin runtime to `stub` and only accepts `full` when a test-only plugin/autonomy execution flag is explicitly enabled.
- Plugin mutation routes remain test-only gated; no route/auth/plugin service source path is changed.
- `open-pr-overlap.json` reports `overlaps: []`.

## Boundary

Builder must not merge. This PR requires §27 v8 military/advisor SIGN after PR-CI terminal true green using branch-protection required contexts. Skipped workflow-condition jobs are non-counted and not proof.

This is not END-BAR, not prod deploy/currentness, not release/latest-install, not organic adoption, not terminal channel/device proof, not HR13/operator visual attestation, not final UI matrix completion, and not final frozen-set completeness.
