### PR TITLE
RUN-AWAITING-APPROVAL-001: project Paused as nonterminal awaiting_approval (was terminal cancelled)

### DIFF
--- a/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
@@ -163,17 +163,23 @@ export function usageLedgerIdForRun(runId: string): string {
 }
 
 /**
- * Map a Rust `LoopStatus` debug token to a TERMINAL TS run status. The TS projection is
- * a completed Rust run, so only terminal statuses are produced (never an active one).
+ * Map a Rust `LoopStatus` debug token to a TS run status. Every GENUINELY-terminal loop
+ * status maps to a terminal TS status (Finished→completed; Bounded/Blocked/Errored/default
+ * →failed). The ONE exception is `Paused`: an owner-approval pause is NONTERMINAL — the run
+ * is AWAITING APPROVAL, not finished — so it maps to the nonterminal `awaiting_approval`
+ * (ENDBAR RUN-AWAITING-APPROVAL-001). Surfacing a paused run as `cancelled`/terminal would
+ * wrongly make a resumable run look done and expose it to the terminal-only retention reaper.
  */
 export function mapLoopStatusToTsStatus(loopStatus: string): string {
   switch (loopStatus) {
     case "Finished":
       return "completed";
     case "Paused":
-      // Owner-approval pause: the loop stopped resumably, but the projected TS row is a
-      // terminal snapshot of THIS receipt — surface it as cancelled (non-error stop).
-      return "cancelled";
+      // Owner-approval pause: the loop stopped RESUMABLY pending approval. This is NONTERMINAL —
+      // the run is awaiting approval, not cancelled/completed — so it maps to `awaiting_approval`
+      // (the reaper deletes only terminal completed/failed/cancelled rows, so a paused run is
+      // preserved for its later resume). NEVER a terminal cancelled here.
+      return "awaiting_approval";
     case "Bounded":
       // max_turns reached without finishing — an incomplete terminal stop.
       return "failed";

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1730,10 +1730,11 @@ async function composeRustReadOnlyAgentRun(args: {
   //
   // We MUST NOT route a paused outcome through the delivered-body readback (it has no body ⇒ it would
   // fail-close at the readback gate before projecting). Instead we BRANCH EARLY: project an HONEST
-  // non-Finished continuity row via `loopStatus:"Paused"` (the projector maps it to the terminal
-  // "cancelled" status — a non-error resumable stop, never a fake "finished"; INV-5 refs-only — the
-  // row stores only the pause refs, NEVER the answer/summary body). The returned result carries an
-  // EMPTY `response` (no body exists yet — the run paused pending approval) and a 0 tool count.
+  // non-Finished continuity row via `loopStatus:"Paused"` (the projector maps it to the NONTERMINAL
+  // "awaiting_approval" status — a resumable, non-error stop pending approval, never a fake "finished"
+  // and never a terminal "cancelled"; INV-5 refs-only — the row stores only the pause refs, NEVER the
+  // answer/summary body). The returned result carries an EMPTY `response` (no body exists yet — the
+  // run paused pending approval) and a 0 tool count.
   if (isPausedDispatchOutcome(wsResult)) {
     const pausedAtIso = args.nowIso();
     const pausedProjection = args.db.withWriteTransaction((db) => {
@@ -1742,15 +1743,16 @@ async function composeRustReadOnlyAgentRun(args: {
         proofOnly: true,
         // `ok` is the receipt-well-formed flag (a fixed `true` on the receipt type — the same value
         // every non-finished mapping uses, e.g. Bounded/Errored); the NON-finished semantics of a
-        // pause are carried by `loopStatus:"Paused"` → the projector's "cancelled" status mapping,
-        // NOT by this flag.
+        // pause are carried by `loopStatus:"Paused"` → the projector's nonterminal "awaiting_approval"
+        // status mapping, NOT by this flag.
         ok: true,
         runId: args.runId,
         routeId: `${args.providerId}:${args.model}`,
         providerId: args.providerId,
         model: args.model,
-        // HONEST non-Finished status: the projector maps "Paused" → the terminal "cancelled" run
-        // status (a resumable, non-error stop) — NEVER a fabricated "completed"/"finished".
+        // HONEST non-Finished status: the projector maps "Paused" → the NONTERMINAL "awaiting_approval"
+        // run status (a resumable, non-error stop pending approval) — NEVER a fabricated
+        // "completed"/"finished", and NEVER a terminal "cancelled".
         loopStatus: "Paused",
         // A paused run executed reads (turns/tools) up to the pause; surface the carried counts when
         // present (absent ⇒ 0, an old server). Counts are refs, never a body.
@@ -1786,7 +1788,8 @@ async function composeRustReadOnlyAgentRun(args: {
     );
     return {
       runId: args.runId,
-      // The projected status is the HONEST terminal mapping of a pause ("cancelled") — NOT Finished.
+      // The projected status is the HONEST nonterminal mapping of a pause ("awaiting_approval") — NOT
+      // Finished, and NOT a terminal "cancelled". The run is awaiting approval and stays resumable.
       status: pausedProjection.status as FridayAgentRuntimeResult["status"],
       // No body exists for a paused run — the empty response keeps the owner-sealed summary OUT of
       // plaintext (INV-5 refs-only). A LATER PR's resume leg delivers the answer after approval.

--- a/test/unit/api/mission-spine/friday-rust-hub-run-continuity-projector-service.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-run-continuity-projector-service.test.ts
@@ -79,16 +79,50 @@ describe("FridayRustHubRunContinuityProjector (executeRun-replace slice 2, fork 
     layers.length = 0;
   });
 
-  it("loop-status → terminal TS status mapping is exhaustive and terminal", () => {
+  it("loop-status → TS status mapping: Paused is the NONTERMINAL awaiting_approval, the rest terminal", () => {
     expect(mapLoopStatusToTsStatus("Finished")).toBe("completed");
-    expect(mapLoopStatusToTsStatus("Paused")).toBe("cancelled");
+    // ENDBAR RUN-AWAITING-APPROVAL-001: an owner-approval pause is NONTERMINAL — the run is
+    // awaiting approval, not cancelled/terminal. It must map to `awaiting_approval`.
+    expect(mapLoopStatusToTsStatus("Paused")).toBe("awaiting_approval");
     expect(mapLoopStatusToTsStatus("Bounded")).toBe("failed");
     expect(mapLoopStatusToTsStatus("Blocked")).toBe("failed");
     expect(mapLoopStatusToTsStatus("Errored")).toBe("failed");
-    // No mapping yields an ACTIVE (non-terminal) status — a projected run is complete.
-    for (const s of ["Finished", "Paused", "Bounded", "Blocked", "Errored", "anything"]) {
+    // Paused must NOT be a terminal status (negative_control: Paused appears cancelled/terminal ⇒ fail).
+    // The reaper deletes only these terminal states — awaiting_approval must be none of them.
+    expect(["completed", "failed", "cancelled"]).not.toContain(mapLoopStatusToTsStatus("Paused"));
+    // Every GENUINELY-terminal loop status still maps to a terminal TS status (no-degrade).
+    for (const s of ["Finished", "Bounded", "Blocked", "Errored", "anything"]) {
       expect(["completed", "failed", "cancelled"]).toContain(mapLoopStatusToTsStatus(s));
     }
+  });
+
+  it("projects a Paused receipt to a NONTERMINAL awaiting_approval row that the reaper never deletes", () => {
+    const db = freshDb();
+    const projector = createFridayRustHubRunContinuityProjectorService();
+
+    const paused: FridayRustHubRunReceipt = {
+      ...FIXTURE_RECEIPT,
+      runId: "hub_run_task_dev_paused_approval",
+      loopStatus: "Paused",
+    };
+    const result = projector.project(db, paused);
+    // ENDBAR RUN-AWAITING-APPROVAL-001: the projected status is the NONTERMINAL awaiting_approval,
+    // never a terminal cancelled/completed/failed.
+    expect(result.status).toBe("awaiting_approval");
+
+    const run = db
+      .prepare("SELECT status FROM friday_agent_runs WHERE id = ?")
+      .get(paused.runId) as { status: string };
+    expect(run.status).toBe("awaiting_approval");
+
+    // The retention reaper deletes ONLY terminal rows (`status IN ('completed','failed','cancelled')`).
+    // A run awaiting approval must be OUTSIDE that set — otherwise a resumable run would be reaped.
+    const reaped = db
+      .prepare(
+        "SELECT COUNT(*) AS n FROM friday_agent_runs WHERE id = ? AND status IN ('completed','failed','cancelled')",
+      )
+      .get(paused.runId) as { n: number };
+    expect(reaped.n).toBe(0);
   });
 
   it("projects ONE agent_run + ONE usage row with the correct Rust→TS column mapping", () => {

--- a/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-rust-route-compose.test.ts
@@ -380,7 +380,7 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(countRows(db, "llm_usage_records", RUN_ID)).toBe(1);
   });
 
-  it("(a-paused) (A3 courier) a PAUSED dispatch → HONEST non-Finished row (cancelled), refs-only, readback SKIPPED", async () => {
+  it("(a-paused) (A3 courier) a PAUSED dispatch → HONEST non-Finished row (awaiting_approval, nonterminal), refs-only, readback SKIPPED", async () => {
     db = createTestDb();
     const ws = makeStubPausedWsClient();
     const readback = makeStubReadback(OWNER_PRINCIPAL);
@@ -404,8 +404,9 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(readback.calls).toHaveLength(0);
 
     // The continuity row is projected HONESTLY: NOT "completed"/Finished — the projector maps the
-    // "Paused" loop status to the terminal "cancelled" run status (a resumable, non-error stop).
-    expect(result.status).toBe("cancelled");
+    // "Paused" loop status to the NONTERMINAL "awaiting_approval" run status (a resumable, non-error
+    // stop pending approval), never a terminal "cancelled" (ENDBAR RUN-AWAITING-APPROVAL-001).
+    expect(result.status).toBe("awaiting_approval");
     // No body exists for a paused run — the response is empty (the owner-sealed summary is kept OUT
     // of the plaintext response; INV-5 refs-only). A LATER PR's resume leg delivers the answer. The
     // route omits an empty `finalResponse` (`result.finalResponse ? {...} : {}`), so it is undefined.
@@ -413,12 +414,14 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(result.finalResponse).toBeUndefined();
     expect(result.toolCallCount).toBe(0);
 
-    // Exactly ONE TS continuity row was projected (idempotent on run_id), with the cancelled status.
+    // Exactly ONE TS continuity row was projected (idempotent on run_id), with the nonterminal
+    // awaiting_approval status — the retention reaper (terminal completed/failed/cancelled only)
+    // never deletes it, so the run survives for its later resume.
     expect(countRows(db, "friday_agent_runs", RUN_ID)).toBe(1);
     const rowStatus = db.withReadConnection((d) =>
       (d.prepare("SELECT status FROM friday_agent_runs WHERE id = ?").get(RUN_ID) as { status: string }).status,
     );
-    expect(rowStatus).toBe("cancelled");
+    expect(rowStatus).toBe("awaiting_approval");
     // The projected row stores a body REF over the pause refs (the action digest) — NEVER the body.
     const rowResponse = db.withReadConnection((d) =>
       (d.prepare("SELECT response_text FROM friday_agent_runs WHERE id = ?").get(RUN_ID) as
@@ -488,7 +491,8 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     expect(readback.calls).toHaveLength(1);
 
     // NO 503: the honest non-Finished terminal is surfaced as the projector's "failed" status —
-    // NEVER "completed", NEVER "cancelled" (cancelled is the resumable Paused mapping; this is not).
+    // NEVER "completed", NEVER "awaiting_approval" (awaiting_approval is the resumable Paused
+    // mapping; this errored terminal is not that).
     expect(result.status).toBe("failed");
     // NO fabricated body — the response is empty and the route omits the empty finalResponse.
     expect(result.response).toBe("");
@@ -1095,9 +1099,9 @@ describe("FridayApiRuntime — execrun S-F-compose (DARK) Rust-route composition
     // Before the fix this was the hardcoded { readOnly: true }, which would block the write tool in
     // Rust before it could pause. (No disabled-tools / max-turns asserted on this route → absent.)
     expect(ws.calls[0].constraints).toEqual({ readOnly: false });
-    // And the organic outcome is the operator-gated PAUSE (projected as the terminal "cancelled"),
-    // never a 503 — which is the whole point of the B4 fix.
-    expect(result.status).toBe("cancelled");
+    // And the organic outcome is the operator-gated PAUSE (projected as the nonterminal
+    // "awaiting_approval"), never a 503 — which is the whole point of the B4 fix.
+    expect(result.status).toBe("awaiting_approval");
   });
 
   it("(b4-b) read-only qualifying run → compose STILL dispatches constraints.readOnly:TRUE (no degrade)", async () => {


### PR DESCRIPTION
## RUN-AWAITING-APPROVAL-001 (P0) — Paused run must project as nonterminal awaiting_approval, not cancelled

**Defect:** `mapLoopStatusToTsStatus` in the Rust-hub run-continuity projector mapped Rust `Paused` (owner-approval pause) → the terminal TS status `cancelled`. So a run that is actually AWAITING APPROVAL appeared cancelled/terminal — and worse, the retention reaper (deletes `completed/failed/cancelled`) then reaped it and marked it a failure episode. negative_control: "Paused appears cancelled or terminal before explicit terminal arm; fail."

**Fix:** map `Paused` → `awaiting_approval` (a canonical nonterminal status). All genuinely-terminal mappings unchanged (Finished→completed; Bounded/Blocked/Errored/default→failed).

**Trace confirming clean (no migration, no downstream break):**
- `awaiting_approval` is canonical (`FridayAgentLoopRunStatus`).
- `friday_agent_runs.status` is `TEXT` with **no CHECK constraint** → round-trips; no migration.
- Retention reaper reaps only `completed/failed/cancelled`; terminal/active status sets treat `awaiting_approval` as nonterminal (desired); engine switches have non-throwing `default` nets. The fix removes the latent reap-as-failure bug.

**Red-first behavioral** (`expected 'cancelled' to be 'awaiting_approval'`) + revert-red; a co-path api-runtime test that had encoded the old buggy `cancelled` behavior is corrected. `tsc`/eslint clean. Scope: projector service + api-runtime + 2 tests. No migration.

**Flagged residual (for reviewer + follow-up):** `awaiting_approval` is not a member of the projected row's read-surface union `FridayAgentRunStatus` (it carries `awaiting_plan_approval`/`awaiting_clarification`); it works via existing `as`-casts. Reviewer is asked to confirm no consumer of the projected status mishandles the value (treats it as failed/terminal or drops it from a status query). Widening that union + auditing consumers is a deliberately-deferred separate change.
