### PR TITLE
Align provider truth tokens

### DIFF
--- a/test/unit/ui/ui-w2-provider-truth-token-contract.test.ts
+++ b/test/unit/ui/ui-w2-provider-truth-token-contract.test.ts
@@ -17,6 +17,6 @@ describe("UI-W2 provider truth token contract", () => {
     expect(source).toContain("var(--color-bg-subtle)");
     expect(source).toContain("var(--color-text-secondary)");
     expect(source).toContain("var(--color-accent)");
-    expect(source).toContain("var(--color-status-danger)");
+    expect(source).toContain("var(--color-text-danger)");
   });
 });

--- a/test/unit/ui/ui-w2-provider-truth-token-contract.test.ts
+++ b/test/unit/ui/ui-w2-provider-truth-token-contract.test.ts
@@ -11,12 +11,14 @@ describe("UI-W2 provider truth token contract", () => {
   it("keeps provider truth chrome on selected color tokens", () => {
     const source = readFileSync(providerTruthSourcePath, "utf8");
 
-    expect(source).not.toMatch(/var\(--(?:surface|ink|accent|accent-soft|rust-500)[^)]*\)/);
+    expect(source).not.toMatch(/var\(--(?:surface|ink|accent|accent-soft|rust)[^)]*\)/);
+    expect(source).not.toContain("var(--ok)");
     expect(source).not.toContain("rgba(15, 125, 140");
 
     expect(source).toContain("var(--color-bg-subtle)");
     expect(source).toContain("var(--color-text-secondary)");
     expect(source).toContain("var(--color-accent)");
+    expect(source).toContain("var(--color-text-success)");
     expect(source).toContain("var(--color-text-danger)");
   });
 });

--- a/test/unit/ui/ui-w2-provider-truth-token-contract.test.ts
+++ b/test/unit/ui/ui-w2-provider-truth-token-contract.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const providerTruthSourcePath = resolve(
+  process.cwd(),
+  "ui/src/components/console/shell/provider-truth.tsx",
+);
+
+describe("UI-W2 provider truth token contract", () => {
+  it("keeps provider truth chrome on selected color tokens", () => {
+    const source = readFileSync(providerTruthSourcePath, "utf8");
+
+    expect(source).not.toMatch(/var\(--(?:surface|ink|accent|accent-soft|rust-500)[^)]*\)/);
+    expect(source).not.toContain("rgba(15, 125, 140");
+
+    expect(source).toContain("var(--color-bg-subtle)");
+    expect(source).toContain("var(--color-text-secondary)");
+    expect(source).toContain("var(--color-accent)");
+    expect(source).toContain("var(--color-status-danger)");
+  });
+});

