### PR TITLE
CHAN-INGRESS §12.1: Lark encrypt-mode decryption + inbound bidi/NEL sanitizer (2 req)

### DIFF
--- a/src/channels/friday-channel-input-sanitizer.ts
+++ b/src/channels/friday-channel-input-sanitizer.ts
@@ -1,11 +1,32 @@
 /**
  * Sanitizes inbound channel message text before it reaches the agent runtime.
- * Strips control characters, zero-width characters, and normalizes whitespace.
+ * Strips control characters, zero-width characters, and Unicode
+ * bidirectional / directional-format controls, folds line/paragraph
+ * separators into whitespace, and normalizes whitespace.
  * Enforces a maximum length to prevent memory/performance issues.
  */
 
 const CONTROL_CHARS = /[\u0000-\u001F\u007F]/g;
 const ZERO_WIDTH = /[\u200B-\u200D\uFEFF]/g;
+
+/**
+ * Unicode bidirectional / directional-format controls exploited by
+ * "trojan-source" concealment and prompt-injection attacks to visually
+ * reorder or hide instructions: the embedding/override formatters
+ * U+202A-U+202E (LRE/RLE/PDF/LRO/RLO), the directional isolates
+ * U+2066-U+2069 (LRI/RLI/FSI/PDI), and the Arabic Letter Mark U+061C.
+ * Removed outright (like zero-width characters) so they cannot alter the
+ * visual order of or conceal the underlying text.
+ */
+const BIDI_FORMAT_CONTROLS = /[\u061C\u202A-\u202E\u2066-\u2069]/g;
+
+/**
+ * Line/paragraph separators not covered by the C0/DEL control strip:
+ * LINE SEPARATOR U+2028, PARAGRAPH SEPARATOR U+2029, and NEL U+0085.
+ * Mapped to a space so they fold into the existing whitespace-normalization
+ * chain consistently with the other separators.
+ */
+const LINE_PARA_SEPARATORS = /[\u0085\u2028\u2029]/g;
 
 /** Maximum channel input length in characters (100 KB of UTF-16). */
 export const FRIDAY_MAX_CHANNEL_INPUT_LENGTH = 50_000;
