### PR TITLE
SEC-CREDENTIAL-INGRESS-001: encrypt MCP env/header secrets at rest (opaque refs + sidecar vault)

### DIFF
--- a/src/agent/mcp/friday-mcp-config-store.ts
+++ b/src/agent/mcp/friday-mcp-config-store.ts
@@ -1,9 +1,65 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { dirname, join } from "node:path";
 
 import type { FridayMcpServerConfig } from "./friday-mcp-adapter.types.js";
+import {
+  decryptSecret,
+  encryptSecret,
+  type FridayEncryptedEnvelope,
+  getStrictMasterKey,
+} from "../../security/friday-secret-crypto.js";
+import {
+  buildFridaySecretRef,
+  parseFridaySecretInput,
+} from "../../security/friday-secret-ref.js";
 
 const CONFIG_FILENAME = "mcp-servers.json";
+const VAULT_FILENAME = "mcp-secrets.json";
+const VAULT_VERSION = 1;
+
+const SECRET_FIELDS = ["env", "headers"] as const;
+type SecretField = (typeof SECRET_FIELDS)[number];
+
+/**
+ * A secret value found at rest that could not be represented as an opaque,
+ * resolvable `secret://` reference. Emitted by {@link FridayMcpConfigStore.load}
+ * so callers/operators can observe (and audit) plaintext that predates
+ * encryption or a broken vault, rather than silently leaking it forever. The
+ * value is re-encrypted on the next `save()`.
+ */
+export interface FridayMcpSecretResidueEntry {
+  serverId: string;
+  field: SecretField;
+  key: string;
+  reason: "legacy-plaintext" | "unresolved-ref";
+}
+
+export interface CreateFridayMcpConfigStoreOptions {
+  /**
+   * Master key used to encrypt/decrypt env & header secret VALUES at rest.
+   *
+   * Defaults to the hub's fail-closed persistent master key resolver
+   * ({@link getStrictMasterKey}) — the same source that guards provider and
+   * multi-tenant secrets. It is resolved lazily (only when a plaintext value
+   * actually needs encrypting on `save`, or a `secret://` ref needs decrypting
+   * on `load`). When it is unavailable, `save` FAILS CLOSED (throws before any
+   * write) so a secret is never silently persisted as plaintext. Tests inject a
+   * fixed key here.
+   */
+  masterKey?: Buffer;
+  /**
+   * Invoked by {@link FridayMcpConfigStore.load} when it encounters legacy
+   * plaintext or an unresolved secret ref at rest. Defaults to a console.warn
+   * summary.
+   */
+  onSecretResidue?: (entries: readonly FridayMcpSecretResidueEntry[]) => void;
+}
+
+interface McpSecretVault {
+  version: number;
+  entries: Record<string, FridayEncryptedEnvelope>;
+}
 
 export interface FridayMcpConfigStore {
   load(): FridayMcpServerConfig[];
@@ -12,23 +68,175 @@ export interface FridayMcpConfigStore {
   removeServer(id: string): FridayMcpServerConfig[];
 }
 
-export function createFridayMcpConfigStore(stateDir: string): FridayMcpConfigStore {
+export function createFridayMcpConfigStore(
+  stateDir: string,
+  options: CreateFridayMcpConfigStoreOptions = {},
+): FridayMcpConfigStore {
   const filePath = join(stateDir, CONFIG_FILENAME);
+  const vaultPath = join(stateDir, VAULT_FILENAME);
+
+  function resolveMasterKey(): Buffer {
+    return options.masterKey ?? getStrictMasterKey();
+  }
+
+  function reportResidue(entries: FridayMcpSecretResidueEntry[]): void {
+    if (entries.length === 0) return;
+    if (options.onSecretResidue) {
+      options.onSecretResidue(entries);
+      return;
+    }
+     
+    console.warn(
+      `[friday][mcp-config-store][SECURITY] ${String(entries.length)} MCP secret value(s) present at rest ` +
+        `without a resolvable encrypted ref (` +
+        entries.map((e) => `${e.serverId}.${e.field}.${e.key}=${e.reason}`).join(", ") +
+        `); they will be re-encrypted on the next save.`,
+    );
+  }
+
+  function readVault(): McpSecretVault {
+    try {
+      const parsed = JSON.parse(readFileSync(vaultPath, "utf8")) as unknown;
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        !Array.isArray(parsed)
+      ) {
+        const entries = (parsed as { entries?: unknown }).entries;
+        if (typeof entries === "object" && entries !== null && !Array.isArray(entries)) {
+          return { version: VAULT_VERSION, entries: entries as Record<string, FridayEncryptedEnvelope> };
+        }
+      }
+    } catch {
+      // Missing/corrupt vault → behave as empty (secrets simply become residue).
+    }
+    return { version: VAULT_VERSION, entries: {} };
+  }
+
+  function isSecretRecord(value: unknown): value is Record<string, string> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
 
   function load(): FridayMcpServerConfig[] {
+    let parsed: unknown;
     try {
-      const raw = readFileSync(filePath, "utf8");
-      const parsed = JSON.parse(raw);
-      if (!Array.isArray(parsed)) return [];
-      return parsed.filter(isValidServerConfig);
+      parsed = JSON.parse(readFileSync(filePath, "utf8"));
     } catch {
       return [];
     }
+    if (!Array.isArray(parsed)) return [];
+    const configs = parsed.filter(isValidServerConfig);
+    if (configs.length === 0) return configs;
+
+    const vault = readVault();
+    const residue: FridayMcpSecretResidueEntry[] = [];
+
+    // Resolve the master key lazily: only if at least one secret ref needs
+    // decrypting. Never throw out of `load` — an unresolvable key/vault means
+    // the opaque ref is returned as-is (fail-safe: no plaintext is exposed).
+    let cachedKey: Buffer | null | undefined;
+    const getKey = (): Buffer | null => {
+      if (cachedKey === undefined) {
+        try {
+          cachedKey = resolveMasterKey();
+        } catch {
+          cachedKey = null;
+        }
+      }
+      return cachedKey;
+    };
+
+    for (const config of configs) {
+      for (const field of SECRET_FIELDS) {
+        const record = config[field];
+        if (!isSecretRecord(record)) continue;
+        for (const [key, rawValue] of Object.entries(record)) {
+          if (typeof rawValue !== "string") continue;
+          const input = parseFridaySecretInput(rawValue, { trimInline: false });
+          if (input.kind === "secret-ref") {
+            const envelope = vault.entries[input.refKey];
+            if (envelope) {
+              const activeKey = getKey();
+              if (activeKey) {
+                try {
+                  record[key] = decryptSecret(envelope, activeKey);
+                  continue;
+                } catch {
+                  // fall through to residue below (leave opaque ref in place)
+                }
+              }
+            }
+            residue.push({ serverId: config.id, field, key, reason: "unresolved-ref" });
+            continue;
+          }
+          // A non-ref literal at rest is legacy plaintext: return it as-is so the
+          // server stays usable, but flag it so it does not silently persist.
+          residue.push({ serverId: config.id, field, key, reason: "legacy-plaintext" });
+        }
+      }
+    }
+
+    reportResidue(residue);
+    return configs;
   }
 
   function save(configs: FridayMcpServerConfig[]): void {
+    const previousVault = readVault();
+    const nextVault: McpSecretVault = { version: VAULT_VERSION, entries: {} };
+
+    // Fail-closed: if any value needs encryption, resolve the key BEFORE writing
+    // anything. When no key is available this throws and NO file (and therefore
+    // no plaintext) is written.
+    const needsKey = configs.some((config) =>
+      SECRET_FIELDS.some((field) => {
+        const record = config[field];
+        if (!isSecretRecord(record)) return false;
+        return Object.values(record).some(
+          (value) =>
+            typeof value === "string" &&
+            parseFridaySecretInput(value, { trimInline: false }).kind !== "secret-ref",
+        );
+      }),
+    );
+    const masterKey = needsKey ? resolveMasterKey() : undefined;
+
+    const redacted = configs.map((config) => {
+      let next = config;
+      for (const field of SECRET_FIELDS) {
+        const record = config[field];
+        if (!isSecretRecord(record)) continue;
+        const rewritten: Record<string, string> = {};
+        for (const [key, value] of Object.entries(record)) {
+          if (typeof value !== "string") {
+            rewritten[key] = value as string;
+            continue;
+          }
+          const input = parseFridaySecretInput(value, { trimInline: false });
+          if (input.kind === "secret-ref") {
+            // Already opaque — preserve its envelope from the existing vault.
+            rewritten[key] = value;
+            const existing = previousVault.entries[input.refKey];
+            if (existing) nextVault.entries[input.refKey] = existing;
+            continue;
+          }
+          // Encrypt the exact literal (env-ref / file-ref / plaintext alike) so
+          // no secret value is left at rest; load() restores it byte-for-byte.
+          const refKey = randomBytes(16).toString("hex");
+          // masterKey is guaranteed present here: `needsKey` is true whenever a
+          // non-secret-ref value exists.
+          nextVault.entries[refKey] = encryptSecret(value, masterKey as Buffer);
+          rewritten[key] = buildFridaySecretRef(refKey);
+        }
+        next = { ...next, [field]: rewritten };
+      }
+      return next;
+    });
+
     mkdirSync(dirname(filePath), { recursive: true });
-    writeFileSync(filePath, JSON.stringify(configs, null, 2), "utf8");
+    // Write the vault first so every ref in the config is resolvable the instant
+    // the config file becomes visible.
+    writeFileSync(vaultPath, JSON.stringify(nextVault, null, 2), { encoding: "utf8", mode: 0o600 });
+    writeFileSync(filePath, JSON.stringify(redacted, null, 2), { encoding: "utf8", mode: 0o600 });
   }
 
   function addServer(config: FridayMcpServerConfig): FridayMcpServerConfig[] {

--- a/test/unit/agent/mcp/friday-mcp-config-store.test.ts
+++ b/test/unit/agent/mcp/friday-mcp-config-store.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
 
 import { createFridayMcpConfigStore } from "../../../../src/agent/mcp/friday-mcp-config-store.js";
 import type { FridayMcpServerConfig } from "../../../../src/agent/mcp/friday-mcp-adapter.types.js";
+import { resetMasterKeyCache } from "../../../../src/security/friday-secret-crypto.js";
 
 let testDir: string;
 
@@ -110,5 +112,144 @@ describe("FridayMcpConfigStore", () => {
     const store = createFridayMcpConfigStore(nestedDir);
     store.addServer(makeServer());
     expect(existsSync(join(nestedDir, "mcp-servers.json"))).toBe(true);
+  });
+});
+
+// SEC-CREDENTIAL-INGRESS-001 (at-rest MCP slice): env/header secret VALUES must
+// become opaque `secret://` references at rest (no plaintext embedded in
+// mcp-servers.json), with ciphertext isolated in a sidecar vault.
+// NOTE: canary literal below is a synthetic test value, never a real credential.
+const MCP_SECRET_CANARY = "sk-live-CANARY-0xDEADBEEF"; // pragma: allowlist secret
+
+describe("FridayMcpConfigStore secret-at-rest encryption", () => {
+  const MASTER_KEY = randomBytes(32);
+
+  function configPath(): string {
+    return join(testDir, "mcp-servers.json");
+  }
+  function vaultPath(): string {
+    return join(testDir, "mcp-secrets.json");
+  }
+
+  it("does not persist env secret values as plaintext (opaque ref + sidecar vault)", () => {
+    const store = createFridayMcpConfigStore(testDir, { masterKey: MASTER_KEY });
+    store.save([makeServer({ id: "gh", env: { GITHUB_TOKEN: MCP_SECRET_CANARY } })]);
+
+    const raw = readFileSync(configPath(), "utf8");
+    // The plaintext secret must NOT appear anywhere in the persisted config file.
+    expect(raw).not.toContain(MCP_SECRET_CANARY);
+    // It is replaced by an opaque reference.
+    expect(raw).toContain("secret://");
+
+    // The sidecar vault exists and holds only opaque ciphertext (no plaintext).
+    expect(existsSync(vaultPath())).toBe(true);
+    const vaultRaw = readFileSync(vaultPath(), "utf8");
+    expect(vaultRaw).not.toContain(MCP_SECRET_CANARY);
+    const vault = JSON.parse(vaultRaw);
+    expect(Object.keys(vault.entries).length).toBe(1);
+  });
+
+  it("round-trips the real secret value on load (resolution still works for spawn/env)", () => {
+    const store = createFridayMcpConfigStore(testDir, { masterKey: MASTER_KEY });
+    store.save([makeServer({ id: "gh", env: { GITHUB_TOKEN: MCP_SECRET_CANARY } })]);
+    const loaded = store.load();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]!.env!.GITHUB_TOKEN).toBe(MCP_SECRET_CANARY);
+  });
+
+  it("encrypts http header secrets at rest and restores them on load", () => {
+    const store = createFridayMcpConfigStore(testDir, { masterKey: MASTER_KEY });
+    store.save([
+      makeServer({
+        id: "http",
+        transport: "http",
+        url: "https://example.test/mcp",
+        headers: { Authorization: `Bearer ${MCP_SECRET_CANARY}` },
+      }),
+    ]);
+    const raw = readFileSync(configPath(), "utf8");
+    expect(raw).not.toContain(MCP_SECRET_CANARY);
+    expect(raw).toContain("secret://");
+    const loaded = store.load();
+    expect(loaded[0]!.headers!.Authorization).toBe(`Bearer ${MCP_SECRET_CANARY}`);
+  });
+
+  it("fail-closed: refuses to persist a secret when no master key is available (never writes plaintext)", () => {
+    const savedEnvKey = process.env.FRIDAY_MASTER_KEY;
+    const savedEnvSource = process.env.FRIDAY_MASTER_KEY_SOURCE;
+    delete process.env.FRIDAY_MASTER_KEY;
+    delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+    resetMasterKeyCache();
+    try {
+      // No injected key → falls back to the real fail-closed hub resolver.
+      const store = createFridayMcpConfigStore(testDir);
+      expect(() =>
+        store.save([makeServer({ id: "gh", env: { GITHUB_TOKEN: MCP_SECRET_CANARY } })]),
+      ).toThrow();
+      // Critical: it must NOT have silently written plaintext to disk.
+      if (existsSync(configPath())) {
+        expect(readFileSync(configPath(), "utf8")).not.toContain(MCP_SECRET_CANARY);
+      } else {
+        expect(existsSync(configPath())).toBe(false);
+      }
+    } finally {
+      if (savedEnvKey !== undefined) process.env.FRIDAY_MASTER_KEY = savedEnvKey;
+      if (savedEnvSource !== undefined) process.env.FRIDAY_MASTER_KEY_SOURCE = savedEnvSource;
+      resetMasterKeyCache();
+    }
+  });
+
+  it("PRODUCTION default path (no injected key, only the env master key) encrypts at rest", () => {
+    // Mirrors friday-hub-bootstrap.ts:2815 exactly: `createFridayMcpConfigStore(stateDir)`
+    // with NO options. The only key available is the persistent hub master key
+    // (here FRIDAY_MASTER_KEY, as prod configures). This proves the default path
+    // uses getStrictMasterKey() and does NOT silently no-op to plaintext.
+    const savedEnvKey = process.env.FRIDAY_MASTER_KEY;
+    const savedEnvSource = process.env.FRIDAY_MASTER_KEY_SOURCE;
+    delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+    process.env.FRIDAY_MASTER_KEY = MASTER_KEY.toString("hex");
+    resetMasterKeyCache();
+    try {
+      const store = createFridayMcpConfigStore(testDir); // no options — identical to bootstrap:2815
+      store.save([makeServer({ id: "gh", env: { GITHUB_TOKEN: MCP_SECRET_CANARY } })]);
+      const raw = readFileSync(configPath(), "utf8");
+      expect(raw).not.toContain(MCP_SECRET_CANARY);
+      expect(raw).toContain("secret://");
+      // The default resolver round-trips too (real hub key decrypts).
+      expect(store.load()[0]!.env!.GITHUB_TOKEN).toBe(MCP_SECRET_CANARY);
+    } finally {
+      if (savedEnvKey !== undefined) process.env.FRIDAY_MASTER_KEY = savedEnvKey;
+      else delete process.env.FRIDAY_MASTER_KEY;
+      if (savedEnvSource !== undefined) process.env.FRIDAY_MASTER_KEY_SOURCE = savedEnvSource;
+      resetMasterKeyCache();
+    }
+  });
+
+  it("tolerates legacy plaintext, reports residue, and re-encrypts on next save", () => {
+    // Simulate a pre-encryption config file that embedded a plaintext env secret.
+    writeFileSync(
+      configPath(),
+      JSON.stringify([{ id: "legacy", command: "node", env: { GITHUB_TOKEN: MCP_SECRET_CANARY } }]),
+      "utf8",
+    );
+
+    const residue: Array<{ serverId: string; reason: string }> = [];
+    const store = createFridayMcpConfigStore(testDir, {
+      masterKey: MASTER_KEY,
+      onSecretResidue: (entries) => residue.push(...entries),
+    });
+
+    const loaded = store.load();
+    // Legacy plaintext is returned as-is so the server stays usable...
+    expect(loaded[0]!.env!.GITHUB_TOKEN).toBe(MCP_SECRET_CANARY);
+    // ...and the residue is reported (legacy-plaintext).
+    expect(residue.length).toBeGreaterThan(0);
+    expect(residue.some((r) => r.reason === "legacy-plaintext")).toBe(true);
+
+    // Re-encrypted on next save → plaintext no longer at rest.
+    store.save(loaded);
+    const raw = readFileSync(configPath(), "utf8");
+    expect(raw).not.toContain(MCP_SECRET_CANARY);
+    expect(raw).toContain("secret://");
   });
 });

