### PR TITLE
BYOK Lane G: agent-runtime provider request-id + receipt coverage (every turn yields a receipt)

### DIFF
--- a/src/agent/runtime/friday-agent-llm-client.ts
+++ b/src/agent/runtime/friday-agent-llm-client.ts
@@ -12,7 +12,7 @@ import type {
   FridayProviderAuthMode,
   FridayProviderBackendKind,
 } from "#providers";
-import { createFridayProviderPromptCacheAdapter } from "#providers";
+import { createFridayProviderPromptCacheAdapter, extractProviderRequestId } from "#providers";
 
 import { validateGatewayUrl } from "../tools/friday-agent-gateway-validation.js";
 import { FRIDAY_AGENT_ERROR_CODES } from "../friday-agent.constants.js";
@@ -190,6 +190,26 @@ export function createFridayAgentLlmClient(
   };
 }
 
+/**
+ * Attaches the provider's request-id to the terminal `message_end` event of a
+ * streamed turn so downstream usage recording can bind an idempotent, verifiable
+ * receipt to the call. Purely additive: non-`message_end` events pass through
+ * untouched, and a null request-id leaves `message_end` exactly as before (no
+ * receipt — the prior behavior for calls that surface no request identifier).
+ */
+async function* attachRequestIdToMessageEnd(
+  events: AsyncIterable<FridayAgentLlmStreamEvent>,
+  requestId: string | null,
+): AsyncIterable<FridayAgentLlmStreamEvent> {
+  for await (const event of events) {
+    if (event.type === "message_end" && requestId) {
+      yield { ...event, requestId };
+    } else {
+      yield event;
+    }
+  }
+}
+
 // ─── Anthropic handler ───
 
 async function* handleAnthropicStream(
@@ -271,7 +291,11 @@ async function* handleAnthropicStream(
     );
   }
 
-  yield* parseAnthropicSSEStream(response.body);
+  // Capture the provider's own request-id from the completed response's
+  // transport headers (`request-id` / `x-request-id`) and bind it to the turn's
+  // message_end so the usage record is idempotent + receipt-backed.
+  const requestId = extractProviderRequestId("anthropic-messages", response.headers, {});
+  yield* attachRequestIdToMessageEnd(parseAnthropicSSEStream(response.body), requestId);
 }
 
 // ─── Ollama handler (non-streaming, tool support via function calling) ───
@@ -503,11 +527,13 @@ async function* handleOpenAIStream(
     );
   }
 
