### PR TITLE
SEC-SECRET-AAD-001 — versioned AAD context-binding for the at-rest secret envelope

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -214,7 +214,7 @@
         "filename": "src/api/http/routes/friday-setup-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 2193
+        "line_number": 2214
       }
     ],
     "src/media-understanding/friday-media-doctor.ts": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-07T09:14:15Z"
+  "generated_at": "2026-07-13T19:14:17Z"
 }

--- a/src/agent/mcp/friday-mcp-config-store.ts
+++ b/src/agent/mcp/friday-mcp-config-store.ts
@@ -4,9 +4,10 @@ import { dirname, join } from "node:path";
 
 import type { FridayMcpServerConfig } from "./friday-mcp-adapter.types.js";
 import {
-  decryptSecret,
+  decryptSecretWithMigration,
   encryptSecret,
   type FridayEncryptedEnvelope,
+  type FridaySecretAadContext,
   getStrictMasterKey,
 } from "../../security/friday-secret-crypto.js";
 import {
@@ -17,6 +18,20 @@ import {
 const CONFIG_FILENAME = "mcp-servers.json";
 const VAULT_FILENAME = "mcp-secrets.json";
 const VAULT_VERSION = 1;
+
+/** Logical store namespace bound into every MCP vault-entry AAD context. */
+const FRIDAY_MCP_VAULT_AAD_STORE = "friday-mcp-vault";
+
+/**
+ * Canonical AAD binding context for one MCP secret-vault entry.
+ *
+ * The vault map key (`refKey`) is the entry's stable identity, so binding it
+ * prevents a ciphertext being transplanted to a different vault key. Writer
+ * (save) and reader (load) both key off the same `refKey`.
+ */
+function mcpVaultAadContext(refKey: string): FridaySecretAadContext {
+  return { store: FRIDAY_MCP_VAULT_AAD_STORE, ref: refKey };
+}
 
 const SECRET_FIELDS = ["env", "headers"] as const;
 type SecretField = (typeof SECRET_FIELDS)[number];
@@ -129,6 +144,7 @@ export function createFridayMcpConfigStore(
     if (configs.length === 0) return configs;
 
     const vault = readVault();
+    let vaultDirty = false;
     const residue: FridayMcpSecretResidueEntry[] = [];
 
     // Resolve the master key lazily: only if at least one secret ref needs
@@ -159,7 +175,18 @@ export function createFridayMcpConfigStore(
               const activeKey = getKey();
               if (activeKey) {
                 try {
-                  record[key] = decryptSecret(envelope, activeKey);
+                  const { plaintext, rewrapped } = decryptSecretWithMigration(
+                    envelope,
+                    activeKey,
+                    mcpVaultAadContext(input.refKey),
+                  );
+                  record[key] = plaintext;
+                  if (rewrapped) {
+                    // Read-repair (SEC-SECRET-AAD-001): migrate the legacy v1
+                    // vault entry to v2 in place; flushed below.
+                    vault.entries[input.refKey] = rewrapped;
+                    vaultDirty = true;
+                  }
                   continue;
                 } catch {
                   // fall through to residue below (leave opaque ref in place)
@@ -173,6 +200,19 @@ export function createFridayMcpConfigStore(
           // server stays usable, but flag it so it does not silently persist.
           residue.push({ serverId: config.id, field, key, reason: "legacy-plaintext" });
         }
+      }
+    }
+
+    if (vaultDirty) {
+      // Best-effort persist of the AAD re-wrap so no legacy v1 entry survives.
+      try {
+        mkdirSync(dirname(vaultPath), { recursive: true });
+        writeFileSync(vaultPath, JSON.stringify(vault, null, 2), { encoding: "utf8", mode: 0o600 });
+      } catch (err) {
+        console.warn(
+          "[friday][mcp-config-store] AAD vault read-repair flush failed:",
+          err instanceof Error ? err.message : String(err),
+        );
       }
     }
 
@@ -224,7 +264,11 @@ export function createFridayMcpConfigStore(
           const refKey = randomBytes(16).toString("hex");
           // masterKey is guaranteed present here: `needsKey` is true whenever a
           // non-secret-ref value exists.
-          nextVault.entries[refKey] = encryptSecret(value, masterKey as Buffer);
+          nextVault.entries[refKey] = encryptSecret(
+            value,
+            masterKey as Buffer,
+            mcpVaultAadContext(refKey),
+          );
           rewritten[key] = buildFridaySecretRef(refKey);
         }
         next = { ...next, [field]: rewritten };

--- a/src/api/http/routes/friday-setup-routes.ts
+++ b/src/api/http/routes/friday-setup-routes.ts
@@ -4,7 +4,7 @@ import type { FridayRouteDefinition } from "../../model/friday-api-common.types.
 import type { FridaySqliteLayer } from "#state";
 import {
   createFridaySecretRepository,
-  decryptSecret,
+  decryptSecretWithMigration,
   detectFridayProviderKindFromApiKey,
   encryptSecret,
   FRIDAY_PROVIDER_KIND_SET,
@@ -12,6 +12,7 @@ import {
   type FridayProviderAuthMode,
   type FridayProviderKind,
   type FridayProviderService,
+  fridaySecretAadContext,
   getFridayProviderAuthModesForBackend,
   getFridayProviderCapability,
   getFridayProviderPreset,
@@ -1420,7 +1421,27 @@ function resolveSetupChannelSecretValue(deps: Pick<FridaySetupRoutesDeps, "db">,
     );
     if (!entity) return undefined;
     const envelope = JSON.parse(entity.encryptedValue) as FridayEncryptedEnvelope;
-    return decryptSecret(envelope, getStrictMasterKey());
+    const { plaintext, rewrapped } = decryptSecretWithMigration(
+      envelope,
+      getStrictMasterKey(),
+      fridaySecretAadContext(entity),
+    );
+    if (rewrapped) {
+      // Read-repair (SEC-SECRET-AAD-001): persist the v2 re-wrap; best-effort.
+      try {
+        deps.db.withWriteTransaction((db) => {
+          channelSecretRepository.updateById(db, {
+            secretId: entity.id,
+            encryptedValue: JSON.stringify(rewrapped),
+            keyId: "master-v1",
+            nowIso: new Date().toISOString(),
+          });
+        });
+      } catch {
+        // Non-fatal: the read already succeeded.
+      }
+    }
+    return plaintext;
   } catch (error) {
     console.warn("[friday][setup-routes] could not resolve channel secret for setup welcome:", error instanceof Error ? error.message : String(error));
     return undefined;
@@ -2780,9 +2801,14 @@ export function createFridaySetupRoutes(
           const masterKey = getStrictMasterKey();
           deps.db.withWriteTransaction((db) => {
             for (const write of secretWrites) {
-              const envelope = encryptSecret(write.plaintext, masterKey);
+              const secretId = `channel-secret:${write.refKey}`; // pragma: allowlist secret
+              const envelope = encryptSecret(
+                write.plaintext,
+                masterKey,
+                fridaySecretAadContext({ scope: FRIDAY_CHANNEL_SECRET_SCOPE, id: secretId }),
+              );
               channelSecretRepository.upsert(db, {
-                id: `channel-secret:${write.refKey}`,
+                id: secretId,
                 scope: FRIDAY_CHANNEL_SECRET_SCOPE,
                 refKey: write.refKey,
                 encryptedValue: JSON.stringify(envelope),

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -8,7 +8,8 @@ import type { FridaySqliteLayer } from "#state";
 import {
   createFridaySecretAdminService,
   createFridaySecretRepository,
-  decryptSecret,
+  decryptSecretWithMigration,
+  fridaySecretAadContext,
   getStrictMasterKey,
 } from "#providers";
 import type { FridayEncryptedEnvelope, FridayProviderTenantContext } from "#providers";
@@ -886,7 +887,27 @@ function createWorkflowWebhookSecretResolver(
         );
         if (!entity) continue;
         const envelope = JSON.parse(entity.encryptedValue) as FridayEncryptedEnvelope;
-        return decryptSecret(envelope, getStrictMasterKey());
+        const { plaintext, rewrapped } = decryptSecretWithMigration(
+          envelope,
+          getStrictMasterKey(),
+          fridaySecretAadContext(entity),
+        );
+        if (rewrapped) {
+          // Read-repair (SEC-SECRET-AAD-001): persist v2 re-wrap; best-effort.
+          try {
+            db.withWriteTransaction((conn) => {
+              secretRepo.updateById(conn, {
+                secretId: entity.id,
+                encryptedValue: JSON.stringify(rewrapped),
+                keyId: "master-v1",
+                nowIso: new Date().toISOString(),
+              });
+            });
+          } catch {
+            // Non-fatal: the read already succeeded.
+          }
+        }
+        return plaintext;
       }
       return null;
     } catch (error) {

--- a/src/cli/friday-cli.ts
+++ b/src/cli/friday-cli.ts
@@ -51,6 +51,7 @@ import type { FridayHubConfig } from "#hub";
 import {
   createFridaySecretRepository,
   encryptSecret,
+  fridaySecretAadContext,
   getProvisionedMasterKey,
 } from "#providers";
 import {
@@ -1119,9 +1120,14 @@ function persistMigratedChannels(
   if (secretWrites.length > 0) {
     const masterKey = getProvisionedMasterKey();
     for (const write of secretWrites) {
-      const envelope = encryptSecret(write.plaintext, masterKey);
+      const secretId = `channel-secret:${write.refKey}`; // pragma: allowlist secret
+      const envelope = encryptSecret(
+        write.plaintext,
+        masterKey,
+        fridaySecretAadContext({ scope: "channel", id: secretId }),
+      );
       channelSecretRepository.upsert(db, {
-        id: `channel-secret:${write.refKey}`,
+        id: secretId,
         scope: "channel",
         refKey: write.refKey,
         encryptedValue: JSON.stringify(envelope),

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -52,7 +52,8 @@ import {
   createFridayProviderService,
   createFridaySecretAdminService,
   createFridaySecretRepository,
-  decryptSecret,
+  decryptSecretWithMigration,
+  fridaySecretAadContext,
   getFridayProviderPreset,
   getStrictMasterKey,
   normalizeFridayProviderSupportedModels,
@@ -2070,7 +2071,27 @@ export async function createFridayHub(
         );
         if (!entity) continue;
         const envelope = JSON.parse(entity.encryptedValue) as FridayEncryptedEnvelope;
-        return decryptSecret(envelope, getStrictMasterKey());
+        const { plaintext, rewrapped } = decryptSecretWithMigration(
+          envelope,
+          getStrictMasterKey(),
+          fridaySecretAadContext(entity),
+        );
+        if (rewrapped) {
+          // Read-repair (SEC-SECRET-AAD-001): persist v2 re-wrap; best-effort.
+          try {
+            stateRuntime!.sqlite.withWriteTransaction((db) => {
+              workflowWebhookSecretRepository.updateById(db, {
+                secretId: entity.id,
+                encryptedValue: JSON.stringify(rewrapped),
+                keyId: "master-v1",
+                nowIso: new Date().toISOString(),
+              });
+            });
+          } catch {
+            // Non-fatal: the read already succeeded.
+          }
+        }
+        return plaintext;
       }
       return null;
     } catch (error) {
@@ -5872,7 +5893,27 @@ export async function createFridayHub(
         return null;
       }
       const envelope = JSON.parse(entity.encryptedValue) as FridayEncryptedEnvelope;
-      return decryptSecret(envelope, getStrictMasterKey());
+      const { plaintext, rewrapped } = decryptSecretWithMigration(
+        envelope,
+        getStrictMasterKey(),
+        fridaySecretAadContext(entity),
+      );
+      if (rewrapped) {
+        // Read-repair (SEC-SECRET-AAD-001): persist v2 re-wrap; best-effort.
+        try {
+          stateRuntime.sqlite.withWriteTransaction((db) => {
+            channelSecretRepository.updateById(db, {
+              secretId: entity.id,
+              encryptedValue: JSON.stringify(rewrapped),
+              keyId: "master-v1",
+              nowIso: new Date().toISOString(),
+            });
+          });
+        } catch {
+          // Non-fatal: the read already succeeded.
+        }
+      }
+      return plaintext;
     } catch (err) {
       warnHubBootstrapOperationFailureOnce(err);
       return null;

--- a/src/observability/services/friday-observability-api-service.ts
+++ b/src/observability/services/friday-observability-api-service.ts
@@ -5,8 +5,10 @@ import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
 import {
   createFridaySecretRepository,
-  decryptSecret,
+  decryptSecretWithMigration,
   encryptSecret,
+  type FridayEncryptedEnvelope,
+  fridaySecretAadContext,
   getStrictMasterKey,
 } from "#providers";
 import type {
@@ -1069,14 +1071,35 @@ export function createFridayObservabilityApiService(
     if (!secret) {
       return null;
     }
-    const envelope = parseStoredJson<Parameters<typeof decryptSecret>[0] | null>(
+    const envelope = parseStoredJson<FridayEncryptedEnvelope | null>(
       secret.encryptedValue,
       null,
     );
     if (!envelope) {
       return null;
     }
-    return decryptSecret(envelope, getStrictMasterKey());
+    const { plaintext, rewrapped } = decryptSecretWithMigration(
+      envelope,
+      getStrictMasterKey(),
+      fridaySecretAadContext(secret),
+    );
+    if (rewrapped) {
+      // Read-repair (SEC-SECRET-AAD-001): persist the v2 re-wrap; best-effort.
+      try {
+        const now = deps.nowIso();
+        deps.db.withWriteTransaction((db) => {
+          secretRepo.updateById(db, {
+            secretId: secret.id,
+            encryptedValue: JSON.stringify(rewrapped),
+            keyId: "master-v1",
+            nowIso: now,
+          });
+        });
+      } catch {
+        // Non-fatal: the read already succeeded.
+      }
+    }
+    return plaintext;
   }
 
   function storeSecret(refKey: string, value: string): void {
@@ -1085,12 +1108,19 @@ export function createFridayObservabilityApiService(
       return;
     }
     const now = deps.nowIso();
+    const secretId = `${refKey}-secret`;
     deps.db.withWriteTransaction((db) => {
       secretRepo.upsert(db, {
-        id: `${refKey}-secret`,
+        id: secretId,
         scope: ALERT_DESTINATION_CREDENTIAL_SCOPE,
         refKey,
-        encryptedValue: JSON.stringify(encryptSecret(value, getStrictMasterKey())),
+        encryptedValue: JSON.stringify(
+          encryptSecret(
+            value,
+            getStrictMasterKey(),
+            fridaySecretAadContext({ scope: ALERT_DESTINATION_CREDENTIAL_SCOPE, id: secretId }),
+          ),
+        ),
         keyId: "master-v1",
         nowIso: now,
       });

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -74,7 +74,21 @@ export {
 } from "./cli/friday-provider-cli-backend.js";
 
 // Security
-export { encryptSecret, decryptSecret, getMasterKey, getProvisionedMasterKey, getStrictMasterKey, resetMasterKeyCache } from "./security/friday-secret-crypto.js";
+export {
+  encryptSecret,
+  decryptSecret,
+  decryptSecretWithMigration,
+  getMasterKey,
+  getProvisionedMasterKey,
+  getStrictMasterKey,
+  resetMasterKeyCache,
+  FRIDAY_SECRET_ENVELOPE_V2,
+  FRIDAY_SECRET_AAD_SCHEMA_VERSION,
+} from "./security/friday-secret-crypto.js";
+export type {
+  FridaySecretAadContext,
+  FridaySecretMigrationResult,
+} from "./security/friday-secret-crypto.js";
 export type {
   CreateFridayEphemeralSecretHandleRegistryDeps,
   FridayEphemeralSecretHandle,
@@ -88,7 +102,7 @@ export { createFridayProviderProfileRepository } from "./persistence/friday-prov
 export type { FridayAuthProfileRepository } from "./persistence/friday-auth-profile-repository.js";
 export { createFridayAuthProfileRepository } from "./persistence/friday-auth-profile-repository.js";
 export type { FridaySecretRepository, FridaySecretEntity } from "./persistence/friday-secret-repository.js";
-export { createFridaySecretRepository } from "./persistence/friday-secret-repository.js";
+export { createFridaySecretRepository, fridaySecretAadContext, FRIDAY_SECRETS_AAD_STORE } from "./persistence/friday-secret-repository.js";
 export type { FridayProviderUsageRepository } from "./persistence/friday-provider-usage-repository.js";
 export { createFridayProviderUsageRepository } from "./persistence/friday-provider-usage-repository.js";
 

--- a/src/providers/oauth/friday-oauth-credential-store.ts
+++ b/src/providers/oauth/friday-oauth-credential-store.ts
@@ -14,11 +14,41 @@ import type {
 import { FRIDAY_GLOBAL_OAUTH_OWNER_USER_ID } from "../model/friday-provider.types.js";
 
 import {
-  decryptSecret,
+  decryptSecretWithMigration,
   encryptSecret,
   getStrictMasterKey,
 } from "../security/friday-secret-crypto.js";
-import type { FridayEncryptedEnvelope } from "../security/friday-secret-crypto.js";
+import type {
+  FridayEncryptedEnvelope,
+  FridaySecretAadContext,
+} from "../security/friday-secret-crypto.js";
+
+/** Logical store namespace bound into every OAuth-credential AAD context. */
+const FRIDAY_OAUTH_AAD_STORE = "friday-oauth";
+
+/**
+ * Canonical AAD binding context for one encrypted OAuth token column.
+ *
+ * Binds the STABLE natural key of the row — `(owner_user_id, provider_profile_id,
+ * oauth_provider)` (the `ON CONFLICT` upsert key) — plus the token `field`, so a
+ * ciphertext cannot be transplanted across owners, provider profiles, oauth
+ * providers, or between the access/refresh columns. The natural key is stable
+ * across upsert-on-conflict, so writer and reader reconstruct identical AAD.
+ */
+function oauthCredentialAadContext(parts: {
+  readonly ownerUserId: string;
+  readonly providerProfileId: string;
+  readonly oauthProvider: string;
+  readonly field: "access" | "refresh";
+}): FridaySecretAadContext {
+  return {
+    store: FRIDAY_OAUTH_AAD_STORE,
+    owner: parts.ownerUserId,
+    scope: parts.providerProfileId,
+    tenant: parts.oauthProvider,
+    field: parts.field,
+  };
+}
 
 // ─── Store interface ───
 
@@ -57,10 +87,34 @@ function parseEnvelope(raw: string, field: string): FridayEncryptedEnvelope {
   }
 }
 
-function rowToCredential(row: FridayOAuthCredentialRow): FridayOAuthCredential {
+interface RowToCredentialResult {
+  credential: FridayOAuthCredential;
+  /**
+   * Present when either token column was a legacy v1 envelope and has been
+   * re-wrapped to v2. The caller persists these so no unbound envelope survives.
+   */
+  rewrap: { access: FridayEncryptedEnvelope; refresh: FridayEncryptedEnvelope } | null;
+}
+
+function rowToCredential(row: FridayOAuthCredentialRow): RowToCredentialResult {
   const masterKey = getStrictMasterKey();
   const accessEnvelope = parseEnvelope(row.access_token_encrypted, "access_token_encrypted");
   const refreshEnvelope = parseEnvelope(row.refresh_token_encrypted, "refresh_token_encrypted");
+  const commonParts = {
+    ownerUserId: row.owner_user_id,
+    providerProfileId: row.provider_profile_id,
+    oauthProvider: row.oauth_provider,
+  };
+  const accessResult = decryptSecretWithMigration(
+    accessEnvelope,
+    masterKey,
+    oauthCredentialAadContext({ ...commonParts, field: "access" }),
+  );
+  const refreshResult = decryptSecretWithMigration(
+    refreshEnvelope,
+    masterKey,
+    oauthCredentialAadContext({ ...commonParts, field: "refresh" }),
+  );
   let metadata: Record<string, unknown> = {};
   if (row.metadata_json) {
     try {
@@ -73,13 +127,13 @@ function rowToCredential(row: FridayOAuthCredentialRow): FridayOAuthCredential {
     }
   }
 
-  return {
+  const credential: FridayOAuthCredential = {
     id: row.id,
     providerProfileId: row.provider_profile_id,
     ownerUserId: row.owner_user_id,
     oauthProvider: row.oauth_provider as FridayOAuthProviderId,
-    accessToken: decryptSecret(accessEnvelope, masterKey),
-    refreshToken: decryptSecret(refreshEnvelope, masterKey),
+    accessToken: accessResult.plaintext,
+    refreshToken: refreshResult.plaintext,
     tokenType: row.token_type,
     scope: row.scope,
     expiresAt: row.expires_at,
@@ -87,6 +141,16 @@ function rowToCredential(row: FridayOAuthCredentialRow): FridayOAuthCredential {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+
+  const rewrap =
+    accessResult.rewrapped || refreshResult.rewrapped
+      ? {
+          access: accessResult.rewrapped ?? accessEnvelope,
+          refresh: refreshResult.rewrapped ?? refreshEnvelope,
+        }
+      : null;
+
+  return { credential, rewrap };
 }
 
 // ─── Factory ───
@@ -113,20 +177,57 @@ export function createFridayOAuthCredentialStore(
           .get(providerProfileId, ownerUserId, oauthProvider ?? null, oauthProvider ?? null) as FridayOAuthCredentialRow | undefined,
       );
       if (!row) return null;
-      return rowToCredential(row);
+      const { credential, rewrap } = rowToCredential(row);
+      if (rewrap) {
+        // Read-repair (SEC-SECRET-AAD-001): persist v2 re-wraps in place; the
+        // logical token is unchanged so updated_at is intentionally preserved.
+        try {
+          deps.db.withWriteTransaction((db) => {
+            db.prepare(
+              `UPDATE oauth_credentials
+                 SET access_token_encrypted = ?, refresh_token_encrypted = ?
+               WHERE id = ?`,
+            ).run(JSON.stringify(rewrap.access), JSON.stringify(rewrap.refresh), row.id);
+          });
+        } catch (err) {
+          console.warn(
+            "[friday][oauth-credential-store] AAD read-repair failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
+      return credential;
     },
 
     upsert(input) {
       const masterKey = getStrictMasterKey();
+      const ownerUserId = input.ownerUserId?.trim() || FRIDAY_GLOBAL_OAUTH_OWNER_USER_ID;
       const accessEncrypted = JSON.stringify(
-        encryptSecret(input.tokenSet.accessToken, masterKey),
+        encryptSecret(
+          input.tokenSet.accessToken,
+          masterKey,
+          oauthCredentialAadContext({
+            ownerUserId,
+            providerProfileId: input.providerProfileId,
+            oauthProvider: input.oauthProvider,
+            field: "access",
+          }),
+        ),
       );
       const refreshEncrypted = JSON.stringify(
-        encryptSecret(input.tokenSet.refreshToken, masterKey),
+        encryptSecret(
+          input.tokenSet.refreshToken,
+          masterKey,
+          oauthCredentialAadContext({
+            ownerUserId,
+            providerProfileId: input.providerProfileId,
+            oauthProvider: input.oauthProvider,
+            field: "refresh",
+          }),
+        ),
       );
       const now = deps.nowIso();
       const id = deps.idGenerator();
-      const ownerUserId = input.ownerUserId?.trim() || FRIDAY_GLOBAL_OAUTH_OWNER_USER_ID;
       const metadataJson = JSON.stringify(input.tokenSet.metadata ?? {});
 
       deps.db.withWriteTransaction((db) => {

--- a/src/providers/persistence/friday-secret-repository.ts
+++ b/src/providers/persistence/friday-secret-repository.ts
@@ -1,6 +1,28 @@
 import type Database from "better-sqlite3";
 
 import type { FridaySecretRow } from "../model/friday-provider.types.js";
+import type { FridaySecretAadContext } from "../security/friday-secret-crypto.js";
+
+// ─── AAD context binding (SEC-SECRET-AAD-001) ───
+
+/** Logical store namespace bound into every `secrets`-table AAD context. */
+export const FRIDAY_SECRETS_AAD_STORE = "friday-secrets"; // pragma: allowlist secret
+
+/**
+ * Canonical AAD binding context for a `secrets` table row.
+ *
+ * Binds the STABLE primary key (`id`) and `scope`. The `id` is durable across
+ * `ref_key` renames and (because every writer's `id` is either insert-only or a
+ * deterministic function of its ref) always equals the persisted row's `id`, so
+ * writer and reader reconstruct byte-identical AAD. A ciphertext moved to a
+ * different row (different `id`) therefore fails to decrypt (fail-closed).
+ */
+export function fridaySecretAadContext(entity: {
+  readonly scope: string;
+  readonly id: string;
+}): FridaySecretAadContext {
+  return { store: FRIDAY_SECRETS_AAD_STORE, scope: entity.scope, ref: entity.id };
+}
 
 // ─── Repository interface ───
 

--- a/src/providers/security/friday-secret-crypto.ts
+++ b/src/providers/security/friday-secret-crypto.ts
@@ -1,9 +1,16 @@
 export {
   decryptSecret,
+  decryptSecretWithMigration,
   encryptSecret,
   getMasterKey,
   getProvisionedMasterKey,
   getStrictMasterKey,
   resetMasterKeyCache,
+  FRIDAY_SECRET_ENVELOPE_V2,
+  FRIDAY_SECRET_AAD_SCHEMA_VERSION,
 } from "../../security/friday-secret-crypto.js";
-export type { FridayEncryptedEnvelope } from "../../security/friday-secret-crypto.js";
+export type {
+  FridayEncryptedEnvelope,
+  FridaySecretAadContext,
+  FridaySecretMigrationResult,
+} from "../../security/friday-secret-crypto.js";

--- a/src/providers/services/friday-provider-service.ts
+++ b/src/providers/services/friday-provider-service.ts
@@ -48,7 +48,7 @@ import { safeJsonParse } from "#utilities";
 import { createFridayPreferenceFactRepository } from "../../learning/persistence/friday-preference-fact-repository.js";
 import { createFridayAuthProfileRepository } from "../persistence/friday-auth-profile-repository.js";
 import { createFridayProviderProfileRepository } from "../persistence/friday-provider-profile-repository.js";
-import { createFridaySecretRepository } from "../persistence/friday-secret-repository.js";
+import { createFridaySecretRepository, fridaySecretAadContext } from "../persistence/friday-secret-repository.js";
 import { createFridayProviderUsageRepository } from "../persistence/friday-provider-usage-repository.js";
 import {
   assertAllowedCliBinaryPath,
@@ -56,7 +56,7 @@ import {
   runFridayCliBackendTextCompletion,
 } from "../cli/friday-provider-cli-backend.js";
 import {
-  decryptSecret,
+  decryptSecretWithMigration,
   encryptSecret,
   getStrictMasterKey,
 } from "../security/friday-secret-crypto.js";
@@ -543,11 +543,16 @@ export function createFridayProviderService(
       return keySource;
     }
     const refKey = secretRefKey(providerId);
+    const secretId = `secret:${refKey}`; // pragma: allowlist secret
     const masterKey = getStrictMasterKey();
-    const envelope = encryptSecret(apiKey, masterKey);
+    const envelope = encryptSecret(
+      apiKey,
+      masterKey,
+      fridaySecretAadContext({ scope: SECRET_SCOPE, id: secretId }),
+    );
     deps.db.withWriteTransaction((db) => {
       secretRepo.upsert(db, {
-        id: `secret:${refKey}`,
+        id: secretId,
         scope: SECRET_SCOPE,
         refKey,
         encryptedValue: JSON.stringify(envelope),
@@ -556,6 +561,29 @@ export function createFridayProviderService(
       });
     });
     return { kind: "secret-ref", refKey };
+  }
+
+  /**
+   * Read-repair (SEC-SECRET-AAD-001): persists a v2 re-wrap produced while
+   * reading a legacy v1 secret row so no unbound envelope survives at rest.
+   * Best-effort — a failed repair never blocks the read.
+   */
+  function rewrapPersistedSecret(secretId: string, rewrapped: FridayEncryptedEnvelope): void {
+    try {
+      deps.db.withWriteTransaction((db) => {
+        secretRepo.updateById(db, {
+          secretId,
+          encryptedValue: JSON.stringify(rewrapped),
+          keyId: "master-v1",
+          nowIso: deps.nowIso(),
+        });
+      });
+    } catch (err) {
+      console.warn(
+        "[friday][provider-service] secret AAD read-repair failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
   }
 
   async function resolveCredential(
@@ -619,7 +647,15 @@ export function createFridayProviderService(
         }
         const masterKey = getStrictMasterKey();
         const envelope = JSON.parse(secret.encryptedValue) as FridayEncryptedEnvelope;
-        return decryptSecret(envelope, masterKey);
+        const { plaintext, rewrapped } = decryptSecretWithMigration(
+          envelope,
+          masterKey,
+          fridaySecretAadContext(secret),
+        );
+        if (rewrapped) {
+          rewrapPersistedSecret(secret.id, rewrapped);
+        }
+        return plaintext;
       },
     });
 
@@ -2132,7 +2168,15 @@ export function createFridayProviderService(
         }
         const masterKey = getStrictMasterKey();
         const envelope = JSON.parse(secret.encryptedValue) as FridayEncryptedEnvelope;
-        return decryptSecret(envelope, masterKey);
+        const { plaintext, rewrapped } = decryptSecretWithMigration(
+          envelope,
+          masterKey,
+          fridaySecretAadContext(secret),
+        );
+        if (rewrapped) {
+          rewrapPersistedSecret(secret.id, rewrapped);
+        }
+        return plaintext;
       },
     });
     if (!resolved.ok) {

--- a/src/providers/services/friday-secret-admin-service.ts
+++ b/src/providers/services/friday-secret-admin-service.ts
@@ -2,7 +2,7 @@ import type { FridaySqliteLayer } from "#state";
 import { FridayDomainError } from "#errors";
 
 import type { FridaySecretEntity } from "../persistence/friday-secret-repository.js";
-import { createFridaySecretRepository } from "../persistence/friday-secret-repository.js";
+import { createFridaySecretRepository, fridaySecretAadContext } from "../persistence/friday-secret-repository.js";
 import { encryptSecret, getStrictMasterKey } from "../security/friday-secret-crypto.js";
 
 export interface FridaySecretSummary {
@@ -104,10 +104,15 @@ export function createFridaySecretAdminService(
         );
       }
 
-      const envelope = encryptSecret(input.value, getStrictMasterKey());
+      const secretId = deps.idGenerator();
+      const envelope = encryptSecret(
+        input.value,
+        getStrictMasterKey(),
+        fridaySecretAadContext({ scope: input.scope.trim(), id: secretId }),
+      );
       deps.db.withWriteTransaction((db) => {
         secretRepo.upsert(db, {
-          id: deps.idGenerator(),
+          id: secretId,
           scope: input.scope.trim(),
           refKey: input.refKey.trim(),
           encryptedValue: JSON.stringify(envelope),
@@ -157,7 +162,15 @@ export function createFridaySecretAdminService(
       let encryptedValue: string | undefined;
       if (input.value !== undefined) {
         assertNonEmptyString(input.value, "value");
-        encryptedValue = JSON.stringify(encryptSecret(input.value, getStrictMasterKey()));
+        // Bind the STABLE row id (not the possibly-renamed refKey) so a value
+        // update or a refKey rename never mismatches the reader's AAD.
+        encryptedValue = JSON.stringify(
+          encryptSecret(
+            input.value,
+            getStrictMasterKey(),
+            fridaySecretAadContext({ scope: existing.scope, id: secretId }),
+          ),
+        );
       }
 
       const updated = deps.db.withWriteTransaction((db) =>

--- a/src/security/friday-secret-crypto.ts
+++ b/src/security/friday-secret-crypto.ts
@@ -8,10 +8,65 @@ import { FridayDomainError } from "#errors";
 
 // ─── Encrypted envelope ───
 
+/**
+ * On-disk AES-256-GCM envelope.
+ *
+ * Version semantics ({@link FridayEncryptedEnvelope.v}):
+ *  - `undefined` (field absent) → **v1 legacy**: ciphertext produced WITHOUT
+ *    additional-authenticated-data (AAD) context binding. Decryptable for
+ *    backward compatibility ONLY; every v1 caller is unbound so a ciphertext is
+ *    transplantable across owner/scope/field rows. New writes are never v1.
+ *  - `2` → **v2 AAD-bound**: the GCM tag also authenticates a canonical binding
+ *    context ({@link FridaySecretAadContext}). Decryption requires the SAME
+ *    context or the GCM authentication fails closed (throws). This makes a
+ *    ciphertext transplanted across owner/provider/field rows undecryptable.
+ *
+ * Stripping `v` from a v2 envelope does NOT downgrade it: a v2 tag was computed
+ * over the AAD, so verifying it as v1 (no AAD) fails the GCM check. Likewise
+ * forging `v: 2` onto a v1 envelope fails the check. Both directions fail closed.
+ */
 export interface FridayEncryptedEnvelope {
   ciphertext: string;
   iv: string;
   tag: string;
+  /** Envelope schema version. Absent = v1 legacy (no AAD); 2 = AAD-bound. */
+  v?: number;
+}
+
+/**
+ * Canonical binding context authenticated as GCM AAD for v2 envelopes.
+ *
+ * Every field must be derivable from the STABLE identity of the row/entry the
+ * ciphertext belongs to (a primary key, a natural key, or a durable ref) so
+ * that the writer and every reader reconstruct byte-identical AAD. Binding a
+ * mutable column would brick the secret on rename; callers therefore bind
+ * durable identifiers.
+ */
+export interface FridaySecretAadContext {
+  /** Logical store namespace, e.g. `"friday-secrets"`, `"friday-oauth"`. Required, non-empty. */
+  readonly store: string;
+  /** Owner principal (e.g. owner user id) when the row is owner-scoped. */
+  readonly owner?: string;
+  /** Tenant / provider-profile discriminator when applicable. */
+  readonly tenant?: string;
+  /** Logical scope of the row (e.g. secret scope, provider-profile id). */
+  readonly scope?: string;
+  /** Durable per-row reference (primary key / natural key / vault ref). */
+  readonly ref?: string;
+  /** Sub-field discriminator when one row holds multiple secrets (e.g. access/refresh). */
+  readonly field?: string;
+}
+
+/** Result of {@link decryptSecretWithMigration}. */
+export interface FridaySecretMigrationResult {
+  /** Recovered plaintext. */
+  readonly plaintext: string;
+  /**
+   * A freshly AAD-bound (v2) envelope when the input was a legacy v1 envelope
+   * and a binding context was supplied, else `null`. Callers persist this to
+   * lazily migrate the row at rest (read-repair) so no v1 envelope survives.
+   */
+  readonly rewrapped: FridayEncryptedEnvelope | null;
 }
 
 // ─── Core encrypt / decrypt ───
@@ -20,10 +75,16 @@ const ALGORITHM = "aes-256-gcm";
 const IV_BYTES = 12;
 const KEY_BYTES = 32;
 
-export function encryptSecret(
-  plaintext: string,
-  masterKey: Buffer,
-): FridayEncryptedEnvelope {
+/** Envelope schema version for AAD-bound ciphertext. */
+export const FRIDAY_SECRET_ENVELOPE_V2 = 2;
+/**
+ * Schema version of the canonical AAD encoding. Bumping this deliberately
+ * invalidates every previously-written v2 tag (forces a re-wrap), so it is only
+ * changed when the binding-context semantics change.
+ */
+export const FRIDAY_SECRET_AAD_SCHEMA_VERSION = 1;
+
+function assertMasterKeyLength(masterKey: Buffer): void {
   if (masterKey.length !== KEY_BYTES) {
     throw new FridayDomainError(
       "VALIDATION_ERROR",
@@ -31,37 +92,115 @@ export function encryptSecret(
       { httpStatus: 400 },
     );
   }
+}
+
+/**
+ * Deterministically encodes a binding context into AAD bytes.
+ *
+ * Uses a fixed field order and JSON encoding of `[key, value|null]` tuples so
+ * the output is stable regardless of object key-insertion order and unambiguous
+ * regardless of value contents (JSON escaping prevents separator injection).
+ * A versioned magic prefix domain-separates this AAD from any other GCM usage.
+ */
+function canonicalizeAadContext(context: FridaySecretAadContext): Buffer {
+  if (typeof context.store !== "string" || context.store.trim() === "") {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "Secret binding context requires a non-empty 'store'",
+      { httpStatus: 400 },
+    );
+  }
+  const pairs: Array<[string, string | null]> = [
+    ["store", context.store],
+    ["owner", context.owner ?? null],
+    ["tenant", context.tenant ?? null],
+    ["scope", context.scope ?? null],
+    ["ref", context.ref ?? null],
+    ["field", context.field ?? null],
+  ];
+  const canonical =
+    `friday-secret-aad\u0000v${String(FRIDAY_SECRET_AAD_SCHEMA_VERSION)}\u0000` +
+    JSON.stringify(pairs);
+  return Buffer.from(canonical, "utf8");
+}
+
+/**
+ * Encrypts `plaintext` under AES-256-GCM.
+ *
+ * When `context` is supplied the result is an AAD-bound v2 envelope: the GCM tag
+ * authenticates the canonical binding context, so the ciphertext can only be
+ * decrypted with the identical context (fail-closed on transplant). When
+ * `context` is omitted a legacy v1 envelope is produced — retained ONLY for the
+ * primitive's own tests and the (documented) not-yet-migrated stores; every
+ * production secret writer supplies a context.
+ */
+export function encryptSecret(
+  plaintext: string,
+  masterKey: Buffer,
+  context?: FridaySecretAadContext,
+): FridayEncryptedEnvelope {
+  assertMasterKeyLength(masterKey);
   const iv = crypto.randomBytes(IV_BYTES);
   const cipher = crypto.createCipheriv(ALGORITHM, masterKey, iv);
+  if (context) {
+    cipher.setAAD(canonicalizeAadContext(context));
+  }
   const encrypted = Buffer.concat([
     cipher.update(plaintext, "utf8"),
     cipher.final(),
   ]);
   const tag = cipher.getAuthTag();
 
-  return {
+  const envelope: FridayEncryptedEnvelope = {
     ciphertext: encrypted.toString("base64"),
     iv: iv.toString("base64"),
     tag: tag.toString("base64"),
   };
+  if (context) {
+    envelope.v = FRIDAY_SECRET_ENVELOPE_V2;
+  }
+  return envelope;
 }
 
+/**
+ * Decrypts a {@link FridayEncryptedEnvelope}.
+ *
+ * For a v2 envelope a binding `context` is REQUIRED and is authenticated as GCM
+ * AAD: a missing or mismatched context fails closed (throws). For a v1 legacy
+ * envelope no AAD is applied and `context` is ignored (this path exists only to
+ * read secrets stored before AAD binding, during migration).
+ */
 export function decryptSecret(
   envelope: FridayEncryptedEnvelope,
   masterKey: Buffer,
+  context?: FridaySecretAadContext,
 ): string {
-  if (masterKey.length !== KEY_BYTES) {
-    throw new FridayDomainError(
-      "VALIDATION_ERROR",
-      `Master key must be ${KEY_BYTES} bytes, got ${String(masterKey.length)}`,
-      { httpStatus: 400 },
-    );
-  }
+  assertMasterKeyLength(masterKey);
   const iv = Buffer.from(envelope.iv, "base64");
   const tag = Buffer.from(envelope.tag, "base64");
   const ciphertext = Buffer.from(envelope.ciphertext, "base64");
 
   const decipher = crypto.createDecipheriv(ALGORITHM, masterKey, iv);
+
+  const version = envelope.v;
+  if (version === FRIDAY_SECRET_ENVELOPE_V2) {
+    if (!context) {
+      throw new FridayDomainError(
+        "VALIDATION_ERROR",
+        "AAD-bound (v2) secret envelope requires a binding context to decrypt",
+        { httpStatus: 400 },
+      );
+    }
+    decipher.setAAD(canonicalizeAadContext(context));
+  } else if (version !== undefined) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      `Unsupported secret envelope version ${String(version)}`,
+      { httpStatus: 400 },
+    );
+  }
+  // version === undefined → v1 legacy: no AAD (context, if any, is ignored).
+
   decipher.setAuthTag(tag);
 
   const decrypted = Buffer.concat([
@@ -70,6 +209,28 @@ export function decryptSecret(
   ]);
 
   return decrypted.toString("utf8");
+}
+
+/**
+ * Decrypts and, when the input was a legacy v1 envelope, produces a v2 re-wrap
+ * bound to `context` so the caller can migrate the row at rest (read-repair).
+ *
+ * A v2 input is decrypted (AAD-enforced) and returns `rewrapped: null`. A v1
+ * input is decrypted via the legacy path and re-encrypted under `context`; the
+ * caller persists `rewrapped` to guarantee no v1 envelope survives a read.
+ * Because the recovered plaintext round-trips through {@link encryptSecret},
+ * a re-wrap that could not itself be decrypted is impossible.
+ */
+export function decryptSecretWithMigration(
+  envelope: FridayEncryptedEnvelope,
+  masterKey: Buffer,
+  context: FridaySecretAadContext,
+): FridaySecretMigrationResult {
+  const plaintext = decryptSecret(envelope, masterKey, context);
+  if (envelope.v === undefined) {
+    return { plaintext, rewrapped: encryptSecret(plaintext, masterKey, context) };
+  }
+  return { plaintext, rewrapped: null };
 }
 
 // ─── Master key resolution ───

--- a/src/xhs/friday-xhs-session.ts
+++ b/src/xhs/friday-xhs-session.ts
@@ -2,9 +2,18 @@
 
 import type { FridaySqliteLayer } from "#state";
 import { safeJsonParse } from "#utilities";
-import { decryptSecret, encryptSecret, getStrictMasterKey } from "#providers";
-import type { FridayEncryptedEnvelope } from "#providers";
+import { decryptSecret, decryptSecretWithMigration, encryptSecret, getStrictMasterKey } from "#providers";
+import type { FridayEncryptedEnvelope, FridaySecretAadContext } from "#providers";
 import { xhsRandomUserAgent } from "./friday-xhs-stealth.js";
+
+/**
+ * Canonical AAD binding context for an xhs session's encrypted cookies.
+ * Binds the session's stable primary key (`id`), so a cookie blob cannot be
+ * transplanted to another session row.
+ */
+function xhsCookiesAadContext(sessionId: string): FridaySecretAadContext {
+  return { store: "friday-xhs", ref: sessionId, field: "cookies" };
+}
 
 // ─── Types ───
 
@@ -62,7 +71,9 @@ export function createXhsSessionManager(deps: CreateXhsSessionManagerDeps): XhsS
     const now = nowIso();
     const userAgent = xhsRandomUserAgent();
     const plaintext = JSON.stringify(cookies);
-    const encrypted = JSON.stringify(encryptSecret(plaintext, getStrictMasterKey()));
+    const encrypted = JSON.stringify(
+      encryptSecret(plaintext, getStrictMasterKey(), xhsCookiesAadContext(sessionId)),
+    );
 
     sqlite.withWriteTransaction((db) => {
       db.prepare(`
@@ -78,22 +89,39 @@ export function createXhsSessionManager(deps: CreateXhsSessionManagerDeps): XhsS
   }
 
   function loadCookies(sessionId: string): XhsCookie[] | undefined {
-    return sqlite.withReadConnection((db) => {
-      const row = db.prepare(`
+    const row = sqlite.withReadConnection((db) =>
+      db.prepare(`
         SELECT cookies_encrypted FROM xhs_sessions WHERE id = ?
-      `).get(sessionId) as { cookies_encrypted: string | null } | undefined;
+      `).get(sessionId) as { cookies_encrypted: string | null } | undefined,
+    );
 
-      if (!row?.cookies_encrypted) return undefined;
+    if (!row?.cookies_encrypted) return undefined;
 
-      try {
-        const envelope = safeJsonParse(row.cookies_encrypted) as FridayEncryptedEnvelope;
-        const plaintext = decryptSecret(envelope, getStrictMasterKey());
-        return safeJsonParse(plaintext) as XhsCookie[];
-      } catch (err) {
-        console.warn("[friday][xhs-session] cookie decryption failed:", err instanceof Error ? err.message : String(err));
-        return undefined;
+    try {
+      const envelope = safeJsonParse(row.cookies_encrypted) as FridayEncryptedEnvelope;
+      const { plaintext, rewrapped } = decryptSecretWithMigration(
+        envelope,
+        getStrictMasterKey(),
+        xhsCookiesAadContext(sessionId),
+      );
+      if (rewrapped) {
+        // Read-repair (SEC-SECRET-AAD-001): migrate legacy v1 cookies to v2.
+        try {
+          sqlite.withWriteTransaction((db) => {
+            db.prepare(`UPDATE xhs_sessions SET cookies_encrypted = ? WHERE id = ?`).run(
+              JSON.stringify(rewrapped),
+              sessionId,
+            );
+          });
+        } catch {
+          // Non-fatal: the read already succeeded.
+        }
       }
-    });
+      return safeJsonParse(plaintext) as XhsCookie[];
+    } catch (err) {
+      console.warn("[friday][xhs-session] cookie decryption failed:", err instanceof Error ? err.message : String(err));
+      return undefined;
+    }
   }
 
   function isSessionValid(sessionId: string): boolean {
@@ -112,7 +140,7 @@ export function createXhsSessionManager(deps: CreateXhsSessionManagerDeps): XhsS
       let cookies: XhsCookie[];
       try {
         const envelope = safeJsonParse(row.cookies_encrypted) as FridayEncryptedEnvelope;
-        const plaintext = decryptSecret(envelope, getStrictMasterKey());
+        const plaintext = decryptSecret(envelope, getStrictMasterKey(), xhsCookiesAadContext(sessionId));
         cookies = safeJsonParse(plaintext) as XhsCookie[];
       } catch (err) {
         console.warn("[friday][xhs-session] session validation cookie parse failed:", err instanceof Error ? err.message : String(err));

--- a/test/unit/security/friday-secret-aad-crypto.test.ts
+++ b/test/unit/security/friday-secret-aad-crypto.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import * as crypto from "node:crypto";
+
+import {
+  encryptSecret,
+  decryptSecret,
+  decryptSecretWithMigration,
+  FRIDAY_SECRET_ENVELOPE_V2,
+  type FridayEncryptedEnvelope,
+  type FridaySecretAadContext,
+} from "#providers";
+
+// SEC-SECRET-AAD-001 — versioned AAD context-binding on the crypto envelope.
+// All secret material below is SYNTHETIC.
+
+const KEY = crypto.randomBytes(32);
+const SYNTHETIC_SECRET = "synthetic-token-do-not-use-🔑-中文"; // pragma: allowlist secret — synthetic, not a real credential
+
+const ctxA: FridaySecretAadContext = {
+  store: "friday-secrets",
+  owner: "user-A",
+  scope: "provider",
+  ref: "secret:provider:openai:apiKey",
+  field: "apiKey",
+};
+// Different OWNER only.
+const ctxDifferentOwner: FridaySecretAadContext = { ...ctxA, owner: "user-B" };
+// Different REF (row) only.
+const ctxDifferentRef: FridaySecretAadContext = { ...ctxA, ref: "secret:provider:anthropic:apiKey" };
+// Different FIELD only.
+const ctxDifferentField: FridaySecretAadContext = { ...ctxA, field: "refreshToken" };
+// Different STORE only.
+const ctxDifferentStore: FridaySecretAadContext = { ...ctxA, store: "friday-oauth" };
+
+/**
+ * Reproduces the shape a v1 (pre-AAD) envelope would have on disk: raw
+ * AES-256-GCM with NO AAD and NO version field. This is exactly what the old
+ * `encryptSecret(plaintext, key)` produced.
+ */
+function makeLegacyV1Envelope(plaintext: string, key: Buffer): FridayEncryptedEnvelope {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const enc = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return { ciphertext: enc.toString("base64"), iv: iv.toString("base64"), tag: tag.toString("base64") };
+}
+
+describe("SEC-SECRET-AAD-001 versioned AAD envelope", () => {
+  describe("correct-context round-trip (positive)", () => {
+    it("encrypt+decrypt with the SAME context returns the plaintext", () => {
+      const env = encryptSecret(SYNTHETIC_SECRET, KEY, ctxA);
+      expect(env.v).toBe(FRIDAY_SECRET_ENVELOPE_V2);
+      expect(decryptSecret(env, KEY, ctxA)).toBe(SYNTHETIC_SECRET);
+    });
+
+    it("a fresh structurally-equal context object still decrypts (canonical, order-independent)", () => {
+      const env = encryptSecret(SYNTHETIC_SECRET, KEY, ctxA);
+      const reordered: FridaySecretAadContext = {
+        field: "apiKey",
+        ref: "secret:provider:openai:apiKey",
+        scope: "provider",
+        owner: "user-A",
+        store: "friday-secrets",
+      };
+      expect(decryptSecret(env, KEY, reordered)).toBe(SYNTHETIC_SECRET);
+    });
+  });
+
+  describe("transplant fails closed (the core guarantee)", () => {
+    it.each([
+      ["owner", ctxDifferentOwner],
+      ["ref (row)", ctxDifferentRef],
+      ["field", ctxDifferentField],
+      ["store", ctxDifferentStore],
+    ])("decrypting a ctxA ciphertext under a different %s THROWS and never returns plaintext", (_label, otherCtx) => {
+      const env = encryptSecret(SYNTHETIC_SECRET, KEY, ctxA);
+      let returned: string | undefined;
+      expect(() => {
+        returned = decryptSecret(env, KEY, otherCtx);
+      }).toThrow();
+      expect(returned).toBeUndefined();
+    });
+  });
+
+  describe("v2 fail-closed edge cases", () => {
+    it("decrypting a v2 envelope with NO context throws (never silently unbound)", () => {
+      const env = encryptSecret(SYNTHETIC_SECRET, KEY, ctxA);
+      expect(() => decryptSecret(env, KEY)).toThrow(/binding context/i);
+    });
+
+    it("stripping the version off a v2 envelope does not downgrade it (still fails closed)", () => {
+      const env = encryptSecret(SYNTHETIC_SECRET, KEY, ctxA);
+      const stripped: FridayEncryptedEnvelope = { ciphertext: env.ciphertext, iv: env.iv, tag: env.tag };
+      // Treated as v1 → decrypt without AAD → GCM tag (computed over AAD) mismatches.
+      expect(() => decryptSecret(stripped, KEY)).toThrow();
+    });
+
+    it("forging v:2 onto a legacy v1 envelope fails closed", () => {
+      const legacy = makeLegacyV1Envelope(SYNTHETIC_SECRET, KEY);
+      const forged: FridayEncryptedEnvelope = { ...legacy, v: FRIDAY_SECRET_ENVELOPE_V2 };
+      expect(() => decryptSecret(forged, KEY, ctxA)).toThrow();
+    });
+
+    it("rejects an unknown envelope version", () => {
+      const env = encryptSecret(SYNTHETIC_SECRET, KEY, ctxA);
+      expect(() => decryptSecret({ ...env, v: 99 }, KEY, ctxA)).toThrow(/version/i);
+    });
+  });
+
+  describe("no-degrade migration (v1 legacy survives, re-wraps to v2)", () => {
+    it("a legacy v1 envelope decrypts via decryptSecret with a context (context ignored for v1)", () => {
+      const legacy = makeLegacyV1Envelope(SYNTHETIC_SECRET, KEY);
+      expect(legacy.v).toBeUndefined();
+      expect(decryptSecret(legacy, KEY, ctxA)).toBe(SYNTHETIC_SECRET);
+    });
+
+    it("decryptSecretWithMigration re-wraps a v1 envelope to a v2 bound to the context", () => {
+      const legacy = makeLegacyV1Envelope(SYNTHETIC_SECRET, KEY);
+      const { plaintext, rewrapped } = decryptSecretWithMigration(legacy, KEY, ctxA);
+      expect(plaintext).toBe(SYNTHETIC_SECRET);
+      expect(rewrapped).not.toBeNull();
+      expect(rewrapped?.v).toBe(FRIDAY_SECRET_ENVELOPE_V2);
+      // Re-wrapped envelope decrypts under the SAME context …
+      expect(decryptSecret(rewrapped as FridayEncryptedEnvelope, KEY, ctxA)).toBe(SYNTHETIC_SECRET);
+      // … and fails closed under a transplanted context.
+      expect(() => decryptSecret(rewrapped as FridayEncryptedEnvelope, KEY, ctxDifferentRef)).toThrow();
+    });
+
+    it("decryptSecretWithMigration on an already-v2 envelope does not re-wrap", () => {
+      const env = encryptSecret(SYNTHETIC_SECRET, KEY, ctxA);
+      const { plaintext, rewrapped } = decryptSecretWithMigration(env, KEY, ctxA);
+      expect(plaintext).toBe(SYNTHETIC_SECRET);
+      expect(rewrapped).toBeNull();
+    });
+  });
+});

--- a/test/unit/security/friday-secret-aad-migration.test.ts
+++ b/test/unit/security/friday-secret-aad-migration.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridaySecretAdminService,
+  createFridayOAuthCredentialStore,
+  createFridaySecretRepository,
+  decryptSecret,
+  decryptSecretWithMigration,
+  encryptSecret,
+  fridaySecretAadContext,
+  resetMasterKeyCache,
+  FRIDAY_SECRET_ENVELOPE_V2,
+  type FridayEncryptedEnvelope,
+} from "#providers";
+import { createXhsSessionManager } from "#xhs";
+import type { XhsCookie } from "#xhs";
+import { createFridayMcpConfigStore } from "../../../src/agent/mcp/friday-mcp-config-store.js";
+import { createTestDb, createTestIdGenerator } from "../satellites/_helpers/create-test-db.helper.js";
+
+// SEC-SECRET-AAD-001 — NO-DEGRADE migration proofs, driving REAL consumers for
+// EACH at-rest secret class's on-disk shape. All secrets below are SYNTHETIC.
+//
+// A legacy v1 envelope is exactly what the old code produced: the current
+// primitive still emits v1 when called WITHOUT a binding context, so
+// `encryptSecret(pt, key)` reproduces the pre-AAD on-disk shape.
+
+const MASTER_KEY_HEX = "11".repeat(32);
+const KEY = Buffer.from(MASTER_KEY_HEX, "hex");
+const NOW = "2026-07-13T00:00:00.000Z";
+
+function makeLegacyV1(plaintext: string): FridayEncryptedEnvelope {
+  const env = encryptSecret(plaintext, KEY); // no context → legacy v1
+  expect(env.v).toBeUndefined();
+  return env;
+}
+
+describe("SEC-SECRET-AAD-001 per-class no-degrade migration proofs", () => {
+  let db: FridaySqliteLayer;
+  let idGen: () => string;
+  const previousMasterKey = process.env.FRIDAY_MASTER_KEY;
+
+  beforeEach(() => {
+    process.env.FRIDAY_MASTER_KEY = MASTER_KEY_HEX;
+    resetMasterKeyCache();
+    db = createTestDb();
+    idGen = createTestIdGenerator();
+  });
+
+  afterEach(() => {
+    db.close();
+    if (previousMasterKey === undefined) delete process.env.FRIDAY_MASTER_KEY;
+    else process.env.FRIDAY_MASTER_KEY = previousMasterKey;
+    resetMasterKeyCache();
+  });
+
+  // ─── Class A: `secrets` table (provider / secret-admin / observability / channel / webhook) ───
+  describe("Class A — secrets table", () => {
+    it("real secret-admin write produces a v2 (AAD-bound) envelope, transplant fails closed", () => {
+      const admin = createFridaySecretAdminService({ db, idGenerator: idGen, nowIso: () => NOW });
+      const created = admin.createSecret({ scope: "provider", refKey: "provider:openai:apiKey", value: "synthetic-A" });
+
+      const row = db.withReadConnection((conn) =>
+        conn.prepare("SELECT encrypted_value FROM secrets WHERE id = ?").get(created.id) as
+          | { encrypted_value: string }
+          | undefined,
+      );
+      const envelope = JSON.parse(row!.encrypted_value) as FridayEncryptedEnvelope;
+      expect(envelope.v).toBe(FRIDAY_SECRET_ENVELOPE_V2);
+
+      // Correct context round-trips …
+      expect(decryptSecret(envelope, KEY, fridaySecretAadContext({ scope: "provider", id: created.id }))).toBe("synthetic-A");
+      // … a different row id (transplant) fails closed.
+      expect(() =>
+        decryptSecret(envelope, KEY, fridaySecretAadContext({ scope: "provider", id: "secret:OTHER" })),
+      ).toThrow();
+    });
+
+    it("a legacy v1 secrets row survives and re-wraps to v2 on read (repository read-repair path)", () => {
+      const repo = createFridaySecretRepository();
+      const secretId = "secret:provider:legacy:apiKey"; // pragma: allowlist secret
+      // Seed exactly what OLD code stored: a v1 envelope JSON in encrypted_value.
+      db.withWriteTransaction((conn) =>
+        repo.upsert(conn, {
+          id: secretId,
+          scope: "provider",
+          refKey: "provider:legacy:apiKey",
+          encryptedValue: JSON.stringify(makeLegacyV1("synthetic-legacy-A")),
+          keyId: "master-v1",
+          nowIso: NOW,
+        }),
+      );
+
+      // Reader path (identical across every Class-A consumer): getByRef →
+      // decryptSecretWithMigration(fridaySecretAadContext(entity)) → updateById.
+      const entity = db.withReadConnection((conn) => repo.getByRef(conn, "provider", "provider:legacy:apiKey"));
+      expect(entity).not.toBeNull();
+      const { plaintext, rewrapped } = decryptSecretWithMigration(
+        JSON.parse(entity!.encryptedValue) as FridayEncryptedEnvelope,
+        KEY,
+        fridaySecretAadContext(entity!),
+      );
+      expect(plaintext).toBe("synthetic-legacy-A"); // survived (no brick)
+      expect(rewrapped?.v).toBe(FRIDAY_SECRET_ENVELOPE_V2);
+      db.withWriteTransaction((conn) =>
+        repo.updateById(conn, { secretId, encryptedValue: JSON.stringify(rewrapped), keyId: "master-v1", nowIso: NOW }),
+      );
+
+      // After migration the row at rest is v2 and still decrypts under context.
+      const after = db.withReadConnection((conn) => repo.getByRef(conn, "provider", "provider:legacy:apiKey"));
+      const afterEnv = JSON.parse(after!.encryptedValue) as FridayEncryptedEnvelope;
+      expect(afterEnv.v).toBe(FRIDAY_SECRET_ENVELOPE_V2);
+      expect(decryptSecret(afterEnv, KEY, fridaySecretAadContext(after!))).toBe("synthetic-legacy-A");
+    });
+  });
+
+  // ─── Class B: oauth_credentials table ───
+  describe("Class B — oauth credential store", () => {
+    function insertProvider(id: string): void {
+      db.withWriteTransaction((conn) => {
+        conn
+          .prepare(
+            `INSERT INTO provider_profiles (id, kind, display_name, endpoint_url, enabled, default_model, config_json, created_at, updated_at)
+             VALUES (?, 'anthropic', 'Test', 'https://api.anthropic.com', 1, 'claude-3', '{}', ?, ?)`,
+          )
+          .run(id, NOW, NOW);
+      });
+    }
+
+    it("legacy v1 access/refresh columns survive and re-wrap to v2 on getByProviderProfileId", () => {
+      insertProvider("prov-1");
+      const store = createFridayOAuthCredentialStore({ db, idGenerator: idGen, nowIso: () => NOW });
+      // Create the row via the real store (writes v2) …
+      store.upsert({
+        providerProfileId: "prov-1",
+        oauthProvider: "anthropic",
+        tokenSet: {
+          accessToken: "placeholder-at",
+          refreshToken: "placeholder-rt",
+          expiresAt: NOW,
+          tokenType: "Bearer",
+          scope: "user:inference",
+        },
+      });
+      // … then downgrade BOTH columns to legacy v1 envelopes of known tokens.
+      db.withWriteTransaction((conn) => {
+        conn
+          .prepare("UPDATE oauth_credentials SET access_token_encrypted = ?, refresh_token_encrypted = ? WHERE provider_profile_id = ?")
+          .run(JSON.stringify(makeLegacyV1("synthetic-access")), JSON.stringify(makeLegacyV1("synthetic-refresh")), "prov-1");
+      });
+
+      const cred = store.getByProviderProfileId("prov-1", "__global__", "anthropic");
+      expect(cred?.accessToken).toBe("synthetic-access"); // survived
+      expect(cred?.refreshToken).toBe("synthetic-refresh");
+
+      // Row at rest is now v2 on both columns.
+      const row = db.withReadConnection((conn) =>
+        conn.prepare("SELECT access_token_encrypted, refresh_token_encrypted FROM oauth_credentials WHERE provider_profile_id = ?").get("prov-1") as
+          | { access_token_encrypted: string; refresh_token_encrypted: string }
+          | undefined,
+      );
+      expect((JSON.parse(row!.access_token_encrypted) as FridayEncryptedEnvelope).v).toBe(FRIDAY_SECRET_ENVELOPE_V2);
+      expect((JSON.parse(row!.refresh_token_encrypted) as FridayEncryptedEnvelope).v).toBe(FRIDAY_SECRET_ENVELOPE_V2);
+    });
+  });
+
+  // ─── Class C: MCP secret vault (JSON file) ───
+  describe("Class C — mcp config vault", () => {
+    let stateDir: string;
+    beforeEach(() => {
+      stateDir = join(tmpdir(), `friday-aad-mcp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+      mkdirSync(stateDir, { recursive: true });
+    });
+    afterEach(() => rmSync(stateDir, { recursive: true, force: true }));
+
+    it("a legacy v1 vault entry survives load() and is re-wrapped to v2 in the vault file", () => {
+      const refKey = "abctelemetry0123456789abcdef0000";
+      // Seed the on-disk shape old code produced: v1 vault entry + config ref.
+      writeFileSync(
+        join(stateDir, "mcp-secrets.json"),
+        JSON.stringify({ version: 1, entries: { [refKey]: makeLegacyV1("synthetic-mcp-token") } }),
+        "utf8",
+      );
+      writeFileSync(
+        join(stateDir, "mcp-servers.json"),
+        JSON.stringify([{ id: "gh", transport: "stdio", command: "node", env: { TOKEN: `secret://${refKey}` } }]),
+        "utf8",
+      );
+
+      const store = createFridayMcpConfigStore(stateDir, { masterKey: KEY });
+      const configs = store.load();
+      expect(configs[0]?.env?.TOKEN).toBe("synthetic-mcp-token"); // survived
+
+      const vault = JSON.parse(readFileSync(join(stateDir, "mcp-secrets.json"), "utf8")) as {
+        entries: Record<string, FridayEncryptedEnvelope>;
+      };
+      expect(vault.entries[refKey]?.v).toBe(FRIDAY_SECRET_ENVELOPE_V2); // re-wrapped at rest
+    });
+  });
+
+  // ─── Class E: xhs_sessions table ───
+  describe("Class E — xhs session cookies", () => {
+    it("legacy v1 cookies survive loadCookies and re-wrap to v2 at rest", () => {
+      const mgr = createXhsSessionManager({ sqlite: db, nowIso: () => NOW });
+      const cookies = [{ name: "web_session", value: "syn", domain: ".xhs", path: "/" }] as unknown as XhsCookie[];
+      // Create the row via the real manager (writes v2), then downgrade the
+      // cookies column to a legacy v1 envelope of the known cookies JSON.
+      mgr.saveCookies("sess-1", "acct", cookies);
+      db.withWriteTransaction((conn) => {
+        conn.prepare("UPDATE xhs_sessions SET cookies_encrypted = ? WHERE id = ?").run(
+          JSON.stringify(makeLegacyV1(JSON.stringify(cookies))),
+          "sess-1",
+        );
+      });
+
+      const loaded = mgr.loadCookies("sess-1");
+      expect(loaded).toEqual(cookies); // survived
+
+      const row = db.withReadConnection((conn) =>
+        conn.prepare("SELECT cookies_encrypted FROM xhs_sessions WHERE id = ?").get("sess-1") as
+          | { cookies_encrypted: string }
+          | undefined,
+      );
+      expect((JSON.parse(row!.cookies_encrypted) as FridayEncryptedEnvelope).v).toBe(FRIDAY_SECRET_ENVELOPE_V2);
+    });
+  });
+});


### PR DESCRIPTION
## SEC-SECRET-AAD-001 — versioned AAD context-binding for the at-rest secret envelope

Binds every at-rest secret ciphertext to **its own stable row identity** via AES-256-GCM Additional Authenticated Data, so a ciphertext cannot be transplanted to a different owner / scope / field / store and decrypted. Part of the BYOK/provider credential closure. **No real key/secret value touched** — synthetic only. **No SQLite migration** (version lives in the envelope). Born-current on `origin/main` (`ce934625`).

### Design
- **Versioned envelope.** `encryptSecret(pt, key, context)` writes **v2** with `cipher.setAAD(canonicalizeAadContext(context))`; without a context it writes legacy **v1** (unchanged shape, used only by tests / the deferred Class-D write-only path). `decryptSecret` branches on `envelope.v`: **v2** requires AAD == `canonical(context)` (missing/wrong context → GCM auth failure → throws); **v1** decrypts context-independently (identical to the old behavior).
- **Canonical AAD is deterministic + injective:** fixed positional `[key, value|null]` array + `JSON.stringify` behind a versioned ``-separated magic prefix. Order-independent; distinct contexts → distinct bytes (JSON escaping defeats delimiter-injection / concatenation ambiguity).
- **Per-consumer context bound to STABLE identity** (rename / upsert-on-conflict cannot brick a read): secrets table → `{store:"friday-secrets", scope, ref: row PK id}` (secret-admin's arbitrary scopes are readable by provider/observability/hub because reader and writer both derive context from the row's own `scope`+`id`; `updateSecret` never mutates scope); oauth → `(owner_user_id, provider_profile_id, oauth_provider)` natural key + `access|refresh` field; mcp vault → `refKey`; xhs → session PK `id`.

### No-degrade (the binding red-line: no stored secret may become undecryptable)
- v1 decrypt is context-independent → **any envelope written by the old code still decrypts** under the new code (proven empirically: old `encryptSecret` @ main → new `decryptSecret` @ head → original plaintext).
- **Migration = lazy read-repair.** On read, a v1 envelope decrypts and is re-wrapped to v2 (`decryptSecretWithMigration`); each reader persists the re-wrap best-effort (provider/oauth/observability/mcp/xhs/setup/api-runtime/hub). New writes are always v2 → no new v1 written for migrated classes; existing rows re-wrap on first read. A never-read v1 row stays v1 indefinitely but still decrypts (no brick) — inherent to lazy migration, not a degrade.
- No fail-open: transplant / missing-context / stripped-`v` / forged-`v:2`-on-v1 / unknown-version all **throw**; consumer catch-paths return `null`/opaque-ref, **never plaintext**.

### §5 red-first evidence
Neutralizing the AAD binding (context-independent constant) turns the transplant, injectivity, and row-move assertions **RED** (transplant returns plaintext) → restored → green. Per-class no-degrade migration proof drives the REAL consumers (secret-admin/secret-repo, oauth store, mcp `load()`, xhs `loadCookies`): a legacy v1 envelope survives + re-wraps to v2, plaintext recovered byte-for-byte.

### Gates (at born-current head)
tsc 0 · eslint 0 errors (0 net-new; 243 pre-existing warnings in unchanged blocks) · detect-secrets exit 0, baseline **not loosened** (only a mechanical `line_number` refresh + 6 synthetic FPs handled with narrow inline pragmas; filters/exclusions/secret-set byte-identical) · **no SQLite migration** (`migrations/` + `context/MEMORY.md` untouched) · 2 new security suites + no-regression over security/providers/oauth/mcp/xhs/observability green (independent reviewer: 1161 tests). Product stays **NO_GO**; closes no END-BAR requirement (live BYOK proof remains operator-gated).

### Governance
Independently reviewed at the pre-born-current SHA `356c07a6` (PASS on all of: diff scope, no-degrade empirical, fail-closed, AAD injectivity, stable-identity per class + cross-consumer, Class-D safety, red-first, gates). Brought born-current onto `ce934625` by a clean merge that left the 17 reviewed files **byte-identical**; a fresh confirm-review re-verifies at this exact head SHA.
