### PR TITLE
INV-ARTIFACT-001: deterministic artifact-inventory reconciliation gate (fixtures slice; OBSERVED unpack release-gated)

### DIFF
--- a/test/contracts/inventory/friday-artifact-inventory-reconcile.contract.test.ts
+++ b/test/contracts/inventory/friday-artifact-inventory-reconcile.contract.test.ts
@@ -1,0 +1,191 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Contract test for INV-ARTIFACT-001 (P0): a deterministic artifact-inventory
+// reconciliation gate. Modeled on the proven Suite-13 coverage-oracle CLI test
+// (test/unit/qa/friday-suite13-coverage-oracle-cli.test.ts): execFileSync the
+// .mjs, feed fixture JSON written under mkdtempSync, assert status + blocker
+// codes. Both negative-control directions are covered — a ghost element
+// (OBSERVED - REGISTRY) and a required element omitted from OBSERVED — plus a
+// balanced passed case, a sha_mismatch case, a duplicate_id case, and a
+// malformed fail-closed case.
+
+const script = "tools/inventory/reconcile.mjs";
+
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+const SHA_C = "c".repeat(64);
+
+function writeJson(dir: string, name: string, value: unknown) {
+  const path = join(dir, name);
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+  return path;
+}
+
+// Declared/expected universe. `required` marks elements that MUST be observed.
+function registryElements() {
+  return [
+    { elementType: "binary", id: "Friday.app/Contents/MacOS/Friday", sha256: SHA_A, required: true },
+    { elementType: "entitlement", id: "com.apple.security.network.client", required: true },
+    { elementType: "config", id: "hub.config.json", sha256: SHA_B, required: true },
+    { elementType: "route", id: "POST /v1/agent/runs", required: false },
+  ];
+}
+
+// Authoritative/enumerated universe that exactly satisfies the registry:
+// every required element present, shas aligned, no ghosts, no dups.
+function observedElementsBalanced() {
+  return [
+    { elementType: "binary", id: "Friday.app/Contents/MacOS/Friday", sha256: SHA_A },
+    { elementType: "entitlement", id: "com.apple.security.network.client" },
+    { elementType: "config", id: "hub.config.json", sha256: SHA_B },
+  ];
+}
+
+function run(args: string[], expectFailure = false) {
+  try {
+    const stdout = execFileSync(process.execPath, [script, ...args], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    return JSON.parse(stdout);
+  } catch (error) {
+    if (!expectFailure) throw error;
+    const stdout = (error as { stdout?: Buffer | string }).stdout?.toString() || "";
+    return JSON.parse(stdout);
+  }
+}
+
+function reconcile(dir: string, registry: unknown, observed: unknown, expectFailure = false) {
+  const registryPath = writeJson(dir, "registry.json", registry);
+  const observedPath = writeJson(dir, "observed.json", observed);
+  return run(
+    [`--registry=${registryPath}`, `--observed=${observedPath}`, "--require-passed"],
+    expectFailure,
+  );
+}
+
+describe("INV-ARTIFACT-001 artifact-inventory reconcile gate", () => {
+  it("passes when OBSERVED exactly satisfies REGISTRY (positive control)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-artifact-"));
+    const report = reconcile(
+      dir,
+      { elements: registryElements() },
+      { elements: observedElementsBalanced() },
+    );
+
+    expect(report.truth).toBe("artifact_inventory_reconcile");
+    expect(report.status).toBe("passed");
+    expect(report.blockers).toEqual([]);
+    expect(report.summary.ghostElementCount).toBe(0);
+    expect(report.summary.requiredUnobservedCount).toBe(0);
+    expect(report.summary.shaMismatchCount).toBe(0);
+    expect(report.summary.duplicateIdCount).toBe(0);
+  });
+
+  it("blocks on a ghost element: OBSERVED contains an element not in REGISTRY", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-artifact-"));
+    const report = reconcile(
+      dir,
+      { elements: registryElements() },
+      {
+        elements: [
+          ...observedElementsBalanced(),
+          { elementType: "flag", id: "experimental_backdoor" },
+        ],
+      },
+      true,
+    );
+
+    expect(report.status).toBe("blocked");
+    expect(report.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "ghost_element", detail: "flag:experimental_backdoor" }),
+      ]),
+    );
+  });
+
+  it("blocks on required_unobserved: a required REGISTRY element is omitted from OBSERVED", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-artifact-"));
+    const report = reconcile(
+      dir,
+      { elements: registryElements() },
+      {
+        // entitlement (required) dropped from the observed universe
+        elements: observedElementsBalanced().filter(
+          (e) => e.elementType !== "entitlement",
+        ),
+      },
+      true,
+    );
+
+    expect(report.status).toBe("blocked");
+    expect(report.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "required_unobserved",
+          detail: "entitlement:com.apple.security.network.client",
+        }),
+      ]),
+    );
+  });
+
+  it("blocks on sha_mismatch: an element present in both universes has differing sha256", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-artifact-"));
+    const observed = observedElementsBalanced().map((e) =>
+      e.elementType === "binary" ? { ...e, sha256: SHA_C } : e,
+    );
+    const report = reconcile(dir, { elements: registryElements() }, { elements: observed }, true);
+
+    expect(report.status).toBe("blocked");
+    expect(report.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "sha_mismatch",
+          detail: "binary:Friday.app/Contents/MacOS/Friday",
+        }),
+      ]),
+    );
+  });
+
+  it("blocks on duplicate_id: the same elementId appears twice in one universe", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-artifact-"));
+    const report = reconcile(
+      dir,
+      { elements: registryElements() },
+      {
+        elements: [
+          ...observedElementsBalanced(),
+          { elementType: "config", id: "hub.config.json", sha256: SHA_B },
+        ],
+      },
+      true,
+    );
+
+    expect(report.status).toBe("blocked");
+    expect(report.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "duplicate_id",
+          detail: expect.stringContaining("config:hub.config.json"),
+        }),
+      ]),
+    );
+  });
+
+  it("fails closed on malformed input: REGISTRY.elements is not an array (typed error, non-zero exit)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-artifact-"));
+    const report = reconcile(
+      dir,
+      { elements: "nope" },
+      { elements: observedElementsBalanced() },
+      true,
+    );
+
+    expect(report.status).toBe("error");
+    expect(report.error.code).toBe("elements_not_array");
+  });
+});

