### PR TITLE
Align usage right rail tokens

### DIFF
--- a/test/unit/ui/ui-w2-right-rail-usage-token-contract.test.ts
+++ b/test/unit/ui/ui-w2-right-rail-usage-token-contract.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const usageRailSourcePath = resolve(
+  process.cwd(),
+  "ui/src/components/console/shell/right-rail-slots/usage.tsx",
+);
+
+describe("UI-W2 usage right rail token contract", () => {
+  it("keeps usage right rail rows on selected color tokens", () => {
+    const source = readFileSync(usageRailSourcePath, "utf8");
+
+    expect(source).not.toMatch(/var\(--(?:surface|ink|accent|accent-soft)[^)]*\)/);
+
+    expect(source).toContain("var(--color-bg-subtle)");
+    expect(source).toContain("var(--color-border-soft)");
+    expect(source).toContain("var(--color-text-primary)");
+    expect(source).toContain("var(--color-text-secondary)");
+    expect(source).toContain("var(--color-accent)");
+  });
+});

--- a/ui/src/components/console/shell/right-rail-slots/usage.tsx
+++ b/ui/src/components/console/shell/right-rail-slots/usage.tsx
@@ -16,13 +16,13 @@ export function UsageRightRailSlot() {
       <header>
         <p
           className="text-[10px] font-semibold uppercase tracking-[0.16em]"
-          style={{ color: "var(--ink-300)" }}
+          style={{ color: "var(--color-text-faint)" }}
         >
           {localize(locale, "用量", "Usage")}
         </p>
         <h3
           className="mt-1 text-sm font-semibold"
-          style={{ color: "var(--ink-900)", fontFamily: "var(--font-serif-sc)" }}
+          style={{ color: "var(--color-text-primary)", fontFamily: "var(--font-serif-sc)" }}
         >
           {localize(locale, "今日花费", "Today's cost")}
         </h3>
@@ -57,24 +57,24 @@ function Row(props: { to: string; Icon: typeof Gauge; title: string; hint: strin
     <li>
       <NavLink
         to={props.to}
-        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--accent-soft)]"
+        className="group flex items-start gap-3 rounded-[var(--radius-md)] border px-3 py-3 transition-colors hover:bg-[color:var(--color-accent-soft)]"
         style={{
-          borderColor: "var(--surface-border)",
-          background: "var(--surface-2)",
+          borderColor: "var(--color-border-soft)",
+          background: "var(--color-bg-subtle)",
         }}
       >
-        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--accent)" }} />
+        <props.Icon className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--color-accent)" }} />
         <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium" style={{ color: "var(--ink-900)" }}>
+          <p className="text-sm font-medium" style={{ color: "var(--color-text-primary)" }}>
             {props.title}
           </p>
-          <p className="mt-0.5 text-xs" style={{ color: "var(--ink-500)" }}>
+          <p className="mt-0.5 text-xs" style={{ color: "var(--color-text-secondary)" }}>
             {props.hint}
           </p>
         </div>
         <ChevronRight
           className="h-4 w-4 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
-          style={{ color: "var(--ink-500)" }}
+          style={{ color: "var(--color-text-secondary)" }}
         />
       </NavLink>
     </li>


### PR DESCRIPTION
## Summary

UI-W2 usage right rail token drift repair. This is a style-token-only update for `ui/src/components/console/shell/right-rail-slots/usage.tsx`, replacing retired `--surface-*`, `--ink-*`, and bare `--accent` aliases with selected `--color-*` tokens.

## Scope

Files changed:
- `test/unit/ui/ui-w2-right-rail-usage-token-contract.test.ts`
- `ui/src/components/console/shell/right-rail-slots/usage.tsx`

No NavLink targets, localized text, row order, icons, API/data hooks, auth, provider, runtime, deploy, security, or persistence behavior is changed.

## Red-first evidence

Evidence: `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-right-rail-usage-token-20260707T0610-0700/`

- Red commit: `a58b5f1d test(uiw2): expose usage rail token drift`, failure `logs/red-right-rail-usage-token.exit=1`.
- Green commit/head: `d2f82523 fix(uiw2): align usage rail tokens`, green `logs/green-right-rail-usage-token.exit=0`, `logs/green-typecheck-src.exit=0`, `logs/green-diff-check.exit=0`.
- Revert-red: `logs/revert-red-right-rail-usage-token.exit=1`.
- Open PR overlap: `open-pr-overlap.exit=0`, `overlaps=[]`.
- Integrity: `sha256sums.verify.exit=0`.

## Independent reviewers

- Reviewer A Averroes `019f3ca7-448b-7a00-8fd2-3a6e478cd65d`: PASS; file `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-right-rail-usage-token-20260707T0610-0700/reviewer-a-averroes-usage-rail-token.md`.
- Reviewer B Wegener `019f3ca7-6098-7350-8433-c9df81a2b393`: PASS; file `/Users/jarvis/Desktop/Friday-Handoff-Log/evidence/ui-w2-right-rail-usage-token-20260707T0610-0700/reviewer-b-wegener-usage-rail-token.md`.

## No-Degrade

Product diff is visual token substitution only. `/usage` and `/observability` route targets, usage/cost/trend copy, row order, icon mapping, hover shape, hooks, APIs, runtime, deploy, and security behavior are unchanged. #1553 is adjacent usage page work but exact file overlap is empty.

## Boundary

Builder must not merge. This PR requires §27 v8 military/advisor SIGN after PR-CI terminal true green using branch-protection required contexts. Missing, failed, or required skipped contexts are RED/NO-GO. Workflow-condition skipped jobs are non-counted and not proof.

This is not rendered visual proof, not END-BAR, not HR13/operator visual attestation, not prod deploy/currentness, not release/latest-install, not organic adoption, not terminal channel/device proof, and not final UI matrix completion.
