### PR TITLE
PRIV-RAW-AUDIO-PER-RUN-CLEANUP: unlink channel attachment temp files on run-terminal (all channels)

### DIFF
--- a/src/engine/adapters/friday-channel-entry-adapter.ts
+++ b/src/engine/adapters/friday-channel-entry-adapter.ts
@@ -9,10 +9,13 @@
  * inbound → engine → result translation.
  */
 
+import { unlink } from "node:fs/promises";
+
 import type {
   FridayEngineRunInput,
   FridayEngineRunResult,
   FridayOrchestrationEngine,
+  FridayRunTerminalStatus,
 } from "../friday-orchestration-engine.types.js";
 import type { FridayChannelAttachment } from "../../channels/friday-channel.types.js";
 
@@ -65,6 +68,78 @@ export const FRIDAY_CHANNEL_CONTROL_ROUTE = "full_agent";
 
 function resolvedAttachmentPath(attachment: FridayChannelAttachment): string | undefined {
   return attachment.localPath ?? attachment.sourceUrl;
+}
+
+// ─── Per-run raw-attachment cleanup (PRIV-RAW-AUDIO per-run slice) ───
+//
+// Inbound channel attachments (raw audio/image/file bytes) are saved to a temp
+// file by the channel layer, with the path on `attachment.localPath`. The run
+// reads that file DURING execution (image -> base64 at LLM-request time;
+// audio/file -> agent tool mid-run), so the file MUST survive until the run
+// reaches a terminal state. This helper unlinks the owned temp files right after
+// the run resolves/rejects (seconds after run-terminal) instead of waiting for
+// the channel lifecycle boundary (the #1570 disconnect/stop backstop), which
+// held raw audio for the whole session.
+
+/**
+ * Suspended runs resume via `engine.resumeRun` and still need to read the file,
+ * so their attachments must NOT be deleted (deleting = use-after-unlink bug).
+ */
+const FRIDAY_SUSPENDED_RUN_STATUSES: ReadonlySet<FridayRunTerminalStatus> = new Set<FridayRunTerminalStatus>([
+  "awaiting_clarification",
+  "awaiting_plan_approval",
+]);
+
+/**
+ * Whether the given attachment.localPath is an owned, on-disk temp path this
+ * processing may unlink: present/non-empty, successfully saved (status
+ * "resolved"), and a real local fs path (not an http(s) sourceUrl).
+ */
+function isOwnedLocalAttachmentPath(attachment: FridayChannelAttachment): attachment is FridayChannelAttachment & { localPath: string } {
+  const localPath = attachment.localPath;
+  return (
+    attachment.status === "resolved" &&
+    typeof localPath === "string" &&
+    localPath.length > 0 &&
+    !/^https?:\/\//i.test(localPath)
+  );
+}
+
+/**
+ * Unlink the raw temp files owned by THIS message's attachments once the run is
+ * genuinely terminal (or on an uncertain-terminal reject). Correlation-safe:
+ * touches only the exact `attachment.localPath` values on THIS message — never a
+ * directory scan, never another run's path. Idempotent: tolerates ENOENT (the
+ * #1570 disconnect() backstop or a double-invoke may have already removed it).
+ *
+ * @param terminalStatus the resolved run status, or `undefined` when the run
+ *   REJECTED/threw (uncertain-terminal → privacy-safe default is to delete).
+ */
+async function cleanupOwnedAttachments(
+  attachments: readonly FridayChannelAttachment[] | undefined,
+  terminalStatus: FridayRunTerminalStatus | undefined,
+): Promise<void> {
+  if (!attachments || attachments.length === 0) return;
+  // Suspended run: the file is still needed on resume — do not delete.
+  if (terminalStatus !== undefined && FRIDAY_SUSPENDED_RUN_STATUSES.has(terminalStatus)) return;
+  await Promise.all(
+    attachments.map(async (attachment) => {
+      if (!isOwnedLocalAttachmentPath(attachment)) return;
+      try {
+        await unlink(attachment.localPath);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") {
+          // Best-effort privacy cleanup: never turn a completed run into a
+          // failure because a temp unlink hit EPERM/EBUSY/etc. The #1570
+          // lifecycle backstop remains as a second sweep.
+          console.warn(
+            `[friday][channel-entry] attachment cleanup failed for ${attachment.localPath}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }),
+  );
 }
 
 function buildAttachmentPrompt(attachments: readonly FridayChannelAttachment[] | undefined): string | undefined {
@@ -153,7 +228,21 @@ export function createFridayChannelEntryAdapter(deps: FridayChannelEntryAdapterD
       idempotencyPrefix: `channel-${msg.channelKind}`,
     };
 
-    return engine.executeRun(input);
+    // Run the engine, then reap this message's owned raw-attachment temp files.
+    // Cleanup runs ONLY after executeRun resolves or rejects — never before, so
+    // the run can still READ the file DURING execution (no-degrade requirement).
+    let result: FridayEngineRunResult;
+    try {
+      result = await engine.executeRun(input);
+    } catch (err) {
+      // REJECT / thrown error → uncertain-terminal. Privacy-safe default: unlink
+      // the owned localPath (this processing owns it and it won't be reused),
+      // then re-throw the ORIGINAL error (never swallow it).
+      await cleanupOwnedAttachments(msg.attachments, undefined);
+      throw err;
+    }
+    await cleanupOwnedAttachments(msg.attachments, result.status);
+    return result;
   }
 
   return { handleMessage };

--- a/test/integration/channels/lark/friday-lark-attachment-cleanup.test.ts
+++ b/test/integration/channels/lark/friday-lark-attachment-cleanup.test.ts
@@ -44,6 +44,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { createFridayLarkChannel } from "#channels";
 import type { FridayChannelPlugin } from "#channels";
+import { createFridayChannelEntryAdapter } from "#engine";
+import type { FridayEngineRunResult } from "#engine";
 
 // Non-secret test credentials for the mocked Lark app (no live auth occurs —
 // token refresh + resource download are stubbed by createMockFetch below).
@@ -404,5 +406,58 @@ describe("Lark/Feishu inbound attachment disk cleanup", () => {
     // … but the foreign / non-owned file is untouched (no dir-wipe).
     expect(fs.existsSync(foreignPath)).toBe(true);
     expect(fs.readFileSync(foreignPath, "utf8")).toBe(foreignMarker);
+  });
+
+  // ── PER-RUN (FULL closure): unlink at the engine-entry seam on run-terminal ──
+  // The strongest variant: drive the REAL save path (normalizeAsync writes a real
+  // file with a unique marker), hand that exact msg.attachments to the shared
+  // engine-entry adapter's handleMessage, stub executeRun to FIRST read the bytes
+  // mid-run (proves NO use-after-unlink / no-degrade) then resolve terminal, and
+  // assert the exact owned path is unlinked SECONDS after run-terminal — not held
+  // until channel teardown. This is PRIV-RAW-AUDIO-PER-RUN-CLEANUP.
+  it("per-run: unlinks the owned audio temp path immediately on run-terminal via the engine-entry adapter", async () => {
+    const marker = "FRIDAY_LARK_PERRUN_SENTINEL_AUDIO_c7a1d0";
+    pushToken(fetchMock.responses, "t-token-perrun");
+    pushAudioResource(fetchMock.responses, "om_perrun", "audio_key_perrun", marker);
+
+    // Real download → saveAttachmentBytes → normalize → owned localPath on disk.
+    const inboundMsg = await plugin.adapters!.inbound!.normalizeAsync!(
+      audioEvent("om_perrun", "audio_key_perrun"),
+    );
+    expect(inboundMsg).not.toBeNull();
+    const localPath = inboundMsg!.attachments?.[0]?.localPath;
+    expect(typeof localPath).toBe("string");
+    expect(fs.existsSync(localPath!)).toBe(true);
+
+    // Stub the engine to READ the bytes DURING the run, then resolve terminal.
+    let bytesDuringRun: string | undefined;
+    const executeRun = vi.fn(async (): Promise<FridayEngineRunResult> => {
+      bytesDuringRun = fs.readFileSync(localPath!, "utf8");
+      return { runId: "run-perrun", status: "completed", toolCallCount: 0, durationMs: 3 };
+    });
+    const adapter = createFridayChannelEntryAdapter({
+      engine: { executeRun },
+      idGenerator: () => "run-perrun",
+      resolveSessionKey: () => "feishu:perrun",
+    });
+
+    const result = await adapter.handleMessage({
+      id: "msg-perrun",
+      channelKind: "feishu",
+      senderId: "ou_perrun",
+      chatId: "oc_perrun",
+      chatType: "direct",
+      text: "please transcribe this voice note",
+      attachments: inboundMsg!.attachments,
+    });
+
+    // NO-DEGRADE: the exact marker bytes were readable DURING the run.
+    expect(bytesDuringRun).toContain(marker);
+    expect(result.status).toBe("completed");
+
+    // Per-run cleanup: the exact owned path is gone right after run-terminal —
+    // no marker survives anywhere under the attachment root.
+    expect(fs.existsSync(localPath!)).toBe(false);
+    expect(filesContainingMarker(attachmentDir, marker)).toEqual([]);
   });
 });

--- a/test/unit/engine/adapters/friday-channel-entry-adapter.test.ts
+++ b/test/unit/engine/adapters/friday-channel-entry-adapter.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   createFridayChannelEntryAdapter,
@@ -6,6 +9,11 @@ import {
   FRIDAY_CHANNEL_CONTROL_ROUTE,
 } from "../../../../src/engine/adapters/friday-channel-entry-adapter.js";
 import { FRIDAY_SUPPORTED_CHANNEL_KINDS } from "../../../../src/channels/friday-channel-config.js";
+import type { FridayChannelAttachment } from "../../../../src/channels/friday-channel.types.js";
+import type {
+  FridayEngineRunResult,
+  FridayRunTerminalStatus,
+} from "../../../../src/engine/friday-orchestration-engine.types.js";
 
 describe("FridayChannelEntryAdapter", () => {
   it("derives tenantContext from inbound channel messages", async () => {
@@ -267,5 +275,225 @@ describe("FridayChannelEntryAdapter", () => {
       task: "Analyze the attached media.",
       taskPrompt: expect.stringContaining("/tmp/friday-channel-attachments/report.pdf"),
     }));
+  });
+});
+
+// ─── PRIV-RAW-AUDIO per-run cleanup (unlink owned temp files on run-terminal) ───
+//
+// The channel-entry adapter is the single shared seam for every channel: it
+// awaits engine.executeRun and holds both msg.attachments[].localPath and the
+// terminal run status. These tests write REAL files to disk, hand them to
+// handleMessage as owned attachments, and assert the exact localPath is unlinked
+// on genuinely-terminal statuses / reject, kept on suspended statuses, and that
+// cleanup never touches a foreign file sharing the same dir.
+describe("FridayChannelEntryAdapter per-run attachment cleanup", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-perrun-cleanup-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Write a real temp file carrying `marker` and return an owned attachment for it. */
+  function writeOwnedAttachment(
+    marker: string,
+    overrides: Partial<FridayChannelAttachment> = {},
+  ): FridayChannelAttachment {
+    const localPath = path.join(dir, `${marker}.bin`);
+    fs.writeFileSync(localPath, marker);
+    return {
+      id: `att-${marker}`,
+      kind: "audio",
+      filename: "voice.mp3",
+      contentType: "audio/mpeg",
+      localPath,
+      status: "resolved",
+      ...overrides,
+    };
+  }
+
+  function makeAdapter(executeRun: ReturnType<typeof vi.fn>) {
+    return createFridayChannelEntryAdapter({
+      engine: { executeRun },
+      idGenerator: () => "run-cleanup",
+      resolveSessionKey: (message) => `${message.channelKind}:${message.chatId}`,
+    });
+  }
+
+  function inbound(attachments: FridayChannelAttachment[]) {
+    return {
+      id: "msg-cleanup",
+      channelKind: "feishu",
+      senderId: "user-c",
+      chatId: "chat-c",
+      chatType: "direct" as const,
+      text: "transcribe this",
+      attachments,
+    };
+  }
+
+  const TERMINAL_DELETE: FridayRunTerminalStatus[] = [
+    "completed",
+    "failed",
+    "cancelled",
+    "failed_tests",
+    "timeout",
+  ];
+  const SUSPENDED_KEEP: FridayRunTerminalStatus[] = [
+    "awaiting_plan_approval",
+    "awaiting_clarification",
+  ];
+
+  it.each(TERMINAL_DELETE)(
+    "unlinks the owned attachment localPath on terminal status %s",
+    async (status) => {
+      const marker = `TERMINAL_${status}`;
+      const attachment = writeOwnedAttachment(marker);
+      expect(fs.existsSync(attachment.localPath!)).toBe(true);
+
+      const executeRun = vi.fn(async (): Promise<FridayEngineRunResult> => ({
+        runId: "run-cleanup",
+        status,
+        toolCallCount: 0,
+        durationMs: 5,
+      }));
+      const adapter = makeAdapter(executeRun);
+
+      const result = await adapter.handleMessage(inbound([attachment]));
+
+      expect(result.status).toBe(status);
+      // Exact owned path unlinked immediately on terminal.
+      expect(fs.existsSync(attachment.localPath!)).toBe(false);
+    },
+  );
+
+  it("reads the file DURING the run then unlinks it (no use-after-unlink / no-degrade)", async () => {
+    const marker = "NO_DEGRADE_READ_DURING_RUN";
+    const attachment = writeOwnedAttachment(marker);
+
+    let bytesSeenDuringRun: string | undefined;
+    const executeRun = vi.fn(async (): Promise<FridayEngineRunResult> => {
+      // The run must still be able to READ the file mid-execution.
+      bytesSeenDuringRun = fs.readFileSync(attachment.localPath!, "utf8");
+      return { runId: "run-cleanup", status: "completed", toolCallCount: 0, durationMs: 5 };
+    });
+    const adapter = makeAdapter(executeRun);
+
+    await adapter.handleMessage(inbound([attachment]));
+
+    expect(bytesSeenDuringRun).toContain(marker); // proves the file was live during the run
+    expect(fs.existsSync(attachment.localPath!)).toBe(false); // and gone after terminal
+  });
+
+  it.each(SUSPENDED_KEEP)(
+    "keeps the owned attachment file on suspended status %s (resume needs it)",
+    async (status) => {
+      const marker = `SUSPENDED_${status}`;
+      const attachment = writeOwnedAttachment(marker);
+
+      const executeRun = vi.fn(async (): Promise<FridayEngineRunResult> => ({
+        runId: "run-cleanup",
+        status,
+        toolCallCount: 0,
+        durationMs: 5,
+      }));
+      const adapter = makeAdapter(executeRun);
+
+      await adapter.handleMessage(inbound([attachment]));
+
+      // File SURVIVES — deleting it would break engine.resumeRun (use-after-unlink).
+      expect(fs.existsSync(attachment.localPath!)).toBe(true);
+      expect(fs.readFileSync(attachment.localPath!, "utf8")).toBe(marker);
+    },
+  );
+
+  it("deletes the owned file AND re-throws the original error when the run rejects", async () => {
+    const marker = "REJECT_THEN_DELETE";
+    const attachment = writeOwnedAttachment(marker);
+    const boom = new Error("engine blew up mid-run");
+
+    const executeRun = vi.fn(async (): Promise<FridayEngineRunResult> => {
+      throw boom;
+    });
+    const adapter = makeAdapter(executeRun);
+
+    // Original error propagates (never swallowed).
+    await expect(adapter.handleMessage(inbound([attachment]))).rejects.toBe(boom);
+    // Uncertain-terminal reject → privacy-safe delete still happened.
+    expect(fs.existsSync(attachment.localPath!)).toBe(false);
+  });
+
+  it("is correlation-safe: never touches a foreign file sharing the same dir", async () => {
+    const ownedMarker = "OWNED_ONLY";
+    const attachment = writeOwnedAttachment(ownedMarker);
+
+    // A foreign file NOT on msg.attachments, in the SAME directory.
+    const foreignPath = path.join(dir, "foreign-not-owned.bin");
+    fs.writeFileSync(foreignPath, "FOREIGN_NOT_ON_MESSAGE");
+
+    const executeRun = vi.fn(async (): Promise<FridayEngineRunResult> => ({
+      runId: "run-cleanup",
+      status: "completed",
+      toolCallCount: 0,
+      durationMs: 5,
+    }));
+    const adapter = makeAdapter(executeRun);
+
+    await adapter.handleMessage(inbound([attachment]));
+
+    expect(fs.existsSync(attachment.localPath!)).toBe(false); // owned removed …
+    expect(fs.existsSync(foreignPath)).toBe(true); // … foreign untouched (no dir scan)
+    expect(fs.readFileSync(foreignPath, "utf8")).toBe("FOREIGN_NOT_ON_MESSAGE");
+  });
+
+  it("is idempotent on double-invoke (ENOENT no-op, no throw)", async () => {
+    const marker = "DOUBLE_INVOKE";
+    const attachment = writeOwnedAttachment(marker);
+
+    const executeRun = vi.fn(async (): Promise<FridayEngineRunResult> => ({
+      runId: "run-cleanup",
+      status: "completed",
+      toolCallCount: 0,
+      durationMs: 5,
+    }));
+    const adapter = makeAdapter(executeRun);
+
+    await adapter.handleMessage(inbound([attachment]));
+    expect(fs.existsSync(attachment.localPath!)).toBe(false);
+
+    // Second invoke with the same (now-stale) attachment must not throw.
+    const second = await adapter.handleMessage(inbound([attachment]));
+    expect(second.status).toBe("completed");
+    expect(fs.existsSync(attachment.localPath!)).toBe(false);
+  });
+
+  it("skips non-owned paths: unresolved status and http sourceUrl-style paths are left alone", async () => {
+    // (a) status !== "resolved" → not successfully saved → do not unlink.
+    const deferredMarker = "DEFERRED_STATUS";
+    const deferred = writeOwnedAttachment(deferredMarker, { status: "deferred" });
+    // (b) an http(s) localPath is a remote ref, not an owned local temp file.
+    const httpAttachment: FridayChannelAttachment = {
+      id: "att-http",
+      kind: "file",
+      status: "resolved",
+      localPath: "https://example.invalid/remote-file.bin",
+    };
+
+    const executeRun = vi.fn(async (): Promise<FridayEngineRunResult> => ({
+      runId: "run-cleanup",
+      status: "completed",
+      toolCallCount: 0,
+      durationMs: 5,
+    }));
+    const adapter = makeAdapter(executeRun);
+
+    // Must not throw despite the http "path", and must leave the deferred file alone.
+    const result = await adapter.handleMessage(inbound([deferred, httpAttachment]));
+    expect(result.status).toBe("completed");
+    expect(fs.existsSync(deferred.localPath!)).toBe(true);
+    expect(fs.readFileSync(deferred.localPath!, "utf8")).toBe(deferredMarker);
   });
 });


### PR DESCRIPTION
## What

Closes the **per-run** terminal-path cleanup of inbound channel attachment temp files, at the single shared engine-entry seam (`friday-channel-entry-adapter.handleMessage`) — so raw audio/image/file bytes are deleted **seconds after run-terminal** instead of at channel teardown, for **all channels**.

Background: attachments are saved to `os.tmpdir()/friday-channel-attachments/...` with the path on `attachment.localPath`. The already-merged partial fix (#1570) only reaps them at the channel **lifecycle** boundary (disconnect/stop), so raw audio persisted for the whole session.

## Fix shape

`handleMessage` now `await`s `engine.executeRun` and invokes `cleanupOwnedAttachments(msg.attachments, status)` **after** it resolves or rejects (never before — the run must still READ the file DURING execution; no-degrade):

- **terminal** (`completed | failed | cancelled | failed_tests | timeout`) → unlink owned paths
- **reject / thrown error** → uncertain-terminal → unlink (privacy-safe default; owned path won't be reused), then **re-throw the original error** (never swallowed)
- **suspended** (`awaiting_clarification | awaiting_plan_approval`) → **keep** (run resumes via `engine.resumeRun` and still needs the file)
- **owned-path filter**: only `status === "resolved"`, present/non-empty `localPath`, real local fs path (skips `http(s)` sourceUrl). **Correlation-safe**: only THIS message's exact paths — no directory scan, no runId/dir wipe. **Idempotent**: tolerates `ENOENT` (the #1570 disconnect() backstop or a double-invoke may have already removed it).

Downstream hub path (`friday-hub-bootstrap.ts`) builds its outbound `result` from `engineResult` fields (**not** `msg.attachments`) after `handleMessage`, so post-run deletion does not degrade outbound behavior (re-confirmed).

## Red-first proof (offline, deterministic — synthetic bytes, no mic, no network)

- Unit matrix (`test/unit/engine/adapters/...`): parametrized over `completed/failed/cancelled/failed_tests/timeout` (deleted), `awaiting_plan_approval/awaiting_clarification` (file **survives**), thrown error (deleted **AND** error propagates), a foreign file in the same dir not on `msg.attachments` (**survives** = correlation-safety), double-invoke (idempotent ENOENT no-op), non-owned paths (unresolved status / http localPath left alone), and a read-during-run no-degrade check.
- Integration (`test/integration/channels/lark/...`): strongest variant — drives the **real** save path (`normalizeAsync` writes a real file with a unique marker), hands that exact `msg.attachments` to `handleMessage`, stubs `executeRun` to first read the bytes mid-run (proves no use-after-unlink) then resolve terminal, and asserts the exact path is unlinked + marker-scan empty.
- Reverting the adapter unlink turns the terminal/reject/per-run assertions **red** with real `AssertionError`s (not import/ENOENT). Both files are `[default]`-collected.

No migration.

## Scope honesty — DEFERRED (NOT closed)

1. **Crash/restart orphan reconciler** — needs a persisted per-run ownership manifest (runId/correlationId + path, no bytes) + a boot hook off `engine.resumeStaleRunsOnBoot()`; approval-expiry/denial cleanup is subsumed by it.
2. **Real-mic-playback negative test** — hardware, operator-gated.
3. **Rust-owned session lifecycle not persisting localPath** — hub mirrors attachments into TS session metadata, but `mirrorChannelSessionMessage` is fail-closed in prod (`TS_RUNTIME_SESSION_RETIRED`), so the path doesn't durably enter the TS store — out of scope to verify the Rust side here.

**PRIV-RAW-AUDIO-001 stays OPEN; product NO_GO unchanged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48