--- a/ui/src/components/console/shell/provider-truth.tsx
+++ b/ui/src/components/console/shell/provider-truth.tsx
@@ -29,10 +29,10 @@ function statusLabel(status: ProviderTruthStatus, locale: AppLocale): string {
 
 function statusDot(status: ProviderTruthStatus): string {
   if (status === "offline") {
-    return "var(--rust-500)";
+    return "var(--color-text-danger)";
   }
   if (status === "degraded" || status === "unavailable") {
-    return "var(--accent)";
+    return "var(--color-accent)";
   }
   return "var(--ok)";
 }
@@ -132,9 +132,9 @@ export function ProviderTruthCompact(props: {
         className,
       )}
       style={{
-        borderColor: "rgba(15, 125, 140, 0.22)",
-        background: "var(--surface-2)",
-        color: "var(--ink-700)",
+        borderColor: "var(--color-border-soft)",
+        background: "var(--color-bg-subtle)",
+        color: "var(--color-text-secondary)",
       }}
     >
       <span
@@ -147,8 +147,8 @@ export function ProviderTruthCompact(props: {
         <span
           className="shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px]"
           style={{
-            borderColor: "rgba(15, 125, 140, 0.20)",
-            color: "var(--ink-300)",
+            borderColor: "var(--color-accent-strong)",
+            color: "var(--color-text-faint)",
             fontFamily: "var(--font-mono-jb)",
           }}
         >
@@ -159,8 +159,8 @@ export function ProviderTruthCompact(props: {
         <span
           className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold"
           style={{
-            background: "var(--accent-soft)",
-            color: "var(--accent)",
+            background: "var(--color-accent-soft)",
+            color: "var(--color-accent)",
           }}
         >
           {localize(locale, `${truth.alertCount} 告警`, `${truth.alertCount} alerts`)}
@@ -243,7 +243,7 @@ export function ProviderTruthCard(props: {
             ) : (
               <ShieldAlert
                 className="h-4 w-4 shrink-0"
-                style={{ color: currentProviderStatus === "offline" ? "var(--rust-500)" : "var(--accent)" }}
+                style={{ color: currentProviderStatus === "offline" ? "var(--color-text-danger)" : "var(--color-accent)" }}
               />
             )}
             <p className="text-sm font-medium text-[color:var(--color-text-primary)]">

--- a/ui/src/components/console/shell/provider-truth.tsx
+++ b/ui/src/components/console/shell/provider-truth.tsx
@@ -34,7 +34,7 @@ function statusDot(status: ProviderTruthStatus): string {
   if (status === "degraded" || status === "unavailable") {
     return "var(--color-accent)";
   }
-  return "var(--ok)";
+  return "var(--color-text-success)";
 }
 
 function backendLabel(backendKind: string | undefined, locale: AppLocale): string {
@@ -239,7 +239,7 @@ export function ProviderTruthCard(props: {
           </p>
           <div className="mt-2 flex items-center gap-2">
             {currentProviderStatus === "healthy" ? (
-              <ShieldCheck className="h-4 w-4 shrink-0" style={{ color: "var(--ok)" }} />
+              <ShieldCheck className="h-4 w-4 shrink-0" style={{ color: "var(--color-text-success)" }} />
             ) : (
               <ShieldAlert
                 className="h-4 w-4 shrink-0"


### PR DESCRIPTION
## Summary

UI-W2 provider truth token drift repair. This is a style-token-only update for `ui/src/components/console/shell/provider-truth.tsx`, replacing retired shell/status aliases (`--surface-*`, `--ink-*`, bare `--accent`, `--rust-*`, `--ok`) and hardcoded teal rgba fragments with selected `--color-*` tokens.

## Scope

Files changed:
- `test/unit/ui/ui-w2-provider-truth-token-contract.test.ts`
- `ui/src/components/console/shell/provider-truth.tsx`

No provider truth state/data/API/route behavior, hook/query, provider service, auth, runtime, deploy, persistence, loading/model copy, alert copy, or backend label logic is changed.

## Red-first evidence

Evidence: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-provider-truth-token-20260707T0550-0700/`

- Initial red commit: `eaf84fc5 test(uiw2): expose provider truth token drift`, counted failure `logs/red-provider-truth-token.counted.exit=1`.
- Initial green commit: `814dfcb5 fix(uiw2): align provider truth tokens`, green `logs/green-provider-truth-token.exit=0`, `logs/green-typecheck-src.exit=0`, `logs/green-diff-check.exit=0`, revert-red `logs/revert-red-provider-truth-token.exit=1`.
- Reviewer-refute red commit: `edc1ab55 test(uiw2): pin provider truth status token families`, failure `logs/red-reviewer-refute-rust-ok-token.exit=1` for `--ok` / rust-family coverage.
- Reviewer-refute green commit/head: `d139dd41 fix(uiw2): finish provider truth status tokens`, green `logs/green-reviewer-refute-rust-ok-token.exit=0`, `logs/green-typecheck-after-refute.exit=0`, `logs/green-diff-check-after-refute.exit=0`, final revert-red `logs/final-revert-red-provider-truth-token.exit=1`, final green rerun `logs/final-green-provider-truth-token-after-refute.v2.exit=0`.

Non-counted evidence:
- `logs/red-provider-truth-token.exit=127`: setup failure before dependency symlink, `vitest` missing.
- `logs/final-green-provider-truth-token-after-refute.exit=1`: invalid concurrent validation mistake, run while reverse-patch validation was active; superseded by sequential `v2.exit=0`.

## Independent reviewers / refutes

- Reviewer A Raman `019f3c9d-4716-7551-95e4-6a1ca887d881`: initial NEEDS-CHANGES for remaining `--ok`, then PASS after `edc1ab55`/`d139dd41`; file `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-provider-truth-token-20260707T0550-0700/reviewer-a-raman-provider-truth-token.md`.
- Reviewer B Schrodinger `019f3c9d-5c4a-73e1-b758-21b525ac0d61`: initial NEEDS-CHANGES for incomplete rust-family regex, then PASS after `edc1ab55`/`d139dd41`; file `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-provider-truth-token-20260707T0550-0700/reviewer-b-schrodinger-provider-truth-token.md`.

## No-Degrade

- Product diff is visual token substitution only.
- `statusTone`, `statusLabel`, `backendLabel`, `alertHeadline`, `alertDetail`, loading/model fallbacks, provider name/model rendering, alert count rendering, and ProviderTruthCard/Compact structure are unchanged except token strings.
- No provider/security/runtime/deploy files changed.
- `open-pr-overlap.json` reports `overlaps: []`.
- `sha256sums.verify.exit=0`.

## Boundary

Builder must not merge. This PR requires §27 v8 military/advisor SIGN after PR-CI terminal true green using branch-protection required contexts. Missing, failed, or required skipped contexts are RED/NO-GO. Workflow-condition skipped jobs are non-counted and not proof.

This is not rendered visual proof, not END-BAR, not HR13/operator visual attestation, not prod deploy/currentness, not release/latest-install, not organic adoption, not terminal channel/device proof, and not final UI matrix completion.