--- a/tools/inventory/element-inventory-schema.md
+++ b/tools/inventory/element-inventory-schema.md
@@ -1,0 +1,117 @@
+# Element-inventory schema — INV-ARTIFACT-001 (P0)
+
+Schema and blocker vocabulary for the deterministic artifact-inventory
+reconciliation gate implemented in [`reconcile.mjs`](./reconcile.mjs).
+
+## Honest scoping (read first)
+
+This slice ships the **pure deterministic reconciler + a red-first behavioral
+negative control on fixtures only**. Producing the real **OBSERVED** universe —
+unpacking a real signed DMG/AAB and crawling the installed runtime — is
+**release-gated and NOT in scope**. The reconciler is the pure engine that the
+operator's later real-artifact unpack will feed. A GREEN verdict from this tool
+means *"the two supplied inventories reconcile"* and says **nothing** about a
+real release. This tool does **not** authorize `release_status: passed`.
+
+## Two inventories
+
+The reconciler consumes two element inventories that share one file shape:
+
+- **REGISTRY** (declared / expected) — what the release is supposed to contain.
+  Entries may carry `required: true` to assert the element MUST be observed.
+- **OBSERVED** (authoritative / enumerated) — what was actually enumerated from
+  the artifact / runtime. In this slice OBSERVED is a fixture; in production it
+  is the (release-gated, out-of-scope) output of a real unpack + crawl.
+
+## File shape
+
+```jsonc
+{
+  // Optional discriminators (metadata; not required by the reconciler).
+  "truth": "artifact_element_inventory",
+  "role": "registry",            // or "observed"
+  "elements": [                   // REQUIRED — must be an array (fail-closed)
+    {
+      "elementType": "binary",   // REQUIRED — one of the six types below
+      "id": "Friday.app/Contents/MacOS/Friday", // REQUIRED — non-empty string
+      "sha256": "…64 hex…",      // OPTIONAL — content digest, if known
+      "required": true            // OPTIONAL (REGISTRY only) — default false
+    }
+  ]
+}
+```
+
+### Field rules (fail-closed — malformed input throws a typed error, exit 3)
+
+| Field         | Rule                                                                       |
+| ------------- | -------------------------------------------------------------------------- |
+| top level     | must be a JSON object (not array/null) with an `elements` **array**        |
+| `elementType` | required string in the six-type set; anything else → `invalid_element_type`|
+| `id`          | required non-empty string (after trim) → else `invalid_element_id`         |
+| `sha256`      | optional; if present must be a non-empty string → else `invalid_sha256`    |
+| `required`    | REGISTRY only; if present must be a boolean → else `invalid_required_flag` |
+
+`required` is ignored on OBSERVED entries (only the registry declares intent).
+
+## The six element types (contract `proof_scope`)
+
+| elementType   | what it enumerates                                          |
+| ------------- | ---------------------------------------------------------- |
+| `binary`      | executables / libraries inside the packaged app            |
+| `entitlement` | code-signing entitlements granted to the binary            |
+| `config`      | shipped config / plist / manifest files                    |
+| `asset`       | bundled static assets                                      |
+| `route`       | HTTP / IPC routes the runtime exposes                      |
+| `flag`        | feature flags / toggles compiled or shipped into the build |
+
+## Element identity
+
+```
+normalizedKey = id.trim()
+elementId     = "{elementType}:{normalizedKey}"
+```
+
+The `elementType` prefix namespaces the key so the same `id` string under two
+different types (e.g. a `binary` and a `config` both named `friday`) never
+collide. Reconciliation is a keyed set-difference over `elementId`.
+
+## Blocker vocabulary
+
+| code                  | meaning                                                             |
+| --------------------- | ------------------------------------------------------------------ |
+| `ghost_element`       | elementId in OBSERVED but not in REGISTRY (unregistered / ghost)    |
+| `required_unobserved` | REGISTRY element with `required: true` that is absent from OBSERVED |
+| `sha_mismatch`        | elementId in both, `sha256` declared on both, and the digests differ |
+| `duplicate_id`        | the same elementId appears twice within one universe               |
+
+A non-`required` registry element that is not observed is **not** a blocker
+(it is optional / may legitimately be absent). `sha_mismatch` fires only when
+BOTH sides declare a `sha256`; a missing digest on either side is not a mismatch.
+
+## Verdict
+
+- **GREEN** iff `ghostElementCount == requiredUnobservedCount ==
+  shaMismatchCount == duplicateIdCount == 0` → `status: "passed"`.
+- Otherwise `status: "blocked"` with the sorted `blockers` list.
+- Malformed input → `status: "error"` and exit **3**, unconditionally
+  (fail-closed: a malformed inventory can never read as passed).
+
+## Determinism
+
+The verdict body (status, blockers, counts) is a **pure function of the two
+input files**. Universes are indexed and iterated in canonical `sort()` order
+on `elementId`, and blockers are sorted by `(code, detail)`. No clock or random
+is consulted in the pass/fail path — `generated_at_utc` in the report is
+**metadata only** and is never read when deciding pass/fail.
+
+## CLI
+
+```
+node tools/inventory/reconcile.mjs \
+  --registry=/abs/registry-inventory.json \
+  --observed=/abs/observed-inventory.json \
+  [--out=/abs/reconcile-report.json] [--require-passed]
+```
+
+Exit codes: `0` passed (or blocked without `--require-passed`), `2` blocked
+under `--require-passed`, `3` malformed input (fail-closed).

