### PR TITLE
SAFE-ROLLBACK-PRECONDITION: don't claim rollback available when backup capture failed

### DIFF
--- a/src/agent/runtime/friday-agent-run-checkpoint.ts
+++ b/src/agent/runtime/friday-agent-run-checkpoint.ts
@@ -149,13 +149,25 @@ export function createFridayRunCheckpoint(deps: CreateRunCheckpointDeps): Friday
       }
     }
 
+    // Truthful reversibility: never claim rollback is available when it is not.
+    //   - A newly-created file (!existed) is reversible by deletion — always true.
+    //   - An EXISTING file is reversible ONLY if its pre-mutation backup was
+    //     actually captured above. If the backup read/write threw (catch at
+    //     the try above → backupPath === undefined), rollback() would
+    //     fail-close with "backup unavailable", so advertising availability
+    //     here would be an over-claim surfaced to the user via the run
+    //     receipt / rollback_available health state.
+    // Computed once and used at BOTH persistence sites (in-memory entry and
+    // the manifest row) so the claim can never diverge between them.
+    const rollbackAvailable = existed ? backupPath !== undefined : true;
+
     const entry: FridayRunCheckpointEntry = {
       filePath: canonicalPath,
       originalPath: filePath,
       existed,
       backupPath,
       snapshotAt: deps.nowIso(),
-      rollbackAvailable: true,
+      rollbackAvailable,
     };
 
     snapshots.set(canonicalPath, entry);
@@ -166,7 +178,7 @@ export function createFridayRunCheckpoint(deps: CreateRunCheckpointDeps): Friday
       existedBefore: existed,
       backupPath,
       snapshotAt: entry.snapshotAt,
-      rollbackAvailable: true,
+      rollbackAvailable,
       updatedAt: entry.snapshotAt,
     } satisfies FridayAgentRunCheckpointManifestEntry);
   }

--- a/test/unit/agent/runtime/friday-agent-run-checkpoint.test.ts
+++ b/test/unit/agent/runtime/friday-agent-run-checkpoint.test.ts
@@ -70,6 +70,115 @@ describe("createFridayRunCheckpoint (B2 retention)", () => {
     expect(fs.existsSync(beforeRollbackBackups[0]!)).toBe(false);
   });
 
