### PR TITLE
NET-TRANSPORT-BOUNDS §12.1: WS realtime-gateway RFC 6455 frame validation + Origin/CSWSH hardening (7 defects)

### DIFF
--- a/src/api/http/friday-http-server.ts
+++ b/src/api/http/friday-http-server.ts
@@ -453,6 +453,213 @@ function isOriginAllowed(origin: string, allowedOrigins: readonly string[]): boo
 }
 
 /**
+ * Decide whether a WebSocket upgrade carrying this `Origin` may proceed.
+ *
+ * Browsers always attach an `Origin`; native / non-browser clients never do.
+ * A cross-site browser origin is a cross-site WebSocket hijacking attempt and
+ * MUST be rejected even when the CORS allowlist is empty (the production
+ * default) — but without breaking the legitimate local UI or native app. So an
+ * Origin, when present, is trusted only if it is (in order):
+ *   1. an explicit allowlist match (or "*"),
+ *   2. the same host as the request's `Host` header (true same-origin), or
+ *   3. a loopback origin (localhost / 127.0.0.1 / ::1) — the local UI or a dev
+ *      server on this machine, never a remote attacker.
+ * An absent Origin is decided by the caller (allowed: non-browser client).
+ */
+function isTrustedWsOrigin(
+  origin: string,
+  hostHeader: string | undefined,
+  allowedOrigins: readonly string[],
+): boolean {
+  if (isOriginAllowed(origin, allowedOrigins)) return true;
+  let parsed: URL;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return false;
+  }
+  if (hostHeader && parsed.host === hostHeader.toLowerCase()) return true;
+  const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+  return LOOPBACK_HOSTNAMES.has(parsed.hostname);
+}
+
+// ─── RFC 6455 inbound (client→server) frame decoding ─────────────────────────
+
+/** Reassembly cursor for a single realtime WebSocket connection (RFC 6455 §5.4). */
+interface WsFrameReaderState {
+  /** Bytes received but not yet fully parsed into frames. */
+  buffer: Buffer;
+  /** Opcode (0x1 text / 0x2 binary) of the in-progress fragmented message, or null. */
+  fragmentedOpcode: number | null;
+  /** Payload chunks accumulated for the in-progress message. */
+  fragmentedChunks: Buffer[];
+  /** Total bytes accumulated for the in-progress message. */
+  fragmentedSize: number;
+}
+
+/** An event surfaced by {@link readWsClientFrames} for the connection loop to act on. */
+type WsClientFrameEvent =
+  | { type: "message"; opcode: number; payload: Buffer } // complete data message (0x1/0x2)
+  | { type: "ping"; payload: Buffer }
+  | { type: "pong" }
+  | { type: "close" }
+  | { type: "protocol-error"; code: number } // close with `code` then drop
+  | { type: "drop" }; // silently destroy (oversized frame)
+
+/**
+ * Validate a client frame header against RFC 6455. Returns the close code to
+ * fail the connection with, or null when the header is well-formed.
+ */
+function wsClientFrameHeaderViolation(
+  fin: boolean,
+  rsv: number,
+  opcode: number,
+  masked: boolean,
+  payloadLen: number,
+): number | null {
+  // §5.2 reserved bits must be zero when no extension is negotiated.
+  if (rsv !== 0) return 1002;
+  // §5.2 opcodes 0x3-0x7 and 0xb-0xf are reserved.
+  const known =
+    opcode === 0x0 ||
+    opcode === 0x1 ||
+    opcode === 0x2 ||
+    opcode === 0x8 ||
+    opcode === 0x9 ||
+    opcode === 0xa;
+  if (!known) return 1002;
+  // §5.1 client→server frames MUST be masked.
+  if (!masked) return 1002;
+  // §5.5 control frames MUST be ≤125 bytes and MUST NOT be fragmented.
+  if (opcode >= 0x8 && (payloadLen > 125 || !fin)) return 1002;
+  return null;
+}
+
+/**
+ * Fold a data frame (0x0 continuation / 0x1 text / 0x2 binary) into the
+ * reassembly `state`. Returns the completed message when this frame finished
+ * one, an `errorCode` on a fragmentation protocol violation, or `{}` while more
+ * fragments are still expected.
+ */
+function assembleWsDataFrame(
+  state: WsFrameReaderState,
+  opcode: number,
+  fin: boolean,
+  payload: Buffer,
+  maxMessageSize: number,
+): { done?: { opcode: number; payload: Buffer }; errorCode?: number } {
+  if (opcode === 0x0) {
+    // Continuation — a data message MUST already be in progress.
+    if (state.fragmentedOpcode === null) return { errorCode: 1002 };
+    state.fragmentedChunks.push(Buffer.from(payload));
+    state.fragmentedSize += payload.length;
+    if (state.fragmentedSize > maxMessageSize) return { errorCode: 1009 };
+    if (!fin) return {}; // more fragments to come
+    const done = {
+      opcode: state.fragmentedOpcode,
+      payload: Buffer.concat(state.fragmentedChunks),
+    };
+    state.fragmentedOpcode = null;
+    state.fragmentedChunks = [];
+    state.fragmentedSize = 0;
+    return { done };
+  }
+  // New data frame — MUST NOT arrive while a message is being assembled.
+  if (state.fragmentedOpcode !== null) return { errorCode: 1002 };
+  if (fin) return { done: { opcode, payload } };
+  // Begin a fragmented message.
+  state.fragmentedOpcode = opcode;
+  state.fragmentedChunks = [Buffer.from(payload)];
+  state.fragmentedSize = payload.length;
+  if (state.fragmentedSize > maxMessageSize) return { errorCode: 1009 };
+  return {};
+}
+
+/**
+ * Pull every fully-buffered client frame out of `state.buffer`, unmasking and
+ * reassembling per RFC 6455 §5. Consumes parsed bytes from `state.buffer` and
+ * yields one {@link WsClientFrameEvent} per frame/message. Stops (returns) when
+ * only a partial frame remains, leaving it buffered for the next chunk.
+ */
+function* readWsClientFrames(
+  state: WsFrameReaderState,
+  maxFrameSize: number,
+  maxMessageSize: number,
+): Generator<WsClientFrameEvent> {
+  while (state.buffer.length >= 2) {
+    const buffer = state.buffer;
+    const firstByte = buffer[0]!;
+    const secondByte = buffer[1]!;
+    const fin = (firstByte & 0x80) !== 0;
+    const rsv = firstByte & 0x70;
+    const opcode = firstByte & 0x0f;
+    const masked = (secondByte & 0x80) !== 0;
+    let payloadLen = secondByte & 0x7f;
+    let offset = 2;
+
+    if (payloadLen === 126) {
+      if (buffer.length < 4) return; // wait for more data
+      payloadLen = buffer.readUInt16BE(2);
+      offset = 4;
+    } else if (payloadLen === 127) {
+      if (buffer.length < 10) return;
+      payloadLen = Number(buffer.readBigUInt64BE(2));
+      offset = 10;
+    }
+
+    // Reject malformed/hostile headers before buffering the (possibly large) payload.
+    const violation = wsClientFrameHeaderViolation(fin, rsv, opcode, masked, payloadLen);
+    if (violation !== null) {
+      yield { type: "protocol-error", code: violation };
+      return;
+    }
+
+    // Guard against oversized frames (RFC 6455 §7.4.1). Prior behavior: silent drop.
+    if (payloadLen > maxFrameSize) {
+      yield { type: "drop" };
+      return;
+    }
+
+    // Client frames are always masked (validated above) → 4-byte masking key.
+    const totalLen = offset + 4 + payloadLen;
+    if (buffer.length < totalLen) return; // wait for the full frame
+
+    const maskKey = buffer.subarray(offset, offset + 4);
+    const payload = buffer.subarray(offset + 4, totalLen);
+    for (let i = 0; i < payload.length; i++) {
+      payload[i] = payload[i]! ^ maskKey[i % 4]!;
+    }
+
+    // Consume the frame from the buffer.
+    state.buffer = buffer.subarray(totalLen);
+
+    // Control frames are handled independently of fragmentation state.
+    if (opcode === 0x8) {
+      yield { type: "close" };
+      return;
+    }
+    if (opcode === 0x9) {
+      yield { type: "ping", payload };
+      continue;
+    }
+    if (opcode === 0xa) {
+      yield { type: "pong" };
+      continue;
+    }
+
+    // Data frame (0x0 / 0x1 / 0x2): reassemble.
+    const res = assembleWsDataFrame(state, opcode, fin, payload, maxMessageSize);
+    if (res.errorCode !== undefined) {
+      yield { type: "protocol-error", code: res.errorCode };
+      return;
+    }
+    if (res.done) {
+      yield { type: "message", opcode: res.done.opcode, payload: res.done.payload };
+    }
+  }
+}
+
+/**
  * Build CORS headers for the given origin.
  */
 function buildCorsHeaders(
@@ -1046,9 +1253,14 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
       return;
     }
 