--- a/tools/inventory/reconcile.mjs
+++ b/tools/inventory/reconcile.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * NAIVE PLACEHOLDER (RED-FIRST) — intentionally incomplete.
+ *
+ * This is the deliberately-wrong first cut committed to prove the contract
+ * test fails BEHAVIORALLY (assertion failure), not structurally (ENOENT):
+ * it reads both inventories but performs NO reconciliation and always reports
+ * status "passed". The ghost/required_unobserved/sha_mismatch/duplicate_id
+ * negative controls therefore see a passing verdict where the contract demands
+ * "blocked". Replaced by the real deterministic reconciler in the GREEN commit.
+ */
+import { readFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+
+function arg(name) {
+  const prefix = `--${name}=`;
+  for (let i = 0; i < args.length; i += 1) {
+    const v = args[i];
+    if (v.startsWith(prefix)) return v.slice(prefix.length);
+    if (v === `--${name}` && args[i + 1]) return args[i + 1];
+  }
+  return "";
+}
+
+const registryPath = arg("registry");
+const observedPath = arg("observed");
+
+// NAIVE: read (so failures are behavioral, not ENOENT) but do NOT validate or
+// reconcile. No shape validation on purpose — malformed input still "passes".
+JSON.parse(readFileSync(registryPath, "utf8"));
+JSON.parse(readFileSync(observedPath, "utf8"));
+
+const report = {
+  truth: "artifact_inventory_reconcile",
+  status: "passed",
+  generated_at_utc: new Date().toISOString(),
+  inputs: { registry: registryPath, observed: observedPath },
+  summary: {
+    registryElementCount: 0,
+    observedElementCount: 0,
+    ghostElementCount: 0,
+    requiredUnobservedCount: 0,
+    shaMismatchCount: 0,
+    duplicateIdCount: 0,
+  },
+  blockers: [],
+  caveat: "NAIVE placeholder — no reconciliation performed.",
+};
+
+console.log(JSON.stringify(report, null, 2));
+process.exit(0);

--- a/tools/inventory/reconcile.mjs
+++ b/tools/inventory/reconcile.mjs
@@ -1,15 +1,71 @@
 #!/usr/bin/env node
 /**
- * NAIVE PLACEHOLDER (RED-FIRST) — intentionally incomplete.
+ * INV-ARTIFACT-001 (P0) — deterministic artifact-inventory reconciliation gate.
  *
- * This is the deliberately-wrong first cut committed to prove the contract
- * test fails BEHAVIORALLY (assertion failure), not structurally (ENOENT):
- * it reads both inventories but performs NO reconciliation and always reports
- * status "passed". The ghost/required_unobserved/sha_mismatch/duplicate_id
- * negative controls therefore see a passing verdict where the contract demands
- * "blocked". Replaced by the real deterministic reconciler in the GREEN commit.
+ * Pure keyed set-difference between two element inventories:
+ *   REGISTRY (declared/expected) vs OBSERVED (authoritative/enumerated).
+ * Emits a typed blocker vocabulary and turns the verdict RED when an artifact
+ * element is unregistered (ghost) or a required element is omitted.
+ *
+ * ── HONEST SCOPING (release-gated boundary) ────────────────────────────────
+ * This ships ONLY the deterministic reconciler + a red-first behavioral
+ * negative control, exercised on FIXTURES. Producing the REAL OBSERVED
+ * universe — unpacking a real signed DMG/AAB and crawling the installed
+ * runtime — is RELEASE-GATED and explicitly NOT in scope here. This slice
+ * does NOT let anyone claim `release_status: passed`; it is the pure engine
+ * that the operator's later real-artifact unpack will feed. GREEN here means
+ * "the two supplied inventories reconcile", nothing about a real release.
+ *
+ * ── DETERMINISM ────────────────────────────────────────────────────────────
+ * The verdict body (status, blockers, counts) is a pure function of the two
+ * input files: universes are indexed and iterated in canonical sort() order
+ * on elementId, and blockers are sorted (code, detail). NO clock or random is
+ * ever consulted in the pass/fail path — `generated_at_utc` is metadata only.
+ *
+ * ── BLOCKER VOCABULARY (contract INV-ARTIFACT-001 proof_scope) ──────────────
+ *   ghost_element        OBSERVED − REGISTRY           (unregistered element)
+ *   required_unobserved  REGISTRY{required} − OBSERVED  (required element omitted)
+ *   sha_mismatch         id in both universes, sha256 present on both and differ
+ *   duplicate_id         same elementId appears twice within one universe
+ * GREEN iff all four counts == 0 → status "passed"; else "blocked".
+ *
+ * ── ELEMENT MODEL ──────────────────────────────────────────────────────────
+ *   elementType ∈ {binary, entitlement, config, asset, route, flag}
+ *   elementId   = "{elementType}:{normalizedKey}"   (normalizedKey = id.trim())
+ * See tools/inventory/element-inventory-schema.md for the full schema.
+ *
+ * ── FAIL-CLOSED ────────────────────────────────────────────────────────────
+ * Malformed input is rejected with a typed InventoryValidationError and exits
+ * 3 UNCONDITIONALLY (a malformed inventory can never read as passed). A clean
+ * "blocked" reconciliation exits 2 only under --require-passed (mirrors
+ * scripts/ops/check-friday-suite13-coverage-oracle.mjs).
+ *
+ * Usage:
+ *   node tools/inventory/reconcile.mjs \
+ *     --registry=/abs/registry-inventory.json \
+ *     --observed=/abs/observed-inventory.json \
+ *     [--out=/abs/reconcile-report.json] [--require-passed]
  */
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+const ELEMENT_TYPES = new Set([
+  "binary",
+  "entitlement",
+  "config",
+  "asset",
+  "route",
+  "flag",
+]);
+
+class InventoryValidationError extends Error {
+  constructor(code, detail) {
+    super(`${code}: ${detail}`);
+    this.name = "InventoryValidationError";
+    this.code = code;
+    this.detail = detail;
+  }
+}
 
 const args = process.argv.slice(2);
 
@@ -23,30 +79,219 @@ function arg(name) {
   return "";
 }
 
-const registryPath = arg("registry");
-const observedPath = arg("observed");
+function usage() {
+  console.error(`usage:
+  node tools/inventory/reconcile.mjs \\
+    --registry=/abs/registry-inventory.json \\
+    --observed=/abs/observed-inventory.json \\
+    [--out=/abs/reconcile-report.json] [--require-passed]
 
-// NAIVE: read (so failures are behavioral, not ENOENT) but do NOT validate or
-// reconcile. No shape validation on purpose — malformed input still "passes".
-JSON.parse(readFileSync(registryPath, "utf8"));
-JSON.parse(readFileSync(observedPath, "utf8"));
+Truth: pure deterministic reconciler over two element inventories. It does NOT
+unpack a real artifact, enumerate a real installed runtime, or authorize
+release_status: passed. Real OBSERVED production is release-gated (out of scope).`);
+}
 
-const report = {
-  truth: "artifact_inventory_reconcile",
-  status: "passed",
-  generated_at_utc: new Date().toISOString(),
-  inputs: { registry: registryPath, observed: observedPath },
-  summary: {
-    registryElementCount: 0,
-    observedElementCount: 0,
-    ghostElementCount: 0,
-    requiredUnobservedCount: 0,
-    shaMismatchCount: 0,
-    duplicateIdCount: 0,
-  },
-  blockers: [],
-  caveat: "NAIVE placeholder — no reconciliation performed.",
-};
+function absolute(path) {
+  return isAbsolute(path) ? path : resolve(path);
+}
 
-console.log(JSON.stringify(report, null, 2));
-process.exit(0);
+/**
+ * Read + parse one inventory file, fail-closed on any structural defect.
+ * Returns the raw `elements` array (element-level validation happens in
+ * indexUniverse). Throws InventoryValidationError on malformed input.
+ */
+function readInventory(role, path) {
+  if (!path) throw new InventoryValidationError("missing_arg", role);
+  if (!isAbsolute(path)) {
+    throw new InventoryValidationError("path_not_absolute", `${role}:${path}`);
+  }
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    throw new InventoryValidationError("unreadable_file", `${role}:${path}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new InventoryValidationError("invalid_json", `${role}:${error.message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new InventoryValidationError("inventory_not_object", role);
+  }
+  if (!Array.isArray(parsed.elements)) {
+    throw new InventoryValidationError("elements_not_array", role);
+  }
+  return parsed.elements;
+}
+
+/**
+ * Validate + index one universe into Map<elementId, {sha256, required}>.
+ * Duplicate elementIds are recorded (first occurrence wins in the map) so the
+ * set-difference stays well-defined while duplicate_id is still reported.
+ * Element-shape defects are fail-closed (typed error). Pure over input.
+ */
+function indexUniverse(role, elements) {
+  const map = new Map();
+  const duplicates = [];
+  for (const [index, element] of elements.entries()) {
+    if (!element || typeof element !== "object" || Array.isArray(element)) {
+      throw new InventoryValidationError("element_not_object", `${role}[${index}]`);
+    }
+    const elementType = element.elementType;
+    if (typeof elementType !== "string" || !ELEMENT_TYPES.has(elementType)) {
+      throw new InventoryValidationError(
+        "invalid_element_type",
+        `${role}[${index}]:${String(elementType)}`,
+      );
+    }
+    if (typeof element.id !== "string" || element.id.trim().length === 0) {
+      throw new InventoryValidationError("invalid_element_id", `${role}[${index}]`);
+    }
+    if (
+      element.sha256 !== undefined &&
+      (typeof element.sha256 !== "string" || element.sha256.trim().length === 0)
+    ) {
+      throw new InventoryValidationError("invalid_sha256", `${role}[${index}]`);
+    }
+    if (
+      role === "registry" &&
+      element.required !== undefined &&
+      typeof element.required !== "boolean"
+    ) {
+      throw new InventoryValidationError("invalid_required_flag", `${role}[${index}]`);
+    }
+
+    const elementId = `${elementType}:${element.id.trim()}`;
+    if (map.has(elementId)) {
+      duplicates.push(elementId);
+      continue;
+    }
+    map.set(elementId, {
+      sha256: typeof element.sha256 === "string" ? element.sha256.trim() : null,
+      required: element.required === true,
+    });
+  }
+  return { map, duplicates };
+}
+
+/**
+ * Pure reconciler. Deterministic: iterates canonical sort() order on elementId
+ * and sorts the final blocker list. No clock/random anywhere in this path.
+ */
+function reconcile(registryElements, observedElements) {
+  const registry = indexUniverse("registry", registryElements);
+  const observed = indexUniverse("observed", observedElements);
+  const blockers = [];
+  const push = (code, detail) => blockers.push({ code, detail });
+
+  // duplicate_id — a dup within EITHER universe
+  for (const elementId of [...registry.duplicates].sort()) {
+    push("duplicate_id", `registry:${elementId}`);
+  }
+  for (const elementId of [...observed.duplicates].sort()) {
+    push("duplicate_id", `observed:${elementId}`);
+  }
+
+  // ── ghost_element block (OBSERVED − REGISTRY) ──
+  // NOTE: isolable unit — the REVERT-RED step comments out exactly this loop to
+  // re-red the ghost contract test while every other case stays green.
+  for (const elementId of [...observed.map.keys()].sort()) {
+    if (!registry.map.has(elementId)) push("ghost_element", elementId);
+  }
+  // ── end ghost_element block ──
+
+  // required_unobserved — REGISTRY{required} − OBSERVED
+  for (const elementId of [...registry.map.keys()].sort()) {
+    const record = registry.map.get(elementId);
+    if (record.required && !observed.map.has(elementId)) {
+      push("required_unobserved", elementId);
+    }
+  }
+
+  // sha_mismatch — present in both, sha256 declared on both, and they differ
+  for (const elementId of [...registry.map.keys()].sort()) {
+    const observedRecord = observed.map.get(elementId);
+    if (!observedRecord) continue;
+    const registryRecord = registry.map.get(elementId);
+    if (
+      registryRecord.sha256 &&
+      observedRecord.sha256 &&
+      registryRecord.sha256 !== observedRecord.sha256
+    ) {
+      push("sha_mismatch", elementId);
+    }
+  }
+
+  const summary = {
+    registryElementCount: registry.map.size,
+    observedElementCount: observed.map.size,
+    ghostElementCount: blockers.filter((b) => b.code === "ghost_element").length,
+    requiredUnobservedCount: blockers.filter((b) => b.code === "required_unobserved").length,
+    shaMismatchCount: blockers.filter((b) => b.code === "sha_mismatch").length,
+    duplicateIdCount: blockers.filter((b) => b.code === "duplicate_id").length,
+  };
+
+  // Canonical, detection-order-independent blocker ordering.
+  blockers.sort((a, b) =>
+    a.code === b.code ? a.detail.localeCompare(b.detail) : a.code.localeCompare(b.code),
+  );
+
+  const status = blockers.length === 0 ? "passed" : "blocked";
+  return { status, blockers, summary };
+}
+
+function main() {
+  if (args.includes("--help") || args.includes("-h")) {
+    usage();
+    process.exit(0);
+  }
+
+  const registryPath = arg("registry");
+  const observedPath = arg("observed");
+  const outPath = arg("out");
+  const requirePassed = args.includes("--require-passed");
+
+  const registryElements = readInventory("registry", registryPath);
+  const observedElements = readInventory("observed", observedPath);
+  const result = reconcile(registryElements, observedElements);
+
+  const report = {
+    truth: "artifact_inventory_reconcile",
+    status: result.status,
+    generated_at_utc: new Date().toISOString(), // metadata only — NEVER in the pass/fail path
+    inputs: { registry: registryPath, observed: observedPath },
+    summary: result.summary,
+    blockers: result.blockers,
+    caveat:
+      "Fixture-scoped deterministic reconciler only. Real OBSERVED universe (signed DMG/AAB unpack + installed-runtime crawl) is release-gated and out of scope; this does NOT authorize release_status: passed.",
+  };
+
+  if (outPath) {
+    const out = absolute(outPath);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, `${JSON.stringify(report, null, 2)}\n`);
+  }
+
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(result.status === "passed" || !requirePassed ? 0 : 2);
+}
+
+try {
+  main();
+} catch (error) {
+  if (error instanceof InventoryValidationError) {
+    // Fail-closed: malformed inventory can never read as passed.
+    const report = {
+      truth: "artifact_inventory_reconcile",
+      status: "error",
+      error: { code: error.code, detail: error.detail, message: error.message },
+      caveat:
+        "Malformed inventory input rejected fail-closed; a malformed inventory can never read as passed.",
+    };
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(3);
+  }
+  throw error;
+}


### PR DESCRIPTION
## INV-ARTIFACT-001 (P0) — deterministic artifact-inventory reconciliation gate

Adds the missing element-level reconciler for the artifact universe (today's `scripts/ops/write-friday-artifact-metadata.mjs` records artifact-level metadata only; there was no element-level set-difference). `tools/inventory/reconcile.mjs` is a pure CLI reconciler that set-diffs a REGISTRY (declared) universe against an OBSERVED (enumerated) universe and turns RED on any of: `ghost_element` (OBSERVED−REGISTRY), `required_unobserved` (REGISTRY{required}−OBSERVED), `sha_mismatch`, `duplicate_id`. GREEN iff all four counts == 0. `elementType ∈ {binary,entitlement,config,asset,route,flag}` (from the contract proof_scope).

Deterministic (canonical sort, `generated_at` is metadata only — no clock/random in the pass/fail path); fail-closed (malformed input → typed `InventoryValidationError`, exit 3); `--require-passed` → exit 2 on blocked (mirrors the Suite-13 coverage oracle).

**Red-first (behavioral):** a naive placeholder impl fails all five negative-control cases behaviorally (`expected 'passed' to be 'blocked'/'error'`, not ENOENT); the full reconciler turns them green (both directions of the contract's negative control — seed a ghost / omit a required element — plus sha_mismatch, duplicate, and a fail-closed malformed case). Revert-red on the ghost loop confirmed. CI-inclusion proven (`vitest --project default` collects `test/contracts/inventory/*.contract.test.ts`).

**Honest scope:** ships the deterministic reconciler + red-first control on FIXTURES. Producing the real OBSERVED universe (signed DMG/AAB unpack + installed-runtime crawl) is RELEASE-GATED and explicitly out of scope — this does NOT authorize `release_status: passed`. A header comment states this. No DB migration. Scope: `tools/inventory/**` + `test/contracts/inventory/**` only.