+  it("truthful flag: an EXISTING file whose backup capture FAILS at snapshot time is NOT marked rollbackAvailable (no over-claim)", () => {
+    // SAFE-ROLLBACK-PRECONDITION: when snapshotBeforeWrite cannot capture a
+    // usable backup for an existing file, the checkpoint entry must NOT claim
+    // the mutation is reversible. Otherwise the run receipt / rollback_available
+    // health state tells the user a lie: it advertises a rollback that will
+    // fail-close at rollback() time.
+    const stateDir = makeStateDir();
+    const targetPath = path.join(stateDir, "target.txt");
+    fs.writeFileSync(targetPath, "ORIGINAL", "utf-8");
+
+    // Force the backup capture to fail deterministically & offline: place a
+    // FILE where `snapshotDir = stateDir/agent-snapshots/<runId>` must be
+    // created, so `mkdirSync(snapshotDir, { recursive: true })` throws ENOTDIR
+    // (its `agent-snapshots` path segment is a file, not a directory) and the
+    // catch at snapshot time fires → backupPath === undefined.
+    fs.writeFileSync(path.join(stateDir, "agent-snapshots"), "block", "utf-8");
+
+    const checkpoint = createFridayRunCheckpoint({
+      runId: "run-nobackup",
+      stateDir,
+      db: makeDb(),
+      nowIso: () => "2026-03-24T00:00:00.000Z",
+    });
+
+    checkpoint.snapshotBeforeWrite(targetPath);
+
+    const entry = checkpoint.entries()[0]!;
+    // Preconditions for this scenario: file existed, but backup was not captured.
+    expect(entry.existed).toBe(true);
+    expect(entry.backupPath).toBeUndefined();
+
+    // THE FIX: the reversibility claim must be honest → false.
+    // (Before the fix this was hardcoded `true` → real AssertionError here.)
+    expect(entry.rollbackAvailable).toBe(false);
+
+    // Receipt truth: hasRollbackCheckpoint(runtime.ts) computes exactly this
+    // predicate — it must NOT advertise availability for this run.
+    expect(checkpoint.entries().some((e) => e.rollbackAvailable)).toBe(false);
+
+    // Tie the claim to reality: rollback genuinely does NOT restore the file.
+    fs.writeFileSync(targetPath, "MUTATED", "utf-8");
+    const result = checkpoint.rollback();
+    expect(result.restoredCount).toBe(0);
+    // File stays in its post-mutation state — the mutation is truly irreversible,
+    // exactly as the (now honest) flag reports. No garbage restore either.
+    expect(fs.readFileSync(targetPath, "utf-8")).toBe("MUTATED");
+  });
+
+  it("no-degrade: an EXISTING file WITH a successful backup stays rollbackAvailable === true and restores", () => {
+    const stateDir = makeStateDir();
+    const targetPath = path.join(stateDir, "target.txt");
+    fs.writeFileSync(targetPath, "ORIGINAL", "utf-8");
+
+    const checkpoint = createFridayRunCheckpoint({
+      runId: "run-ok",
+      stateDir,
+      db: makeDb(),
+      nowIso: () => "2026-03-24T00:00:00.000Z",
+    });
+
+    checkpoint.snapshotBeforeWrite(targetPath);
+
+    const entry = checkpoint.entries()[0]!;
+    expect(entry.existed).toBe(true);
+    expect(entry.backupPath).toBeDefined();
+    // The happy path is unchanged: a captured backup ⇒ reversible ⇒ true.
+    expect(entry.rollbackAvailable).toBe(true);
+
+    fs.writeFileSync(targetPath, "MUTATED", "utf-8");
+    const result = checkpoint.rollback();
+    expect(result.restoredCount).toBe(1);
+    expect(result.errors).toEqual([]);
+    expect(fs.readFileSync(targetPath, "utf-8")).toBe("ORIGINAL");
+  });
+
+  it("no-degrade: a NEWLY-CREATED file (did not exist) stays rollbackAvailable === true and rollback reverses by deleting it", () => {
+    // Verifies the `!existed` branch of rollback() truly reverses the mutation
+    // by DELETING the created file — which is why keeping `true` for
+    // existed === false is honest (the fix intentionally does not touch it).
+    const stateDir = makeStateDir();
+    const targetPath = path.join(stateDir, "created.txt");
+    // Note: file does NOT exist at snapshot time.
+
+    const checkpoint = createFridayRunCheckpoint({
+      runId: "run-new",
+      stateDir,
+      db: makeDb(),
+      nowIso: () => "2026-03-24T00:00:00.000Z",
+    });
+
+    checkpoint.snapshotBeforeWrite(targetPath);
+
+    const entry = checkpoint.entries()[0]!;
+    expect(entry.existed).toBe(false);
+    expect(entry.backupPath).toBeUndefined();
+    // A file that did not exist is reversible by deletion ⇒ honestly true.
+    expect(entry.rollbackAvailable).toBe(true);
+
+    // Simulate the write that created the file.
+    fs.writeFileSync(targetPath, "NEW-CONTENT", "utf-8");
+    expect(fs.existsSync(targetPath)).toBe(true);
+
+    const result = checkpoint.rollback();
+    expect(result.restoredCount).toBe(1);
+    expect(result.errors).toEqual([]);
+    // Reversal for a created file == deletion.
+    expect(fs.existsSync(targetPath)).toBe(false);
+  });
+
   it("B2 fail-closed: rollback returns an error when the backup file has been deleted between snapshot and rollback", () => {
     const stateDir = makeStateDir();
     const targetPath = path.join(stateDir, "target.txt");


### PR DESCRIPTION
## Defect (verified live truthfulness over-claim)

`src/agent/runtime/friday-agent-run-checkpoint.ts` — `snapshotBeforeWrite` stamped `rollbackAvailable: true` **unconditionally** for every snapshotted file. For an EXISTING file, the backup read/write is wrapped in try/catch; on failure the catch sets `backupPath = undefined` but execution continues and the entry is still stamped `true` at both persistence sites (the in-memory `entry` and the `repo.upsert(...)` manifest row).

`rollback()` already fail-closes for exactly this case (`entry.existed && !entry.backupPath` → pushes `"backup unavailable: snapshot was not captured at write time"` and does NOT restore). **So there is no corruption** — the defect is purely that the reversible **claim is a lie** (over-claim).

## Live seam (confirmed, not test-only)

`friday-agent-runtime.ts` GAP-8 loop (`~:3372`) calls `runCheckpoint.snapshotBeforeWrite(filePath)` before each write-tool in the live agent loop (active whenever `deps.workdir` is set). The flag is read back by `hasRollbackCheckpoint` (`runtime.ts:786` → `entries().some(e => e.rollbackAvailable)`), which flows into `friday-api-runtime.ts`, `friday-hub-bootstrap.ts`, and `friday-agent-routes.ts`, and `buildFridayAgentRunHealthSnapshot` turns a `true` into the `state: "rollback_available"` health/receipt surface shown to the user. So a user is told "rollback available" when a rollback would fail.

## Fix (minimal, no-degrade, truthful)

Compute the flag honestly **once** and use it at **both** sites that previously hardcoded `true`:

```ts
const rollbackAvailable = existed ? backupPath !== undefined : true;
```

- Newly-created file (`!existed`) → reversible by deletion → `true` (unchanged).
- Existing file → reversible only if the pre-mutation backup was actually captured.
- `rollback()` is **unchanged** (it already fail-closes correctly — no-degrade).
- **No migration** (flag recomputed at snapshot time; the manifest column already exists).
- Blast radius = this one file; consumers only read the boolean.

## `!existed`-branch verification

Confirmed by reading `rollback()` (`:206-212`) and by a dedicated test: for a file that did not exist, rollback's `else` branch `unlinkSync(entry.filePath)` **deletes** the created file (`restoredCount++`). So a created file is genuinely reversible and keeping `rollbackAvailable: true` for `existed === false` is correct — intentionally untouched.

## Red-first evidence

New test `truthful flag: an EXISTING file whose backup capture FAILS at snapshot time is NOT marked rollbackAvailable` forces the backup capture to fail deterministically & offline: it writes a **file** at `stateDir/agent-snapshots` so `mkdirSync(snapshotDir, { recursive: true })` throws `ENOTDIR` (the `agent-snapshots` path segment is a file, not a dir) → the catch fires → `backupPath === undefined`.

- Reverting ONLY the flag computation to `const rollbackAvailable = true;` → that test fails with a real `AssertionError: expected true to be false` at `expect(entry.rollbackAvailable).toBe(false)`; the other 8 tests stay green.
- Restore → all 9 green.

Regression (no-degrade, green before & after): existing file **with** successful backup → `true` + rollback restores; newly-created file → `true` + rollback deletes.

## Gate results

- Full checkpoint suite: **9/9 green**. Importer tests: runtime (163) + health-snapshot + api-runtime route-registration (50) all green.
- `npx tsc --noEmit`: exit 0. `eslint` on changed files: **0 errors** (only pre-existing `detect-non-literal-fs-filename` warnings on unchanged source lines; diff adds no new fs calls). `detect-secrets-hook --baseline .secrets.baseline`: exit 0 (baseline/excludes untouched).
- Changed files = ONLY `friday-agent-run-checkpoint.ts` + its test. Does not touch `friday-agent-runtime.ts` / batch-executor / presentation / adapters (born-current-mergeable in parallel).

## Scope honesty

Fixes the over-claim so the receipt tells the truth; closes NO END-BAR requirement; product stays NO_GO. Born off `origin/main` 4bbeb48f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48