### PR TITLE
RUN-RESOURCE-CONFLICT: canonicalize tool-batch conflict keys (./, .., trailing-slash, darwin case)

### DIFF
--- a/src/agent/runtime/friday-agent-tool-batch-executor.ts
+++ b/src/agent/runtime/friday-agent-tool-batch-executor.ts
@@ -14,6 +14,8 @@
  * the default. The batch executor is an opt-in enhancement.
  */
 
+import { normalize } from "node:path";
+
 import { isMutatingToolCall } from "./friday-agent-tool-mutation.js";
 
 // ─── Types ───
@@ -105,6 +107,42 @@ export function extractFilePaths(toolName: string, args: Record<string, unknown>
   return paths;
 }
 
+// ─── Conflict-key canonicalization ───
+
+/**
+ * Canonicalize a file path for use as a CONFLICT-DETECTION KEY only.
+ *
+ * Two same-turn mutating tools can target the SAME underlying file via
+ * different path spellings (`/tmp/a.txt` vs `/tmp/./a.txt`, trailing slash,
+ * `..` segments, and — on macOS — case variants). If the conflict graph keys
+ * on the raw string, those spellings hash to distinct keys, the tools are
+ * judged non-conflicting, and they run concurrently — corrupting the file
+ * with a lost/interleaved write.
+ *
+ * This function collapses those spellings so equivalent paths share a key:
+ * - `normalize(p)` folds `.`, `..`, and duplicate separators.
+ * - a trailing separator is stripped (except a bare root) so `/d/` == `/d`.
+ * - on darwin only, the key is lowercased because the filesystem is
+ *   case-insensitive there; on Linux the FS is case-sensitive so distinct-case
+ *   paths intentionally remain distinct.
+ *
+ * IMPORTANT: this affects ONLY the conflict key. The literal path passed to
+ * the tool executor is never rewritten. Canonicalization can only make MORE
+ * paths compare equal, so it can only ADD serialization — it never removes a
+ * real conflict and never wrongly parallelizes two genuinely-different files.
+ */
+export function canonicalizeConflictKey(p: string): string {
+  let key = normalize(p);
+  // Strip a trailing separator (but keep a bare root like "/").
+  if (key.length > 1 && (key.endsWith("/") || key.endsWith("\\"))) {
+    key = key.slice(0, -1);
+  }
+  if (process.platform === "darwin") {
+    key = key.toLowerCase();
+  }
+  return key;
+}
+
 // ─── Dependency classification ───
 
 /**
@@ -137,7 +175,7 @@ export function classifyToolBatchDependencies(
     // Check for conflicts with current group
     let hasConflict = false;
     for (const p of paths) {
-      const existingMutating = groupPaths.get(p);
+      const existingMutating = groupPaths.get(canonicalizeConflictKey(p));
       if (existingMutating !== undefined) {
         // Path overlap — conflict if either side is mutating
         if (existingMutating || isMutating) {
@@ -156,8 +194,11 @@ export function classifyToolBatchDependencies(
 
     currentGroup.push(toolUse);
     for (const p of paths) {
-      // Mark as mutating if this tool or a previous tool on same path is mutating
-      groupPaths.set(p, (groupPaths.get(p) ?? false) || isMutating);
+      // Mark as mutating if this tool or a previous tool on same path is mutating.
+      // Key on the canonicalized path so different spellings of the same file
+      // (`./`, `..`, trailing slash, darwin case) share one conflict entry.
+      const key = canonicalizeConflictKey(p);
+      groupPaths.set(key, (groupPaths.get(key) ?? false) || isMutating);
     }
   }
 

--- a/test/unit/agent/runtime/friday-agent-tool-batch-executor.test.ts
+++ b/test/unit/agent/runtime/friday-agent-tool-batch-executor.test.ts
@@ -19,6 +19,83 @@ describe("friday-agent-tool-batch-executor", () => {
     expect(groups[1]?.tools.map((tool) => tool.id)).toEqual(["3", "4"]);
   });
 
+  // ─── Conflict-key canonicalization (RUN-RESOURCE-CONFLICT-001) ───
+  // Two same-turn MUTATING writes that target the SAME underlying file via
+  // different path spellings must be serialized into 2 groups. Without
+  // canonicalization the raw strings hash to distinct keys → judged
+  // non-conflicting → placed in one parallel group → lost/interleaved write.
+
+  it("serializes two mutating writes on the same file spelled with a `.` segment", () => {
+    const groups = classifyToolBatchDependencies([
+      { id: "1", name: "write", input: { path: "/tmp/a.txt", content: "x" } },
+      { id: "2", name: "write", input: { path: "/tmp/./a.txt", content: "y" } },
+    ]);
+    // TODAY (raw-key) returns 1 → real AssertionError "expected 1 to be 2".
+    expect(groups).toHaveLength(2);
+    expect(groups[0]?.tools.map((tool) => tool.id)).toEqual(["1"]);
+    expect(groups[1]?.tools.map((tool) => tool.id)).toEqual(["2"]);
+  });
+
+  it("serializes two mutating writes on the same file with vs without a trailing slash", () => {
+    const groups = classifyToolBatchDependencies([
+      { id: "1", name: "write", input: { path: "/tmp/dir/", content: "x" } },
+      { id: "2", name: "write", input: { path: "/tmp/dir", content: "y" } },
+    ]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("serializes two mutating writes on the same file spelled with a `..` segment", () => {
+    const groups = classifyToolBatchDependencies([
+      { id: "1", name: "write", input: { path: "/tmp/x/../a.txt", content: "x" } },
+      { id: "2", name: "write", input: { path: "/tmp/a.txt", content: "y" } },
+    ]);
+    expect(groups).toHaveLength(2);
+  });
+
+  // Darwin-only: the macOS filesystem is case-insensitive, so `/tmp/A.txt` and
+  // `/tmp/a.txt` are the SAME file and two writes must be serialized. On Linux
+  // (case-sensitive) they are DIFFERENT files, so this assertion is guarded.
+  it.skipIf(process.platform !== "darwin")(
+    "serializes two mutating writes that differ only by case on darwin",
+    () => {
+      const groups = classifyToolBatchDependencies([
+        { id: "1", name: "write", input: { path: "/tmp/A.txt", content: "x" } },
+        { id: "2", name: "write", input: { path: "/tmp/a.txt", content: "y" } },
+      ]);
+      expect(groups).toHaveLength(2);
+    },
+  );
+
+  // Linux-only mirror: distinct-case paths are DISTINCT files on a
+  // case-sensitive FS, so they must stay parallelizable (no over-serialization).
+  it.skipIf(process.platform === "darwin")(
+    "keeps case-distinct writes parallel on a case-sensitive filesystem",
+    () => {
+      const groups = classifyToolBatchDependencies([
+        { id: "1", name: "write", input: { path: "/tmp/A.txt", content: "x" } },
+        { id: "2", name: "write", input: { path: "/tmp/a.txt", content: "y" } },
+      ]);
+      expect(groups).toHaveLength(1);
+    },
+  );
+
+  it("keeps genuinely distinct files parallel (no-degrade)", () => {
+    const groups = classifyToolBatchDependencies([
+      { id: "1", name: "write", input: { path: "/tmp/a.txt", content: "x" } },
+      { id: "2", name: "write", input: { path: "/tmp/b.txt", content: "y" } },
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.tools.map((tool) => tool.id)).toEqual(["1", "2"]);
+  });
+
+  it("keeps non-mutating reads on the same canonical path in one group", () => {
+    const groups = classifyToolBatchDependencies([
+      { id: "1", name: "read", input: { path: "/tmp/a.txt" } },
+      { id: "2", name: "read", input: { path: "/tmp/./a.txt" } },
+    ]);
+    expect(groups).toHaveLength(1);
+  });
+
   it("preserves original order in returned results", async () => {
     const groups = classifyToolBatchDependencies([
       { id: "1", name: "read", input: { path: "/tmp/a.txt" } },


### PR DESCRIPTION
## Defect (RUN-RESOURCE-CONFLICT-001 — live)

The agent tool-batch conflict graph decides which `tool_use` blocks may run in parallel. It keyed conflict detection on the **RAW path string**, so two same-turn **MUTATING** tools targeting the **SAME** underlying file via different spellings were wrongly judged non-conflicting → placed in one parallel group → run concurrently via `Promise.allSettled` → **lost-update / interleaved-write corruption** of a real user's file.

`src/agent/runtime/friday-agent-tool-batch-executor.ts`:
- `classifyToolBatchDependencies` conflict-detected via `groupPaths.get(p)` / `groupPaths.set(p, …)` keyed on the raw string, so `/tmp/a.txt` vs `/tmp/./a.txt` (also trailing slash, `..` segments, and macOS case variants) → distinct keys → no conflict → same parallel group.

## Live seam (unconditional)

`friday-agent-runtime.ts` `classifyToolBatchDependencies(executableBlocks)` (inside `if (executableToolUses.length>0 && !aborted)` — no flag) → `executeToolBatch(groups, …)` runs same-group tools in parallel. Consumed by `createFridayAgentRuntime` → the live API runtime.

## Fix (minimal, surgical, no-degrade)

Added `canonicalizeConflictKey(p: string): string` and applied it **only at the conflict-KEY sites** (`groupPaths.get(...)` and `groupPaths.set(...)`):
- `normalize(p)` — folds `.`, `..`, duplicate separators.
- strip a trailing separator (except a bare root `/`).
- lowercase the key **only when `process.platform === "darwin"`** (case-insensitive FS). On Linux the FS is case-sensitive, so distinct-case paths stay distinct.

The literal path passed to the tool executor is **never** rewritten. `extractFilePaths`' public contract is unchanged — its literal output is relied on by other runtime callers (`friday-agent-runtime.ts:4921`, `:7847`) for real file operations (`fileVersionTracker.checkBeforeWrite`), so it was intentionally left untouched.

**No-degrade rationale:** canonicalization can only make MORE paths compare equal → only ADDS serialization, never removes a real conflict; genuinely-distinct files are never merged into incorrect parallelism, and a false-merge merely serializes two writes (both still happen, ordered) — no correctness loss.

## Red-first evidence

Reverting **only** the two `canonicalizeConflictKey(...)` key-site calls (back to raw `p`) makes the normalize assertions throw real `AssertionError`s:

```
× serializes two mutating writes on the same file spelled with a `.` segment
  AssertionError: expected [ { tools: [ …(2) ] } ] to have a length of 2 but got 1
× serializes two mutating writes on the same file with vs without a trailing slash
  AssertionError: expected [ { tools: [ …(2) ] } ] to have a length of 2 but got 1
× serializes two mutating writes on the same file spelled with a `..` segment
  AssertionError: expected [ { tools: [ …(2) ] } ] to have a length of 2 but got 1
× serializes two mutating writes that differ only by case on darwin
  AssertionError: expected [ { tools: [ …(2) ] } ] to have a length of 2 but got 1
```

Restoring the fix → all green (the no-degrade tests — distinct files stay parallel, non-mutating reads on the same canonical path stay grouped — remain green in both states).

## Gate results

- **RED-FIRST PROVEN**: yes (4 real AssertionErrors on revert; green on restore).
- **Full suite green**: executor file (10 passed, 1 skipped) + all `test/unit/agent/runtime/` (606 passed, 1 skipped).
- `npx tsc --noEmit`: **exit 0**.
- `npm run lint`: **0 errors** (pre-existing warnings only; none in changed files).
- `detect-secrets-hook --baseline .secrets.baseline <both files>`: **exit 0** (baseline/excludes untouched).
- **No migration.** Changed files = ONLY `friday-agent-tool-batch-executor.ts` + its test (`git diff --stat origin/main` = 2 files, 121 insertions, 3 deletions). Did NOT touch `friday-agent-runtime.ts` / `friday-agent-run-presentation.ts` / engine adapters (born-current-mergeable in parallel).

## Platform nuance

The darwin case-fold test is guarded with `it.skipIf(process.platform !== "darwin")` and a Linux-only mirror asserts case-distinct paths stay parallel. The platform-agnostic red anchors are the `.`/`..`/trailing-slash cases (pass on Linux CI).

## Scope honesty

Fixes the live tool-batch conflict-key defect. Closes **NO** END-BAR requirement; product stays **NO_GO**.

Born off origin/main `4bbeb48f`.