-  if (api === "openai-responses" || api === "openai-codex-responses") {
-    yield* parseOpenAIResponsesSSEStream(response.body);
-  } else {
-    yield* parseOpenAISSEStream(response.body);
-  }
+  // Capture the provider's own request-id (`x-request-id` header) and bind it to
+  // the turn's message_end so the usage record is idempotent + receipt-backed.
+  const requestId = extractProviderRequestId(api, response.headers, {});
+  const parsed = api === "openai-responses" || api === "openai-codex-responses"
+    ? parseOpenAIResponsesSSEStream(response.body)
+    : parseOpenAISSEStream(response.body);
+  yield* attachRequestIdToMessageEnd(parsed, requestId);
 }
 
 function shouldIncludeOpenAiStreamUsage(_baseUrl: string): boolean {

--- a/src/agent/runtime/friday-agent-llm-client.types.ts
+++ b/src/agent/runtime/friday-agent-llm-client.types.ts
@@ -47,6 +47,14 @@ export interface FridayAgentLlmMessageEndEvent {
   backendKind?: FridayProviderBackendKind;
   /** Estimated cost in USD for this turn. */
   costUsd?: number;
+  /**
+   * The provider's own request identifier for the completed turn (x-request-id /
+   * request-id header, or the response body id). Surfaced so the agent-runtime
+   * usage record is idempotent on it and carries a tamper-detectable receipt.
+   * Null/absent for providers that surface none (e.g. local Ollama) or backends
+   * with no HTTP response (CLI) — those record without a receipt, as before.
+   */
+  requestId?: string | null;
   /** Ordered failed attempts before the successful route, if any. */
   attempts?: FridayProviderAttempt[];
   routingDecisionReason?: string;

--- a/src/agent/runtime/friday-agent-runtime.ts
+++ b/src/agent/runtime/friday-agent-runtime.ts
@@ -2407,6 +2407,10 @@ export function createFridayAgentRuntime(
                 costUsd: turnMeta.costUsd,
                 cacheReadInputTokens: turnMeta.cacheReadInputTokens,
                 cacheCreationInputTokens: turnMeta.cacheCreationInputTokens,
+                // Bind the provider's request-id when the turn surfaced one so the
+                // usage write is idempotent + receipt-backed. Omitted entirely when
+                // absent, preserving the prior (request-id-less) call shape.
+                ...(turnMeta.requestId ? { requestId: turnMeta.requestId } : {}),
               });
             } catch (err) {
               // Non-fatal: usage persistence should not break run execution.
@@ -7138,6 +7142,7 @@ interface TurnMeta {
   actualProviderApi?: string;
   backendKind?: FridayProviderBackendKind;
   costUsd?: number;
+  requestId?: string | null;
   attempts?: FridayProviderAttempt[];
   routingDecisionReason?: string;
   learningAdjusted?: boolean;
@@ -7212,6 +7217,7 @@ async function streamLlmResponse(
             actualProviderApi: event.actualProviderApi,
             backendKind: event.backendKind,
             costUsd: event.costUsd,
+            requestId: event.requestId,
             attempts: event.attempts,
             routingDecisionReason: event.routingDecisionReason,
             learningAdjusted: event.learningAdjusted,

--- a/src/agent/runtime/friday-agent-runtime.types.ts
+++ b/src/agent/runtime/friday-agent-runtime.types.ts
@@ -295,6 +295,13 @@ export interface FridayAgentUsageTurn {
   inputTokens: number;
   outputTokens: number;
   costUsd?: number;
+  /**
+   * The provider's own request identifier for this turn, when the completed
+   * provider response surfaced one. Threaded into recordUsage so the write is
+   * idempotent on it and binds a durable receipt. Absent/null when no request-id
+   * was surfaced — recorded without a receipt, as before (back-compat).
+   */
+  requestId?: string | null;
   /** Anthropic prompt cache: tokens read from cache. */
   cacheReadInputTokens?: number;
   /** Anthropic prompt cache: tokens written to cache. */

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -5439,6 +5439,10 @@ export async function createFridayHub(
           total: usage.inputTokens + usage.outputTokens,
         },
         costUsd: usage.costUsd ?? 0,
+        // Provider request-id (when the turn surfaced one): makes the write
+        // idempotent on it (no double-count on retry/replay) and binds a durable
+        // receipt to the agent turn. Null/absent ⇒ recorded without a receipt.
+        requestId: usage.requestId,
         metadata: { source: "agent-runtime" },
       });
 	    },
@@ -5718,6 +5722,10 @@ export async function createFridayHub(
               total: usage.inputTokens + usage.outputTokens,
             },
             costUsd: usage.costUsd ?? 0,
+            // Provider request-id (when the turn surfaced one): makes the write
+            // idempotent on it (no double-count on retry/replay) and binds a
+            // durable receipt to the child agent turn. Null/absent ⇒ no receipt.
+            requestId: usage.requestId,
             metadata: { source: "agent-runtime" },
           });
         },

