### PR TITLE
SEC-CREDENTIAL-INGRESS: encrypt satellite pairing code at rest

### DIFF
--- a/src/satellites/persistence/friday-satellite-pairing-request-repository.ts
+++ b/src/satellites/persistence/friday-satellite-pairing-request-repository.ts
@@ -1,5 +1,11 @@
 import type Database from "better-sqlite3";
 import type { FridaySatellitePairingRequestRow } from "../model/friday-satellite.types.js";
+import {
+  decryptSecret,
+  encryptSecret,
+  type FridayEncryptedEnvelope,
+  getStrictMasterKey,
+} from "../../security/friday-secret-crypto.js";
 
 export interface InsertPairingRequestInput {
   id: string;
@@ -10,6 +16,36 @@ export interface InsertPairingRequestInput {
   requestedByUserAgent?: string;
   expiresAt: string;
   nowIso: string;
+}
+
+/**
+ * A pairing `code` found at rest as legacy plaintext (not an encrypted
+ * envelope). Emitted by {@link FridaySatellitePairingRequestRepository.getRequest}
+ * / getRequestBySatelliteId so operators can observe (and audit) plaintext that
+ * predates encryption, rather than silently leaking it forever. Such a code is
+ * re-encrypted the next time its request row is (re)inserted.
+ */
+export interface FridaySatellitePairingCodeResidueEntry {
+  requestId: string;
+  reason: "legacy-plaintext";
+}
+
+export interface CreateFridaySatellitePairingRequestRepositoryOptions {
+  /**
+   * Master key used to encrypt/decrypt the pairing `code` VALUE at rest.
+   *
+   * Defaults to the hub's fail-closed persistent master key resolver
+   * ({@link getStrictMasterKey}) — the same source that guards provider, MCP,
+   * and multi-tenant secrets. {@link FridaySatellitePairingRequestRepository.insertRequest}
+   * FAILS CLOSED (throws BEFORE the INSERT) when it is unavailable, so a
+   * plaintext code is never silently persisted. Tests inject a fixed key here.
+   */
+  masterKey?: Buffer;
+  /**
+   * Invoked by getRequest / getRequestBySatelliteId when a legacy plaintext
+   * code is encountered at rest. Defaults to a console.warn summary.
+   */
+  onSecretResidue?: (entry: FridaySatellitePairingCodeResidueEntry) => void;
 }
 
 export interface FridaySatellitePairingRequestRepository {
@@ -31,9 +67,86 @@ export interface FridaySatellitePairingRequestRepository {
   deleteResolvedBefore(db: Database.Database, cutoffIso: string): number;
 }
 
-export function createFridaySatellitePairingRequestRepository(): FridaySatellitePairingRequestRepository {
+/**
+ * Detect an inline encrypted envelope stored in the TEXT `code` column. A
+ * 6-digit legacy plaintext code (or any non-JSON-object value) yields `null`,
+ * so it is treated as legacy plaintext rather than an envelope.
+ */
+function parseCodeEnvelope(value: string): FridayEncryptedEnvelope | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (
+    typeof obj.ciphertext === "string" &&
+    typeof obj.iv === "string" &&
+    typeof obj.tag === "string"
+  ) {
+    return { ciphertext: obj.ciphertext, iv: obj.iv, tag: obj.tag };
+  }
+  return null;
+}
+
+export function createFridaySatellitePairingRequestRepository(
+  options: CreateFridaySatellitePairingRequestRepositoryOptions = {},
+): FridaySatellitePairingRequestRepository {
+  function resolveMasterKey(): Buffer {
+    return options.masterKey ?? getStrictMasterKey();
+  }
+
+  function reportResidue(entry: FridaySatellitePairingCodeResidueEntry): void {
+    if (options.onSecretResidue) {
+      options.onSecretResidue(entry);
+      return;
+    }
+    console.warn(
+      `[friday][satellite-pairing-repo][SECURITY] pairing request ${entry.requestId} has a plaintext ` +
+        `code at rest (${entry.reason}); it will be re-encrypted the next time the request is inserted.`,
+    );
+  }
+
+  /**
+   * Restore the plaintext `code` on a fetched row. An envelope is decrypted;
+   * a non-envelope value is legacy plaintext → returned as-is + residue
+   * reported. FAIL-SAFE: never throws on a key/decrypt failure — the opaque
+   * envelope is left in place (mirroring the MCP config-store `load`).
+   */
+  function restoreCode(
+    row: FridaySatellitePairingRequestRow | undefined,
+  ): FridaySatellitePairingRequestRow | undefined {
+    if (!row) return row;
+    const envelope = parseCodeEnvelope(row.code);
+    if (!envelope) {
+      reportResidue({ requestId: row.id, reason: "legacy-plaintext" });
+      return row;
+    }
+    let key: Buffer;
+    try {
+      key = resolveMasterKey();
+    } catch {
+      return row; // fail-safe: key unavailable → leave opaque, never throw
+    }
+    try {
+      row.code = decryptSecret(envelope, key);
+    } catch {
+      // fail-safe: decrypt failure → leave the opaque envelope in place
+    }
+    return row;
+  }
+
   return {
     insertRequest(db, input) {
+      // Fail-closed: resolve the master key BEFORE the INSERT. When no key is
+      // available this throws and NO row (and therefore no plaintext code) is
+      // written.
+      const key = resolveMasterKey();
+      const encryptedCode = JSON.stringify(encryptSecret(input.code, key));
       db.prepare(
         `INSERT INTO satellite_pairing_requests (
           id, satellite_id, code, nonce, requested_by_ip, requested_by_user_agent,
@@ -42,7 +155,7 @@ export function createFridaySatellitePairingRequestRepository(): FridaySatellite
       ).run(
         input.id,
         input.satelliteId,
-        input.code,
+        encryptedCode,
         input.nonce,
         input.requestedByIp ?? null,
         input.requestedByUserAgent ?? null,
@@ -53,17 +166,19 @@ export function createFridaySatellitePairingRequestRepository(): FridaySatellite
     },
 
     getRequest(db, id) {
-      return db
+      const row = db
         .prepare("SELECT * FROM satellite_pairing_requests WHERE id = ?")
         .get(id) as FridaySatellitePairingRequestRow | undefined;
+      return restoreCode(row);
     },
 
     getRequestBySatelliteId(db, satelliteId, status) {
-      return db
+      const row = db
         .prepare(
           "SELECT * FROM satellite_pairing_requests WHERE satellite_id = ? AND status = ? ORDER BY created_at DESC LIMIT 1",
         )
         .get(satelliteId, status) as FridaySatellitePairingRequestRow | undefined;
+      return restoreCode(row);
     },
 
     updateStatus(db, id, status, resolverUserId, nowIso) {

--- a/test/unit/satellites/persistence/friday-satellite-pairing-request-repository.test.ts
+++ b/test/unit/satellites/persistence/friday-satellite-pairing-request-repository.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+
+import type { FridaySqliteLayer } from "#state";
+import { createFridaySatellitePairingRequestRepository } from "#satellites";
+import { createTestDb } from "../_helpers/create-test-db.helper.js";
+import { resetMasterKeyCache } from "../../../../src/security/friday-secret-crypto.js";
+
+// SEC-CREDENTIAL-INGRESS: the 6-digit operator pairing-confirmation `code` must
+// NOT be persisted as plaintext in satellite_pairing_requests.code. It is stored
+// as an inline encrypted envelope in the existing TEXT column and decrypted on
+// read (mirroring oauth_credentials.*_encrypted / the MCP config-store slice).
+// NOTE: the canary below is a synthetic test value, never a real credential.
+const PAIRING_CODE_CANARY = "424242"; // pragma: allowlist secret
+const PUBLIC_NONCE = "public-challenge-nonce-abc123";
+
+const MASTER_KEY = randomBytes(32);
+
+let layer: FridaySqliteLayer;
+
+function seedSatellite(id: string): void {
+  layer.writer
+    .prepare(
+      `INSERT INTO satellites (id, display_name, type, pairing_status, trust_level, public_key,
+         token_version, transport, platform, arch, app_version, node_version, tags_json, created_at, updated_at)
+       VALUES (?, ?, 'phone', 'pending', 'restricted', 'pk', 1, 'ws', 'linux', 'arm64', '1.0', '22.0', '[]', ?, ?)`,
+    )
+    .run(id, `Satellite ${id}`, "2026-07-12T00:00:00.000Z", "2026-07-12T00:00:00.000Z");
+}
+
+beforeEach(() => {
+  layer = createTestDb();
+  // satellite_pairing_requests.satellite_id is an enforced FK → seed the parents.
+  seedSatellite("sat-1");
+  seedSatellite("sat-legacy");
+});
+
+afterEach(() => {
+  layer.close();
+});
+
+function insertInput(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "req-1",
+    satelliteId: "sat-1",
+    code: PAIRING_CODE_CANARY,
+    nonce: PUBLIC_NONCE,
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    nowIso: "2026-07-12T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function rawColumn(id: string, column: "code" | "nonce"): string | undefined {
+  const row = layer.writer
+    .prepare(`SELECT ${column} AS v FROM satellite_pairing_requests WHERE id = ?`)
+    .get(id) as { v: string } | undefined;
+  return row?.v;
+}
+
+describe("FridaySatellitePairingRequestRepository pairing-code-at-rest encryption", () => {
+  it("does not persist the pairing code as plaintext (inline encrypted envelope at rest)", () => {
+    const repo = createFridaySatellitePairingRequestRepository({ masterKey: MASTER_KEY });
+    layer.withWriteTransaction((db) => repo.insertRequest(db, insertInput()));
+
+    const raw = rawColumn("req-1", "code");
+    expect(raw).toBeDefined();
+    // BEHAVIORAL RED (fails pre-fix): today the column IS the plaintext canary.
+    expect(raw!).not.toContain(PAIRING_CODE_CANARY);
+    // It is an opaque AES-256-GCM envelope (ciphertext / iv / tag), not the code.
+    const envelope = JSON.parse(raw!) as Record<string, unknown>;
+    expect(typeof envelope.ciphertext).toBe("string");
+    expect(typeof envelope.iv).toBe("string");
+    expect(typeof envelope.tag).toBe("string");
+  });
+
+  it("round-trips the real code on getRequest / getRequestBySatelliteId", () => {
+    const repo = createFridaySatellitePairingRequestRepository({ masterKey: MASTER_KEY });
+    layer.withWriteTransaction((db) => repo.insertRequest(db, insertInput()));
+
+    const byId = layer.withReadConnection((db) => repo.getRequest(db, "req-1"));
+    expect(byId?.code).toBe(PAIRING_CODE_CANARY);
+
+    const bySat = layer.withReadConnection((db) =>
+      repo.getRequestBySatelliteId(db, "sat-1", "pending"),
+    );
+    expect(bySat?.code).toBe(PAIRING_CODE_CANARY);
+
+    // The `nonce` is a PUBLIC challenge — it MUST stay plaintext at rest and be
+    // returned byte-identical (never encrypted).
+    expect(rawColumn("req-1", "nonce")).toBe(PUBLIC_NONCE);
+    expect(byId?.nonce).toBe(PUBLIC_NONCE);
+  });
+
+  it("fail-closed: refuses to insert (never writes plaintext) when no master key is available", () => {
+    const savedEnvKey = process.env.FRIDAY_MASTER_KEY;
+    const savedEnvSource = process.env.FRIDAY_MASTER_KEY_SOURCE;
+    delete process.env.FRIDAY_MASTER_KEY;
+    delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+    resetMasterKeyCache();
+    try {
+      // No injected key → falls back to the real fail-closed hub resolver.
+      const repo = createFridaySatellitePairingRequestRepository();
+      expect(() =>
+        layer.withWriteTransaction((db) => repo.insertRequest(db, insertInput())),
+      ).toThrow();
+
+      // Critical: it threw BEFORE the INSERT — no row (and no plaintext) persisted.
+      const count = layer.writer
+        .prepare("SELECT COUNT(*) AS n FROM satellite_pairing_requests")
+        .get() as { n: number };
+      expect(count.n).toBe(0);
+    } finally {
+      if (savedEnvKey !== undefined) process.env.FRIDAY_MASTER_KEY = savedEnvKey;
+      if (savedEnvSource !== undefined) process.env.FRIDAY_MASTER_KEY_SOURCE = savedEnvSource;
+      resetMasterKeyCache();
+    }
+  });
+
+  it("PRODUCTION default path (no injected key, only FRIDAY_MASTER_KEY) encrypts + round-trips", () => {
+    // Proves the default resolver is getStrictMasterKey(): with NO options and
+    // only the persistent hub key configured (as prod does), the code is still
+    // encrypted at rest and decrypts on read.
+    const savedEnvKey = process.env.FRIDAY_MASTER_KEY;
+    const savedEnvSource = process.env.FRIDAY_MASTER_KEY_SOURCE;
+    delete process.env.FRIDAY_MASTER_KEY_SOURCE;
+    process.env.FRIDAY_MASTER_KEY = MASTER_KEY.toString("hex");
+    resetMasterKeyCache();
+    try {
+      const repo = createFridaySatellitePairingRequestRepository(); // no options
+      layer.withWriteTransaction((db) => repo.insertRequest(db, insertInput()));
+
+      expect(rawColumn("req-1", "code")).not.toContain(PAIRING_CODE_CANARY);
+      const got = layer.withReadConnection((db) => repo.getRequest(db, "req-1"));
+      expect(got?.code).toBe(PAIRING_CODE_CANARY);
+    } finally {
+      if (savedEnvKey !== undefined) process.env.FRIDAY_MASTER_KEY = savedEnvKey;
+      else delete process.env.FRIDAY_MASTER_KEY;
+      if (savedEnvSource !== undefined) process.env.FRIDAY_MASTER_KEY_SOURCE = savedEnvSource;
+      resetMasterKeyCache();
+    }
+  });
+
+  it("tolerates legacy plaintext code, reports residue, and does not rewrite it on read", () => {
+    // Pre-seed a row exactly as a pre-encryption insert would (plaintext code).
+    layer.writer
+      .prepare(
+        `INSERT INTO satellite_pairing_requests
+           (id, satellite_id, code, nonce, status, expires_at, created_at, updated_at)
+         VALUES ('legacy-1', 'sat-legacy', ?, ?, 'pending', '2099-01-01T00:00:00.000Z', ?, ?)`,
+      )
+      .run(PAIRING_CODE_CANARY, PUBLIC_NONCE, "2026-07-12T00:00:00.000Z", "2026-07-12T00:00:00.000Z");
+
+    const residue: Array<{ requestId: string; reason: string }> = [];
+    const repo = createFridaySatellitePairingRequestRepository({
+      masterKey: MASTER_KEY,
+      onSecretResidue: (entry) => residue.push(entry),
+    });
+
+    const got = layer.withReadConnection((db) => repo.getRequest(db, "legacy-1"));
+    // Legacy plaintext is returned as-is so the request stays usable...
+    expect(got?.code).toBe(PAIRING_CODE_CANARY);
+    // ...and the residue is reported (legacy-plaintext) for audit / re-encryption.
+    expect(residue.some((r) => r.requestId === "legacy-1" && r.reason === "legacy-plaintext")).toBe(
+      true,
+    );
+    // FAIL-SAFE: a read never mutates — the row stays as-is (flagged, not silently
+    // re-encrypted); it is re-encrypted only on the next insertRequest.
+    expect(rawColumn("legacy-1", "code")).toBe(PAIRING_CODE_CANARY);
+  });
+});

--- a/test/unit/satellites/services/friday-satellite-pairing-service.test.ts
+++ b/test/unit/satellites/services/friday-satellite-pairing-service.test.ts
@@ -39,7 +39,7 @@ describe("FridaySatellitePairingService", () => {
   const LATER = "2025-01-15T10:05:00.000Z";
 
   const satelliteRepo = createFridaySatelliteRepository();
-  const pairingRequestRepo = createFridaySatellitePairingRequestRepository();
+  const pairingRequestRepo = createFridaySatellitePairingRequestRepository({ masterKey: Buffer.alloc(32, 7) }); // SEC-CREDENTIAL-INGRESS: fixed test key (insertRequest fail-closes without one)
   const capabilityRepo = createFridaySatelliteCapabilityRepository();
   const apiTokenRepo = createFridayApiTokenRepository();
   const checkpointRepo = createFridayStreamCheckpointRepository();

--- a/test/unit/satellites/services/friday-satellite-registration-retirement-guard.test.ts
+++ b/test/unit/satellites/services/friday-satellite-registration-retirement-guard.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { randomBytes } from "node:crypto";
 
 import type { FridaySqliteLayer } from "#state";
 import { FridayDomainError } from "#errors";
@@ -24,6 +25,10 @@ import { createTestDb, createTestIdGenerator } from "../_helpers/create-test-db.
 
 const RETIRED_CODE = "TS_RUNTIME_SATELLITE_PAIRING_RETIRED";
 const NOW = "2026-06-10T00:00:00.000Z";
+// SEC-CREDENTIAL-INGRESS: insertRequest fail-closes without a master key; inject
+// a fixed test key via the repo's additive `options.masterKey` seam so the
+// legacy-path-preserved register() case can encrypt the pairing code at rest.
+const TEST_MASTER_KEY = randomBytes(32);
 
 const baseInput: FridaySatelliteRegistrationInput = {
   type: "phone",
@@ -48,7 +53,7 @@ describe("FridaySatelliteRegistrationService TS-retirement method guard", () => 
     return createFridaySatelliteRegistrationService({
       db,
       satelliteRepo: createFridaySatelliteRepository(),
-      pairingRequestRepo: createFridaySatellitePairingRequestRepository(),
+      pairingRequestRepo: createFridaySatellitePairingRequestRepository({ masterKey: TEST_MASTER_KEY }),
       capabilityRepo: createFridaySatelliteCapabilityRepository(),
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,

--- a/test/unit/satellites/services/friday-satellite-registration-service.test.ts
+++ b/test/unit/satellites/services/friday-satellite-registration-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
 import type { FridaySqliteLayer } from "#state";
 import type { FridaySatelliteRegistrationInput } from "#satellites";
 import { createFridaySatelliteRepository } from "#satellites";
@@ -6,6 +7,11 @@ import { createFridaySatellitePairingRequestRepository } from "#satellites";
 import { createFridaySatelliteCapabilityRepository } from "#satellites";
 import { createFridaySatelliteRegistrationService } from "#satellites";
 import { createTestDb, createTestIdGenerator } from "../_helpers/create-test-db.helper.js";
+
+// SEC-CREDENTIAL-INGRESS: insertRequest now fail-closes without a master key.
+// Inject a fixed test key via the repo's additive `options.masterKey` seam so
+// the pairing `code` is encrypted at rest during these unit tests.
+const TEST_MASTER_KEY = randomBytes(32);
 
 describe("FridaySatelliteRegistrationService", () => {
   let db: FridaySqliteLayer;
@@ -37,7 +43,7 @@ describe("FridaySatelliteRegistrationService", () => {
     return createFridaySatelliteRegistrationService({
       db,
       satelliteRepo: createFridaySatelliteRepository(),
-      pairingRequestRepo: createFridaySatellitePairingRequestRepository(),
+      pairingRequestRepo: createFridaySatellitePairingRequestRepository({ masterKey: TEST_MASTER_KEY }),
       capabilityRepo: createFridaySatelliteCapabilityRepository(),
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,
@@ -105,7 +111,7 @@ describe("FridaySatelliteRegistrationService", () => {
     const service = createFridaySatelliteRegistrationService({
       db,
       satelliteRepo: createFridaySatelliteRepository(),
-      pairingRequestRepo: createFridaySatellitePairingRequestRepository(),
+      pairingRequestRepo: createFridaySatellitePairingRequestRepository({ masterKey: TEST_MASTER_KEY }),
       capabilityRepo: createFridaySatelliteCapabilityRepository(),
       idGenerator: createTestIdGenerator(),
       nowIso: () => NOW,


### PR DESCRIPTION
## Sink
`satellite_pairing_requests.code` — the 6-digit **operator pairing-confirmation secret** — was persisted **PLAINTEXT**. It was the last enumerated plaintext AT-REST credential sink (every other bearer credential at rest is already encrypted/hashed; only this and the deferred/LARGE `.env` provider-key seam remained).

## Fix
`src/satellites/persistence/friday-satellite-pairing-request-repository.ts` — inline-envelope in the existing TEXT column (precedent: `oauth_credentials.*_encrypted` / the MCP config-store slice #1576):

- **`insertRequest`** resolves the master key FIRST (`options.masterKey ?? getStrictMasterKey()`) and **FAILS CLOSED** — throws BEFORE the INSERT, so a plaintext code is never written when no key is available. Stores `JSON.stringify(encryptSecret(code, key))`.
- **`getRequest` / `getRequestBySatelliteId`** detect the envelope → `decryptSecret` → restore `row.code`. **FAIL-SAFE**: never throw on key/decrypt failure (leave the opaque envelope in place, mirroring MCP `load`). A non-envelope value = legacy plaintext → returned as-is + **residue reported** (`onSecretResidue`, defaults to `console.warn`).
- Additive **`options.masterKey`** (test injection) + `options.onSecretResidue`; default resolver = `getStrictMasterKey`.
- `listPendingExpiredBefore` / `deleteResolvedBefore` unchanged (they don't read `code`; row delete removes the ciphertext).
- The `nonce` is a **PUBLIC challenge — NOT encrypted** (a test pins it byte-identical at rest).
- **NO migration** (`code` is already TEXT; additive; legacy tolerated).

## Red-first evidence
New production-seam test over a **REAL migrated in-memory DB** (`runFridayMigrations(FRIDAY_SQLITE_MIGRATIONS)` via the satellites test-db helper — the genuine `satellite_pairing_requests` table). Canary `"424242"`.

Reverting **ONLY** the repo encryption (repo file → origin/main) re-fails the behavioral assertions with **real AssertionErrors**:
- `expected '424242' not to contain '424242'` (behavioral RED, line 69)
- `expected '424242' not to contain '424242'` (prod-default path, line 133)
- `expected [Function] to throw an error` (fail-closed insert)
- `expected false to be true` (legacy-residue reporting)

Restoring the change → all 5 green. Tests cover: envelope-at-rest, `getRequest`/`getRequestBySatelliteId` round-trip, fail-closed insert (0 rows persisted), PRODUCTION default path (only `FRIDAY_MASTER_KEY` set → proves default resolver), legacy-plaintext tolerance + residue + non-mutating read.

## Gate results
- **RED-first PROVEN** (see above).
- **No regression**: 175/175 tests green across 21 files — all `test/unit/satellites/**`, `friday-fleet-dashboard-service.test.ts` (25), `friday-retention-job.test.ts` (15), `friday-satellite-pairing-routes.test.ts`.
- **Typecheck** exit 0. **`eslint`** 0 errors on the repo file (test files are eslint-ignored by config).
- **`detect-secrets-hook --baseline .secrets.baseline`** exit 0 on all changed files; `.secrets.baseline` **NOT modified** (loosening avoided).
- **NO migration.**

## Blast-radius correction (honest)
The task assumed the fleet dashboard "reads via the repo so it stays byte-identical." **It does not** — the fleet dashboard displays `pairingCode` via a **separate raw `SELECT id, code, ...`** in `src/api/fleet/friday-fleet-dashboard-repository.ts::getLatestPairingRequest` (it does **not** decrypt).

Impact is **nil in the live/default runtime**: the only writer through this repo (`registration-service.register` → `insertRequest`) is **retired/fail-closed** (`TS_RUNTIME_SATELLITE_PAIRING_RETIRED` → 503), so **no encrypted rows are ever created in live**; legacy/Rust-written plaintext rows still display byte-identically. The one non-live inconsistency (the fleet dashboard would render the envelope for a TS-written encrypted row **only** with the retirement gate disabled — tests / a future un-retirement) is flagged as an explicit **follow-up: a one-line decrypt in `getLatestPairingRequest`**, deliberately deferred to honor the strict satellites/persistence-only scope and avoid touching `src/api/fleet` (and the in-flight Lark/channel branch).

## Scope / diff
Changed files (5, satellites-only; **zero overlap** with the in-flight Lark/channel branch):
- `src/satellites/persistence/friday-satellite-pairing-request-repository.ts` (the fix)
- `test/unit/satellites/persistence/friday-satellite-pairing-request-repository.test.ts` (new red-first test)
- 3 existing satellite tests that exercise `insertRequest` now inject the test key via the new `options.masterKey` seam (`registration-service`, `pairing-service`, `registration-retirement-guard`) — **required by the fail-closed change + no-regression gate**. The `pairing-service` edit is kept **net-zero-lines** so a baseline-tracked secret's line number does not drift → `.secrets.baseline` stays untouched.

## Scope-honesty
Defense-in-depth closing the **last enumerated AT-REST plaintext credential sink**. Value caveat: the code is 6-digit, `expires_at`-bounded, and approval already requires an authenticated operator session — encrypting it hardens at-rest DB exposure, it is not a new access-control boundary. The `.env` provider-key seam stays **LARGE/deferred**. Closes **NO END-BAR requirement**; product stays **NO_GO**. Born off `origin/main` b255b2a4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48