--- a/test/unit/agent/mcp/friday-mcp-deeplink-apply.test.ts
+++ b/test/unit/agent/mcp/friday-mcp-deeplink-apply.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 
 import { createFridayDeepLinkApplyService } from "../../../../src/api/runtime/friday-deep-link-apply-service.js";
 import { createFridayMcpConfigStore } from "../../../../src/agent/mcp/friday-mcp-config-store.js";
+import { resetMasterKeyCache } from "../../../../src/security/friday-secret-crypto.js";
 import { isForbiddenEnvVar, isSecretShapedEnvKey } from "../../../../src/agent/mcp/friday-mcp-adapter.js";
 import {
   createFridayMutatingActionGate,
@@ -21,14 +22,24 @@ const NOW = "2026-05-14T00:00:00.000Z";
 const TOKEN_SECRET = "test-secret"; // pragma: allowlist secret
 
 let testDir: string;
+let savedMasterKeyEnv: string | undefined;
 
 beforeEach(() => {
   testDir = join(tmpdir(), `friday-mcp-apply-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   mkdirSync(testDir, { recursive: true });
+  // The MCP config store now encrypts env/header secret values at rest and
+  // FAILS CLOSED without a master key. Provision a fixed hub key (as prod does
+  // via FRIDAY_MASTER_KEY) so persisted env vars encrypt and round-trip.
+  savedMasterKeyEnv = process.env.FRIDAY_MASTER_KEY;
+  process.env.FRIDAY_MASTER_KEY = "a".repeat(64); // 32 bytes hex // pragma: allowlist secret
+  resetMasterKeyCache();
 });
 
 afterEach(() => {
   rmSync(testDir, { recursive: true, force: true });
+  if (savedMasterKeyEnv !== undefined) process.env.FRIDAY_MASTER_KEY = savedMasterKeyEnv;
+  else delete process.env.FRIDAY_MASTER_KEY;
+  resetMasterKeyCache();
 });
 
 function makeProviderService(): FridayProviderService {


### PR DESCRIPTION
## Gap (SEC-CREDENTIAL-INGRESS-001 — at-rest MCP slice)

`src/agent/mcp/friday-mcp-config-store.ts` `save()` persisted each MCP server's `env` and `headers` secret **values as plaintext** into an ordinary-perms `mcp-servers.json`. The acceptance bar requires provider/MCP secrets to be **opaque references at rest** (no plaintext in files).

## Fix (opaque-ref routing + sidecar vault)

- **`save()`**: every `env`/`headers` value that is not already a `secret://` ref is `encryptSecret`'d into a sidecar vault `mcp-secrets.json` keyed by a random refKey; the written config carries only `secret://<refKey>` opaque refs. Both files written `0600`.
- **`load()`**: resolves each `secret://` ref via the vault → `decryptSecret` → restores the real value **in-memory**, so the adapter's child-env / HTTP-header use is byte-identical. Kept **synchronous** (crypto is sync) so `friday-hub-bootstrap.ts:2817` is untouched. Legacy plaintext is returned as-is **and residue-reported** (re-encrypted on next `save()`). `load()` never throws on key/crypto failure (fail-safe: the opaque ref stays, no plaintext exposed).
- **Factory**: additive `options?: { masterKey?; onSecretResidue? }`. Default key source = **`getStrictMasterKey`** — the same fail-closed persistent hub key that already wires the sibling provider / multi-tenant `SecretManager` (bootstrap `masterKeyResolver: getStrictMasterKey`). Resolved lazily.

## Production key wiring / #1 anti-proof-theater

`friday-hub-bootstrap.ts:2815` constructs the store with **NO options**, so the default resolver `getStrictMasterKey()` supplies the **real persistent hub key** (env `FRIDAY_MASTER_KEY` / keychain) that already guards provider secrets in the same bootstrap. `save()` reaches production via the deep-link apply service (`friday-deep-link-apply-service.ts:463 mcpConfigStore.addServer`). If **no key is available**, `save()` **FAILS CLOSED** — it resolves the key before any write and throws, so it can never silently no-op to plaintext. Proven by:
- a test exercising the **exact prod construction** (no injected key, only `FRIDAY_MASTER_KEY` set) that asserts no plaintext at rest + round-trip, and
- a **no-key fail-closed** test asserting `save()` throws and writes no plaintext.

## Red-first / offline / deterministic

RED against current code: `expect(raw).not.toContain(SECRET)` fails with a real `AssertionError` (plaintext embedded). GREEN post-fix: file contains only `secret://…` + opaque ciphertext in the sidecar; `store.load()[0].env.GITHUB_TOKEN === SECRET`. REVERT-RED confirmed. All tests inject a test master key (`randomBytes(32)`) — no network. New tests are `[default]`-collected.

## Scope honesty

This closes the **at-rest file sink** for MCP env/header secrets only. It does **not** by itself close the transient child-env delivery at spawn (the configured MCP server legitimately needs the real value), diagnostics/export redaction (separate **SEC-EVENT-REDACTION-001**), or the CLI `--token`/`.env` seam (larger, deferred). **SEC-CREDENTIAL-INGRESS-001 stays OPEN; product NO_GO unchanged.** **No migration** (additive; `load()` tolerates legacy plaintext and re-encrypts on next `save()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48