--- a/test/unit/agent/runtime/friday-agent-runtime-usage-receipt.test.ts
+++ b/test/unit/agent/runtime/friday-agent-runtime-usage-receipt.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridayAgentRuntime,
+  createFridayAgentEventEmitter,
+} from "#agent";
+import type {
+  CreateFridayAgentRuntimeDeps,
+  FridayAgentLlmClient,
+  FridayAgentLlmStreamEvent,
+} from "#agent";
+import {
+  createFridayProviderService,
+  resetMasterKeyCache,
+} from "#providers";
+import type { FridayProviderService, FridayProviderApi } from "#providers";
+import { createTestDb, createTestIdGenerator } from "../../satellites/_helpers/create-test-db.helper.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BYOK-PROVIDER-COST-RECEIPT — agent-runtime request-id + receipt coverage.
+//
+// The generator inference-client path already binds a provider request-id +
+// receipt to its usage writes. Agent turns did NOT: both usageRecorder callbacks
+// in the hub called recordUsage() with no request-id, so every agent turn was
+// persisted with a NULL request_id and no receipt (non-idempotent, unverifiable).
+//
+// These tests drive the REAL agent-runtime usage-emission path — streamLlmResponse
+// consumes a SIMULATED provider response (a fake llmClient whose message_end
+// carries a synthetic request-id, exactly as the real HTTP client now surfaces it
+// from the response's request-id header) → turnMeta → the runtime's usageRecorder
+// → the REAL provider service.recordUsage → REAL sqlite (v102 migration applied).
+// The receipt is then read back through the REAL service.getCallReceipt. No mock
+// stands in for the recording/receipt mechanism. The only simulated part is the
+// upstream provider HTTP response, which must never be a real provider call.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Agent-runtime usage: provider request-id + receipt coverage", () => {
+  const NOW = "2026-02-20T10:00:00.000Z";
+  const TEST_MASTER_KEY = Buffer.alloc(32, 17).toString("hex");
+
+  let db: FridaySqliteLayer;
+  let service: FridayProviderService;
+  let idGenerator: () => string;
+  let originalMasterKey: string | undefined;
+
+  beforeEach(() => {
+    db = createTestDb();
+    idGenerator = createTestIdGenerator();
+    originalMasterKey = process.env.FRIDAY_MASTER_KEY;
+    process.env.FRIDAY_MASTER_KEY = TEST_MASTER_KEY;
+    resetMasterKeyCache();
+    service = createFridayProviderService({ db, idGenerator, nowIso: () => NOW });
+  });
+
+  afterEach(() => {
+    db.close();
+    if (originalMasterKey === undefined) delete process.env.FRIDAY_MASTER_KEY;
+    else process.env.FRIDAY_MASTER_KEY = originalMasterKey;
+    resetMasterKeyCache();
+    vi.restoreAllMocks();
+  });
+
+  async function createProvider(): Promise<string> {
+    const profile = await service.createProvider({
+      kind: "openai",
+      name: "OpenAI",
+      baseUrl: "https://api.openai.com",
+      authMode: "api-key",
+      api: "openai-completions",
+      apiKey: "test-agent-receipt-key", // pragma: allowlist secret
+      supportedModels: ["gpt-4o"],
+      defaultModel: "gpt-4o",
+      validateOnSave: false,
+    });
+    return profile.id;
+  }
+
+  // A usageRecorder that mirrors the hub bootstrap callbacks 1:1 (source
+  // "agent-runtime", request-id threaded through). This is the exact seam the
+  // production hub wires between the agent runtime and the provider service.
+  function makeUsageRecorder(
+    providerApi: FridayProviderApi,
+  ): NonNullable<CreateFridayAgentRuntimeDeps["usageRecorder"]> {
+    return async (usage) => {
+      await service.recordUsage({
+        providerId: usage.providerId,
+        providerApi: (usage.providerApi as FridayProviderApi) ?? providerApi,
+        model: usage.model,
+        routeStrategy: "configured",
+        taskComplexity: "medium",
+        usage: {
+          input: usage.inputTokens,
+          output: usage.outputTokens,
+          cacheRead: usage.cacheReadInputTokens ?? 0,
+          cacheWrite: usage.cacheCreationInputTokens ?? 0,
+          total: usage.inputTokens + usage.outputTokens,
+        },
+        costUsd: usage.costUsd ?? 0,
+        requestId: usage.requestId,
+        metadata: { source: "agent-runtime" },
+      });
+    };
+  }
+
+  function mockLlmClient(events: FridayAgentLlmStreamEvent[]): FridayAgentLlmClient {
+    return {
+      async *stream() {
+        for (const event of events) yield event;
+      },
+    };
+  }
+
+  function runtimeFor(
+    providerId: string,
+    events: FridayAgentLlmStreamEvent[],
+  ) {
+    return createFridayAgentRuntime({
+      allowTestOnlyAgentRunExecution: true,
+      db,
+      llmClient: mockLlmClient(events),
+      model: "gpt-4o",
+      providerId,
+      systemPrompt: "You are a test agent.",
+      tools: [],
+      eventEmitter: createFridayAgentEventEmitter(),
+      idGenerator,
+      nowIso: () => NOW,
+      usageRecorder: makeUsageRecorder("openai-completions"),
+    });
+  }
+
+  function countRows(requestId: string): number {
+    return db.withReadConnection((conn) =>
+      (conn.prepare(
+        "SELECT COUNT(*) AS n FROM llm_usage_records WHERE request_id = ?",
+      ).get(requestId) as { n: number }).n,
+    );
+  }
+
+  it("binds the provider request-id + a valid receipt to an agent turn", async () => {
+    const providerId = await createProvider();
+    const requestId = "chatcmpl-AGENT-RECEIPT-001";
+
+    const runtime = runtimeFor(providerId, [
+      { type: "text_delta", text: "done" },
+      {
+        type: "message_end",
+        stopReason: "end_turn",
+        inputTokens: 1000,
+        outputTokens: 500,
+        actualProviderId: providerId,
+        actualModel: "gpt-4o",
+        actualProviderApi: "openai-completions",
+        costUsd: 0.05,
+        requestId,
+      },
+    ]);
+
+    const result = await runtime.executeRun({ task: "agent receipt turn" });
+    expect(result.status).toBe("completed");
+
+    // Row persisted keyed by the provider's own request-id (was NULL pre-lane).
+    expect(countRows(requestId)).toBe(1);
+
+    // Receipt reads back through the REAL service and verifies (tamper-free).
+    const lookup = await service.getCallReceipt(requestId);
+    expect(lookup).not.toBeNull();
+    expect(lookup?.receiptValid).toBe(true);
+    expect(lookup?.receipt.requestId).toBe(requestId);
+    expect(lookup?.receipt.providerKind).toBe("openai");
+    expect(lookup?.receipt.model).toBe("gpt-4o");
+    expect(lookup?.receipt.inputTokens).toBe(1000);
+    expect(lookup?.receipt.outputTokens).toBe(500);
+    expect(lookup?.receipt.costUsd).toBeCloseTo(0.05, 6);
+  });
+
+  it("is idempotent on the request-id — the same agent turn twice is ONE row / ONE charge", async () => {
+    const providerId = await createProvider();
+    const requestId = "chatcmpl-AGENT-RECEIPT-DUP";
+
+    const events: FridayAgentLlmStreamEvent[] = [
+      { type: "text_delta", text: "done" },
+      {
+        type: "message_end",
+        stopReason: "end_turn",
+        inputTokens: 200,
+        outputTokens: 80,
+        actualProviderId: providerId,
+        actualModel: "gpt-4o",
+        actualProviderApi: "openai-completions",
+        costUsd: 0.01,
+        requestId,
+      },
+    ];
+
+    // Two independent runs surface the SAME provider request-id (retry / replay).
+    await runtimeFor(providerId, events).executeRun({ task: "turn A" });
+    await runtimeFor(providerId, events).executeRun({ task: "turn B" });
+
+    expect(countRows(requestId)).toBe(1);
+    const totalCost = db.withReadConnection((conn) =>
+      (conn.prepare(
+        "SELECT COALESCE(SUM(cost_usd), 0) AS s FROM llm_usage_records WHERE request_id = ?",
+      ).get(requestId) as { s: number }).s,
+    );
+    expect(totalCost).toBeCloseTo(0.01, 6);
+  });
+
+  it("no-degrade: a turn with no request-id still records (NULL, no receipt) without crashing", async () => {
+    const providerId = await createProvider();
+
+    const runtime = runtimeFor(providerId, [
+      { type: "text_delta", text: "done" },
+      {
+        type: "message_end",
+        stopReason: "end_turn",
+        inputTokens: 10,
+        outputTokens: 4,
+        actualProviderId: providerId,
+        actualModel: "gpt-4o",
+        actualProviderApi: "openai-completions",
+        costUsd: 0.0001,
+        // no requestId — the pre-lane / no-request-id-provider shape.
+      },
+    ]);
+
+    const result = await runtime.executeRun({ task: "turn without request-id" });
+    expect(result.status).toBe("completed");
+
+    // The row is still written, with a NULL request_id and no receipt.
+    const nullRows = db.withReadConnection((conn) =>
+      (conn.prepare(
+        "SELECT COUNT(*) AS n FROM llm_usage_records WHERE provider_id = ? AND request_id IS NULL AND receipt IS NULL",
+      ).get(providerId) as { n: number }).n,
+    );
+    expect(nullRows).toBe(1);
+  });
+});


