### PR TITLE
NEEDS-ME: classify awaiting_clarification as needs-human on health snapshot

### DIFF
--- a/src/agent/runtime/friday-agent-run-presentation.ts
+++ b/src/agent/runtime/friday-agent-run-presentation.ts
@@ -56,8 +56,16 @@ export function buildFridayAgentRunHealthSnapshot(input: {
 
   const runStatus = String(run.status);
 
-  if (runStatus === "awaiting_plan_approval" || runStatus === "awaiting_tool_approval") {
-    reasonCodes.push(runStatus === "awaiting_tool_approval" ? "tool_approval_required" : "plan_approval_required");
+  if (
+    runStatus === "awaiting_plan_approval"
+    || runStatus === "awaiting_tool_approval"
+    || runStatus === "awaiting_clarification"
+  ) {
+    const reasonCode =
+      runStatus === "awaiting_tool_approval" ? "tool_approval_required"
+      : runStatus === "awaiting_clarification" ? "clarification_required"
+      : "plan_approval_required";
+    reasonCodes.push(reasonCode);
     return {
       state: "needs_approval",
       rollbackAvailable: false,

--- a/test/unit/agent/runtime/friday-agent-run-health-snapshot.test.ts
+++ b/test/unit/agent/runtime/friday-agent-run-health-snapshot.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import { buildFridayAgentRunHealthSnapshot } from "../../../../src/agent/runtime/friday-agent-run-presentation.js";
+import { buildFridayAgentReplayableEvidenceReceipt } from "../../../../src/agent/services/friday-agent-evidence-receipt.js";
+import type {
+  FridayAgentActualExecution,
+  FridayAgentRunRecord,
+  FridayAgentRunStatus,
+} from "../../../../src/agent/model/friday-agent.types.js";
+
+/**
+ * Coverage for the "Needs Me" run-health classifier
+ * (buildFridayAgentRunHealthSnapshot). The anchor of this file is the
+ * awaiting_clarification gap: a run waiting on the user's answer must surface as
+ * human-action-required ("needs_approval") rather than silently "healthy".
+ *
+ * The cross-classifier consistency block ties the health snapshot to its sibling
+ * classifier inside the evidence receipt so the two cannot silently diverge on
+ * the human-waiting statuses again.
+ */
+
+function makeRun(overrides: Partial<FridayAgentRunRecord> = {}): FridayAgentRunRecord {
+  return {
+    id: "run-health-fixture",
+    task: "demo task",
+    status: "executing",
+    sessionKey: "session-health-fixture",
+    attempt: 1,
+    maxAttempts: 3,
+    ...overrides,
+  };
+}
+
+// The three canonical run statuses that mean "a human decision is pending".
+// awaiting_tool_approval is intentionally NOT a member of FridayAgentRunStatus
+// (the presentation code reads it defensively via String(run.status)); it is
+// cast at the call site to mirror that runtime-only value.
+const HUMAN_WAITING_STATUSES = [
+  "awaiting_clarification",
+  "awaiting_plan_approval",
+  "awaiting_tool_approval",
+] as const;
+
+const CLARIFICATION_STATUS = "awaiting_clarification" satisfies FridayAgentRunStatus;
+
+describe("buildFridayAgentRunHealthSnapshot — awaiting_clarification (Needs Me anchor)", () => {
+  it("classifies awaiting_clarification as needs_approval with clarification_required", () => {
+    const snapshot = buildFridayAgentRunHealthSnapshot({
+      run: makeRun({ status: CLARIFICATION_STATUS }),
+    });
+
+    // RED anchor: against the pre-fix classifier this run falls through every
+    // branch and returns { state: "healthy", reasonCodes: [] }, so both of these
+    // assertions throw real AssertionErrors.
+    expect(snapshot.state).toBe("needs_approval");
+    expect(snapshot.reasonCodes).toContain("clarification_required");
+    expect(snapshot.rollbackAvailable).toBe(false);
+  });
+});
+
+describe("run-health <> evidence-receipt cross-classifier consistency", () => {
+  it.each(HUMAN_WAITING_STATUSES)(
+    "both siblings agree a human is needed for status %s",
+    (status) => {
+      const healthSnapshot = buildFridayAgentRunHealthSnapshot({
+        // awaiting_tool_approval is a runtime-only string, hence the cast.
+        run: makeRun({ status: status as FridayAgentRunStatus }),
+      });
+      const receipt = buildFridayAgentReplayableEvidenceReceipt({
+        runId: "run-cross-classifier",
+        task: "demo task",
+        status,
+      });
+
+      expect(healthSnapshot.state).toBe("needs_approval");
+      expect(receipt.receiptStatus).toBe("waiting_for_human");
+    },
+  );
+});
+
+describe("buildFridayAgentRunHealthSnapshot — regression matrix (green before and after the fix)", () => {
+  it("classifies awaiting_plan_approval as needs_approval with plan_approval_required", () => {
+    const snapshot = buildFridayAgentRunHealthSnapshot({
+      run: makeRun({ status: "awaiting_plan_approval" }),
+    });
+
+    expect(snapshot.state).toBe("needs_approval");
+    expect(snapshot.reasonCodes).toContain("plan_approval_required");
+  });
+
+  it("classifies awaiting_tool_approval (runtime-only status) as needs_approval with tool_approval_required", () => {
+    const snapshot = buildFridayAgentRunHealthSnapshot({
+      run: makeRun({ status: "awaiting_tool_approval" as FridayAgentRunStatus }),
+    });
+
+    expect(snapshot.state).toBe("needs_approval");
+    expect(snapshot.reasonCodes).toContain("tool_approval_required");
+  });
+
+  it("prefers rollback_available over every other signal", () => {
+    const snapshot = buildFridayAgentRunHealthSnapshot({
+      // Even with a human-waiting status, an available rollback wins the branch.
+      run: makeRun({ status: CLARIFICATION_STATUS }),
+      rollbackAvailable: true,
+    });
+
+    expect(snapshot.state).toBe("rollback_available");
+    expect(snapshot.rollbackAvailable).toBe(true);
+    expect(snapshot.reasonCodes).toContain("rollback_available");
+  });
+
+  it("classifies a non-retryable failure as failed", () => {
+    const snapshot = buildFridayAgentRunHealthSnapshot({
+      run: makeRun({ status: "failed", errorMessage: "assertion failed: unexpected output" }),
+    });
+
+    expect(snapshot.state).toBe("failed");
+    expect(snapshot.reasonCodes).toContain("failed");
+  });
+
+  it("classifies a 429/overloaded failure as retryable", () => {
+    const snapshot = buildFridayAgentRunHealthSnapshot({
+      run: makeRun({ status: "failed", errorMessage: "provider returned 429 overloaded, please retry" }),
+    });
+
+    expect(snapshot.state).toBe("retryable");
+    expect(snapshot.reasonCodes).toContain("retryable_provider_or_network_failure");
+  });
+
+  it("classifies fallback / blocked-tool / learning-adjusted execution as degraded", () => {
+    const actualExecution = {
+      turns: [],
+      fallbackAttempts: [{ providerId: "primary" }],
+      blockedTools: [{ toolName: "shell", reason: "policy" }],
+      learningAdjusted: true,
+    } as unknown as FridayAgentActualExecution;
+
+    const snapshot = buildFridayAgentRunHealthSnapshot({
+      run: makeRun({ status: "executing", actualExecution }),
+    });
+
+    expect(snapshot.state).toBe("degraded");
+    expect(snapshot.reasonCodes).toEqual(
+      expect.arrayContaining(["route_fallback", "blocked_tools", "learning_adjusted_route"]),
+    );
+  });
+
+  it("classifies a clean completed run as healthy with no reason codes", () => {
+    const snapshot = buildFridayAgentRunHealthSnapshot({
+      run: makeRun({ status: "completed" }),
+    });
+
+    expect(snapshot.state).toBe("healthy");
+    expect(snapshot.reasonCodes).toHaveLength(0);
+  });
+
+  it("classifies a clean executing run as healthy with no reason codes", () => {
+    const snapshot = buildFridayAgentRunHealthSnapshot({
+      run: makeRun({ status: "executing" }),
+    });
+
+    expect(snapshot.state).toBe("healthy");
+    expect(snapshot.reasonCodes).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Defect (confirmed at main b255b2a4)
`buildFridayAgentRunHealthSnapshot` (`src/agent/runtime/friday-agent-run-presentation.ts`) handled only `awaiting_plan_approval` / `awaiting_tool_approval` in its human-action-required branch. A run with the canonical status **`awaiting_clarification`** (a member of `FridayAgentRunStatus`) fell through every branch and returned `state: "healthy"`, `reasonCodes: []` — so a run waiting on the user's answer never surfaced on the **"Needs Me"** surface (health.state is consumed at `src/api/runtime/friday-api-runtime.ts` and `src/hub/friday-hub-bootstrap.ts`). Its sibling classifier `classifyReceipt` (via `HUMAN_WAITING_STATUSES`) already treats `awaiting_clarification` as `waiting_for_human`, so the two disagreed → real user-facing defect (run hangs, user never prompted).

## Fix (minimal; matches the existing reasonCode disambiguation pattern)
Extend the human-action-required branch to also match `awaiting_clarification`, returning `state: "needs_approval"` (the coarse "human action required" bucket) with a **distinct reasonCode `clarification_required`** (mirrors the `plan_approval_required` / `tool_approval_required` split). No new enum member, no consumer changes; the defensive `awaiting_tool_approval` string check is **preserved**. The evidence-receipt file is untouched (already correct).

## Red-first evidence (revert-red)
Reverting ONLY the classifier change (test file intact) → exactly **2** REAL AssertionErrors, the other **10** regression cases stayed green:
```
FAIL … awaiting_clarification (Needs Me anchor) > classifies awaiting_clarification as needs_approval with clarification_required
AssertionError: expected 'healthy' to be 'needs_approval'    (test file line 55:28)

FAIL … cross-classifier consistency > both siblings agree a human is needed for status awaiting_clarification
AssertionError: expected 'healthy' to be 'needs_approval'    (test file line 75:36)
```
Restore → all 12 green.

## Gate results
- New test file (12 tests) GREEN; `test/unit/agent/runtime/` collateral run: **600 passed / 41 files**, no regressions.
- `npx vitest list --project default <file>` → all 12 discovered under the [default] project.
- `npx tsc --noEmit` exit **0**.
- `npm run lint` exit **0** (0 errors; the pre-existing complexity=35 warning on the function is **identical with and without this change** — complexity-neutral, no degrade).
- `detect-secrets-hook --baseline .secrets.baseline <new-test-file>` exit **0** (baseline/excludes untouched).
- NO migration. `git diff --stat origin/main` = ONLY `src/agent/runtime/friday-agent-run-presentation.ts` (+10/-2) and the new test file (+165).

## Scope honesty
Closes the Needs Me health-snapshot `awaiting_clarification` gap only. Does **NOT** close any END-BAR requirement; product stays **NO_GO**. Scan of every module enumerating the approval statuses found NO other same-shape divergence — all siblings (`friday-agent-runtime`, `friday-agent-planning-gate`, `friday-agent-evidence-blocks` L263-264, `friday-agent-unified-task-state` L270-274, `friday-api-runtime`, `friday-agent-routes`, engine, hub) already handle `awaiting_clarification`; the health snapshot was the sole outlier.

Born off origin/main b255b2a4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48