-    // Validate Origin header to prevent cross-site WebSocket hijacking
-    const origin = req.headers.origin ?? "";
-    if (corsOrigins.length > 0 && origin && !isOriginAllowed(origin, corsOrigins)) {
+    // Reject cross-site WebSocket hijacking. A browser always sends `Origin`;
+    // native / non-browser clients never do. When an Origin IS present it must
+    // be trusted (allowlist / same-origin / loopback) — this holds even for the
+    // DEFAULT empty allowlist, where the previous `corsOrigins.length > 0` guard
+    // let ANY hostile cross-site page through. A missing Origin is a non-browser
+    // client and is allowed, so the local UI and native app keep working.
+    const origin = req.headers.origin;
+    if (origin && !isTrustedWsOrigin(origin, req.headers.host, corsOrigins)) {
       socket.write("HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n");
       socket.destroy();
       return;
@@ -1126,112 +1338,112 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
       wsConnections.delete(socket);
     }
 
-    // Process any data that arrived during the upgrade (head buffer)
-    let buffer = head.length > 0 ? Buffer.from(head) : Buffer.alloc(0);
+    // Inbound frame state: accumulated bytes + RFC 6455 §5.4 reassembly cursor.
+    const frameState: WsFrameReaderState = {
+      buffer: head.length > 0 ? Buffer.from(head) : Buffer.alloc(0),
+      fragmentedOpcode: null,
+      fragmentedChunks: [],
+      fragmentedSize: 0,
+    };
+    const MAX_WS_FRAME_SIZE = 1_048_576; // 1 MB — single frame ceiling (§7.4.1 → 1009)
+    const MAX_WS_MESSAGE_SIZE = 4_194_304; // 4 MB — assembled (multi-fragment) message ceiling
+    const MAX_WS_BUFFER_SIZE = 4_194_304; // 4 MB — accumulated un-parsed buffer ceiling
+
+    /**
+     * Dispatch a complete TEXT message: rate-limit, strict-UTF-8 decode (§8.1),
+     * then JSON-parse and forward to the gateway. Returns true when the
+     * connection was torn down (the caller must then stop reading).
+     */
+    function handleCompletedTextMessage(payload: Buffer): boolean {
+      // Rate limit: drop connection if client sends too many frames.
+      if (!checkWsRateLimit()) {
+        console.warn(`[friday][http-server] WebSocket rate limit exceeded for conn ${connId}`);
+        const errFrame: FridayRealtimeServerFrame = {
+          type: "error",
+          code: "RATE_LIMITED",
+          message: "Too many frames per second",
+          retryable: true,
+        };
+        socket.write(encodeWsTextFrame(JSON.stringify(errFrame)));
+        sendWsClose(socket, 1008); // Policy Violation
+        cleanup();
+        socket.destroy();
+        return true;
+      }
+
+      // §8.1 text frames MUST be valid UTF-8. Reject (1007) before JSON.parse
+      // rather than silently substituting U+FFFD.
+      let text: string;
+      try {
+        text = new TextDecoder("utf-8", { fatal: true }).decode(payload);
+      } catch {
+        sendWsClose(socket, 1007); // Invalid frame payload data
+        cleanup();
+        socket.destroy();
+        return true;
+      }
+
+      try {
+        const clientFrame = JSON.parse(text) as FridayRealtimeClientFrame;
+        const responses = deps.wsGateway.handleClientFrame(conn, clientFrame);
+        sendFrames(responses);
+      } catch (err) {
+        console.warn("[friday][http-server] operation failed:", err instanceof Error ? err.message : String(err));
+        // Malformed JSON — send error frame (connection stays open, prior behavior).
+        const errFrame: FridayRealtimeServerFrame = {
+          type: "error",
+          code: "INVALID_FRAME",
+          message: "Failed to parse client frame as JSON",
+          retryable: false,
+        };
+        socket.write(encodeWsTextFrame(JSON.stringify(errFrame)));
+      }
+      return false;
+    }
 
     socket.on("data", (chunk: Buffer) => {
-      buffer = Buffer.concat([buffer, chunk]);
+      frameState.buffer = Buffer.concat([frameState.buffer, chunk]);
 
       // Guard against accumulated buffer exceeding max size (prevents DoS via fragmented frames)
-      const MAX_WS_BUFFER_SIZE = 4_194_304; // 4 MB
-      if (buffer.length > MAX_WS_BUFFER_SIZE) {
+      if (frameState.buffer.length > MAX_WS_BUFFER_SIZE) {
         socket.destroy();
         return;
       }
 
-      // Parse WebSocket frames
-      while (buffer.length >= 2) {
-        const firstByte = buffer[0]!;
-        const secondByte = buffer[1]!;
-        const opcode = firstByte & 0x0f;
-        const masked = (secondByte & 0x80) !== 0;
-        let payloadLen = secondByte & 0x7f;
-        let offset = 2;
-
-        if (payloadLen === 126) {
-          if (buffer.length < 4) return; // wait for more data
-          payloadLen = buffer.readUInt16BE(2);
-          offset = 4;
-        } else if (payloadLen === 127) {
-          if (buffer.length < 10) return;
-          payloadLen = Number(buffer.readBigUInt64BE(2));
-          offset = 10;
-        }
-
-        // Guard against oversized frames to prevent memory exhaustion (RFC 6455 §7.4.1 code 1009)
-        const MAX_WS_FRAME_SIZE = 1_048_576; // 1 MB
-        if (payloadLen > MAX_WS_FRAME_SIZE) {
+      for (const ev of readWsClientFrames(frameState, MAX_WS_FRAME_SIZE, MAX_WS_MESSAGE_SIZE)) {
+        if (ev.type === "drop") {
+          // Oversized frame — silent teardown (matches prior behavior).
           socket.destroy();
           return;
         }
-
-        const maskSize = masked ? 4 : 0;
-        const totalLen = offset + maskSize + payloadLen;
-        if (buffer.length < totalLen) return; // wait for more data
-
-        const maskKey = masked ? buffer.subarray(offset, offset + 4) : undefined;
-        const payloadData = buffer.subarray(offset + maskSize, totalLen);
-
-        // Unmask if masked (client→server frames are always masked per RFC 6455)
-        if (maskKey) {
-          for (let i = 0; i < payloadData.length; i++) {
-            payloadData[i] = payloadData[i]! ^ maskKey[i % 4]!;
-          }
+        if (ev.type === "protocol-error") {
+          sendWsClose(socket, ev.code); // RFC 6455 §7.1.7
+          cleanup();
+          socket.destroy();
+          return;
         }
-
-        // Consume the frame from the buffer
-        buffer = buffer.subarray(totalLen);
-
-        // Handle by opcode
-        if (opcode === 0x1) {
-          // Rate limit: drop connection if client sends too many frames
-          if (!checkWsRateLimit()) {
-            console.warn(`[friday][http-server] WebSocket rate limit exceeded for conn ${connId}`);
-            const errFrame: FridayRealtimeServerFrame = {
-              type: "error",
-              code: "RATE_LIMITED",
-              message: "Too many frames per second",
-              retryable: true,
-            };
-            socket.write(encodeWsTextFrame(JSON.stringify(errFrame)));
-            sendWsClose(socket, 1008); // Policy Violation
-            cleanup();
-            socket.destroy();
-            return;
-          }
-
-          // Text frame → parse as client frame and forward to gateway
-          try {
-            const clientFrame = JSON.parse(payloadData.toString("utf-8")) as FridayRealtimeClientFrame;
-            const responses = deps.wsGateway.handleClientFrame(conn, clientFrame);
-            sendFrames(responses);
-          } catch (err) {
-        console.warn("[friday][http-server] operation failed:", err instanceof Error ? err.message : String(err));
-            // Malformed JSON — send error frame
-            const errFrame: FridayRealtimeServerFrame = {
-              type: "error",
-              code: "INVALID_FRAME",
-              message: "Failed to parse client frame as JSON",
-              retryable: false,
-            };
-            socket.write(encodeWsTextFrame(JSON.stringify(errFrame)));
-          }
-        } else if (opcode === 0x8) {
-          // Close frame
+        if (ev.type === "close") {
           sendWsClose(socket, 1000);
           cleanup();
           socket.destroy();
           return;
-        } else if (opcode === 0x9) {
-          // Ping → respond with pong
-          const pong = Buffer.alloc(2 + payloadData.length);
-          pong[0] = 0x8a; // FIN + pong
-          pong[1] = payloadData.length;
-          payloadData.copy(pong, 2);
-          socket.write(pong);
-        } else if (opcode === 0xa) {
-          // Pong — no action needed
         }
+        if (ev.type === "ping") {
+          // Ping → respond with pong echoing the (≤125B, validated) payload.
+          const pong = Buffer.alloc(2 + ev.payload.length);
+          pong[0] = 0x8a; // FIN + pong
+          pong[1] = ev.payload.length; // ≤125 by the control-frame cap
+          ev.payload.copy(pong, 2);
+          socket.write(pong);
+          continue;
+        }
+        if (ev.type === "pong") {
+          continue; // no action needed
+        }
+        // ev.type === "message": a complete data message.
+        if (ev.opcode === 0x1 && handleCompletedTextMessage(ev.payload)) return;
+        // Binary messages (opcode 0x2) are not part of the realtime protocol;
+        // they are ignored, preserving the prior silent-drop behavior.
       }
     });
 

--- a/src/api/http/friday-http-server.ts
+++ b/src/api/http/friday-http-server.ts
@@ -495,7 +495,17 @@ interface WsFrameReaderState {
   fragmentedChunks: Buffer[];
   /** Total bytes accumulated for the in-progress message. */
   fragmentedSize: number;
+  /** Number of frames accumulated for the in-progress message (bounds empty-fragment floods). */
+  fragmentedCount: number;
 }
+
+/**
+ * Maximum frames a single fragmented message may span. A legitimate client
+ * splits a message into a handful of fragments; this bound tears down a
+ * connection that streams unbounded (e.g. zero-length) continuation frames —
+ * which do not advance the byte-size cap — within a fixed number of frames.
+ */
+const MAX_WS_FRAGMENTS = 1024;
 
 /** An event surfaced by {@link readWsClientFrames} for the connection loop to act on. */
 type WsClientFrameEvent =
@@ -553,15 +563,19 @@ function assembleWsDataFrame(
     if (state.fragmentedOpcode === null) return { errorCode: 1002 };
     state.fragmentedChunks.push(Buffer.from(payload));
     state.fragmentedSize += payload.length;
-    if (state.fragmentedSize > maxMessageSize) return { errorCode: 1009 };
+    state.fragmentedCount += 1;
+    // Bound BOTH assembled bytes AND fragment COUNT. A zero-length continuation
+    // adds 0 bytes, so the size cap alone would never trip on an empty-fragment
+    // flood — the count cap tears the connection down within MAX_WS_FRAGMENTS.
+    if (state.fragmentedSize > maxMessageSize || state.fragmentedCount > MAX_WS_FRAGMENTS) {
+      return { errorCode: 1009 };
+    }
     if (!fin) return {}; // more fragments to come
     const done = {
       opcode: state.fragmentedOpcode,
       payload: Buffer.concat(state.fragmentedChunks),
     };
-    state.fragmentedOpcode = null;
-    state.fragmentedChunks = [];
-    state.fragmentedSize = 0;
+    resetWsFragmentState(state);
     return { done };
   }
   // New data frame — MUST NOT arrive while a message is being assembled.
@@ -571,8 +585,17 @@ function assembleWsDataFrame(
   state.fragmentedOpcode = opcode;
   state.fragmentedChunks = [Buffer.from(payload)];
   state.fragmentedSize = payload.length;
+  state.fragmentedCount = 1;
   if (state.fragmentedSize > maxMessageSize) return { errorCode: 1009 };
   return {};
+}
+
+/** Clear a connection's in-progress fragmentation state (on completion or teardown). */
+function resetWsFragmentState(state: WsFrameReaderState): void {
+  state.fragmentedOpcode = null;
+  state.fragmentedChunks = [];
+  state.fragmentedSize = 0;
+  state.fragmentedCount = 0;
 }
 
 /**
@@ -1336,6 +1359,8 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
       clearInterval(pingInterval);
       unsubscribe?.();
       wsConnections.delete(socket);
+      // Drop any in-progress fragmentation buffers so they cannot leak past teardown.
+      resetWsFragmentState(frameState);
     }
 
     // Inbound frame state: accumulated bytes + RFC 6455 §5.4 reassembly cursor.
@@ -1344,6 +1369,7 @@ export function createFridayHttpServer(deps: FridayHttpServerDeps): FridayHttpSe
       fragmentedOpcode: null,
       fragmentedChunks: [],
       fragmentedSize: 0,
+      fragmentedCount: 0,
     };
     const MAX_WS_FRAME_SIZE = 1_048_576; // 1 MB — single frame ceiling (§7.4.1 → 1009)
     const MAX_WS_MESSAGE_SIZE = 4_194_304; // 4 MB — assembled (multi-fragment) message ceiling

--- a/test/unit/api/http/friday-http-server-ws-rfc6455-frames.test.ts
+++ b/test/unit/api/http/friday-http-server-ws-rfc6455-frames.test.ts
@@ -1,0 +1,493 @@
+import * as net from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createFridayHttpRouteRegistry,
+  createFridayHttpServer,
+} from "#api";
+import type {
+  FridayAuthMiddlewareFactory,
+  FridayHttpServer,
+  FridayRealtimeClientFrame,
+  FridayRealtimeServerFrame,
+  FridayRealtimeWsGateway,
+} from "#api";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Harness: a real net.Socket pair driving the actual friday-http-server WS
+// realtime upgrade + inbound frame parser (handleRealtimeUpgrade). Every test
+// exercises the real code path — no mocking of the parser.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        server.close();
+        reject(new Error("failed to allocate free port"));
+        return;
+      }
+      const port = addr.port;
+      server.close((closeErr) => {
+        if (closeErr) reject(closeErr);
+        else resolve(port);
+      });
+    });
+    server.on("error", reject);
+  });
+}
+
+interface RecordingGateway extends FridayRealtimeWsGateway {
+  received: FridayRealtimeClientFrame[];
+}
+
+function makeRecordingWsGateway(
+  respond: FridayRealtimeServerFrame[] = [],
+): RecordingGateway {
+  const received: FridayRealtimeClientFrame[] = [];
+  return {
+    received,
+    createConnection: (connId) => ({
+      connId,
+      principal: null,
+      subscriptions: new Map(),
+      authenticated: false,
+    }),
+    handleClientFrame: (_conn, frame) => {
+      received.push(frame);
+      return respond;
+    },
+    shouldDeliverEvent: () => false,
+  };
+}
+
+function makeStubMiddleware(): FridayAuthMiddlewareFactory {
+  return {
+    requireAuth: () => ({ passed: true as const }),
+    requireAnyScope: () => ({ passed: true as const }),
+    requireAnyRole: () => ({ passed: true as const }),
+    enforceRateLimit: () => ({ passed: true as const }),
+  };
+}
+
+/** Perform the HTTP upgrade and return the connected socket once 101 arrives. */
+function wsHandshake(
+  port: number,
+  path = "/v1/realtime/ws",
+  extraHeaders: Record<string, string> = {},
+): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    let response = "";
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      reject(new Error("handshake timeout"));
+    }, 4000);
+    const onData = (chunk: Buffer): void => {
+      response += chunk.toString("utf-8");
+      if (response.includes("\r\n\r\n")) {
+        clearTimeout(timeout);
+        socket.removeListener("data", onData);
+        if (response.startsWith("HTTP/1.1 101")) {
+          resolve(socket);
+        } else {
+          socket.destroy();
+          reject(new Error(`handshake not 101: ${response.split("\r\n")[0]}`));
+        }
+      }
+    };
+    socket.on("connect", () => {
+      const lines = [
+        `GET ${path} HTTP/1.1`,
+        `Host: 127.0.0.1:${String(port)}`,
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+        "Sec-WebSocket-Version: 13",
+        ...Object.entries(extraHeaders).map(([k, v]) => `${k}: ${v}`),
+        "",
+        "",
+      ];
+      socket.write(lines.join("\r\n"));
+    });
+    socket.on("data", onData);
+    socket.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+/** Return the raw HTTP status line for an upgrade attempt (used for Origin gating). */
+function upgradeStatusLine(
+  port: number,
+  path: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    let response = "";
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      reject(new Error("upgrade timeout"));
+    }, 4000);
+    socket.on("connect", () => {
+      const lines = [
+        `GET ${path} HTTP/1.1`,
+        `Host: 127.0.0.1:${String(port)}`,
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+        "Sec-WebSocket-Version: 13",
+        ...Object.entries(extraHeaders).map(([k, v]) => `${k}: ${v}`),
+        "",
+        "",
+      ];
+      socket.write(lines.join("\r\n"));
+    });
+    socket.on("data", (chunk) => {
+      response += chunk.toString("utf-8");
+      if (response.includes("\r\n")) {
+        clearTimeout(timeout);
+        socket.destroy();
+        resolve(response.split("\r\n")[0] ?? "");
+      }
+    });
+    socket.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+interface BuildFrameOpts {
+  opcode: number;
+  payload?: Buffer;
+  fin?: boolean;
+  /** RSV bits already positioned in the 0x70 mask (e.g. 0x40 = RSV1). */
+  rsv?: number;
+  masked?: boolean;
+  maskKey?: Buffer;
+}
+
+/** Craft a raw client→server WebSocket frame (masked by default per RFC 6455). */
+function buildFrame(opts: BuildFrameOpts): Buffer {
+  const payload = opts.payload ?? Buffer.alloc(0);
+  const fin = opts.fin ?? true;
+  const rsv = opts.rsv ?? 0;
+  const masked = opts.masked ?? true;
+  const firstByte = (fin ? 0x80 : 0) | (rsv & 0x70) | (opts.opcode & 0x0f);
+  const len = payload.length;
+  const maskBit = masked ? 0x80 : 0;
+  let header: Buffer;
+  if (len < 126) {
+    header = Buffer.from([firstByte, maskBit | len]);
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = firstByte;
+    header[1] = maskBit | 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = firstByte;
+    header[1] = maskBit | 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  if (!masked) return Buffer.concat([header, payload]);
+  const maskKey = opts.maskKey ?? Buffer.from([0x12, 0x34, 0x56, 0x78]);
+  const out = Buffer.alloc(len);
+  for (let i = 0; i < len; i++) out[i] = payload[i]! ^ maskKey[i % 4]!;
+  return Buffer.concat([header, maskKey, out]);
+}
+
+interface ParsedFrame {
+  opcode: number;
+  payload: Buffer;
+}
+
+/** Parse unmasked server→client frames from a raw buffer. */
+function parseServerFrames(buf: Buffer): ParsedFrame[] {
+  const out: ParsedFrame[] = [];
+  let off = 0;
+  while (off + 2 <= buf.length) {
+    const opcode = buf[off]! & 0x0f;
+    let len = buf[off + 1]! & 0x7f;
+    let hdr = 2;
+    if (len === 126) {
+      if (off + 4 > buf.length) break;
+      len = buf.readUInt16BE(off + 2);
+      hdr = 4;
+    } else if (len === 127) {
+      if (off + 10 > buf.length) break;
+      len = Number(buf.readBigUInt64BE(off + 2));
+      hdr = 10;
+    }
+    if (off + hdr + len > buf.length) break;
+    out.push({ opcode, payload: buf.subarray(off + hdr, off + hdr + len) });
+    off += hdr + len;
+  }
+  return out;
+}
+
+interface DriveResult {
+  frames: ParsedFrame[];
+  closeCode: number | null;
+  texts: string[];
+  closed: boolean;
+}
+
+/** Write frames to the socket, collect the server's reply, resolve on close/quiet. */
+function driveFrames(
+  socket: net.Socket,
+  frames: Buffer[],
+  waitMs = 400,
+): Promise<DriveResult> {
+  return new Promise((resolve) => {
+    let buf = Buffer.alloc(0);
+    let closed = false;
+    let done = false;
+    const finish = (): void => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      socket.removeAllListeners("data");
+      const parsed = parseServerFrames(buf);
+      let closeCode: number | null = null;
+      const texts: string[] = [];
+      for (const f of parsed) {
+        if (f.opcode === 0x8 && f.payload.length >= 2) closeCode = f.payload.readUInt16BE(0);
+        else if (f.opcode === 0x1) texts.push(f.payload.toString("utf-8"));
+      }
+      socket.destroy();
+      resolve({ frames: parsed, closeCode, texts, closed });
+    };
+    socket.on("data", (d: Buffer) => {
+      buf = Buffer.concat([buf, d]);
+    });
+    socket.on("close", () => {
+      closed = true;
+      finish();
+    });
+    socket.on("error", () => {
+      closed = true;
+      finish();
+    });
+    const timer = setTimeout(finish, waitMs);
+    for (const fr of frames) socket.write(fr);
+  });
+}
+
+const TEXT = (s: string): Buffer => Buffer.from(s, "utf-8");
+
+describe("FridayHttpServer realtime WS — RFC 6455 inbound frame validation", () => {
+  let server: FridayHttpServer | null = null;
+  let port = 0;
+  let gateway: RecordingGateway;
+
+  beforeEach(async () => {
+    port = await findFreePort();
+    gateway = makeRecordingWsGateway([{ type: "pong", at: "2026-07-13T00:00:00.000Z" }]);
+    server = createFridayHttpServer({
+      routes: createFridayHttpRouteRegistry(),
+      wsGateway: gateway,
+      middleware: makeStubMiddleware(),
+      host: "127.0.0.1",
+      port,
+      // DEFAULT security posture: empty CORS allowlist (matches production default).
+    });
+    await server.listen();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+  });
+
+  // ── Defect #1: unmasked client frames MUST be rejected (close 1002) ──────────
+  it("[#1] rejects an UNMASKED client text frame with close 1002", async () => {
+    const socket = await wsHandshake(port);
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x1, payload: TEXT('{"type":"ping","at":"x"}'), masked: false }),
+    ]);
+    expect(res.closeCode).toBe(1002);
+    expect(gateway.received).toHaveLength(0);
+  });
+
+  it("[#1 no-degrade] a normal MASKED text frame still round-trips to handleClientFrame", async () => {
+    const socket = await wsHandshake(port);
+    const frame: FridayRealtimeClientFrame = { type: "ping", at: "2026-07-13T12:00:00.000Z" };
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x1, payload: TEXT(JSON.stringify(frame)) }),
+    ]);
+    expect(res.closeCode).toBeNull();
+    expect(gateway.received).toEqual([frame]);
+    // Server frame echoed back unchanged (byte-for-byte prior behavior).
+    expect(res.texts.some((t) => t.includes('"pong"'))).toBe(true);
+  });
+
+  // ── Defect #2: any RSV bit set (no extension negotiated) → close 1002 ─────────
+  it("[#2] rejects a frame with RSV1 set with close 1002", async () => {
+    const socket = await wsHandshake(port);
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x1, payload: TEXT('{"type":"ping","at":"x"}'), rsv: 0x40 }),
+    ]);
+    expect(res.closeCode).toBe(1002);
+    expect(gateway.received).toHaveLength(0);
+  });
+
+  // ── Defect #3: reserved opcodes 0x3-0x7 / 0xb-0xf → close 1002 ────────────────
+  it("[#3] rejects a reserved data opcode 0x3 with close 1002", async () => {
+    const socket = await wsHandshake(port);
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x3, payload: TEXT("x") }),
+    ]);
+    expect(res.closeCode).toBe(1002);
+  });
+
+  it("[#3] rejects a reserved control opcode 0xb with close 1002", async () => {
+    const socket = await wsHandshake(port);
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0xb, payload: TEXT("x") }),
+    ]);
+    expect(res.closeCode).toBe(1002);
+  });
+
+  // ── Defect #4: control frames MUST be ≤125 bytes and unfragmented (FIN=1) ─────
+  it("[#4] rejects an oversized (>125B) control ping with close 1002", async () => {
+    const socket = await wsHandshake(port);
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x9, payload: Buffer.alloc(200, 0x61) }),
+    ]);
+    expect(res.closeCode).toBe(1002);
+  });
+
+  it("[#4] rejects a fragmented control ping (FIN=0) with close 1002", async () => {
+    const socket = await wsHandshake(port);
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x9, payload: TEXT("hi"), fin: false }),
+    ]);
+    expect(res.closeCode).toBe(1002);
+  });
+
+  it("[#4 no-degrade] a valid ≤125B ping is echoed as a pong without corruption", async () => {
+    const socket = await wsHandshake(port);
+    const pingPayload = TEXT("keepalive-123");
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x9, payload: pingPayload }),
+    ]);
+    expect(res.closeCode).toBeNull();
+    const pong = res.frames.find((f) => f.opcode === 0xa);
+    expect(pong).toBeDefined();
+    expect(pong!.payload.equals(pingPayload)).toBe(true);
+  });
+
+  // ── Defect #5: invalid UTF-8 in a text frame → close 1007 (before JSON.parse) ─
+  it("[#5] rejects invalid UTF-8 in a text frame with close 1007", async () => {
+    const socket = await wsHandshake(port);
+    // 0xff is never a valid UTF-8 byte.
+    const bad = Buffer.from([0x7b, 0x22, 0xff, 0x22, 0x7d]); // { " <0xff> " }
+    const res = await driveFrames(socket, [buildFrame({ opcode: 0x1, payload: bad })]);
+    expect(res.closeCode).toBe(1007);
+    expect(gateway.received).toHaveLength(0);
+  });
+
+  it("[#5 no-degrade] valid multibyte UTF-8 text is decoded and forwarded intact", async () => {
+    const socket = await wsHandshake(port);
+    const frame = { type: "ping", at: "文字-café-2026" } as unknown as FridayRealtimeClientFrame;
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x1, payload: TEXT(JSON.stringify(frame)) }),
+    ]);
+    expect(res.closeCode).toBeNull();
+    expect(gateway.received).toEqual([frame]);
+  });
+
+  // ── Defect #6: fragmentation / continuation (opcode 0x0) ──────────────────────
+  it("[#6] rejects a continuation frame with no message in progress (close 1002)", async () => {
+    const socket = await wsHandshake(port);
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x0, payload: TEXT("orphan") }),
+    ]);
+    expect(res.closeCode).toBe(1002);
+  });
+
+  it("[#6] rejects a new data frame while a fragmented message is in progress (close 1002)", async () => {
+    const socket = await wsHandshake(port);
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x1, payload: TEXT('{"type":'), fin: false }),
+      buildFrame({ opcode: 0x1, payload: TEXT('"ping"}'), fin: true }),
+    ]);
+    expect(res.closeCode).toBe(1002);
+  });
+
+  it("[#6 no-degrade] a properly fragmented text message reassembles and forwards", async () => {
+    const socket = await wsHandshake(port);
+    const whole = '{"type":"ping","at":"2026-07-13T00:00:00.000Z"}';
+    const mid = 10;
+    const res = await driveFrames(socket, [
+      buildFrame({ opcode: 0x1, payload: TEXT(whole.slice(0, mid)), fin: false }),
+      buildFrame({ opcode: 0x0, payload: TEXT(whole.slice(mid)), fin: true }),
+    ]);
+    expect(res.closeCode).toBeNull();
+    expect(gateway.received).toEqual([JSON.parse(whole)]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Defect #7: Origin hardening — default DENY cross-site, ALLOW localhost/native.
+// Runs on the DEFAULT empty-allowlist config (production posture).
+// ─────────────────────────────────────────────────────────────────────────────
+describe("FridayHttpServer realtime WS — Origin hardening (default empty allowlist)", () => {
+  let server: FridayHttpServer | null = null;
+  let port = 0;
+
+  beforeEach(async () => {
+    port = await findFreePort();
+    server = createFridayHttpServer({
+      routes: createFridayHttpRouteRegistry(),
+      wsGateway: makeRecordingWsGateway(),
+      middleware: makeStubMiddleware(),
+      host: "127.0.0.1",
+      port,
+      // corsOrigins defaults to [] — cross-site hijacking must still be blocked.
+    });
+    await server.listen();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+  });
+
+  it("[#7] rejects a hostile cross-site browser Origin with 403", async () => {
+    const line = await upgradeStatusLine(port, "/v1/realtime/ws", {
+      Origin: "https://evil.example.com",
+    });
+    expect(line).toContain("403");
+  });
+
+  it("[#7 no-degrade] allows a missing Origin (native / non-browser client)", async () => {
+    const socket = await wsHandshake(port, "/v1/realtime/ws");
+    socket.destroy();
+    // wsHandshake resolves only on HTTP/1.1 101.
+    expect(socket).toBeDefined();
+  });
+
+  it("[#7 no-degrade] allows a same-host localhost Origin", async () => {
+    const line = await upgradeStatusLine(port, "/v1/realtime/ws", {
+      Origin: `http://127.0.0.1:${String(port)}`,
+    });
+    expect(line).toContain("101");
+  });
+
+  it("[#7 no-degrade] allows a loopback (localhost) Origin on a different port", async () => {
+    const line = await upgradeStatusLine(port, "/v1/realtime/ws", {
+      Origin: "http://localhost:5173",
+    });
+    expect(line).toContain("101");
+  });
+});

--- a/test/unit/api/http/friday-http-server-ws-rfc6455-frames.test.ts
+++ b/test/unit/api/http/friday-http-server-ws-rfc6455-frames.test.ts
@@ -274,7 +274,14 @@ function driveFrames(
       finish();
     });
     const timer = setTimeout(finish, waitMs);
-    for (const fr of frames) socket.write(fr);
+    try {
+      for (const fr of frames) {
+        if (socket.destroyed) break;
+        socket.write(fr);
+      }
+    } catch {
+      // Peer may tear down mid-write (expected for flood / oversize cases).
+    }
   });
 }
 