### PR DESCRIPTION
## Agent-runtime provider request-id + receipt coverage — every turn yields a receipt

Part of the BYOK/provider closure (the last agent-doable item). Closes the coverage gap E left honest: E wired per-call request-id + tamper-evident receipt into the **generator inference-client** path, but the **agent-runtime** `usageRecorder` callbacks recorded with NULL request-id (their interface had no request-id field), so a live BYOK **agent turn** produced no receipt. This lane threads request-id from the provider response through the agent-runtime turn into `recordUsage`, so **any turn — including the eventual live-proof turn — yields a real request-id-bound, tamper-evident receipt.** No real key, no real provider call (simulated response only). Born-current on `origin/main` (`6e499a4c`).

### Scout correction (surfaced by implementer)
The provider response object is **NOT** reachable at `friday-agent-runtime.ts` (it only sees `turnMeta` built from `message_end` stream events). The real request-id extraction point is the **inner LLM client** (`friday-agent-llm-client.ts`), where `response.headers` is live. Surfacing it via the existing `message_end` event is **additive plumbing, not a refactor**.

### What this threads (5 production files, +62 lines)
- `friday-agent-llm-client.types.ts` — optional `requestId` on `FridayAgentLlmMessageEndEvent`.
- `friday-agent-llm-client.ts` — imports `extractProviderRequestId`; new `attachRequestIdToMessageEnd` helper; Anthropic + OpenAI (all 3 variants) handlers extract request-id from `response.headers` and bind it to `message_end`. Ollama/CLI surface none → unchanged.
- `friday-agent-runtime.ts` — `TurnMeta` gains `requestId`, populated from `event.requestId`, threaded into `usageRecorder` via **conditional spread** (`...(turnMeta.requestId ? {requestId} : {})`).
- `friday-agent-runtime.types.ts` — `FridayAgentUsageTurn` gains optional `requestId`.
- `friday-hub-bootstrap.ts` — both usageRecorder callbacks (main @5427, child @5706) pass `requestId: usage.requestId` into `recordUsage`.

