### PR TITLE
SEC-SETUP-BOOTSTRAP-001 Slice 4: install-nonce reaper + crash-recovery hardening

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -196,7 +196,7 @@
         "filename": "src/api/http/routes/friday-auth-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 158
+        "line_number": 164
       }
     ],
     "src/api/http/routes/friday-provider-routes.ts": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-14T01:08:31Z"
+  "generated_at": "2026-07-14T03:04:37Z"
 }

--- a/src/api/http/routes/friday-auth-routes.ts
+++ b/src/api/http/routes/friday-auth-routes.ts
@@ -77,10 +77,16 @@ export function createFridayAuthRoutes(
       operationId: "auth.bootstrap.challenge",
       method: "POST",
       path: "/v1/auth/bootstrap/challenge",
-      // SEC-SETUP-BOOTSTRAP-001: first-boot device-claim leg. Mints a single-use
-      // install nonce. Loopback-only + first-boot gates are enforced in
-      // authService.issueBootstrapChallenge before any side effect (same posture
-      // as auth.bootstrap.local.passphrase). Only the nonce HASH is persisted.
+      // SEC-SETUP-BOOTSTRAP-001: device-claim challenge leg. Mints a single-use
+      // install nonce. authService.issueBootstrapChallenge enforces ONLY (a)
+      // loopback-only ingress and (b) required-field presence (installId/osUser/
+      // origin) before any side effect — it does NOT gate on first-boot/ownership
+      // (unlike auth.bootstrap.local.passphrase, which checks the owner slot).
+      // Minting a challenge post-ownership is harmless: the ownership gate is the
+      // owner CAS enforced downstream at auth.bootstrap.device-claim, which fails
+      // closed (409) if already claimed. Only the nonce HASH is persisted; the
+      // raw nonce is returned once. Expired/unconsumed nonces are reaped by the
+      // retention sweep (bounded), so this route cannot grow the ledger unbounded.
       auth: { public: true, allowUnauthenticatedMutation: true },
       rateLimitPolicyId: "auth.login",
       async handler(ctx): Promise<FridayAuthBootstrapChallengeResponse> {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -192,6 +192,13 @@ export type { FridaySubagentRoutesDeps } from "./http/routes/friday-subagent-rou
 export { createFridayRealtimeEventRepository } from "./persistence/friday-realtime-event-repository.js";
 export type { FridayRealtimeEventRepository } from "./persistence/friday-realtime-event-repository.js";
 export { createFridayRealtimeCheckpointRepository } from "./persistence/friday-realtime-checkpoint-repository.js";
+export { createFridaySetupBootstrapNonceRepository } from "./persistence/friday-setup-bootstrap-nonce-repository.js";
+export type {
+  FridaySetupBootstrapNonceRepository,
+  FridaySetupBootstrapNonceRow,
+  SweepFridaySetupBootstrapNoncesInput,
+  SweepFridaySetupBootstrapNoncesResult,
+} from "./persistence/friday-setup-bootstrap-nonce-repository.js";
 
 // Multi-tenant security routes (B-002)
 export { createFridayMultiTenantSecurityRoutes } from "./http/routes/friday-multi-tenant-security-routes.js";

--- a/src/api/persistence/friday-setup-bootstrap-nonce-repository.ts
+++ b/src/api/persistence/friday-setup-bootstrap-nonce-repository.ts
@@ -52,12 +52,62 @@ export interface ConsumeFridaySetupBootstrapNonceInput {
   claimedUserId: string;
 }
 
+// ─── Sweep (reaper / TTL) inputs ───
+
+export interface SweepFridaySetupBootstrapNoncesInput {
+  /**
+   * Wall-clock ISO (Z, lexicographically comparable to `expires_at`). Rows that
+   * are UNCONSUMED and whose `expires_at <= nowIso` are permanently unusable —
+   * the consume CAS requires `expires_at > now` — so they are dead weight and
+   * are reaped. This bounds the local table growth a loopback caller could cause
+   * by minting unbounded challenge nonces (OBS-2).
+   */
+  nowIso: string;
+  /**
+   * ISO cutoff (Z) for CONSUMED rows: a consumed nonce whose `consumed_at` is
+   * strictly older than this is past its retention horizon and is reaped. The
+   * authoritative owner<->device binding lives durably on `users.password_hash`
+   * (the device-owner sentinel), so aging out the consumed nonce row does NOT
+   * relax the single-owner invariant — the owner CAS (`password_hash IS NULL`)
+   * plus the fact a deleted row yields `changes = 0` on any consume both keep a
+   * replayed claim closed. The row is retained for a generous horizon (audit +
+   * defence-in-depth belt) before reclamation.
+   */
+  consumedRetentionCutoffIso: string;
+  /**
+   * Max rows deleted PER class (expired-unconsumed / consumed-retired) per sweep
+   * pass. Bounds the work so the sweep itself cannot be turned into a long lock;
+   * a backlog drains across successive scheduled passes.
+   */
+  batchLimit: number;
+}
+
+export interface SweepFridaySetupBootstrapNoncesResult {
+  /** Expired UNCONSUMED nonce rows deleted this pass. */
+  deletedExpiredUnconsumed: number;
+  /** CONSUMED nonce rows past the retention horizon deleted this pass. */
+  deletedConsumedRetired: number;
+}
+
 // ─── Repository interface ───
 
 export interface FridaySetupBootstrapNonceRepository {
   insertNonce(db: Database.Database, input: InsertFridaySetupBootstrapNonceInput): void;
   findByHash(db: Database.Database, nonceHash: string): FridaySetupBootstrapNonceRow | null;
   findById(db: Database.Database, id: string): FridaySetupBootstrapNonceRow | null;
+  /**
+   * Bounded reaper for the install-nonce ledger. Deletes (a) expired UNCONSUMED
+   * nonces (past `expires_at`) and (b) CONSUMED nonces past a retention horizon.
+   * Each class is capped at `batchLimit` rows via a subquery LIMIT (better-sqlite3
+   * is not compiled with `DELETE ... LIMIT`). ADDITIVE / no-degrade: it only
+   * removes rows that are already unusable (expired) or authoritative-elsewhere
+   * (consumed → binding held on `users.password_hash`); it never touches a LIVE
+   * unconsumed-unexpired nonce nor the owner slot. Returns per-class delete counts.
+   */
+  sweepExpiredAndRetired(
+    db: Database.Database,
+    input: SweepFridaySetupBootstrapNoncesInput,
+  ): SweepFridaySetupBootstrapNoncesResult;
   /**
    * Single-use compare-and-consume of an owner-claim nonce.
    *
@@ -114,6 +164,48 @@ export function createFridaySetupBootstrapNonceRepository(): FridaySetupBootstra
           .prepare("SELECT * FROM friday_setup_bootstrap_nonces WHERE id = ?")
           .get(id) as FridaySetupBootstrapNonceRow | undefined) ?? null
       );
+    },
+
+    sweepExpiredAndRetired(db, input) {
+      const limit = Math.max(0, Math.floor(input.batchLimit));
+      if (limit === 0) {
+        return { deletedExpiredUnconsumed: 0, deletedConsumedRetired: 0 };
+      }
+
+      // (a) Expired UNCONSUMED nonces. These are the OBS-2 growth vector: a
+      // loopback caller can mint unbounded challenge rows, each unusable once
+      // `expires_at` passes. The subquery LIMIT bounds a single pass; the
+      // idx on (expires_at, consumed_at) serves the predicate + ORDER BY.
+      const deletedExpiredUnconsumed = db
+        .prepare(
+          `DELETE FROM friday_setup_bootstrap_nonces
+             WHERE id IN (
+               SELECT id FROM friday_setup_bootstrap_nonces
+                WHERE consumed_at IS NULL
+                  AND expires_at <= :nowIso
+                ORDER BY expires_at ASC
+                LIMIT :limit
+             )`,
+        )
+        .run({ nowIso: input.nowIso, limit }).changes;
+
+      // (b) CONSUMED nonces past the retention horizon. The authoritative owner
+      // binding is on `users.password_hash`; the consumed nonce row is an audit
+      // + defence-in-depth record we keep for a generous window, then reclaim.
+      const deletedConsumedRetired = db
+        .prepare(
+          `DELETE FROM friday_setup_bootstrap_nonces
+             WHERE id IN (
+               SELECT id FROM friday_setup_bootstrap_nonces
+                WHERE consumed_at IS NOT NULL
+                  AND consumed_at < :cutoff
+                ORDER BY consumed_at ASC
+                LIMIT :limit
+             )`,
+        )
+        .run({ cutoff: input.consumedRetentionCutoffIso, limit }).changes;
+
+      return { deletedExpiredUnconsumed, deletedConsumedRetired };
     },
 
     consumeOwnerClaimNonce(db, input) {

--- a/src/jobs/retention/friday-retention-job.ts
+++ b/src/jobs/retention/friday-retention-job.ts
@@ -1,11 +1,17 @@
 import type { FridaySqliteLayer } from "#state";
 import type { FridayOutboxMessageRepository, FridaySatelliteHeartbeatRepository, FridaySatellitePairingRequestRepository } from "#satellites";
 import type { FridayLearningEventLedger, FridaySkillRunStore } from "#ledger";
+// Type-only import (erased at compile) — avoids a runtime jobs->api edge; the
+// concrete repo is injected by the wiring layer (see friday-satellite-runtime).
+import type { FridaySetupBootstrapNonceRepository } from "../../api/persistence/friday-setup-bootstrap-nonce-repository.js";
 import type {
   FridayRetentionJobResult,
   FridayRetentionPolicy,
 } from "./friday-retention.types.js";
-import { FRIDAY_DEFAULT_RETENTION_POLICY } from "./friday-retention.types.js";
+import {
+  FRIDAY_BOOTSTRAP_NONCE_SWEEP_BATCH_LIMIT,
+  FRIDAY_DEFAULT_RETENTION_POLICY,
+} from "./friday-retention.types.js";
 
 export interface FridayRetentionJob {
   run(nowIso?: string): FridayRetentionJobResult;
@@ -18,6 +24,7 @@ export interface CreateRetentionJobDeps {
   outboxRepo: FridayOutboxMessageRepository;
   learningLedger: FridayLearningEventLedger;
   skillRunStore: FridaySkillRunStore;
+  bootstrapNonceRepo: FridaySetupBootstrapNonceRepository;
   policy?: FridayRetentionPolicy;
   nowIso: () => string;
 }
@@ -46,6 +53,8 @@ export function createFridayRetentionJob(deps: CreateRetentionJobDeps): FridayRe
         deletedAgentRuns: 0,
         deletedLlmUsageRecords: 0,
         deletedErrorIncidents: 0,
+        deletedExpiredBootstrapNonces: 0,
+        deletedConsumedBootstrapNonces: 0,
       };
 
       result.markedPairingExpired = deps.db.withWriteTransaction((db) => {
@@ -121,6 +130,23 @@ export function createFridayRetentionJob(deps: CreateRetentionJobDeps): FridayRe
           )
           .run(errorCutoff).changes;
       });
+
+      // Setup-bootstrap install-nonce reaper (OBS-2). Bounded per pass; reaps
+      // expired UNCONSUMED nonces (dead weight / DoS vector) and CONSUMED nonces
+      // past their retention horizon. No-degrade: never touches a live
+      // unconsumed-unexpired nonce nor the owner slot.
+      {
+        const bootstrapNonceCutoff = subtractDays(nowIso, policy.bootstrapNoncesConsumedDays);
+        const swept = deps.db.withWriteTransaction((db) =>
+          deps.bootstrapNonceRepo.sweepExpiredAndRetired(db, {
+            nowIso,
+            consumedRetentionCutoffIso: bootstrapNonceCutoff,
+            batchLimit: FRIDAY_BOOTSTRAP_NONCE_SWEEP_BATCH_LIMIT,
+          }),
+        );
+        result.deletedExpiredBootstrapNonces = swept.deletedExpiredUnconsumed;
+        result.deletedConsumedBootstrapNonces = swept.deletedConsumedRetired;
+      }
 
       // Run PRAGMA optimize after cleanup to update query planner statistics
       try {

--- a/src/jobs/retention/friday-retention.types.ts
+++ b/src/jobs/retention/friday-retention.types.ts
@@ -8,6 +8,14 @@ export interface FridayRetentionPolicy {
   agentRunsDays: number;
   llmUsageRecordsDays: number;
   errorIncidentsDays: number;
+  /**
+   * Retention horizon for CONSUMED setup-bootstrap install-nonce rows. Expired
+   * UNCONSUMED nonces are always reaped once past `expires_at` (no policy knob —
+   * they are unusable); this bounds how long a consumed nonce (an audit +
+   * defence-in-depth record whose authoritative binding lives on
+   * `users.password_hash`) is retained before reclamation. Generous by default.
+   */
+  bootstrapNoncesConsumedDays: number;
 }
 
 export const FRIDAY_DEFAULT_RETENTION_POLICY: FridayRetentionPolicy = {
@@ -20,7 +28,15 @@ export const FRIDAY_DEFAULT_RETENTION_POLICY: FridayRetentionPolicy = {
   agentRunsDays: 90,
   llmUsageRecordsDays: 180,
   errorIncidentsDays: 90,
+  bootstrapNoncesConsumedDays: 365,
 };
+
+/**
+ * Max setup-bootstrap nonce rows deleted PER class (expired-unconsumed /
+ * consumed-retired) per retention pass. Bounds the reaper's work so it cannot
+ * hold a long write lock; any backlog drains across successive scheduled runs.
+ */
+export const FRIDAY_BOOTSTRAP_NONCE_SWEEP_BATCH_LIMIT = 1000;
 
 export interface FridayRetentionJobResult {
   markedPairingExpired: number;
@@ -34,4 +50,8 @@ export interface FridayRetentionJobResult {
   deletedAgentRuns: number;
   deletedLlmUsageRecords: number;
   deletedErrorIncidents: number;
+  /** Expired UNCONSUMED setup-bootstrap install-nonces reaped this pass. */
+  deletedExpiredBootstrapNonces: number;
+  /** CONSUMED setup-bootstrap install-nonces past retention reaped this pass. */
+  deletedConsumedBootstrapNonces: number;
 }

--- a/src/satellites/runtime/friday-satellite-runtime.ts
+++ b/src/satellites/runtime/friday-satellite-runtime.ts
@@ -12,6 +12,10 @@ import { createFridaySatelliteHeartbeatRepository } from "../persistence/friday-
 import { createFridayOutboxMessageRepository } from "../persistence/friday-outbox-message-repository.js";
 import { createFridayStreamCheckpointRepository } from "../persistence/friday-stream-checkpoint-repository.js";
 import { createFridayApiTokenRepository } from "../persistence/friday-satellite-api-token-repository.js";
+// Direct file import (not the #api barrel) — src/api already imports #satellites,
+// so a satellites -> #api edge would close a module cycle. This repo file has no
+// cross-module imports, so importing it directly is cycle-free.
+import { createFridaySetupBootstrapNonceRepository } from "../../api/persistence/friday-setup-bootstrap-nonce-repository.js";
 import { createFridayResumeCursorSigner } from "../protocol/friday-resume-cursor-signer.js";
 import { createFridayAckResumeValidator } from "../protocol/friday-ack-resume-validator.js";
 import { createFridaySatelliteRegistrationService } from "../services/friday-satellite-registration-service.js";
@@ -202,6 +206,7 @@ export function createFridaySatelliteRuntime(
   const localRunner = createFridaySatelliteLocalRunnerService({ sync });
 
   // Retention
+  const bootstrapNonceRepo = createFridaySetupBootstrapNonceRepository();
   const retention = createFridayRetentionJob({
     db,
     pairingRequestRepo,
@@ -209,6 +214,7 @@ export function createFridaySatelliteRuntime(
     outboxRepo,
     learningLedger,
     skillRunStore,
+    bootstrapNonceRepo,
     policy: retentionPolicy,
     nowIso,
   });

--- a/test/adversarial/bootstrap-nonce-lifecycle.test.ts
+++ b/test/adversarial/bootstrap-nonce-lifecycle.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Adversarial Bootstrap-Nonce Lifecycle (SEC-SETUP-BOOTSTRAP-001, slice 4)
+ *
+ * Fork-agnostic hardening of the Slice-1 install-nonce primitive:
+ *   - OBS-2 reaper: a bounded TTL/retention sweep for friday_setup_bootstrap_nonces
+ *     so a loopback caller cannot mint unbounded challenge rows (local DoS).
+ *   - Crash/restart recovery: the single-use / expiry / owner-CAS invariants hold
+ *     across a simulated process restart (real file-backed sqlite, reopened).
+ *
+ * These tests run the REAL production code (auth service + nonce repository)
+ * against a REAL file-backed sqlite layer (createFridaySqliteLayer → real
+ * migrations → real WAL), seeded with admin-001 EXACTLY as the hub seeds it
+ * (password_hash NULL, is_local_only=1). No in-memory mock.
+ *
+ * Red-first: each assertion targets a real DEFECT that appears when the
+ * corresponding guard is removed (see PR body sever→RED→restore→GREEN evidence),
+ * not a missing-symbol error.
+ *
+ * ADDITIVE / no-degrade: the reaper only removes rows that are already unusable
+ * (expired-unconsumed) or authoritative-elsewhere (consumed → owner binding held
+ * on users.password_hash). It never touches a live unconsumed-unexpired nonce
+ * nor the owner slot.
+ */
+
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createFridayAuthService, createFridaySetupBootstrapNonceRepository } from "#api";
+import { FridayDomainError } from "#errors";
+import { createFridaySqliteLayer } from "#state";
+import type { FridaySqliteLayer } from "#state";
+
+const OWNER_ID = "admin-001";
+const NOW = "2026-07-13T00:00:00.000Z";
+const AFTER_TTL = "2026-07-13T00:10:00.000Z"; // > NOW + 300s (nonce TTL)
+const LOOPBACK = "127.0.0.1";
+const ORIGIN = "https://friday.localhost";
+const DEVICE_PUBKEY = crypto.randomBytes(32).toString("base64url");
+const DEVICE_ID = "device-abc-001";
+const OWNER_HASH_PREFIX = "device-owner$v1$";
+const BOOTSTRAP_TTL_SEC = 300;
+
+const nonceRepo = createFridaySetupBootstrapNonceRepository();
+
+// Monotonic across the whole file so distinct issued challenges never collide on
+// the nonce-row PRIMARY KEY (id), which persists across a simulated restart.
+let idCounter = 0;
+
+function sha256Hex(v: string): string {
+  return crypto.createHash("sha256").update(v).digest("hex");
+}
+
+function seedOwner(db: FridaySqliteLayer): void {
+  db.withWriteTransaction((conn) => {
+    conn
+      .prepare(
+        `INSERT INTO users (id, email, display_name, role, password_hash, is_local_only, last_login_at, created_at, updated_at, deleted_at)
+         VALUES (?, ?, ?, ?, NULL, 1, NULL, ?, ?, NULL)`,
+      )
+      .run(OWNER_ID, "admin@friday.dev", "Admin", "admin", NOW, NOW);
+  });
+}
+
+function makeService(db: FridaySqliteLayer, nowIso: string = NOW) {
+  return createFridayAuthService({
+    db,
+    idGenerator: () => `id-${String(++idCounter).padStart(6, "0")}`,
+    nowIso: () => nowIso,
+    tokenSecret: "test-secret-key-for-nonce-lifecycle-01", // pragma: allowlist secret
+    accessTokenTtlSec: 900,
+    refreshTokenTtlSec: 604_800,
+    hubId: "test-hub",
+    bootstrapNonceTtlSec: BOOTSTRAP_TTL_SEC,
+  });
+}
+
+function readOwnerHash(db: FridaySqliteLayer): string | null {
+  return db.withReadConnection((conn) => {
+    const row = conn.prepare("SELECT password_hash AS h FROM users WHERE id = ?").get(OWNER_ID) as
+      | { h: string | null }
+      | undefined;
+    return row?.h ?? null;
+  });
+}
+
+function readNonceRow(db: FridaySqliteLayer, nonce: string): Record<string, unknown> | null {
+  return db.withReadConnection((conn) => {
+    const row = conn
+      .prepare("SELECT * FROM friday_setup_bootstrap_nonces WHERE nonce_hash = ?")
+      .get(sha256Hex(nonce)) as Record<string, unknown> | undefined;
+    return row ?? null;
+  });
+}
+
+function countNonces(db: FridaySqliteLayer): number {
+  return db.withReadConnection((conn) =>
+    (conn.prepare("SELECT COUNT(*) AS c FROM friday_setup_bootstrap_nonces").get() as { c: number }).c,
+  );
+}
+
+function issueNonce(db: FridaySqliteLayer, over?: { origin?: string; nowIso?: string }): string {
+  const svc = makeService(db, over?.nowIso ?? NOW);
+  const res = svc.issueBootstrapChallenge(
+    { installId: "install-1", osUser: "jarvis", origin: over?.origin ?? ORIGIN },
+    LOOPBACK,
+  );
+  return res.nonce;
+}
+
+function claimReq(over?: Partial<{ nonce: string; origin: string; devicePublicKey: string; deviceId: string }>) {
+  return {
+    nonce: over?.nonce ?? "",
+    devicePublicKey: over?.devicePublicKey ?? DEVICE_PUBKEY,
+    deviceId: over?.deviceId ?? DEVICE_ID,
+    origin: over?.origin ?? ORIGIN,
+    installId: "install-1",
+    osUser: "jarvis",
+  };
+}
+
+/** Runs the production reaper against the file-backed layer. */
+function runReaper(
+  db: FridaySqliteLayer,
+  over?: { nowIso?: string; consumedRetentionCutoffIso?: string; batchLimit?: number },
+) {
+  return db.withWriteTransaction((conn) =>
+    nonceRepo.sweepExpiredAndRetired(conn, {
+      nowIso: over?.nowIso ?? NOW,
+      consumedRetentionCutoffIso: over?.consumedRetentionCutoffIso ?? "2000-01-01T00:00:00.000Z",
+      batchLimit: over?.batchLimit ?? 1000,
+    }),
+  );
+}
+
+/** Backdated raw insert to fabricate aged / bulk rows without a real clock. */
+function insertRawNonce(
+  db: FridaySqliteLayer,
+  id: string,
+  over?: Partial<{ expiresAt: string; consumedAt: string | null }>,
+): void {
+  db.withWriteTransaction((conn) => {
+    conn
+      .prepare(
+        `INSERT INTO friday_setup_bootstrap_nonces
+           (id, nonce_hash, kind, hub_id, install_id, os_user, origin, action,
+            created_at, expires_at, consumed_at)
+         VALUES (?, ?, 'install_owner_claim', 'h', 'i', 'u', ?, 'owner-claim', ?, ?, ?)`,
+      )
+      .run(
+        id,
+        `hash-${id}`,
+        ORIGIN,
+        "2024-01-01T00:00:00.000Z",
+        over?.expiresAt ?? "2999-01-01T00:00:00.000Z",
+        over?.consumedAt ?? null,
+      );
+  });
+}
+
+let db: FridaySqliteLayer;
+let tmpDir: string;
+let dbPath: string;
+
+function openLayer(): FridaySqliteLayer {
+  return createFridaySqliteLayer({
+    dbPath,
+    readPoolSize: 2,
+    pragmas: { busyTimeoutMs: 5_000, synchronous: "NORMAL" },
+  });
+}
+
+/** Simulate a process restart: close the writer + readers and reopen the file. */
+function restart(): void {
+  db.close();
+  db = openLayer();
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-secsetup-s4-"));
+  dbPath = path.join(tmpDir, "friday.db");
+  db = openLayer();
+  seedOwner(db);
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("SEC-SETUP-BOOTSTRAP-001 s4: nonce reaper (OBS-2)", () => {
+  it("reaps expired unconsumed nonces but preserves a live one", () => {
+    // Live nonce: issued at NOW, expires NOW+300s.
+    const live = issueNonce(db, { nowIso: NOW });
+    // Expired unconsumed nonce: issued in the past so it is already dead at NOW.
+    insertRawNonce(db, "dead", { expiresAt: "2026-07-12T00:00:00.000Z", consumedAt: null });
+    expect(countNonces(db)).toBe(2);
+
+    const res = runReaper(db, { nowIso: NOW });
+
+    expect(res.deletedExpiredUnconsumed).toBe(1);
+    expect(res.deletedConsumedRetired).toBe(0);
+    // Live nonce survives and is still present.
+    expect(readNonceRow(db, live)).not.toBeNull();
+    // The dead raw row (nonce_hash='hash-dead') is gone.
+    const deadRow = db.withReadConnection((conn) =>
+      conn.prepare("SELECT id FROM friday_setup_bootstrap_nonces WHERE nonce_hash = 'hash-dead'").get(),
+    );
+    expect(deadRow).toBeUndefined();
+    expect(countNonces(db)).toBe(1);
+  });
+
+  it("NO-DEGRADE: reaping a consumed nonce does NOT release the owner slot", () => {
+    // Real issue → claim: owner flips to the device sentinel, nonce consumed.
+    const nonce = issueNonce(db);
+    makeService(db).claimOwnerWithDeviceKey(claimReq({ nonce }), LOOPBACK);
+    const ownerHash = readOwnerHash(db);
+    expect(ownerHash).toBe(`${OWNER_HASH_PREFIX}${sha256Hex(DEVICE_PUBKEY)}`);
+    expect(readNonceRow(db, nonce)?.consumed_at).not.toBeNull();
+
+    // Reap consumed rows past retention (cutoff far in the future).
+    const res = runReaper(db, {
+      nowIso: NOW,
+      consumedRetentionCutoffIso: "2999-01-01T00:00:00.000Z",
+    });
+
+    expect(res.deletedConsumedRetired).toBe(1);
+    expect(readNonceRow(db, nonce)).toBeNull();
+    // The authoritative owner binding is untouched — single-owner still holds.
+    expect(readOwnerHash(db)).toBe(ownerHash);
+    // And a fresh claim still cannot seize the already-owned slot.
+    const nonce2 = issueNonce(db);
+    let caught: unknown;
+    try {
+      makeService(db).claimOwnerWithDeviceKey(claimReq({ nonce: nonce2 }), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_ALREADY_DONE");
+    expect(readOwnerHash(db)).toBe(ownerHash);
+  });
+
+  it("bounds the work per pass by batchLimit; a backlog drains over passes", () => {
+    for (let i = 0; i < 5; i++) {
+      insertRawNonce(db, `dead-${i}`, { expiresAt: "2026-07-12T00:00:00.000Z", consumedAt: null });
+    }
+    expect(countNonces(db)).toBe(5);
+
+    const first = runReaper(db, { nowIso: NOW, batchLimit: 2 });
+    expect(first.deletedExpiredUnconsumed).toBe(2);
+    expect(countNonces(db)).toBe(3);
+
+    const second = runReaper(db, { nowIso: NOW, batchLimit: 2 });
+    expect(second.deletedExpiredUnconsumed).toBe(2);
+    expect(countNonces(db)).toBe(1);
+
+    const third = runReaper(db, { nowIso: NOW, batchLimit: 2 });
+    expect(third.deletedExpiredUnconsumed).toBe(1);
+    expect(countNonces(db)).toBe(0);
+  });
+
+  it("a batchLimit of 0 is a no-op (defensive)", () => {
+    insertRawNonce(db, "dead", { expiresAt: "2026-07-12T00:00:00.000Z", consumedAt: null });
+    const res = runReaper(db, { nowIso: NOW, batchLimit: 0 });
+    expect(res.deletedExpiredUnconsumed).toBe(0);
+    expect(countNonces(db)).toBe(1);
+  });
+});
+
+describe("SEC-SETUP-BOOTSTRAP-001 s4: crash / restart recovery", () => {
+  it("(a) issued-but-unconsumed nonce survives restart: no partial owner, still claimable", () => {
+    const nonce = issueNonce(db, { nowIso: NOW });
+    // Crash before the claim.
+    restart();
+
+    // No partial owner-claim: the slot is still NULL after restart.
+    expect(readOwnerHash(db)).toBeNull();
+    // The nonce persisted valid and is still consumable within its TTL.
+    const res = makeService(db, NOW).claimOwnerWithDeviceKey(claimReq({ nonce }), LOOPBACK);
+    expect(res.claimed).toBe(true);
+    expect(readOwnerHash(db)).toBe(`${OWNER_HASH_PREFIX}${sha256Hex(DEVICE_PUBKEY)}`);
+  });
+
+  it("(a) issued-but-unconsumed nonce past TTL after restart: claim rejected, then reaped, no partial owner", () => {
+    const nonce = issueNonce(db, { nowIso: NOW });
+    restart();
+
+    // Clock is now past the nonce TTL: the claim is rejected as expired.
+    let caught: unknown;
+    try {
+      makeService(db, AFTER_TTL).claimOwnerWithDeviceKey(claimReq({ nonce }), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_NONCE_INVALID");
+    expect(readOwnerHash(db)).toBeNull();
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+
+    // The reaper then reclaims the expired, unconsumed row.
+    const res = runReaper(db, { nowIso: AFTER_TTL });
+    expect(res.deletedExpiredUnconsumed).toBe(1);
+    expect(readNonceRow(db, nonce)).toBeNull();
+    expect(readOwnerHash(db)).toBeNull();
+  });
+
+  it("(b) a consumed nonce stays consumed across restart (single-use holds)", () => {
+    const nonce = issueNonce(db);
+    makeService(db).claimOwnerWithDeviceKey(claimReq({ nonce }), LOOPBACK);
+    expect(readNonceRow(db, nonce)?.consumed_at).not.toBeNull();
+
+    restart();
+
+    // Isolate the single-use nonce gate from the owner fast-path: clear the owner
+    // slot, then replay the SAME nonce. It must still be rejected as consumed —
+    // proving consumed_at durably survived the restart.
+    db.withWriteTransaction((conn) =>
+      conn.prepare("UPDATE users SET password_hash = NULL WHERE id = ?").run(OWNER_ID),
+    );
+    let caught: unknown;
+    try {
+      makeService(db).claimOwnerWithDeviceKey(claimReq({ nonce }), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_NONCE_INVALID");
+    expect(readOwnerHash(db)).toBeNull();
+  });
+
+  it("(c) owner-claim is idempotent under retry-after-restart: 409, never a double-claim", () => {
+    const nonceA = issueNonce(db);
+    makeService(db).claimOwnerWithDeviceKey(claimReq({ nonce: nonceA }), LOOPBACK);
+    const ownerHash = readOwnerHash(db);
+    expect(ownerHash).toBe(`${OWNER_HASH_PREFIX}${sha256Hex(DEVICE_PUBKEY)}`);
+
+    restart();
+
+    // A retried claim after restart — even with a FRESH nonce and a DIFFERENT
+    // device — cannot re-own: it fails closed (409) and leaves the owner intact.
+    const nonceB = issueNonce(db);
+    const otherKey = crypto.randomBytes(32).toString("base64url");
+    let caught: unknown;
+    try {
+      makeService(db).claimOwnerWithDeviceKey(
+        claimReq({ nonce: nonceB, devicePublicKey: otherKey, deviceId: "device-other" }),
+        LOOPBACK,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_ALREADY_DONE");
+    // No double-claim: owner hash unchanged (still device-A's binding).
+    expect(readOwnerHash(db)).toBe(ownerHash);
+  });
+
+  it("(e) no-degrade: passphrase bootstrap still works across a restart", () => {
+    makeService(db).bootstrapLocalPassphrase({ passphrase: "owner-passphrase-xyz" }, LOOPBACK);
+    const afterPass = readOwnerHash(db);
+    expect(afterPass?.startsWith("scrypt$")).toBe(true);
+
+    restart();
+
+    // The passphrase owner persists and a device claim still cannot seize it.
+    expect(readOwnerHash(db)).toBe(afterPass);
+    const nonce = issueNonce(db);
+    let caught: unknown;
+    try {
+      makeService(db).claimOwnerWithDeviceKey(claimReq({ nonce }), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_ALREADY_DONE");
+    expect(readOwnerHash(db)).toBe(afterPass);
+  });
+});

--- a/test/adversarial/evidence/secsetup-s4-crash-recovery-redfirst.txt
+++ b/test/adversarial/evidence/secsetup-s4-crash-recovery-redfirst.txt
@@ -1,0 +1,48 @@
+SEC-SETUP-BOOTSTRAP-001 slice 4 — §5 red-first evidence: crash/restart recovery
+target suite: test/adversarial/bootstrap-nonce-lifecycle.test.ts
+              (REAL file-backed sqlite created, closed, and REOPENED to simulate
+               a process restart; admin-001 seeded as the hub seeds it)
+method: start GREEN (hardened working tree), remove ONE S1 owner-claim guard at a
+        time -> the crash-recovery assertion that relies on it going RED across the
+        restart (a real defect, not a compile error), restore -> GREEN. This proves
+        the S1 single-use / expiry / single-owner invariants still hold after a
+        restart (no-degrade of S1) and that each test is load-bearing.
+
+BASELINE (hardened): Tests  9 passed (9)
+
+GUARD REMOVED: single-use consume CAS  (AND consumed_at IS NULL -> AND 1=1)
+  (src/api/persistence/friday-setup-bootstrap-nonce-repository.ts, consumeOwnerClaimNonce)
+  A consumed nonce can now be re-consumed, so single-use no longer survives restart.
+  RED  ×  crash / restart recovery > (b) a consumed nonce stays consumed across restart (single-use holds)
+  RED  Tests  1 failed | 8 passed (9)
+  RESTORE: Tests  9 passed (9)
+
+GUARD REMOVED: freshness/expiry consume CAS  (AND expires_at > :nowIso -> AND 1=1)
+  (src/api/persistence/friday-setup-bootstrap-nonce-repository.ts, consumeOwnerClaimNonce)
+  An expired nonce can now be consumed, so a post-TTL claim after restart succeeds.
+  RED  ×  crash / restart recovery > (a) issued-but-unconsumed nonce past TTL after restart: claim rejected, then reaped, no partial owner
+  RED  Tests  1 failed | 8 passed (9)
+  RESTORE: Tests  9 passed (9)
+
+GUARD REMOVED: owner slot single-writer (claim path)  — BOTH the fast-fail owner
+              check (`if (localUser.password_hash)` -> `if (false)`) AND the owner
+              CAS predicate (`WHERE id = ? AND password_hash IS NULL` -> `WHERE id = ?`)
+  (src/api/auth/friday-auth-service.ts, claimOwnerWithDeviceKey)
+  With both removed, a fresh claim can seize an ALREADY-owned slot (single-owner
+  degrades). Surfaced by:
+  RED  ×  crash / restart recovery > (e) no-degrade: passphrase bootstrap still works across a restart
+          (a device claim now overwrites the existing scrypt passphrase owner)
+  RED  ×  nonce reaper (OBS-2) > NO-DEGRADE: reaping a consumed nonce does NOT release the owner slot
+          (after the consumed row is reaped, the severed CAS lets a fresh claim re-own)
+  RED  Tests  2 failed | 7 passed (9)
+  NOTE (defence-in-depth, expected): test "(c) owner-claim is idempotent under
+       retry-after-restart" STAYS GREEN even with both guards removed, because the
+       partial UNIQUE(kind) WHERE consumed_at IS NOT NULL belt independently rejects
+       the SECOND consume (the prior consumed nonce row is still present). It only
+       degrades once ALL THREE layers (early-check + owner CAS + the partial-unique
+       belt) are gone — which is why (e)/NO-DEGRADE (no surviving consumed row in
+       play) are the tests that expose the single-writer guard directly.
+  RESTORE: Tests  9 passed (9)
+
+FINAL working tree: both source files restored byte-for-byte (auth-service shows
+                    zero diff vs base; adversarial suite GREEN 9/9).

--- a/test/adversarial/evidence/secsetup-s4-reaper-redfirst.txt
+++ b/test/adversarial/evidence/secsetup-s4-reaper-redfirst.txt
@@ -1,0 +1,29 @@
+SEC-SETUP-BOOTSTRAP-001 slice 4 — §5 red-first evidence: nonce reaper (OBS-2)
+target suites:
+  test/adversarial/bootstrap-nonce-lifecycle.test.ts   (real file-backed sqlite)
+  test/unit/jobs/retention/friday-retention-job.test.ts (retention-job wiring)
+method: start GREEN (hardened working tree), NEUTRALIZE the reaper -> the
+        deletion-asserting tests go RED (expired/overflow rows PERSIST, counts
+        stay 0 — a real defect, not a compile error), restore -> GREEN.
+
+BASELINE (hardened): Tests  28 passed (28)   [adversarial 9 + retention 19]
+
+GUARD NEUTRALIZED: reaper sweep
+  (src/api/persistence/friday-setup-bootstrap-nonce-repository.ts —
+   sweepExpiredAndRetired forced to a no-op: `const limit = Math.max(0, Math.floor(
+   input.batchLimit))` -> `const limit = 0`, so it early-returns {0,0} and deletes
+   nothing; expired-unconsumed + past-retention-consumed rows PERSIST.)
+  RED  ×  bootstrap-nonce-lifecycle > nonce reaper (OBS-2) > reaps expired unconsumed nonces but preserves a live one
+  RED  ×  bootstrap-nonce-lifecycle > nonce reaper (OBS-2) > NO-DEGRADE: reaping a consumed nonce does NOT release the owner slot
+  RED  ×  bootstrap-nonce-lifecycle > nonce reaper (OBS-2) > bounds the work per pass by batchLimit; a backlog drains over passes
+  RED  ×  bootstrap-nonce-lifecycle > crash / restart recovery > (a) issued-but-unconsumed nonce past TTL after restart: claim rejected, then reaped, no partial owner
+  RED  ×  friday-retention-job > FridayRetentionJob > reaps expired unconsumed bootstrap nonces but preserves live ones
+  RED  ×  friday-retention-job > FridayRetentionJob > reaps a consumed bootstrap nonce past the retention horizon
+  RED  Tests  6 failed | 22 passed (28)
+  (control: the no-op/keep assertions — "a batchLimit of 0 is a no-op",
+   "keeps a recently-consumed …", "never reaps a consumed nonce within the
+   retention horizon", "returns all zeros …" — stay GREEN, proving the RED is
+   the missing deletion, not a blanket break.)
+  RESTORE: Tests  28 passed (28)
+
+FINAL working tree: reaper file restored byte-for-byte (GREEN 28/28); auth-service untouched.

--- a/test/unit/jobs/retention/friday-retention-job.test.ts
+++ b/test/unit/jobs/retention/friday-retention-job.test.ts
@@ -5,6 +5,7 @@ import { createFridaySatelliteHeartbeatRepository } from "#satellites";
 import { createFridayOutboxMessageRepository } from "#satellites";
 import { createFridayLearningEventLedger } from "#ledger";
 import { createFridaySkillRunStore } from "#ledger";
+import { createFridaySetupBootstrapNonceRepository } from "#api";
 import { createFridayRetentionJob } from "#jobs";
 import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
 
@@ -16,6 +17,38 @@ describe("FridayRetentionJob", () => {
   const pairingRequestRepo = createFridaySatellitePairingRequestRepository();
   const heartbeatRepo = createFridaySatelliteHeartbeatRepository();
   const outboxRepo = createFridayOutboxMessageRepository();
+  const bootstrapNonceRepo = createFridaySetupBootstrapNonceRepository();
+
+  function insertNonce(
+    id: string,
+    over?: Partial<{ expiresAt: string; consumedAt: string | null; kind: string }>,
+  ) {
+    // kind CHECK allows only 'install_owner_claim'; consumed rows are also bound
+    // by the partial UNIQUE(kind) WHERE consumed_at IS NOT NULL, so tests that
+    // need multiple consumed rows must key off distinct behaviour, not kind.
+    db.writer
+      .prepare(
+        `INSERT INTO friday_setup_bootstrap_nonces
+           (id, nonce_hash, kind, hub_id, install_id, os_user, origin, action,
+            created_at, expires_at, consumed_at)
+         VALUES (?, ?, 'install_owner_claim', 'h', 'i', 'u', 'o', 'owner-claim', ?, ?, ?)`,
+      )
+      .run(
+        id,
+        `hash-${id}`,
+        "2024-01-01T00:00:00.000Z",
+        over?.expiresAt ?? "2999-01-01T00:00:00.000Z",
+        over?.consumedAt ?? null,
+      );
+  }
+
+  function countNonces(): number {
+    return (
+      db.writer
+        .prepare("SELECT COUNT(*) AS c FROM friday_setup_bootstrap_nonces")
+        .get() as { c: number }
+    ).c;
+  }
 
   function insertSatellite(id: string) {
     db.writer
@@ -46,6 +79,7 @@ describe("FridayRetentionJob", () => {
     agentRunsDays: number;
     llmUsageRecordsDays: number;
     errorIncidentsDays: number;
+    bootstrapNoncesConsumedDays: number;
   }>) {
     return createFridayRetentionJob({
       db,
@@ -54,6 +88,7 @@ describe("FridayRetentionJob", () => {
       outboxRepo,
       learningLedger: createFridayLearningEventLedger({ db }),
       skillRunStore: createFridaySkillRunStore({ db }),
+      bootstrapNonceRepo,
       nowIso: () => NOW,
       policy: {
         learningEventsDays: 90,
@@ -65,6 +100,7 @@ describe("FridayRetentionJob", () => {
         agentRunsDays: 90,
         llmUsageRecordsDays: 180,
         errorIncidentsDays: 90,
+        bootstrapNoncesConsumedDays: 365,
         ...policy,
       },
     });
@@ -316,6 +352,70 @@ describe("FridayRetentionJob", () => {
     expect(result.deletedAgentRuns).toBe(0);
     expect(result.deletedLlmUsageRecords).toBe(0);
     expect(result.deletedErrorIncidents).toBe(0);
+    expect(result.deletedExpiredBootstrapNonces).toBe(0);
+    expect(result.deletedConsumedBootstrapNonces).toBe(0);
+  });
+
+  it("reaps expired unconsumed bootstrap nonces but preserves live ones", () => {
+    // Expired + unconsumed → dead weight, must be reaped.
+    insertNonce("nonce-expired", { expiresAt: "2025-06-14T00:00:00.000Z", consumedAt: null });
+    // Not yet expired + unconsumed → live, must be preserved.
+    insertNonce("nonce-live", { expiresAt: "2025-06-16T00:00:00.000Z", consumedAt: null });
+
+    const job = createJob();
+    const result = job.run(NOW);
+
+    expect(result.deletedExpiredBootstrapNonces).toBe(1);
+    expect(result.deletedConsumedBootstrapNonces).toBe(0);
+    const remaining = db.writer
+      .prepare("SELECT id FROM friday_setup_bootstrap_nonces")
+      .all() as Array<{ id: string }>;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe("nonce-live");
+  });
+
+  it("reaps a consumed bootstrap nonce past the retention horizon", () => {
+    // Only ONE consumed owner-claim row can exist (partial UNIQUE(kind) WHERE
+    // consumed_at IS NOT NULL). Consumed long ago (> 365 days) → reaped.
+    insertNonce("nonce-old-consumed", {
+      expiresAt: "2024-01-01T00:05:00.000Z",
+      consumedAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    const job = createJob();
+    const result = job.run(NOW);
+
+    expect(result.deletedConsumedBootstrapNonces).toBe(1);
+    expect(result.deletedExpiredBootstrapNonces).toBe(0);
+    expect(countNonces()).toBe(0);
+  });
+
+  it("keeps a recently-consumed bootstrap nonce (within the retention horizon)", () => {
+    // Consumed recently (well within 365 days) → kept.
+    insertNonce("nonce-recent-consumed", {
+      expiresAt: "2025-06-15T00:05:00.000Z",
+      consumedAt: "2025-06-14T00:00:00.000Z",
+    });
+
+    const job = createJob();
+    const result = job.run(NOW);
+
+    expect(result.deletedConsumedBootstrapNonces).toBe(0);
+    expect(countNonces()).toBe(1);
+  });
+
+  it("never reaps a consumed nonce still within the retention horizon", () => {
+    // consumed_at == cutoff boundary (NOW - 365d) is NOT strictly older → kept.
+    insertNonce("nonce-boundary", {
+      expiresAt: "2024-06-15T10:05:00.000Z",
+      consumedAt: "2024-06-15T10:00:00.000Z", // exactly 365 days before NOW
+    });
+
+    const job = createJob();
+    const result = job.run(NOW);
+
+    expect(result.deletedConsumedBootstrapNonces).toBe(0);
+    expect(countNonces()).toBe(1);
   });
 
   it("deletes old audit logs", () => {


### PR DESCRIPTION
## SEC-SETUP-BOOTSTRAP-001 — Slice 4: install-nonce reaper + crash-recovery hardening

Fork-agnostic hardening of the Slice-1 install-nonce primitive (base main `c6b7335a`). Closes the two review-flagged LOW backlog items. **ADDITIVE / no-degrade**: does not weaken S1's owner-claim atomicity/replay/loopback/crash-safety, and does not touch the local-passphrase bootstrap path. Builder PR — **do not merge** (separate merge-executor + independent reviewers gate this).

### OBS-2 — nonce reaper / TTL sweep
- New bounded `FridaySetupBootstrapNonceRepository.sweepExpiredAndRetired()`: deletes **(a)** expired **UNCONSUMED** nonces (past `expires_at` — the loopback table-growth/DoS vector) and **(b)** **CONSUMED** nonces past a retention horizon. Each class capped by a subquery `LIMIT` (better-sqlite3 is not compiled with `DELETE ... LIMIT`); a backlog drains across passes.
- **Reused the existing canonical retention job** `src/jobs/retention/friday-retention-job.ts` — already registered as the hourly `retention-sweep` scheduler job in `friday-hub-bootstrap.ts` (no new scheduler invented). Added policy field `bootstrapNoncesConsumedDays` (default **365**), two result counts, and a batch-limit constant. The repo is injected via the same DI pattern as the other retention repos; wired in `friday-satellite-runtime.ts` (direct file import, not the `#api` barrel, because `src/api` already imports `#satellites` — a `satellites → #api` value edge would close a module cycle).
- **Single-owner is not relaxed**: the authoritative owner↔device binding lives on `users.password_hash` (the device-owner sentinel), so aging out a consumed nonce row never releases ownership; and a deleted row yields `changes = 0` on any replayed consume.

### Crash / restart recovery (tests)
Real file-backed sqlite closed and **reopened** to simulate a process restart (`test/adversarial/bootstrap-nonce-lifecycle.test.ts`). Proves across the restart: **(a)** an issued-but-unconsumed nonce stays valid until expiry then is reaped, with no partial owner-claim; **(b)** a consumed nonce stays consumed (single-use holds); **(c)** owner-claim is idempotent under retry-after-restart (409, never a double-claim); plus **(e)** the passphrase path still works across a restart.

### OBS-1 — comment fix (comment-only, no behavior change)
Corrected the `/v1/auth/bootstrap/challenge` route comment, which falsely claimed `issueBootstrapChallenge` enforces a "first-boot gate". It enforces **only** loopback + required-field presence; the ownership gate is the owner CAS downstream at `device-claim` (which fails closed 409 if already claimed). Did **not** add a behavior-changing first-boot gate (default to comment fix per spec).

### Attestation-theater
No attestation is faked anywhere: the device-credential path stays honestly opaque/unverified (a future S2a adds the real P-256 proof-of-possession verifier). This slice is pure nonce hygiene.

### Migration
**None.** The reaper uses existing columns (`consumed_at`, `expires_at`) and the existing `idx_..._expires (expires_at, consumed_at)` index. No schema change → `context/MEMORY.md` migration count unchanged, and no "Deployment restart required" schema line. (The TS-hub code change itself takes effect on the next normal hub rebuild/restart; not a schema/migration restart.)

### §5 red-first evidence (`test/adversarial/evidence/secsetup-s4-*.txt`)
- **Reaper**: neutralize the sweep (`batchLimit → 0`, no-op) → 6 deletion-asserting tests go **RED** (expired/overflow rows persist), the no-op/keep-control assertions stay GREEN; restore → **GREEN 28/28**.
- **Crash-recovery guards** (sever→RED→restore→GREEN on the reopened DB):
  - single-use consume CAS (`AND consumed_at IS NULL` removed) → `(b) consumed stays consumed across restart` RED.
  - freshness/expiry CAS (`AND expires_at > :now` removed) → `(a) post-TTL claim after restart rejected + reaped` RED.
  - owner slot single-writer (claim early-check + owner CAS predicate removed) → `(e)` and `NO-DEGRADE-reaping` RED (a fresh/passphrase owner is seized). Documented defence-in-depth: `(c)` stays GREEN under this sever because the partial-`UNIQUE(kind)` belt independently rejects the second consume.

### Gates
- `npx tsc --noEmit`: **0 errors**
- `npx eslint` (changed src files): **0 errors** (test files are outside the lint scope, as with the S1 adversarial test)
- detect-secrets baseline: only line-number drift of the pre-existing `friday-auth-routes.ts` entry (158→164, from the expanded comment); **no new secret**; baseline refreshed + committed. Test token carries `// pragma: allowlist secret`.
- Tests: **111 passed** across the new suites + S1 (`bootstrap-device-claim`, `bootstrap-claim-race`), auth routes, mock/integration bootstrap, and satellite-runtime resume — **no-degrade confirmed** (S1 flows + passphrase path untouched).

### Files changed
- `src/api/persistence/friday-setup-bootstrap-nonce-repository.ts` — reaper method + sweep types
- `src/jobs/retention/friday-retention.types.ts` — policy field, result counts, batch-limit const
- `src/jobs/retention/friday-retention-job.ts` — wire reaper into the hourly retention pass
- `src/satellites/runtime/friday-satellite-runtime.ts` — construct + inject the nonce repo
- `src/api/index.ts` — barrel export (repo + sweep types)
- `src/api/http/routes/friday-auth-routes.ts` — OBS-1 comment fix
- `test/unit/jobs/retention/friday-retention-job.test.ts` — reaper wiring + zero-assertions
- `test/adversarial/bootstrap-nonce-lifecycle.test.ts` — reaper + crash-recovery suite (new)
- `test/adversarial/evidence/secsetup-s4-*.txt` — §5 red-first evidence (new)
- `.secrets.baseline` — line-drift refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48