@@ -432,6 +439,34 @@ describe("FridayHttpServer realtime WS — RFC 6455 inbound frame validation", (
     ]);
     expect(res.closeCode).toBeNull();
     expect(gateway.received).toEqual([JSON.parse(whole)]);
+  });
+
+  // ── Defect #6 (DoS): bound the reassembly accumulation ────────────────────────
+  it("[#6-dos] tears down a zero-length continuation flood within a bounded frame count (1009)", async () => {
+    const socket = await wsHandshake(port);
+    // Start a fragmented text message, then stream empty continuations. Each adds
+    // 0 bytes (never trips the size cap) but MUST be bounded by the fragment count.
+    const frames: Buffer[] = [buildFrame({ opcode: 0x1, payload: Buffer.alloc(0), fin: false })];
+    // Comfortably past MAX_WS_FRAGMENTS (1024) so the count cap must fire.
+    for (let i = 0; i < 1100; i++) {
+      frames.push(buildFrame({ opcode: 0x0, payload: Buffer.alloc(0), fin: false }));
+    }
+    const res = await driveFrames(socket, frames, 1500);
+    expect(res.closeCode).toBe(1009);
+    expect(gateway.received).toHaveLength(0); // message never completes
+  });
+
+  it("[#6-dos] tears down when accumulated fragments exceed the 4MB message cap (1009)", async () => {
+    const socket = await wsHandshake(port);
+    const chunk = Buffer.alloc(1_000_000, 0x61); // 1MB, under the 1MB single-frame cap
+    const frames: Buffer[] = [buildFrame({ opcode: 0x1, payload: chunk, fin: false })];
+    // 1 start + 4 continuations = 5MB > 4MB assembled ceiling.
+    for (let i = 0; i < 4; i++) {
+      frames.push(buildFrame({ opcode: 0x0, payload: chunk, fin: false }));
+    }
+    const res = await driveFrames(socket, frames, 1500);
+    expect(res.closeCode).toBe(1009);
+    expect(gateway.received).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## NET-TRANSPORT-BOUNDS §12.1 — WebSocket realtime-gateway RFC 6455 inbound frame validation + Origin hardening (7 defects, 1 file)

Single cohesive PR over the **realtime WS ingress trust boundary**: `src/api/http/friday-http-server.ts`, the hand-rolled WebSocket frame parser for `/v1/realtime/ws` + `/v1/ws` — the run-event **result-delivery** surface. Born off `origin/main` `90f003e9`. Diff = 2 files (1 src + 1 new test).

**Live seam (unconditional):** `createFridayHttpServer` is instantiated in the default hub boot (`src/cli/friday-cli-run-loop.ts:70`, `.listen()` at :88); `handleRealtimeUpgrade` routes the two WS paths and feeds `deps.wsGateway.handleClientFrame`. No test-only flag, not 503-fenced, not Rust-owned — the parser runs for every live client.

Each defect is independently red-first-proven; a fully-compliant client (masked, valid UTF-8, valid opcode, ≤125B control, proper Origin, normal fragmentation) is **byte-for-byte unchanged** (strictly no-degrade — we only ADD rejection of malformed/hostile input + correct reassembly).

| # | Defect (before) | Fix | Close code |
|---|---|---|---|
| 1 | Unmasked client frames accepted (RFC §5.1 requires masking) | reject in `wsClientFrameHeaderViolation` before unmask/payload | 1002 |
| 2 | RSV1/2/3 never validated (`firstByte & 0x0f` dropped them) | `rsv !== 0 → close` (first check) | 1002 |
| 3 | Reserved opcodes 0x3-0x7/0xb-0xf silently no-op'd | opcode whitelist; else close | 1002 |
| 4 | Control frames allowed >125B / fragmented; pong echo length corruption | `opcode>=0x8 && (len>125 || !fin) → close`; correct 7-bit pong length | 1002 |
| 5 | Text frames not strict-UTF-8 (`toString` substitutes U+FFFD) | `TextDecoder(...,{fatal:true})` before JSON.parse | 1007 |
| 6 | Fragmentation (opcode 0x0 / FIN) unhandled | correct reassembly; orphan/interleave → 1002; **bounded** by 4MB size cap AND `MAX_WS_FRAGMENTS=1024` count cap → 1009; state reset on completion + every teardown | 1002 / 1009 |
| 7 | Origin not required on empty (default) allowlist → cross-site WS hijack (CSWSH) | `isTrustedWsOrigin`: hostile cross-site Origin → 403; missing Origin (native) + same-Host + loopback → allowed | 403 |

### #7 no-degrade design (does NOT break the local UI)
The old guard short-circuited to ACCEPT on the default empty allowlist. New logic: a present Origin must be allowlisted/`*` **or** same host as the request `Host` header **or** loopback; a **missing** Origin (native/non-browser client) is allowed. On the default empty allowlist: `https://evil.example.com` → **403**, while `http://127.0.0.1:<port>` / `http://localhost:5173` / no-Origin → **101**. Not spoofable in a browser CSWSH (the browser sets Origin to the attacker's real origin ≠ target Host). Residual: a malicious *same-machine* local app with a loopback Origin is trusted — lower severity, documented.

### #1 no-degrade (internal clients)
Grep-verified: the only binder of these WS paths is this server itself; every internal `new WebSocket` targets an external gateway (Discord/Lark/Slack/QQ) or the separate Rust hub (whose sealed client masks). Browser `WebSocket` + the `ws` library mask by default. No internal client sends unmasked frames here — enforcing masking is safe.

### Review trail (this PR was gated before merge)
- Independent adversarial review #1 @ `632c6f32`: PASSed #1-5,#7 but **FAILed #6** — the reassembly 4MB cap was byte-size only, so a flood of zero-length continuation frames grew the chunk array unbounded (OOM). Not merged.
- Fix @ `eb27f5e2` (+66/−5, #6 only): `MAX_WS_FRAGMENTS=1024` count cap + `resetWsFragmentState` on completion and every teardown path. 2 new DoS tests (zero-length flood → 1009 bounded teardown; accumulated >4MB → 1009).
- Fresh independent review #2 @ `eb27f5e2`: **PASS** — delta touches only #6, other 6 byte-identical, per-connection memory bounded (~5MB worst case, no residual OOM / counter-evasion), no-degrade intact, red-first genuine on the real socket path.

### Gates (at head SHA)
tsc 0 · lint 0 errors (0 net-new warnings) · detect-secrets exit 0 (baseline untouched) · focused 19/19 · no-regression `test/unit/api/http` 1312/1312 · no migration · born-current. Product stays **NO_GO**; closes no END-BAR requirement.