### §5 red-first evidence
New negtest `test/unit/agent/runtime/friday-agent-runtime-usage-receipt.test.ts` drives the **real** runtime → `recordUsage` → sqlite (v102) → `getCallReceipt` path with a **simulated** provider response (synthetic request-id via a fake llmClient; no real key, no real call). Asserts: (a) an agent turn now yields a row bound to the request-id with a **valid receipt**; (b) same request-id twice = **one row / one charge** (idempotent); (c) a no-request-id turn still records NULL/no-receipt without crashing. **Severing the runtime threading flips (a) and (b) RED** (`expected +0 to be 1` — request_id NULL) while (c) stays green — the threading is load-bearing. Restored → green.

### No-degrade
`requestId` is optional/nullable everywhere; when a turn surfaces none, the conditional spread omits the key entirely, so the pre-lane call shape is byte-for-byte preserved and the record lands NULL/no-receipt exactly as before. The existing exact-match test "records usage metadata when LLM reports actual provider fields" stays green. **No migration** (v102 columns already exist).

### Gates
tsc **0 errors** · eslint (changed files) **0 errors** (90 pre-existing warnings in the >7000-line files, unrelated) · detect-secrets-hook exit 0, `.secrets.baseline` **unchanged** (not loosened) · 3 new tests green · no-regression **985 tests / 68 files** across `test/unit/agent/runtime/` + `test/unit/providers/` (incl. receipt/idempotency + inference-client-receipt suites) · born-current. Product stays **NO_GO**.