@@ -18,7 +39,9 @@ export function sanitizeChannelInput(input: string): string {
   return bounded
     .normalize("NFC")
     .replace(CONTROL_CHARS, " ")
+    .replace(BIDI_FORMAT_CONTROLS, "")
     .replace(ZERO_WIDTH, "")
+    .replace(LINE_PARA_SEPARATORS, " ")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/src/channels/lark/lark-webhook-relay.ts
+++ b/src/channels/lark/lark-webhook-relay.ts
@@ -5,7 +5,7 @@
  * owns HTTP webhook ingress state and challenge/event dispatch semantics.
  */
 
-import { createHash, timingSafeEqual } from "node:crypto";
+import { createDecipheriv, createHash, timingSafeEqual } from "node:crypto";
 
 export interface LarkWebhookRelayResult {
   accepted: boolean;
@@ -19,7 +19,8 @@ export interface LarkWebhookRelayResult {
     | "LARK_TOKEN_MISSING"
     | "LARK_TOKEN_INVALID"
     | "LARK_SIGNATURE_MISSING"
-    | "LARK_SIGNATURE_INVALID";
+    | "LARK_SIGNATURE_INVALID"
+    | "LARK_DECRYPT_FAILED";
 }
 
 export interface LarkWebhookRelayService {
@@ -68,6 +69,87 @@ export function validateLarkWebhookSignature(
   } catch {
     return false;
   }
+}
+
+/**
+ * Decrypt a Lark/Feishu event-encryption envelope.
+ *
+ * When an "Encrypt Key" is configured on the Lark app, the platform POSTs
+ * `{"encrypt":"<base64>"}` instead of the plaintext payload. The scheme
+ * (per Lark/Feishu event subscription docs) is:
+ *   - AES-256-CBC with PKCS7 padding
+ *   - key    = sha256(encryptKey)                       (32 bytes)
+ *   - buffer = base64_decode(encrypt)
+ *   - iv     = buffer[0..16], ciphertext = buffer[16..]
+ *   - plaintext = JSON string of the real event / url_verification payload
+ *
+ * Returns the parsed plaintext object, or null if the envelope is malformed,
+ * undecryptable, or does not decode to a JSON object (never throws).
+ */
+function decryptLarkEnvelope(
+  encrypted: string,
+  encryptKey: string,
+): Record<string, unknown> | null {
+  try {
+    const aesKey = createHash("sha256").update(encryptKey, "utf8").digest();
+    const buffer = Buffer.from(encrypted, "base64");
+    if (buffer.length <= 16) {
+      return null;
+    }
+    const iv = buffer.subarray(0, 16);
+    const ciphertext = buffer.subarray(16);
+    const decipher = createDecipheriv("aes-256-cbc", aesKey, iv);
+    const plaintext = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]).toString("utf8");
+    const parsed = JSON.parse(plaintext) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+type LarkPayloadResolution =
+  | { ok: true; payload: Record<string, unknown>; encryptMode: boolean }
+  | { ok: false; result: LarkWebhookRelayResult };
+
+/**
+ * Resolve the effective payload for dispatch.
+ *
+ * In encrypt mode (an Encrypt Key is configured AND the body carries an
+ * `encrypt` envelope) the signature — computed over the RAW encrypted body — is
+ * verified FIRST, then the envelope is decrypted so the real event flows through
+ * the same downstream token + dispatch checks. Non-encrypt mode (no encryptKey
+ * OR no `encrypt` field) returns the parsed body unchanged with encryptMode
+ * false, preserving the legacy path byte-for-byte.
+ */
+function resolveLarkPayload(
+  payload: Record<string, unknown>,
+  encryptKey: string | null,
+  rawBody: string,
+  signatureHeader?: string,
+  timestampHeader?: string,
+  nonceHeader?: string,
+): LarkPayloadResolution {
+  const encryptEnvelope = typeof payload.encrypt === "string" ? payload.encrypt : null;
+  if (encryptKey === null || encryptEnvelope === null) {
+    return { ok: true, payload, encryptMode: false };
+  }
+  if (!signatureHeader || !timestampHeader || !nonceHeader) {
+    return { ok: false, result: { accepted: false, statusCode: 401, code: "LARK_SIGNATURE_MISSING" } };
+  }
+  if (!validateLarkWebhookSignature(timestampHeader, nonceHeader, encryptKey, rawBody, signatureHeader)) {
+    return { ok: false, result: { accepted: false, statusCode: 403, code: "LARK_SIGNATURE_INVALID" } };
+  }
+  const decrypted = decryptLarkEnvelope(encryptEnvelope, encryptKey);
+  if (decrypted === null) {
+    return { ok: false, result: { accepted: false, statusCode: 400, code: "LARK_DECRYPT_FAILED" } };
+  }
+  return { ok: true, payload: decrypted, encryptMode: true };
 }
 
 function constantTimeStringEqual(left: string, right: string): boolean {
@@ -131,6 +213,23 @@ export function createLarkWebhookRelayService(): LarkWebhookRelayService {
         };
       }
 
+      // Encrypt mode (Encrypt Key configured + `{"encrypt":...}` envelope):
+      // verify the signature over the raw body, decrypt, and continue with the
+      // decrypted payload. Non-encrypt mode is passed through unchanged.
+      const resolution = resolveLarkPayload(
+        payload,
+        encryptKey,
+        rawBody,
+        signatureHeader,
+        timestampHeader,
+        nonceHeader,
+      );
+      if (!resolution.ok) {
+        return resolution.result;
+      }
+      payload = resolution.payload;
+      const encryptMode = resolution.encryptMode;
+
       const payloadToken = extractPayloadToken(payload);
 
       if (payload.type === "url_verification") {
@@ -184,7 +283,7 @@ export function createLarkWebhookRelayService(): LarkWebhookRelayService {
         };
       }
 
-      if (encryptKey) {
+      if (encryptKey && !encryptMode) {
         if (!signatureHeader || !timestampHeader || !nonceHeader) {
           return {
             accepted: false,

--- a/test/unit/channels/friday-channel-input-sanitizer.test.ts
+++ b/test/unit/channels/friday-channel-input-sanitizer.test.ts
@@ -63,3 +63,83 @@ describe("sanitizeChannelInput", () => {
     expect(FRIDAY_MAX_CHANNEL_INPUT_LENGTH).toBeGreaterThan(0);
   });
 });
+
+/** Build a string from a codepoint so the source stays free of invisible chars. */
+const cp = (code: number): string => String.fromCodePoint(code);
+
+describe("sanitizeChannelInput bidi / directional-format concealment", () => {
+  // Trojan-source / prompt-injection concealment vectors. Each of these passes
+  // through the sanitizer unchanged BEFORE this hardening (real RED anchors).
+  const BIDI_CONTROLS: ReadonlyArray<readonly [string, number]> = [
+    ["U+202A LRE", 0x202a],
+    ["U+202B RLE", 0x202b],
+    ["U+202C PDF", 0x202c],
+    ["U+202D LRO", 0x202d],
+    ["U+202E RLO", 0x202e],
+    ["U+2066 LRI", 0x2066],
+    ["U+2067 RLI", 0x2067],
+    ["U+2068 FSI", 0x2068],
+    ["U+2069 PDI", 0x2069],
+    ["U+061C ALM", 0x061c],
+  ];
+
+  it.each(BIDI_CONTROLS)(
+    "removes %s so it cannot reorder or conceal instructions",
+    (_name, code) => {
+      const ch = cp(code);
+      const out = sanitizeChannelInput(`a${ch}b`);
+      expect(out).not.toContain(ch);
+      expect(out).toBe("ab");
+    },
+  );
+
+  it("neutralizes a right-to-left-override concealment attempt", () => {
+    const rlo = cp(0x202e);
+    const out = sanitizeChannelInput(`delete${rlo}account`);
+    expect(out).not.toContain(rlo);
+    expect(out).toBe("deleteaccount");
+  });
+});
+
+describe("sanitizeChannelInput line / paragraph separator normalization", () => {
+  // NEL U+0085 is NOT matched by JS `\s` and NOT in the C0/DEL control strip,
+  // so it passes through unchanged BEFORE this hardening (real RED anchor).
+  it("maps NEL U+0085 to a space", () => {
+    const nel = cp(0x0085);
+    const out = sanitizeChannelInput(`alpha${nel}beta`);
+    expect(out).not.toContain(nel);
+    expect(out).toBe("alpha beta");
+  });
+
+  // U+2028 / U+2029 are already folded by the trailing whitespace collapse
+  // today; the explicit mapping makes the intent robust and order-independent.
+  it("maps LINE SEPARATOR U+2028 to a space", () => {
+    const ls = cp(0x2028);
+    const out = sanitizeChannelInput(`alpha${ls}beta`);
+    expect(out).not.toContain(ls);
+    expect(out).toBe("alpha beta");
+  });
+
+  it("maps PARAGRAPH SEPARATOR U+2029 to a space", () => {
+    const ps = cp(0x2029);
+    const out = sanitizeChannelInput(`alpha${ps}beta`);
+    expect(out).not.toContain(ps);
+    expect(out).toBe("alpha beta");
+  });
+});
+
+describe("sanitizeChannelInput no-degrade with new strips", () => {
+  it("preserves emoji unchanged", () => {
+    expect(sanitizeChannelInput("hello 👍 world 🎉")).toBe("hello 👍 world 🎉");
+  });
+
+  it("preserves CJK and Arabic letters unchanged", () => {
+    expect(sanitizeChannelInput("你好世界 مرحبا")).toBe("你好世界 مرحبا");
+  });
+
+  it("removes zero-width and folds control chars alongside the new bidi strip", () => {
+    // Mixed payload: control (NUL) + zero-width (ZWSP) + RLO override between words.
+    const mixed = `hello${cp(0x00)}${cp(0x200b)}${cp(0x202e)}world`;
+    expect(sanitizeChannelInput(mixed)).toBe("hello world");
+  });
+});

--- a/test/unit/channels/lark/lark-webhook-relay.test.ts
+++ b/test/unit/channels/lark/lark-webhook-relay.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createCipheriv, createHash, randomBytes } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   createLarkWebhookRelayService,
@@ -9,6 +9,18 @@ function sign(timestamp: string, nonce: string, encryptKey: string, rawBody: str
   return createHash("sha256")
     .update(`${timestamp}${nonce}${encryptKey}${rawBody}`, "utf-8")
     .digest("hex");
+}
+
+/**
+ * Encrypt a plaintext payload with the exact Lark/Feishu event-encryption
+ * scheme the relay must decrypt: AES-256-CBC, key = sha256(encryptKey),
+ * random 16-byte IV prepended to the ciphertext, base64-encoded.
+ */
+function larkEncrypt(plaintext: string, encryptKey: string, iv = randomBytes(16)): string {
+  const key = createHash("sha256").update(encryptKey, "utf8").digest();
+  const cipher = createCipheriv("aes-256-cbc", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  return Buffer.concat([iv, ciphertext]).toString("base64");
 }
 
 describe("lark-webhook-relay", () => {
@@ -150,6 +162,152 @@ describe("lark-webhook-relay", () => {
       accepted: false,
       statusCode: 403,
       code: "LARK_TOKEN_INVALID",
+    });
+  });
+
+  describe("encrypt mode (Encrypt Key configured)", () => {
+    it("decrypts and dispatches an encrypted im.message.receive_v1 event", async () => {
+      const relay = createLarkWebhookRelayService();
+      const received: Array<Record<string, unknown>> = [];
+      relay.setVerificationToken("vt");
+      relay.setEncryptKey("ek");
+      await relay.start((payload) => {
+        received.push(payload);
+      });
+
+      const event = {
+        schema: "2.0",
+        header: { event_type: "im.message.receive_v1", token: "vt" },
+        event: { message: { message_id: "om_enc_1" } },
+      };
+      const rawBody = JSON.stringify({ encrypt: larkEncrypt(JSON.stringify(event), "ek") });
+      const signature = sign("1700000000", "nonce-enc", "ek", rawBody);
+
+      // RED anchor: today the token check runs on the still-encrypted envelope
+      // (no header.token) → 401 LARK_TOKEN_MISSING and the handler never fires.
+      expect(
+        relay.handleHttpWebhook(rawBody, signature, "1700000000", "nonce-enc"),
+      ).toEqual({
+        accepted: true,
+        statusCode: 200,
+      });
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual(event);
+    });
+
+    it("decrypts and answers an encrypted url_verification challenge", async () => {
+      const relay = createLarkWebhookRelayService();
+      relay.setVerificationToken("vt");
+      relay.setEncryptKey("ek");
+      await relay.start(() => {});
+
+      const challenge = {
+        type: "url_verification",
+        challenge: "enc-challenge-1",
+        token: "vt",
+      };
+      const rawBody = JSON.stringify({ encrypt: larkEncrypt(JSON.stringify(challenge), "ek") });
+      const signature = sign("1700000001", "nonce-enc2", "ek", rawBody);
+
+      expect(
+        relay.handleHttpWebhook(rawBody, signature, "1700000001", "nonce-enc2"),
+      ).toEqual({
+        accepted: true,
+        statusCode: 200,
+        challenge: "enc-challenge-1",
+      });
+    });
+
+    it("rejects an encrypted event whose signature is invalid (no-degrade)", async () => {
+      const relay = createLarkWebhookRelayService();
+      const received: Array<Record<string, unknown>> = [];
+      relay.setVerificationToken("vt");
+      relay.setEncryptKey("ek");
+      await relay.start((payload) => {
+        received.push(payload);
+      });
+
+      const event = {
+        schema: "2.0",
+        header: { event_type: "im.message.receive_v1", token: "vt" },
+        event: {},
+      };
+      const rawBody = JSON.stringify({ encrypt: larkEncrypt(JSON.stringify(event), "ek") });
+      const wrongSignature = sign("1700000000", "nonce-enc", "different-key", rawBody);
+
+      expect(
+        relay.handleHttpWebhook(rawBody, wrongSignature, "1700000000", "nonce-enc"),
+      ).toEqual({
+        accepted: false,
+        statusCode: 403,
+        code: "LARK_SIGNATURE_INVALID",
+      });
+      expect(received).toHaveLength(0);
+    });
+
+    it("rejects an encrypted event missing signature headers (no-degrade)", async () => {
+      const relay = createLarkWebhookRelayService();
+      relay.setVerificationToken("vt");
+      relay.setEncryptKey("ek");
+      await relay.start(() => {});
+
+      const event = {
+        schema: "2.0",
+        header: { event_type: "im.message.receive_v1", token: "vt" },
+        event: {},
+      };
+      const rawBody = JSON.stringify({ encrypt: larkEncrypt(JSON.stringify(event), "ek") });
+
+      expect(relay.handleHttpWebhook(rawBody)).toEqual({
+        accepted: false,
+        statusCode: 401,
+        code: "LARK_SIGNATURE_MISSING",
+      });
+    });
+
+    it("fails closed on a signature-valid but undecryptable envelope", async () => {
+      const relay = createLarkWebhookRelayService();
+      const received: Array<Record<string, unknown>> = [];
+      relay.setVerificationToken("vt");
+      relay.setEncryptKey("ek");
+      await relay.start((payload) => {
+        received.push(payload);
+      });
+
+      // Valid base64, correct signature over rawBody, but the ciphertext block
+      // is malformed (16-byte IV + a non-block-aligned tail) → cannot decrypt.
+      const tampered = Buffer.concat([Buffer.alloc(16, 7), Buffer.from("garbage-xx", "utf8")]).toString("base64");
+      const rawBody = JSON.stringify({ encrypt: tampered });
+      const signature = sign("1700000002", "nonce-enc3", "ek", rawBody);
+
+      const result = relay.handleHttpWebhook(rawBody, signature, "1700000002", "nonce-enc3");
+      expect(result.accepted).toBe(false);
+      expect(result.statusCode).toBeGreaterThanOrEqual(400);
+      expect(result.statusCode).toBeLessThan(500);
+      expect(result.code).toBe("LARK_DECRYPT_FAILED");
+      expect(received).toHaveLength(0);
+    });
+
+    it("leaves the non-encrypt plaintext path unchanged (regression)", async () => {
+      const relay = createLarkWebhookRelayService();
+      const received: Array<Record<string, unknown>> = [];
+      relay.setVerificationToken("vt");
+      // No encrypt key: plaintext delivery, no signature headers required.
+      await relay.start((payload) => {
+        received.push(payload);
+      });
+
+      const rawBody = JSON.stringify({
+        schema: "2.0",
+        header: { event_type: "im.message.receive_v1", token: "vt" },
+        event: { message: { message_id: "om_plain_1" } },
+      });
+
+      expect(relay.handleHttpWebhook(rawBody)).toEqual({
+        accepted: true,
+        statusCode: 200,
+      });
+      expect(received).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## §12.1 aggregate — CHAN-INGRESS: channel inbound ingress integrity (2 strongly-related requirements)

Single cohesive PR over the **channel inbound ingress trust boundary** (untrusted webhook/message → verify + normalize before it reaches the agent runtime). Tier-1 "pair a channel → first message". Each requirement independently red-first-proven; files disjoint; diff = 4 files (+365/-5). Born off `origin/main` `d741cc1f`. Members were built on separate branches and aggregated (no individual PRs) per contract §12.1 大而内聚.

### Requirement 1 — Lark/Feishu encrypt-mode decryption (STRONG, functional)
`src/channels/lark/lark-webhook-relay.ts`: with an Encrypt Key configured, Lark POSTs `{"encrypt":"<base64>"}` (no `header.token`), so the token check ran on the still-encrypted body → **401 `LARK_TOKEN_MISSING` before any decryption**. There was **no AES decryption anywhere** in the Lark code. Result: every encrypted `im.message.receive_v1` event AND the `url_verification` handshake were silently dropped → encrypt-mode webhook setup could never complete (total silent ingress breakage for a user who enables Encrypt Key).
- **Live seam:** POST → live route `friday-channel-webhook-routes.ts:57` → `relay.handleHttpWebhook` → `onEvent(payload)` dispatch. Fires in default runtime for any encrypt-mode Lark app (encryptKey is a live user config; `setEncryptKey` at `friday-lark-channel.ts:850`).
- **Fix:** `resolveLarkPayload` helper — in encrypt mode: validate signature over the RAW encrypted body first (`LARK_SIGNATURE_MISSING`/`INVALID` preserved) → AES-256-CBC decrypt (key `sha256(encryptKey)`, IV = first 16 bytes of base64-decoded envelope, PKCS7) → parse plaintext → then the existing token / url_verification / event dispatch on the DECRYPTED payload. **Non-encrypt mode byte-for-byte unchanged.** Malformed/undecryptable → `LARK_DECRYPT_FAILED` (400) fail-closed, never throws/accepts. No migration.
- **Red-first:** revert the decrypt-and-reorder → 5 encrypt-mode tests throw real AssertionErrors (401 instead of accept/challenge/sig-codes); non-encrypt regression + 7 originals stay green; restore → 13/13. Importers 48/48 green.

### Requirement 2 — inbound sanitizer: bidi/trojan-source + NEL (MODERATE, hardening)
`src/channels/friday-channel-input-sanitizer.ts`: stripped C0/C1 + zero-width but not Unicode bidi/directional-override (U+202A–202E, isolates U+2066–2069, U+061C) or the NEL line separator (U+0085) — trojan-source/prompt-injection concealment vectors reaching the agent.
- **Live seam:** inbound channel message → `friday-hub-bootstrap.ts:9334 sanitizeChannelInput(msg.text)` → normalized text to the agent. Unconditional in default runtime for every enrolled channel.
- **Fix:** additive — `BIDI_FORMAT_CONTROLS` removed (like zero-width); NEL/line-para separators mapped to space. Honest correction: JS `\s` already folds U+2028/U+2029 (documented in tests); the genuinely-missing line-sep vector is **NEL U+0085**, now closed, plus the 10 bidi/format chars. Existing strips/NFC/length/collapse untouched. No migration.
- **Red-first:** revert the two new strips → 13 real AssertionErrors (10 bidi + RLO concealment + NEL + mixed payload); 17 stay green; restore → 30/30.

### Gates
Each req: red-first proven, typecheck 0, lint 0 errors, detect-secrets exit 0 (baseline untouched), source hygiene (no literal invisible chars committed). Independent adversarial review at the aggregate head SHA + all branch-protection required contexts present+success at that SHA required before merge (`--match-head-commit`). Product stays **NO_GO**; closes no END-BAR requirement.
