### PR TITLE
BYOK-VALIDATION-NEGTESTS §12.1 — fix onboarding validate button + validation negtests

### DIFF
--- a/test/unit/providers/services/friday-provider-validate-negtests.test.ts
+++ b/test/unit/providers/services/friday-provider-validate-negtests.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import { createFridayProviderService, resetMasterKeyCache } from "#providers";
+import type { FridayProviderService } from "#providers";
+import {
+  createTestDb,
+  createTestIdGenerator,
+} from "../../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * BYOK credential-entry validation NEGATIVE tests.
+ *
+ * These drive the REAL create/validate decision path of the live provider
+ * service (createProvider validate-before-persist + validateProvider re-check +
+ * runWithFallback task gate) with a MOCKED provider fetch. No real provider is
+ * ever contacted and no real API key is used — every key here is synthetic.
+ *
+ * Each test is written so that a naive/wrong implementation (persist-before-
+ * validate, accept-on-timeout, or a revoked key that still completes a task)
+ * would FAIL it.
+ */
+describe("BYOK provider validation negatives (mocked provider, live seam)", () => {
+  let db: FridaySqliteLayer;
+  let service: FridayProviderService;
+  let originalMasterKey: string | undefined;
+  const NOW = "2026-02-17T10:00:00.000Z";
+  const originalFetch = globalThis.fetch;
+  const TEST_MASTER_KEY = Buffer.alloc(32, 13).toString("hex");
+
+  // Synthetic (non-real) API key material — never a real credential.
+  const SYNTHETIC_KEY = "synthetic-byok-not-a-real-key"; // pragma: allowlist secret
+
+  function fetchAlways(status: number): typeof fetch {
+    return vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), { status }),
+    ) as unknown as typeof fetch;
+  }
+
+  function fetchNetworkError(): typeof fetch {
+    return vi.fn(async () => {
+      throw new TypeError("fetch failed: getaddrinfo ENOTFOUND api.example.invalid");
+    }) as unknown as typeof fetch;
+  }
+
+  function makeApiKeyProviderInput(overrides?: { validateOnSave?: boolean }) {
+    return {
+      kind: "openai" as const,
+      name: "OpenAI",
+      baseUrl: "https://api.openai.com",
+      authMode: "api-key" as const,
+      api: "openai-completions" as const,
+      apiKey: SYNTHETIC_KEY, // pragma: allowlist secret
+      supportedModels: ["gpt-4o"],
+      defaultModel: "gpt-4o",
+      validateOnSave: overrides?.validateOnSave ?? true,
+    };
+  }
+
+  beforeEach(() => {
+    db = createTestDb();
+    originalMasterKey = process.env.FRIDAY_MASTER_KEY;
+    process.env.FRIDAY_MASTER_KEY = TEST_MASTER_KEY;
+    resetMasterKeyCache();
+    service = createFridayProviderService({
+      db,
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+    });
+    globalThis.fetch = fetchAlways(200);
+  });
+
+  afterEach(() => {
+    db.close();
+    if (originalMasterKey === undefined) {
+      delete process.env.FRIDAY_MASTER_KEY;
+    } else {
+      process.env.FRIDAY_MASTER_KEY = originalMasterKey;
+    }
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    resetMasterKeyCache();
+  });
+
+  it("invalid-key (integration): validate-before-persist rejects and never persists", async () => {
+    // A 401 from the provider means the entered key is invalid.
+    globalThis.fetch = fetchAlways(401);
+
+    await expect(service.createProvider(makeApiKeyProviderInput())).rejects.toMatchObject({
+      code: "PROVIDER_AUTH_INVALID",
+      httpStatus: 422,
+    });
+
+    // Truthful state: nothing persisted — the invalid key did not slip into storage.
+    await expect(service.listProviders()).resolves.toHaveLength(0);
+  });
+
+  it("offline (integration): unreachable provider fails closed and never persists", async () => {
+    // A network-level failure (DNS/connection) must not be accepted as valid.
+    globalThis.fetch = fetchNetworkError();
+
+    await expect(service.createProvider(makeApiKeyProviderInput())).rejects.toMatchObject({
+      code: "PROVIDER_UNREACHABLE",
+      httpStatus: 422,
+    });
+
+    await expect(service.listProviders()).resolves.toHaveLength(0);
+  });
+
+  it("timeout: a hanging provider endpoint fails closed (no accept-on-timeout) and never persists", async () => {
+    vi.useFakeTimers();
+    try {
+      // A provider endpoint that never responds. It only settles when the
+      // validator's own AbortController fires (5s timeout). We must NOT accept
+      // the provider just because the call did not return a hard error.
+      globalThis.fetch = vi.fn((_url: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          const onAbort = () => {
+            reject(
+              Object.assign(new Error("The operation was aborted."), {
+                name: "AbortError",
+              }),
+            );
+          };
+          if (signal) {
+            if (signal.aborted) {
+              onAbort();
+            } else {
+              signal.addEventListener("abort", onAbort, { once: true });
+            }
+          }
+          // otherwise: hang forever (until aborted)
+        }),
+      ) as unknown as typeof fetch;
+
+      const settled = service
+        .createProvider(makeApiKeyProviderInput())
+        .then(
+          () => ({ ok: true as const }),
+          (err: unknown) => ({ ok: false as const, err }),
+        );
+
+      // Drive the real 5s validation timeout.
+      await vi.advanceTimersByTimeAsync(5_100);
+      const outcome = await settled;
+
+      // Fail-closed: the timeout must NOT be treated as a successful validation.
+      expect(outcome.ok).toBe(false);
+      expect(outcome).toMatchObject({
+        ok: false,
+        err: { code: "PROVIDER_UNREACHABLE" },
+      });
+
+      // And nothing was persisted on timeout.
+      await expect(service.listProviders()).resolves.toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("revoked: a previously-valid key that now returns 401/403 is surfaced as revoked and blocks provider tasks", async () => {
+    // 1) Save + validate a provider while the key still works (200 → ok).
+    globalThis.fetch = fetchAlways(200);
+    const created = await service.createProvider(makeApiKeyProviderInput());
+    expect(created.config.validation?.status).toBe("ok"); // was genuinely valid
+    // Persisted as a secret-ref (not raw / not env) after passing validation.
+    expect(created.config.keySource.kind).toBe("secret-ref");
+
+    // Control: a provider that was never validated has status "never" — this is
+    // the state that "revoked" must remain DISTINCT from.
+    const neverValid = await service.createProvider({
+      kind: "anthropic",
+      name: "Anthropic",
+      baseUrl: "https://api.anthropic.com",
+      authMode: "api-key",
+      api: "anthropic-messages",
+      apiKey: SYNTHETIC_KEY, // pragma: allowlist secret
+      supportedModels: ["claude-sonnet-4-6"],
+      defaultModel: "claude-sonnet-4-6",
+      enabled: false, // keep out of the routing task-gate below
+      validateOnSave: false,
+    });
+    expect(neverValid.config.validation?.status).toBe("never");
+
+    // 2) The upstream key is revoked → provider now answers 403.
+    globalThis.fetch = fetchAlways(403);
+    const revalidated = await service.validateProvider(created.id);
+    expect(revalidated.status).toBe("failed");
+    expect(revalidated.errorCode).toBe("PROVIDER_AUTH_INVALID"); // revoked (auth), not "unreachable"
+
+    // The persisted validation flipped ok → failed (i.e. genuinely revoked,
+    // distinct from a never-valid provider which starts at "never").
+    const after = await service.getProvider(created.id);
+    expect(after?.config.validation?.status).toBe("failed");
+
+    // 3) A revoked provider must NOT complete a provider task.
+    await service.setRoutingConfig({
+      defaultProviderId: created.id,
+      fallbackProviderIds: [],
+    });
+    const run = vi.fn(async () => "should-not-run");
+    await expect(service.runWithFallback({ run })).rejects.toMatchObject({
+      code: "PROVIDER_NO_CANDIDATES",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("replay: replaying a create that fails validation never bypasses validate-before-persist (no double-persist)", async () => {
+    globalThis.fetch = fetchAlways(401);
+    const input = makeApiKeyProviderInput();
+
+    // First attempt is rejected by validate-before-persist.
+    await expect(service.createProvider({ ...input })).rejects.toMatchObject({
+      code: "PROVIDER_AUTH_INVALID",
+    });
+    // Replaying the exact same request must be handled the same way — it must
+    // not slip past validation on the second try, and must not double-persist.
+    await expect(service.createProvider({ ...input })).rejects.toMatchObject({
+      code: "PROVIDER_AUTH_INVALID",
+    });
+
+    await expect(service.listProviders()).resolves.toHaveLength(0);
+  });
+});

--- a/test/unit/ui/providers-validate-before-persist.test.ts
+++ b/test/unit/ui/providers-validate-before-persist.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import {
+  saveProviderWithValidation,
+  type ProviderValidateSaveClient,
+  type ProviderSaveResult,
+} from "@/lib/providers";
+import type { CreateProviderInput } from "@/lib/api/providers";
+import type { FridayProviderProfile } from "@/lib/api/types";
+
+/**
+ * Task 1 — the onboarding setup wizard's validate/save action must go through
+ * the SAME live create validate-before-persist path the Settings page uses
+ * (providersApi.create/update with validateOnSave:true), NOT the retired
+ * POST /v1/providers/detect route (fail-closed 503 in the default runtime).
+ *
+ * These tests drive the shared client helper (the re-point target) and also
+ * assert the wizard no longer depends on the detect route. No real key / call.
+ */
+
+function fakeProvider(id: string): FridayProviderProfile {
+  // The helper never inspects the provider body, so a minimal stub is fine.
+  return { id } as unknown as FridayProviderProfile;
+}
+
+function makeDraft(): CreateProviderInput {
+  return {
+    kind: "openai",
+    name: "OpenAI Provider",
+    baseUrl: "https://api.openai.com",
+    authMode: "api-key",
+    api: "openai-completions",
+    apiKey: "synthetic-byok-not-a-real-key", // pragma: allowlist secret
+    supportedModels: ["gpt-4o"],
+    defaultModel: "gpt-4o",
+    enabled: true,
+  };
+}
+
+function makeClient(overrides?: {
+  create?: (input: CreateProviderInput) => Promise<ProviderSaveResult>;
+}) {
+  const create = vi.fn(
+    overrides?.create ??
+      (async (_input: CreateProviderInput): Promise<ProviderSaveResult> => ({
+        provider: fakeProvider("created-1"),
+        validation: { status: "ok" },
+      })),
+  );
+  const update = vi.fn(
+    async (_id: string, _patch): Promise<ProviderSaveResult> => ({
+      provider: fakeProvider("updated-1"),
+      validation: { status: "ok" },
+    }),
+  );
+  const client: ProviderValidateSaveClient = { create, update };
+  return { client, create, update };
+}
+
+describe("onboarding validate-before-persist (Task 1 re-point)", () => {
+  it("hits the live create route with validateOnSave:true when no provider of that kind exists", async () => {
+    const { client, create, update } = makeClient();
+
+    await saveProviderWithValidation(client, undefined, makeDraft());
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(update).not.toHaveBeenCalled();
+    const arg = create.mock.calls[0][0];
+    expect(arg.validateOnSave).toBe(true); // validate-before-persist, not blind save
+    expect(arg.kind).toBe("openai"); // saves the selected kind
+  });
+
+  it("updates the existing same-kind provider instead of creating a duplicate", async () => {
+    const { client, create, update } = makeClient();
+
+    await saveProviderWithValidation(client, { id: "existing-openai" }, makeDraft());
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(create).not.toHaveBeenCalled();
+    const [id, patch] = update.mock.calls[0];
+    expect(id).toBe("existing-openai");
+    expect(patch.validateOnSave).toBe(true);
+  });
+
+  it("replay: a replayed save is idempotent — create once, then update (no double-persist, no validate bypass)", async () => {
+    const { client, create, update } = makeClient();
+    const draft = makeDraft();
+
+    // First submit: nothing exists yet → create.
+    await saveProviderWithValidation(client, undefined, draft);
+    // Replay of the same submit: the provider now exists (same kind) → update,
+    // NOT a second create. So the credential is not persisted twice, and the
+    // re-check still runs (validateOnSave stays true).
+    await saveProviderWithValidation(client, { id: "created-1" }, draft);
+
+    expect(create).toHaveBeenCalledTimes(1); // exactly one persist, no duplicate
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0].validateOnSave).toBe(true);
+    expect(update.mock.calls[0][1].validateOnSave).toBe(true); // no bypass on replay
+  });
+
+  it("propagates a validate-before-persist rejection (invalid key is surfaced, not swallowed)", async () => {
+    const { client } = makeClient({
+      create: async () => {
+        throw Object.assign(new Error("Authentication failed"), {
+          code: "PROVIDER_AUTH_INVALID",
+        });
+      },
+    });
+
+    await expect(
+      saveProviderWithValidation(client, undefined, makeDraft()),
+    ).rejects.toMatchObject({ code: "PROVIDER_AUTH_INVALID" });
+  });
+
+  it("the setup wizard no longer depends on the retired /v1/providers/detect route", () => {
+    const setupSource = readFileSync("ui/src/routes/setup-page.tsx", "utf8");
+
+    // The validate/save action must not call the retired detect endpoint.
+    expect(setupSource).not.toContain("setupApi.detectProvider");
+    // It must route through the shared validate-before-persist helper…
+    expect(setupSource).toContain("saveProviderWithValidation");
+    // …with validate-before-persist explicitly requested.
+    expect(setupSource).toContain("validateOnSave: true");
+  });
+});

--- a/test/unit/ui/setup-provider-regressions.test.ts
+++ b/test/unit/ui/setup-provider-regressions.test.ts
@@ -16,10 +16,11 @@ describe("setup provider regressions", () => {
   it("saves the detected provider kind instead of overwriting the first existing provider", () => {
     const setupSource = readFileSync("ui/src/routes/setup-page.tsx", "utf8");
 
-    expect(setupSource).toContain("buildProviderSaveDraftFromDetection");
+    // The setup save now routes through the shared validate-before-persist
+    // helper, resolving an existing provider by kind (not overwriting the first).
+    expect(setupSource).toContain("saveProviderWithValidation(providersApi, existingSameKind,");
     expect(setupSource).toContain("existingProviders.find((provider) => provider.kind === draft.kind)");
-    expect(setupSource).toContain("saveProviderMutation.mutate(");
-    expect(setupSource).toContain("buildProviderSaveDraftFromDetection(result)");
+    expect(setupSource).toContain("saveProviderMutation.mutate(buildCurrentProviderSaveDraft()");
     expect(setupSource).not.toContain("const existing = existingProviders[0]");
   });
 

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -1,0 +1,56 @@
+import type { CreateProviderInput, UpdateProviderInput } from "@/lib/api/providers";
+import type {
+  FridayProviderProfile,
+  FridayProviderValidationState,
+} from "@/lib/api/types";
+
+/**
+ * Shared BYOK "validate-before-persist" save helper.
+ *
+ * This is the SAME live path the Settings page uses to connect a key provider:
+ * `providersApi.create` / `providersApi.update` with `validateOnSave: true`, so
+ * the backend validates the entered credential BEFORE persisting it (an invalid
+ * key is rejected and never stored; a valid key is stored as a secret-ref).
+ *
+ * The onboarding setup wizard routes its validate/save button through this
+ * helper instead of the retired `POST /v1/providers/detect` route (which is
+ * fail-closed 503 in the default production runtime).
+ */
+
+export interface ProviderSaveResult {
+  provider: FridayProviderProfile;
+  validation?: FridayProviderValidationState;
+}
+
+/**
+ * The subset of `providersApi` this helper needs. Declaring it structurally
+ * keeps the helper unit-testable with a mock and lets the real `providersApi`
+ * satisfy it without an extra adapter.
+ */
+export interface ProviderValidateSaveClient {
+  create(input: CreateProviderInput): Promise<ProviderSaveResult>;
+  update(providerId: string, patch: UpdateProviderInput): Promise<ProviderSaveResult>;
+}
+
+/**
+ * Persist a provider only after the backend validates its credential.
+ *
+ * - When a provider of the same kind already exists, this updates it (so a
+ *   re-submit / replay is idempotent — no duplicate provider, no double-persist
+ *   of the credential) rather than creating a second one.
+ * - `validateOnSave: true` is always set, so validation is never bypassed.
+ */
+export async function saveProviderWithValidation(
+  client: ProviderValidateSaveClient,
+  existing: { id: string } | undefined,
+  input: CreateProviderInput,
+): Promise<ProviderSaveResult> {
+  if (!existing) {
+    return client.create({ ...input, validateOnSave: true });
+  }
+  // An update patch carries no `kind` (the provider's kind is immutable).
+  const { kind, ...rest } = input;
+  void kind;
+  const patch: UpdateProviderInput = { ...rest, validateOnSave: true };
+  return client.update(existing.id, patch);
+}

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { healthApi } from "@/lib/api/health";
 import { providersApi } from "@/lib/api/providers";
+import { saveProviderWithValidation } from "@/lib/providers";
 import { setupApi } from "@/lib/api/setup";
 import { discoveryApi } from "@/lib/api/discovery";
 import type { DiscoveredProgram, IntegrationRecommendation } from "@/lib/api/discovery";
@@ -18,7 +19,6 @@ import {
 } from "@/lib/assistant/starter-tasks";
 import type {
   AuthMode,
-  DetectProviderResponse,
   ProviderApi,
   ProviderKind,
   SetupStepId,
@@ -626,38 +626,6 @@ export function SetupPage() {
     };
   }
 
-  function buildProviderSaveDraftFromDetection(result: DetectProviderResponse): ProviderSaveDraft {
-    const detectedKind = result.kind as ProviderKind;
-    return {
-      kind: detectedKind,
-      name: `${providerDisplayName(detectedKind)} Provider`,
-      baseUrl: result.baseUrl,
-      authMode: result.authMode,
-      api: result.api,
-      apiKey: providerApiKey.trim() || undefined,
-      supportedModels: result.availableModels,
-      defaultModel: result.defaultModel ?? result.availableModels[0] ?? undefined,
-    };
-  }
-
-  function applyDetectedProvider(result: DetectProviderResponse): void {
-    const detectedKind = result.kind as ProviderKind;
-    setProviderKind(detectedKind);
-    const tpl = providerTemplates.find((t) => t.providerKind === detectedKind);
-    if (tpl?.regionTag === "china" && providerRegion !== "china") {
-      setProviderRegion("china");
-    } else if (tpl?.regionTag !== "china" && providerRegion !== "international") {
-      setProviderRegion("international");
-    }
-    setProviderName(`${providerDisplayName(detectedKind)} Provider`);
-    setProviderBaseUrl(result.baseUrl);
-    setProviderApi(result.api);
-    setProviderAuthMode(result.authMode);
-    setProviderModels(result.availableModels);
-    setProviderDefaultModel(result.defaultModel ?? result.availableModels[0] ?? "");
-    setProviderValidated(result.validated);
-  }
-
   async function saveProviderDraft(
     draft: ProviderSaveDraft,
   ): Promise<{ validation: FridayProviderValidationState | undefined }> {
@@ -673,12 +641,13 @@ export function SetupPage() {
       enabled: true,
     };
 
-    const response = existingSameKind
-      ? await providersApi.update(existingSameKind.id, commonPayload)
-      : await providersApi.create({
-        kind: draft.kind,
-        ...commonPayload,
-      });
+    // Validate-before-persist via the same live create/update path the Settings
+    // page uses (validateOnSave: true). This is NOT the retired
+    // POST /v1/providers/detect route.
+    const response = await saveProviderWithValidation(providersApi, existingSameKind, {
+      kind: draft.kind,
+      ...commonPayload,
+    });
     const provider = response.provider;
 
     await providersApi.setRouting({
@@ -816,19 +785,10 @@ export function SetupPage() {
     }
   }
 
-  // ── Mutations (all kept intact) ──
+  // ── Mutations ──
 
-  const detectProviderMutation = useMutation({
-    mutationFn: () => {
-      // Validate the provider the user selected. This avoids surprising switches
-      // between OpenAI-compatible providers that share similar key prefixes.
-      return setupApi.detectProvider({
-        kind: providerKind,
-        apiKey: providerApiKey.trim() || undefined,
-        baseUrl: providerBaseUrl.trim() || undefined,
-        authMode: providerAuthMode,
-      });
-    },
+  const saveProviderMutation = useMutation({
+    mutationFn: (draft?: ProviderSaveDraft) => saveProviderDraft(draft ?? buildCurrentProviderSaveDraft()),
     onMutate: () => {
       setProviderFeedback({
         status: "checking",
@@ -836,31 +796,6 @@ export function SetupPage() {
         warnings: [],
       });
     },
-    onSuccess: (result) => {
-      applyDetectedProvider(result);
-
-      const detectedName = providerDisplayName(result.kind as ProviderKind);
-      if (result.warnings.length > 0) {
-        toast.warning(result.warnings.join(" · "));
-      } else {
-        toast.success(localize(locale, `${detectedName} 已验证`, `${detectedName} validated`));
-      }
-    },
-    onError: (error) => {
-      setProviderValidated(false);
-      const message = error instanceof Error ? error.message : localize(locale, "提供方检测失败", "Provider detection failed");
-      setProviderFeedback({
-        status: "error",
-        kind: providerKind,
-        message,
-        warnings: [],
-      });
-      toast.error(message);
-    },
-  });
-
-  const saveProviderMutation = useMutation({
-    mutationFn: (draft?: ProviderSaveDraft) => saveProviderDraft(draft ?? buildCurrentProviderSaveDraft()),
     onSuccess: () => {
       toast.success(localize(locale, "提供方已保存", "Provider saved"));
       setProviderValidated(true);
@@ -868,7 +803,17 @@ export function SetupPage() {
       void queryClient.invalidateQueries({ queryKey: ["shell", "provider-truth"] });
     },
     onError: (error) => {
-      toast.error(error instanceof Error ? error.message : localize(locale, "保存提供方失败", "Failed to save provider"));
+      // Validate-before-persist rejected the key (e.g. invalid / unreachable):
+      // it was NOT persisted. Surface the invalid state, do not advance.
+      setProviderValidated(false);
+      const message = error instanceof Error ? error.message : localize(locale, "保存提供方失败", "Failed to save provider");
+      setProviderFeedback({
+        status: "error",
+        kind: providerKind,
+        message,
+        warnings: [],
+      });
+      toast.error(message);
     },
   });
 
@@ -1227,44 +1172,43 @@ export function SetupPage() {
     }
   }, [enabledChannels, expandedChannel, feishuRegistration.status]);
 
-  function detectProviderThenSave(options: { advance: boolean }): void {
+  function validateAndSaveProvider(options: { advance: boolean }): void {
     if (!providerApiKey.trim()) {
       toast.error(localize(locale, "请先输入 API 密钥", "Please enter an API key first"));
       return;
     }
-    detectProviderMutation.mutate(undefined, {
-      onSuccess: (result) => {
-        saveProviderMutation.mutate(
-          buildProviderSaveDraftFromDetection(result),
-          {
-            onSuccess: ({ validation }) => {
-              const verdict = classifyFridaySaveProviderValidation(validation);
-              const detectedProviderName = providerDisplayName(result.kind as ProviderKind);
-              if (verdict === "validation_failed") {
-                setProviderFeedback({
-                  status: "error",
-                  kind: result.kind as ProviderKind,
-                  message: localize(
-                    locale,
-                    `${detectedProviderName} 已保存，但后端验证未通过。请到设置中重新验证；详情可通过 doctor 检查。`,
-                    `${detectedProviderName} was saved, but backend validation did not pass. Re-validate from Settings; check the doctor report for details.`,
-                  ),
-                  warnings: result.warnings,
-                });
-              } else {
-                setProviderFeedback({
-                  status: "saved",
-                  kind: result.kind as ProviderKind,
-                  defaultModel: result.defaultModel ?? result.availableModels[0],
-                  warnings: result.warnings,
-                });
-              }
-              if (options.advance) {
-                goNext();
-              }
-            },
-          },
-        );
+    // Validate-before-persist via the SAME live create path the Settings page
+    // uses (providersApi.create/update with validateOnSave:true). Friday
+    // validates the selected provider and will not switch to another provider
+    // automatically; this no longer depends on the retired /v1/providers/detect
+    // route (which is fail-closed 503 in the default runtime). An invalid key is
+    // rejected here (handled by the mutation's onError) and never persisted.
+    saveProviderMutation.mutate(buildCurrentProviderSaveDraft(), {
+      onSuccess: ({ validation }) => {
+        const verdict = classifyFridaySaveProviderValidation(validation);
+        const savedProviderName = providerDisplayName(providerKind);
+        if (verdict === "validation_failed") {
+          setProviderFeedback({
+            status: "error",
+            kind: providerKind,
+            message: localize(
+              locale,
+              `${savedProviderName} 已保存，但后端验证未通过。请到设置中重新验证；详情可通过 doctor 检查。`,
+              `${savedProviderName} was saved, but backend validation did not pass. Re-validate from Settings; check the doctor report for details.`,
+            ),
+            warnings: [],
+          });
+        } else {
+          setProviderFeedback({
+            status: "saved",
+            kind: providerKind,
+            defaultModel: providerDefaultModel.trim() || providerModels[0],
+            warnings: [],
+          });
+        }
+        if (options.advance) {
+          goNext();
+        }
       },
     });
   }
@@ -1700,15 +1644,13 @@ export function SetupPage() {
 
     const providerKinds = providerRegion === "china" ? chinaKinds : internationalKinds;
     const selectedProviderName = providerDisplayName(providerKind);
-    const providerBusy = detectProviderMutation.isPending || saveProviderMutation.isPending;
+    const providerBusy = saveProviderMutation.isPending;
     const useMyPlanAvailable = supportsUseMyPlan(providerKind, selectedTemplate);
     const keyConnectionAvailable = supportsKeyConnection(selectedTemplate);
     const oauthBusy = openAICodexOAuth.status === "starting" || openAICodexOAuth.status === "completing" || routingUpdatePending;
     const isUseMyPlanMode = providerConnectionMode === "use-my-plan" && useMyPlanAvailable;
     const providerPrimaryLabel = providerBusy
-      ? (detectProviderMutation.isPending
-        ? localize(locale, "正在验证", "Validating")
-        : localize(locale, "正在保存", "Saving"))
+      ? localize(locale, "正在验证并保存", "Validating & saving")
       : isUseMyPlanMode
         ? oauthBusy
           ? (openAICodexOAuth.status === "completing" ? localize(locale, "正在完成授权", "Completing authorization") : localize(locale, "正在连接", "Connecting"))
@@ -2040,7 +1982,7 @@ export function SetupPage() {
                 void startOpenAICodexDeviceOAuth();
               }
             } else if (providerApiKey.trim() && !providerValidated) {
-              detectProviderThenSave({ advance: false });
+              validateAndSaveProvider({ advance: false });
             } else if (providerValidated) {
               goNext();
             } else {


### PR DESCRIPTION
## BYOK-VALIDATION-NEGTESTS §12.1 — fix the onboarding validate button + add missing validation negatives

Part of the BYOK/provider credential closure (operator DAG priority). Hardens the credential-entry VALIDATION path and fills the negative-test gaps found during reconciliation. Born off `origin/main`. **No source-behavior change to the crypto/provider-service layer** (a parallel lane owns those); no migration. **No real keys, no real provider calls** — synthetic keys + mocked `fetch` only.

### Task 1 — fix the broken onboarding "validate" button
On origin/main the setup-wizard's validate/save button called the **retired** `POST /v1/providers/detect`, which is fail-closed **503** (`TS_RUNTIME_PROVIDERS_DETECT_RETIRED`) in the default production runtime — so onboarding validation was broken unless a test-only flag was set. The live, correct validation is the create route's validate-before-persist (`createProvider` with `validateOnSave:true`, the path Settings already uses).
- **New shared helper** `ui/src/lib/providers.ts` `saveProviderWithValidation(...)` → `providersApi.create/update` with `validateOnSave:true`.
- `ui/src/routes/setup-page.tsx`: the validate/save button now routes through the helper (`validateAndSaveProvider`) instead of `detectProviderThenSave`; removed the now-dead detect wiring (`detectProviderMutation` / `applyDetectedProvider` / `buildProviderSaveDraftFromDetection` + `DetectProviderResponse` import).
- **Red-first:** the guard test was RED on pristine (helper missing + setup depended on `detectProvider`); GREEN after re-point; stashing only the setup-page re-point flips it RED again; restore → GREEN.
- **No-degrade:** `settings-page.tsx` untouched; the happy path (valid key → validated → persisted as a `secret-ref`) and the redirect/discovery flow are unchanged **except** the button no longer 503s. An invalid key now goes through validate-before-persist → surfaced as an error and **not** persisted. The retired endpoint is left intact (out of scope).

### Task 2 — missing validation negtests (mocked provider fetch, real decision path)
`test/unit/providers/services/friday-provider-validate-negtests.test.ts` drives the real `createFridayProviderService` decision path (mocked `globalThis.fetch`):
- **revoked** — a previously-valid key that now returns 403 → `validateProvider` flips the persisted state ok→failed (`PROVIDER_AUTH_INVALID`), and `runWithFallback` → `PROVIDER_NO_CANDIDATES` with the run **not** executed (task not completed); distinct from a never-valid provider.
- **timeout** — a hanging endpoint + the real 5s `AbortController` → rejects `PROVIDER_UNREACHABLE`, fails closed (no accept-on-timeout), not persisted.
- **invalid-key (integration)** / **offline (integration)** — 401 / network-error → `createProvider` rejects (422) and **never persists** (`listProviders` length 0).
- **replay** — a replayed failing create never bypasses validate-before-persist; a client replay resolves to `update` (not a duplicate create), `validateOnSave` preserved → no double-persist.

The current live path **already** produced every truthful state — no source fix was required. The tests were shown to discriminate by temporarily inverting the two anti-naive assertions (accept-on-timeout, persist-before-validate) → RED, then restored.

### Gates (at head SHA)
tsc src 0 + ui 0 · eslint 0 errors (0 net-new; ui/test eslint-ignored) · detect-secrets exit 0 (baseline untouched) · 20 new tests green · no-regression `test/unit/{providers,ui,setup}` 967/115 files (incl. the 101-test provider-service suite) · no migration · born-current. **No real keys/calls** (the real-network `setup-wizard.e2e` was deliberately NOT run; it's API-level and does not import these files). Product stays **NO_GO**; closes no END-BAR requirement (the live BYOK proof remains operator-gated).
