### PR TITLE
feat(secsetup): server-side owner-claim proof-of-possession verifier (SEC-SETUP-BOOTSTRAP-001 Slice 2a)

### DIFF
--- a/src/api/auth/device-attest/friday-device-poposession-verifier.ts
+++ b/src/api/auth/device-attest/friday-device-poposession-verifier.ts
@@ -1,0 +1,201 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · Slice 2a ───
+//
+// Production server-side proof-of-possession verifier for the device-bound
+// owner-claim transcript. Crypto is delegated ENTIRELY to Node's built-in
+// `node:crypto` (KeyObject + crypto.verify) — there is no hand-rolled EC math.
+//
+// This module verifies signature + possession only. It NEVER asserts key
+// protection, NEVER grants owner authority, and NEVER mutates state. See the
+// types file for the full scope contract.
+
+import { verify as cryptoVerify, type KeyObject } from "node:crypto";
+import {
+  ALLOWED_ALGORITHMS,
+  ALLOWED_TRANSCRIPT_VERSIONS,
+  canonicalDevicePublicKeyHash,
+  decodeFlexibleBase64,
+  encodeOwnerClaimTranscript,
+  importPresentedPublicKey,
+  isLowS,
+  isP256PublicKey,
+  OWNER_CLAIM_ALGORITHM,
+  OWNER_CLAIM_KIND,
+  ownerClaimTranscriptDigestHex,
+  parseCanonicalP1363Signature,
+} from "./friday-owner-claim-transcript.js";
+import type {
+  FridayOwnerClaimPoPVerifier,
+  OwnerClaimPoPFailure,
+  OwnerClaimPoPResult,
+  OwnerClaimPresentationResult,
+  OwnerClaimTranscript,
+  VerifyOwnerClaimPossessionInput,
+  VerifyOwnerClaimPresentationInput,
+} from "./friday-owner-claim-transcript.types.js";
+
+function reject(
+  reason: OwnerClaimPoPFailure["reason"],
+  detail?: string,
+): OwnerClaimPoPFailure {
+  return detail === undefined ? { ok: false, reason } : { ok: false, reason, detail };
+}
+
+// ─── Required-field structural validation ───
+
+function isNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Return the name of the first required transcript field that is missing/empty,
+ * or null when all are present. Fields are checked EXPLICITLY (no dynamic
+ * indexing) so the required set is auditable and lint-clean.
+ */
+function firstMissingField(transcript: OwnerClaimTranscript): string | null {
+  if (!isNonEmptyString(transcript.hubId)) return "hubId";
+  if (!isNonEmptyString(transcript.installId)) return "installId";
+  if (!isNonEmptyString(transcript.osUser)) return "osUser";
+  if (!isNonEmptyString(transcript.deviceId)) return "deviceId";
+  if (!isNonEmptyString(transcript.action)) return "action";
+  if (!isNonEmptyString(transcript.origin)) return "origin";
+  if (!isNonEmptyString(transcript.channel)) return "channel";
+  if (!isNonEmptyString(transcript.nonce)) return "nonce";
+  if (!isNonEmptyString(transcript.expiresAt)) return "expiresAt";
+  if (!isNonEmptyString(transcript.devicePublicKeyHash)) return "devicePublicKeyHash";
+  return null;
+}
+
+// ─── Verification pipeline ───
+
+function verifyPossession(
+  input: VerifyOwnerClaimPossessionInput,
+): OwnerClaimPoPResult {
+  const { transcript, devicePublicKey, signature, nowMs } = input;
+
+  // 1. Transcript-version allowlist.
+  if (!ALLOWED_TRANSCRIPT_VERSIONS.has(transcript.transcriptVersion)) {
+    return reject("unsupported_transcript_version", String(transcript.transcriptVersion));
+  }
+
+  // 2. Algorithm allowlist (bound INTO the transcript, so substitution changes bytes).
+  if (!ALLOWED_ALGORITHMS.has(transcript.algorithm)) {
+    return reject("unsupported_algorithm", String(transcript.algorithm));
+  }
+
+  // 3. Kind discriminator + required non-empty fields.
+  if (transcript.kind !== OWNER_CLAIM_KIND) {
+    return reject("malformed_transcript", "kind");
+  }
+  const missing = firstMissingField(transcript);
+  if (missing) {
+    return reject("malformed_transcript", missing);
+  }
+
+  // 4. Freshness / expiry (bound in the transcript).
+  const expiryMs = Date.parse(transcript.expiresAt);
+  if (Number.isNaN(expiryMs)) {
+    return reject("malformed_transcript", "expiresAt");
+  }
+  if (!Number.isFinite(nowMs)) {
+    return reject("expired", "invalid-clock");
+  }
+  if (nowMs >= expiryMs) {
+    return reject("expired");
+  }
+
+  // 5. Import + curve-check the presented public key.
+  let key: KeyObject;
+  try {
+    key = importPresentedPublicKey(devicePublicKey);
+  } catch (err) {
+    return reject("invalid_public_key", err instanceof Error ? err.name : "import-failed");
+  }
+  if (!isP256PublicKey(key)) {
+    return reject("unsupported_key", "expected-prime256v1");
+  }
+
+  // 6. Bind the transcript's public-key hash to the ACTUAL presented key.
+  const actualKeyHash = canonicalDevicePublicKeyHash(key);
+  if (actualKeyHash !== transcript.devicePublicKeyHash) {
+    return reject("public_key_hash_mismatch");
+  }
+
+  // 7. Decode + structurally validate the signature (canonical raw P-1363 only).
+  let sigBytes: Buffer;
+  try {
+    sigBytes = decodeFlexibleBase64(signature.value);
+  } catch {
+    return reject("malformed_signature", "undecodable");
+  }
+  const parsed = parseCanonicalP1363Signature(sigBytes);
+  if (!parsed) {
+    return reject("malformed_signature", "expected-64-byte-raw-in-range");
+  }
+
+  // 8. Malleability: enforce low-S canonical form (reject high-S twin).
+  if (!isLowS(parsed.s)) {
+    return reject("non_canonical_signature", "high-s");
+  }
+
+  // 9. Cryptographic ECDSA verification over the canonical transcript bytes.
+  const canonicalBytes = encodeOwnerClaimTranscript(transcript);
+  let cryptoValid: boolean;
+  try {
+    cryptoValid = cryptoVerify(
+      "sha256",
+      canonicalBytes,
+      { key, dsaEncoding: "ieee-p1363" },
+      parsed.raw,
+    );
+  } catch (err) {
+    return reject("signature_mismatch", err instanceof Error ? err.name : "verify-error");
+  }
+  if (!cryptoValid) {
+    return reject("signature_mismatch");
+  }
+
+  // Possession proven. keyProtection is ALWAYS "unverified" — protection is
+  // NEVER inferred from a successful signature or from the key type.
+  return {
+    ok: true,
+    keyProtection: "unverified",
+    algorithm: OWNER_CLAIM_ALGORITHM,
+    transcriptVersion: transcript.transcriptVersion,
+    transcriptDigestHex: ownerClaimTranscriptDigestHex(transcript),
+    devicePublicKeyHash: actualKeyHash,
+  };
+}
+
+// ─── Factory (stable seam) ───
+
+export function createFridayOwnerClaimPoPVerifier(): FridayOwnerClaimPoPVerifier {
+  return { verifyPossession };
+}
+
+// ─── Composed presentation seam (S3 integration plug-point) ───
+//
+// Composes the single-use nonce guard with possession verification into the
+// result S3 wires into the auth service (with the DB-backed nonce repository).
+//
+// Ordering rationale: possession is verified FIRST (pure, no side effects); the
+// nonce is consumed ONLY after possession succeeds — mirroring the atomic
+// single-transaction consume+bind of the production nonce repository, where a
+// failed claim leaves the nonce un-burned. A replayed VALID presentation is
+// still rejected because the second consume returns "replayed".
+export function verifyOwnerClaimPresentation(
+  input: VerifyOwnerClaimPresentationInput,
+): OwnerClaimPresentationResult {
+  const { verifier, nonceConsumer, ...possessionInput } = input;
+
+  const possession = verifier.verifyPossession(possessionInput);
+  if (!possession.ok) {
+    return { ok: false, reason: possession.reason, ...(possession.detail !== undefined ? { detail: possession.detail } : {}) };
+  }
+
+  const outcome = nonceConsumer.consume(possessionInput.transcript.nonce);
+  if (outcome === "replayed") {
+    return { ok: false, reason: "nonce_replayed" };
+  }
+
+  return { ...possession, nonceConsumed: true };
+}

--- a/src/api/auth/device-attest/friday-owner-claim-nonce-consumer.ts
+++ b/src/api/auth/device-attest/friday-owner-claim-nonce-consumer.ts
@@ -1,0 +1,46 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · Slice 2a ───
+//
+// REFERENCE in-memory single-use nonce consumer.
+//
+// TRUTH LABEL: this is a reference / test implementation only. It is NOT the
+// production single-use store. Production replay/expiry/single-use enforcement
+// is the durable, atomic, DB-backed nonce repository already shipped in Slice 1
+// (`friday-setup-bootstrap-nonce-repository`), which the S3 integration wires
+// into the `OwnerClaimNonceConsumer` seam. This reference impl exists so the
+// verifier seam can be exercised and so replay + restart-survival are provable at
+// this layer via an explicit persisted-snapshot round-trip.
+
+import type {
+  OwnerClaimNonceConsumeOutcome,
+  OwnerClaimNonceConsumer,
+} from "./friday-owner-claim-transcript.types.js";
+
+export interface InMemoryOwnerClaimNonceConsumer extends OwnerClaimNonceConsumer {
+  /**
+   * Export the set of already-consumed nonces. Simulates the durable state a
+   * restart would re-read; feed it back into the factory to model a restart.
+   */
+  snapshot(): string[];
+}
+
+/**
+ * Build a reference single-use nonce consumer. Pass a prior `snapshot` to model a
+ * restart that re-reads persisted consumed state — replays are still rejected
+ * across the restart boundary.
+ */
+export function createInMemoryOwnerClaimNonceConsumer(
+  snapshot?: readonly string[],
+): InMemoryOwnerClaimNonceConsumer {
+  const consumed = new Set<string>(snapshot ?? []);
+
+  return {
+    consume(nonce: string): OwnerClaimNonceConsumeOutcome {
+      if (consumed.has(nonce)) return "replayed";
+      consumed.add(nonce);
+      return "fresh";
+    },
+    snapshot(): string[] {
+      return [...consumed];
+    },
+  };
+}

--- a/src/api/auth/device-attest/friday-owner-claim-transcript.ts
+++ b/src/api/auth/device-attest/friday-owner-claim-transcript.ts
@@ -1,0 +1,175 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · Slice 2a ───
+//
+// Canonical owner-claim transcript encoding + P-256 signature primitives.
+//
+// The encoding is a DETERMINISTIC, length-prefixed binary framing with a fixed
+// field order and a domain-separation prefix. Because the verifier reconstructs
+// the bytes from the typed fields (it never parses an attacker-supplied byte
+// blob), there is exactly ONE valid encoding of a given transcript — alternate /
+// ambiguous encodings cannot exist by construction. The u32 length prefix on
+// every field removes field-boundary ambiguity (e.g. it prevents a hubId/installId
+// split from colliding with a different split of the same concatenation).
+
+import { createHash, createPublicKey, type KeyObject } from "node:crypto";
+import type {
+  OwnerClaimSignatureAlgorithm,
+  OwnerClaimTranscript,
+  OwnerClaimTranscriptVersion,
+} from "./friday-owner-claim-transcript.types.js";
+
+// ─── Allowlists (value constants) ───
+
+export const OWNER_CLAIM_TRANSCRIPT_VERSION: OwnerClaimTranscriptVersion =
+  "friday-owner-claim-v1";
+
+export const OWNER_CLAIM_ALGORITHM: OwnerClaimSignatureAlgorithm =
+  "ECDSA_P256_SHA256";
+
+export const ALLOWED_TRANSCRIPT_VERSIONS: ReadonlySet<string> = new Set([
+  OWNER_CLAIM_TRANSCRIPT_VERSION,
+]);
+
+export const ALLOWED_ALGORITHMS: ReadonlySet<string> = new Set([
+  OWNER_CLAIM_ALGORITHM,
+]);
+
+/** Fixed claim-kind discriminator that MUST appear in every transcript. */
+export const OWNER_CLAIM_KIND = "install_owner_claim" as const;
+
+// ─── Domain separation ───
+
+const TRANSCRIPT_DOMAIN = "friday.owner-claim.transcript";
+
+// ─── NIST P-256 curve order (n) and n/2 for low-S enforcement ───
+
+export const P256_ORDER_N = BigInt(
+  "0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551",
+);
+export const P256_HALF_ORDER = P256_ORDER_N >> 1n;
+
+/** IEEE P-1363 raw signature length for P-256 (r‖s, 32 + 32). */
+export const P256_P1363_SIGNATURE_BYTES = 64;
+
+// ─── Canonical encoding ───
+
+function lengthPrefixed(value: string): Buffer {
+  const body = Buffer.from(value, "utf8");
+  const prefix = Buffer.alloc(4);
+  prefix.writeUInt32BE(body.byteLength, 0);
+  return Buffer.concat([prefix, body]);
+}
+
+/**
+ * Deterministically encode a transcript to its canonical bytes:
+ * `LP(domain) ‖ LP(field_0) ‖ … ‖ LP(field_n)` where LP(x) = u32be(len) ‖ utf8(x).
+ *
+ * The field order below is part of the wire contract and MUST NOT be reordered
+ * without bumping the transcript version. Fields are listed EXPLICITLY (rather
+ * than iterated over a key array) so the exact signed layout is auditable at a
+ * glance and there is no dynamic property access.
+ */
+export function encodeOwnerClaimTranscript(
+  transcript: OwnerClaimTranscript,
+): Buffer {
+  return Buffer.concat([
+    lengthPrefixed(TRANSCRIPT_DOMAIN),
+    lengthPrefixed(transcript.transcriptVersion),
+    lengthPrefixed(transcript.algorithm),
+    lengthPrefixed(transcript.kind),
+    lengthPrefixed(transcript.hubId),
+    lengthPrefixed(transcript.installId),
+    lengthPrefixed(transcript.osUser),
+    lengthPrefixed(transcript.deviceId),
+    lengthPrefixed(transcript.action),
+    lengthPrefixed(transcript.origin),
+    lengthPrefixed(transcript.channel),
+    lengthPrefixed(transcript.nonce),
+    lengthPrefixed(transcript.expiresAt),
+    lengthPrefixed(transcript.devicePublicKeyHash),
+  ]);
+}
+
+/** SHA-256 hex digest of the canonical transcript bytes. */
+export function ownerClaimTranscriptDigestHex(
+  transcript: OwnerClaimTranscript,
+): string {
+  return createHash("sha256").update(encodeOwnerClaimTranscript(transcript)).digest("hex");
+}
+
+// ─── Public-key normalization + hashing ───
+
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+
+/** Decode a base64 or base64url string to a Buffer (tolerant of either alphabet). */
+export function decodeFlexibleBase64(value: string): Buffer {
+  const trimmed = value.trim();
+  if (BASE64URL_RE.test(trimmed.replace(/=+$/, "")) && /[-_]/.test(trimmed)) {
+    return Buffer.from(trimmed, "base64url");
+  }
+  return Buffer.from(trimmed, "base64");
+}
+
+/**
+ * Import a presented public key (SPKI DER base64/base64url or SPKI PEM) into a
+ * KeyObject. Throws on unparseable input (caller maps to `invalid_public_key`).
+ */
+export function importPresentedPublicKey(input:
+  | { encoding: "spki-der-base64"; value: string }
+  | { encoding: "spki-pem"; value: string }): KeyObject {
+  if (input.encoding === "spki-pem") {
+    return createPublicKey(input.value);
+  }
+  const der = decodeFlexibleBase64(input.value);
+  return createPublicKey({ key: der, format: "der", type: "spki" });
+}
+
+/** True iff the KeyObject is an EC key on the NIST P-256 (prime256v1) curve. */
+export function isP256PublicKey(key: KeyObject): boolean {
+  if (key.asymmetricKeyType !== "ec") return false;
+  const named = key.asymmetricKeyDetails?.namedCurve;
+  return named === "prime256v1";
+}
+
+/**
+ * Canonical device-public-key hash: SHA-256 hex over the SPKI DER export of the
+ * key. Independent of the presented encoding, so the transcript's bound hash is
+ * compared against a normalized representation.
+ */
+export function canonicalDevicePublicKeyHash(key: KeyObject): string {
+  const der = key.export({ format: "der", type: "spki" });
+  return createHash("sha256").update(der).digest("hex");
+}
+
+// ─── P-1363 signature parsing + low-S (malleability) enforcement ───
+
+export interface ParsedP1363Signature {
+  r: bigint;
+  s: bigint;
+  raw: Buffer;
+}
+
+function bufToBigInt(buf: Buffer): bigint {
+  return buf.byteLength === 0 ? 0n : BigInt("0x" + buf.toString("hex"));
+}
+
+/**
+ * Parse a canonical IEEE P-1363 raw P-256 signature. Returns null for any
+ * non-canonical length or out-of-range scalar (r or s not in [1, n-1]). This is
+ * the sole accepted signature encoding: DER and every other framing is rejected
+ * here as malformed.
+ */
+export function parseCanonicalP1363Signature(
+  raw: Buffer,
+): ParsedP1363Signature | null {
+  if (raw.byteLength !== P256_P1363_SIGNATURE_BYTES) return null;
+  const r = bufToBigInt(raw.subarray(0, 32));
+  const s = bufToBigInt(raw.subarray(32, 64));
+  if (r <= 0n || r >= P256_ORDER_N) return null;
+  if (s <= 0n || s >= P256_ORDER_N) return null;
+  return { r, s, raw };
+}
+
+/** True iff s is in the low-S (canonical, non-malleable) half: s ≤ n/2. */
+export function isLowS(s: bigint): boolean {
+  return s <= P256_HALF_ORDER;
+}

--- a/src/api/auth/device-attest/friday-owner-claim-transcript.types.ts
+++ b/src/api/auth/device-attest/friday-owner-claim-transcript.types.ts
@@ -1,0 +1,206 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · Slice 2a ───
+//
+// Server-side proof-of-possession (PoP) verifier types for the device-bound
+// owner-claim transcript.
+//
+// SCOPE (binding, per operator): this module verifies a CANONICAL owner-claim
+// transcript + a P-256 ECDSA signature over it. It proves that the signer holds
+// the private key for the presented public key, and that the signed transcript
+// binds every claim field (hub / install / os-user / device / action / origin /
+// channel / nonce / expiry / public-key-hash). It does NOT — and MUST NOT —
+// assert key protection (Secure Enclave / Keychain / attestation), grant owner
+// authority, mutate any store, or treat nonce-possession alone as identity. Key
+// protection is derived server-side by a FUTURE slice with a native bridge; here
+// it is always reported as `"unverified"`.
+
+// ─── Algorithm + version allowlists (value constants live in the impl) ───
+
+/** The single canonical transcript encoding version accepted by this verifier. */
+export type OwnerClaimTranscriptVersion = "friday-owner-claim-v1";
+
+/**
+ * The single canonical signature algorithm accepted by this verifier:
+ * ECDSA over the NIST P-256 (secp256r1 / prime256v1) curve with SHA-256, using
+ * the IEEE P-1363 fixed-width raw (r‖s, 32+32 bytes) signature encoding and an
+ * enforced low-S (canonical) form.
+ */
+export type OwnerClaimSignatureAlgorithm = "ECDSA_P256_SHA256";
+
+// ─── Key protection (NEVER inferred here) ───
+
+/**
+ * Key-protection posture. This verifier ALWAYS returns `"unverified"`: a valid
+ * signature proves possession, NOT that the key lives in the Secure Enclave or a
+ * Keychain ACL. A later slice + native attestation bridge derives the real
+ * posture server-side. Downstream code MUST NOT treat `"unverified"` as any form
+ * of hardware-backed assurance.
+ */
+export type OwnerClaimKeyProtection = "unverified";
+
+// ─── Canonical transcript fields ───
+
+/**
+ * The full set of fields bound by the canonical owner-claim transcript. The
+ * signature is computed over the deterministic encoding of ALL of these; a
+ * change to ANY field changes the signed bytes and therefore fails verification.
+ */
+export interface OwnerClaimTranscript {
+  /** Explicit, allow-listed transcript-encoding version. */
+  transcriptVersion: OwnerClaimTranscriptVersion;
+  /** Explicit, allow-listed signature algorithm (bound INTO the transcript). */
+  algorithm: OwnerClaimSignatureAlgorithm;
+  /** Fixed claim kind discriminator. */
+  kind: "install_owner_claim";
+  /** Hub identity the claim is bound to. */
+  hubId: string;
+  /** Stable installation id for this hub install. */
+  installId: string;
+  /** OS user the install runs as. */
+  osUser: string;
+  /** Device identity bound to the owner. */
+  deviceId: string;
+  /** Bound action label (e.g. "owner-claim"). */
+  action: string;
+  /** Loopback origin the claim is presented from. */
+  origin: string;
+  /** Presentation channel (e.g. "install-ipc"). */
+  channel: string;
+  /** Raw single-use challenge nonce previously issued by the hub. */
+  nonce: string;
+  /** Absolute expiry (ISO-8601) after which the claim is stale. */
+  expiresAt: string;
+  /**
+   * SHA-256 hex digest of the canonical SPKI DER of the device public key. The
+   * verifier recomputes this from the presented key and rejects on mismatch, so
+   * the signed transcript is cryptographically bound to a specific public key.
+   */
+  devicePublicKeyHash: string;
+}
+
+// ─── Presented public key ───
+
+/**
+ * The device public key presented alongside the transcript + signature. Encodings
+ * accepted: SPKI DER (base64 or base64url) or SPKI PEM. The verifier normalizes
+ * to canonical SPKI DER before hashing + verifying, so alternate encodings of the
+ * SAME key are equivalent, and a non-P-256 key is rejected.
+ */
+export type OwnerClaimPresentedPublicKey =
+  | { encoding: "spki-der-base64"; value: string }
+  | { encoding: "spki-pem"; value: string };
+
+// ─── Presented signature ───
+
+/**
+ * The canonical signature encoding: IEEE P-1363 fixed-width raw (r‖s), exactly 64
+ * bytes, base64 or base64url. DER / alternate encodings are rejected as malformed.
+ */
+export interface OwnerClaimPresentedSignature {
+  encoding: "ieee-p1363-base64";
+  value: string;
+}
+
+// ─── Verifier input ───
+
+export interface VerifyOwnerClaimPossessionInput {
+  transcript: OwnerClaimTranscript;
+  devicePublicKey: OwnerClaimPresentedPublicKey;
+  signature: OwnerClaimPresentedSignature;
+  /** Wall-clock epoch milliseconds used for the freshness (expiry) gate. */
+  nowMs: number;
+}
+
+// ─── Typed failure reasons (discriminated, never thrown strings) ───
+
+export type OwnerClaimPoPRejectReason =
+  | "unsupported_transcript_version"
+  | "unsupported_algorithm"
+  | "malformed_transcript"
+  | "expired"
+  | "invalid_public_key"
+  | "unsupported_key"
+  | "public_key_hash_mismatch"
+  | "malformed_signature"
+  | "non_canonical_signature"
+  | "signature_mismatch";
+
+// ─── Verifier result (discriminated union) ───
+
+export interface OwnerClaimPoPSuccess {
+  ok: true;
+  /** ALWAYS "unverified" — possession proven, protection NOT inferred. */
+  keyProtection: OwnerClaimKeyProtection;
+  algorithm: OwnerClaimSignatureAlgorithm;
+  transcriptVersion: OwnerClaimTranscriptVersion;
+  /** SHA-256 hex of the canonical transcript bytes that were verified. */
+  transcriptDigestHex: string;
+  /** SHA-256 hex of the canonical SPKI DER of the verified public key. */
+  devicePublicKeyHash: string;
+}
+
+export interface OwnerClaimPoPFailure {
+  ok: false;
+  reason: OwnerClaimPoPRejectReason;
+  /**
+   * Non-sensitive diagnostic detail. NEVER contains the nonce, signature, or any
+   * key material.
+   */
+  detail?: string;
+}
+
+export type OwnerClaimPoPResult = OwnerClaimPoPSuccess | OwnerClaimPoPFailure;
+
+// ─── Stable verifier seam (later slices plug in without copying crypto) ───
+
+export interface FridayOwnerClaimPoPVerifier {
+  /**
+   * Stateless verification of transcript-field binding + P-256 ECDSA
+   * proof-of-possession. Pure: no side effects, grants NO authority.
+   */
+  verifyPossession(input: VerifyOwnerClaimPossessionInput): OwnerClaimPoPResult;
+}
+
+// ─── Single-use nonce seam (replay / restart survival) ───
+
+/** Outcome of attempting to consume a single-use owner-claim nonce. */
+export type OwnerClaimNonceConsumeOutcome = "fresh" | "replayed";
+
+/**
+ * The single-use nonce seam. Production wires the durable, atomic DB-backed
+ * nonce repository (SEC-SETUP-BOOTSTRAP-001 Slice 1) here; this module ships an
+ * in-memory REFERENCE implementation for tests + composition demos only.
+ */
+export interface OwnerClaimNonceConsumer {
+  /**
+   * Consume a nonce exactly once. Returns "fresh" the first time and "replayed"
+   * on every subsequent presentation of the same nonce (including after a
+   * state-reload / restart).
+   */
+  consume(nonce: string): OwnerClaimNonceConsumeOutcome;
+}
+
+// ─── Composed presentation seam (S3 integration plug-point) ───
+
+export type OwnerClaimPresentationRejectReason =
+  | OwnerClaimPoPRejectReason
+  | "nonce_replayed";
+
+export interface OwnerClaimPresentationSuccess extends OwnerClaimPoPSuccess {
+  nonceConsumed: true;
+}
+
+export interface OwnerClaimPresentationFailure {
+  ok: false;
+  reason: OwnerClaimPresentationRejectReason;
+  detail?: string;
+}
+
+export type OwnerClaimPresentationResult =
+  | OwnerClaimPresentationSuccess
+  | OwnerClaimPresentationFailure;
+
+export interface VerifyOwnerClaimPresentationInput
+  extends VerifyOwnerClaimPossessionInput {
+  verifier: FridayOwnerClaimPoPVerifier;
+  nonceConsumer: OwnerClaimNonceConsumer;
+}

--- a/src/api/auth/device-attest/index.ts
+++ b/src/api/auth/device-attest/index.ts
@@ -1,0 +1,52 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · Slice 2a — device-attest barrel ───
+//
+// Server-side proof-of-possession verifier for the device-bound owner-claim
+// transcript. Verifies signature + private-key possession + transcript-field
+// binding ONLY. Never asserts key protection, never grants owner authority.
+
+export type {
+  FridayOwnerClaimPoPVerifier,
+  OwnerClaimKeyProtection,
+  OwnerClaimNonceConsumeOutcome,
+  OwnerClaimNonceConsumer,
+  OwnerClaimPoPFailure,
+  OwnerClaimPoPRejectReason,
+  OwnerClaimPoPResult,
+  OwnerClaimPoPSuccess,
+  OwnerClaimPresentationFailure,
+  OwnerClaimPresentationRejectReason,
+  OwnerClaimPresentationResult,
+  OwnerClaimPresentationSuccess,
+  OwnerClaimPresentedPublicKey,
+  OwnerClaimPresentedSignature,
+  OwnerClaimSignatureAlgorithm,
+  OwnerClaimTranscript,
+  OwnerClaimTranscriptVersion,
+  VerifyOwnerClaimPossessionInput,
+  VerifyOwnerClaimPresentationInput,
+} from "./friday-owner-claim-transcript.types.js";
+
+export {
+  createFridayOwnerClaimPoPVerifier,
+  verifyOwnerClaimPresentation,
+} from "./friday-device-poposession-verifier.js";
+
+export { createInMemoryOwnerClaimNonceConsumer } from "./friday-owner-claim-nonce-consumer.js";
+export type { InMemoryOwnerClaimNonceConsumer } from "./friday-owner-claim-nonce-consumer.js";
+
+export {
+  ALLOWED_ALGORITHMS,
+  ALLOWED_TRANSCRIPT_VERSIONS,
+  OWNER_CLAIM_ALGORITHM,
+  OWNER_CLAIM_KIND,
+  OWNER_CLAIM_TRANSCRIPT_VERSION,
+  P256_HALF_ORDER,
+  P256_ORDER_N,
+  P256_P1363_SIGNATURE_BYTES,
+  canonicalDevicePublicKeyHash,
+  encodeOwnerClaimTranscript,
+  isLowS,
+  isP256PublicKey,
+  ownerClaimTranscriptDigestHex,
+  parseCanonicalP1363Signature,
+} from "./friday-owner-claim-transcript.js";

--- a/test/adversarial/_secsetup-s2a.helpers.ts
+++ b/test/adversarial/_secsetup-s2a.helpers.ts
@@ -1,0 +1,140 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · Slice 2a — test helpers ───
+//
+// TRUTH LABEL: every keypair and signature produced here is a SOFTWARE
+// development / test key generated on the fly with Node crypto. These are NOT
+// Secure Enclave keys and NOT final-product attestation evidence. They exist
+// solely to drive the REAL production verifier through positive + adversarial
+// paths.
+//
+// Signing reuses the PRODUCTION canonical encoder (`encodeOwnerClaimTranscript`)
+// so the test signs exactly what the verifier verifies. The test never
+// re-implements ECDSA verification — it only generates keys, signs, and performs
+// deterministic signature-scalar manipulations (low-S normalization, high-S
+// twin) to exercise the malleability guard.
+
+import {
+  generateKeyPairSync,
+  sign as cryptoSign,
+  type KeyObject,
+} from "node:crypto";
+import {
+  P256_ORDER_N,
+  canonicalDevicePublicKeyHash,
+  encodeOwnerClaimTranscript,
+} from "../../src/api/auth/device-attest/index.js";
+import type {
+  OwnerClaimTranscript,
+} from "../../src/api/auth/device-attest/index.js";
+
+export interface TestDeviceKey {
+  publicKey: KeyObject;
+  privateKey: KeyObject;
+  /** Canonical SPKI DER of the public key, base64. */
+  spkiDerBase64: string;
+  /** SHA-256 hex of the canonical SPKI DER. */
+  publicKeyHash: string;
+}
+
+/** Generate a fresh software P-256 (prime256v1) dev/test keypair. */
+export function generateTestDeviceKey(): TestDeviceKey {
+  const { publicKey, privateKey } = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1",
+  });
+  const der = publicKey.export({ format: "der", type: "spki" });
+  return {
+    publicKey,
+    privateKey,
+    spkiDerBase64: Buffer.from(der).toString("base64"),
+    publicKeyHash: canonicalDevicePublicKeyHash(publicKey),
+  };
+}
+
+/** Build a well-formed base transcript bound to `key`, with optional overrides. */
+export function makeTranscript(
+  key: TestDeviceKey,
+  overrides: Partial<OwnerClaimTranscript> = {},
+): OwnerClaimTranscript {
+  return {
+    transcriptVersion: "friday-owner-claim-v1",
+    algorithm: "ECDSA_P256_SHA256",
+    kind: "install_owner_claim",
+    hubId: "hub-abc",
+    installId: "install-123",
+    osUser: "jarvis",
+    deviceId: "device-xyz",
+    action: "owner-claim",
+    origin: "https://127.0.0.1:8765",
+    channel: "install-ipc",
+    nonce: "nonce-0001",
+    expiresAt: "2999-01-01T00:00:00.000Z",
+    devicePublicKeyHash: key.publicKeyHash,
+    ...overrides,
+  };
+}
+
+function bufToBigInt(buf: Buffer): bigint {
+  return buf.byteLength === 0 ? 0n : BigInt("0x" + buf.toString("hex"));
+}
+
+function bigIntTo32(value: bigint): Buffer {
+  const hex = value.toString(16).padStart(64, "0");
+  return Buffer.from(hex, "hex");
+}
+
+/** Normalize a raw P-1363 signature to canonical low-S form (s ≤ n/2). */
+export function toLowS(raw: Buffer): Buffer {
+  const r = raw.subarray(0, 32);
+  let s = bufToBigInt(raw.subarray(32, 64));
+  if (s > P256_ORDER_N >> 1n) s = P256_ORDER_N - s;
+  return Buffer.concat([r, bigIntTo32(s)]);
+}
+
+/** Produce the high-S malleable twin (s → n − s) of a raw P-1363 signature. */
+export function toHighSTwin(raw: Buffer): Buffer {
+  const r = raw.subarray(0, 32);
+  const s = bufToBigInt(raw.subarray(32, 64));
+  return Buffer.concat([r, bigIntTo32(P256_ORDER_N - s)]);
+}
+
+/**
+ * Sign a transcript over its PRODUCTION canonical bytes, returning a canonical
+ * (low-S) raw P-1363 signature as base64. Signs whatever transcript is given, so
+ * "sign A, present B" attacks are expressible by signing one and presenting
+ * another.
+ */
+export function signTranscriptLowS(
+  key: TestDeviceKey,
+  transcript: OwnerClaimTranscript,
+): string {
+  const bytes = encodeOwnerClaimTranscript(transcript);
+  const raw = cryptoSign("sha256", bytes, {
+    key: key.privateKey,
+    dsaEncoding: "ieee-p1363",
+  });
+  return toLowS(raw).toString("base64");
+}
+
+/** Raw (un-normalized) P-1363 signature bytes over a transcript. */
+export function signTranscriptRaw(
+  key: TestDeviceKey,
+  transcript: OwnerClaimTranscript,
+): Buffer {
+  const bytes = encodeOwnerClaimTranscript(transcript);
+  return cryptoSign("sha256", bytes, {
+    key: key.privateKey,
+    dsaEncoding: "ieee-p1363",
+  });
+}
+
+/** DER-encoded (non-canonical for this verifier) signature over a transcript. */
+export function signTranscriptDerBase64(
+  key: TestDeviceKey,
+  transcript: OwnerClaimTranscript,
+): string {
+  const bytes = encodeOwnerClaimTranscript(transcript);
+  const der = cryptoSign("sha256", bytes, {
+    key: key.privateKey,
+    dsaEncoding: "der",
+  });
+  return Buffer.from(der).toString("base64");
+}

--- a/test/adversarial/evidence/secsetup-s2a-expiry.txt
+++ b/test/adversarial/evidence/secsetup-s2a-expiry.txt
@@ -1,0 +1,9 @@
+# secsetup-s2a-expiry.txt
+# SEC-SETUP-BOOTSTRAP-001 Slice 2a — red-first (mutation) evidence
+# generated: 2026-07-14T03:45:03.736Z
+# keys/signatures: SOFTWARE dev/test material (Node crypto) — NOT attestation evidence
+
+GUARD: freshness — reject when nowMs >= transcript.expiresAt
+ATTACK: present a signature-valid but EXPIRED transcript
+NEUTRALIZED (skip expiry gate): signature-accepted=true  => RED
+GUARDED   (production verifier): ok=false reason=expired  => GREEN

--- a/test/adversarial/evidence/secsetup-s2a-field-binding.txt
+++ b/test/adversarial/evidence/secsetup-s2a-field-binding.txt
@@ -1,0 +1,9 @@
+# secsetup-s2a-field-binding.txt
+# SEC-SETUP-BOOTSTRAP-001 Slice 2a — red-first (mutation) evidence
+# generated: 2026-07-14T03:45:03.736Z
+# keys/signatures: SOFTWARE dev/test material (Node crypto) — NOT attestation evidence
+
+GUARD: hubId (and every field) bound into the canonical signed bytes
+ATTACK: sign a claim for hub-A, present it as a claim for hub-B
+NEUTRALIZED (encoder drops hubId): digests collide=true, cross-hub accepted=true  => RED
+GUARDED   (production encoder)    : ok=false reason=signature_mismatch  => GREEN

--- a/test/adversarial/evidence/secsetup-s2a-malleability.txt
+++ b/test/adversarial/evidence/secsetup-s2a-malleability.txt
@@ -1,0 +1,9 @@
+# secsetup-s2a-malleability.txt
+# SEC-SETUP-BOOTSTRAP-001 Slice 2a — red-first (mutation) evidence
+# generated: 2026-07-14T03:45:03.734Z
+# keys/signatures: SOFTWARE dev/test material (Node crypto) — NOT attestation evidence
+
+GUARD: low-S canonical-signature enforcement (ECDSA malleability)
+ATTACK: present the high-S twin (r, n-s) of a valid low-S signature
+NEUTRALIZED (no low-S check, raw crypto.verify): accepted=true  => RED
+GUARDED   (production verifier)                : ok=false reason=non_canonical_signature  => GREEN

--- a/test/adversarial/evidence/secsetup-s2a-replay.txt
+++ b/test/adversarial/evidence/secsetup-s2a-replay.txt
@@ -1,0 +1,9 @@
+# secsetup-s2a-replay.txt
+# SEC-SETUP-BOOTSTRAP-001 Slice 2a — red-first (mutation) evidence
+# generated: 2026-07-14T03:45:03.737Z
+# keys/signatures: SOFTWARE dev/test material (Node crypto) — NOT attestation evidence
+
+GUARD: single-use nonce consumer (replay defense) composed over possession
+ATTACK: present the SAME valid nonce+signature twice
+NEUTRALIZED (possession-only, stateless): 1st ok=true, 2nd ok=true  => RED
+GUARDED   (with single-use consumer)    : 1st ok=true, 2nd ok=false reason=nonce_replayed  => GREEN

--- a/test/adversarial/secsetup-s2a-poposession-verifier.test.ts
+++ b/test/adversarial/secsetup-s2a-poposession-verifier.test.ts
@@ -1,0 +1,463 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · Slice 2a ───
+//
+// Adversarial + property suite for the production owner-claim proof-of-possession
+// verifier. Every test drives the REAL production verifier (never a re-implemented
+// algorithm). All keys/signatures are software dev/test material (see helpers) and
+// are NOT final-product attestation evidence.
+//
+// Core assertion across all negatives: the presentation is ZERO-EFFECT — it
+// returns a typed rejection and grants NO owner authority (the verifier is a pure
+// function with no state and no authority-bearing output).
+
+import { describe, expect, it } from "vitest";
+import { generateKeyPairSync, randomBytes } from "node:crypto";
+import {
+  createFridayOwnerClaimPoPVerifier,
+  createInMemoryOwnerClaimNonceConsumer,
+  encodeOwnerClaimTranscript,
+  ownerClaimTranscriptDigestHex,
+  verifyOwnerClaimPresentation,
+} from "../../src/api/auth/device-attest/index.js";
+import type {
+  OwnerClaimPoPResult,
+  OwnerClaimTranscript,
+} from "../../src/api/auth/device-attest/index.js";
+import {
+  generateTestDeviceKey,
+  makeTranscript,
+  signTranscriptDerBase64,
+  signTranscriptLowS,
+  signTranscriptRaw,
+  toHighSTwin,
+  toLowS,
+  type TestDeviceKey,
+} from "./_secsetup-s2a.helpers.js";
+
+const verifier = createFridayOwnerClaimPoPVerifier();
+const NOW = Date.parse("2025-01-01T00:00:00.000Z");
+
+/** Verify a transcript signed by `key`, presenting `key`'s SPKI DER. */
+function verifySigned(
+  key: TestDeviceKey,
+  signed: OwnerClaimTranscript,
+  presented: OwnerClaimTranscript = signed,
+  signatureB64: string = signTranscriptLowS(key, signed),
+  nowMs: number = NOW,
+): OwnerClaimPoPResult {
+  return verifier.verifyPossession({
+    transcript: presented,
+    devicePublicKey: { encoding: "spki-der-base64", value: key.spkiDerBase64 },
+    signature: { encoding: "ieee-p1363-base64", value: signatureB64 },
+    nowMs,
+  });
+}
+
+function expectReject(result: OwnerClaimPoPResult, reason: string): void {
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.reason).toBe(reason);
+}
+
+// ─── Happy path ───
+
+describe("SEC-SETUP-S2a · positive proof-of-possession", () => {
+  it("verifies a well-formed transcript + canonical signature", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const result = verifySigned(key, t);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.algorithm).toBe("ECDSA_P256_SHA256");
+      expect(result.transcriptVersion).toBe("friday-owner-claim-v1");
+      expect(result.devicePublicKeyHash).toBe(key.publicKeyHash);
+      expect(result.transcriptDigestHex).toBe(ownerClaimTranscriptDigestHex(t));
+    }
+  });
+
+  it("NEVER asserts key protection — always 'unverified' on success", () => {
+    const key = generateTestDeviceKey();
+    const result = verifySigned(key, makeTranscript(key));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.keyProtection).toBe("unverified");
+      // No owner-authority / enclave / attestation field is emitted.
+      expect(Object.keys(result).sort()).toEqual(
+        [
+          "algorithm",
+          "devicePublicKeyHash",
+          "keyProtection",
+          "ok",
+          "transcriptDigestHex",
+          "transcriptVersion",
+        ].sort(),
+      );
+      expect(result).not.toHaveProperty("userId");
+      expect(result).not.toHaveProperty("owner");
+    }
+  });
+
+  it("is a pure function — verifying twice yields an identical result and no state", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const sig = signTranscriptLowS(key, t);
+    const a = verifySigned(key, t, t, sig);
+    const b = verifySigned(key, t, t, sig);
+    expect(a).toEqual(b);
+    expect(a.ok).toBe(true);
+  });
+});
+
+// ─── Field-binding negatives (each mutated field breaks the signature) ───
+
+describe("SEC-SETUP-S2a · transcript-field binding (zero-effect)", () => {
+  const boundFields: Array<[string, Partial<OwnerClaimTranscript>]> = [
+    ["wrong Hub", { hubId: "hub-evil" }],
+    ["wrong install", { installId: "install-evil" }],
+    ["wrong OS user", { osUser: "root" }],
+    ["wrong device", { deviceId: "device-evil" }],
+    ["wrong action", { action: "delete-owner" }],
+    ["wrong origin", { origin: "https://evil.example" }],
+    ["wrong channel", { channel: "public-web" }],
+    ["wrong nonce", { nonce: "nonce-evil" }],
+  ];
+
+  for (const [label, mutation] of boundFields) {
+    it(`rejects ${label} presented over a signature for the original`, () => {
+      const key = generateTestDeviceKey();
+      const signed = makeTranscript(key);
+      const presented = { ...signed, ...mutation };
+      // Sign the ORIGINAL, present the MUTATED transcript.
+      expectReject(verifySigned(key, signed, presented), "signature_mismatch");
+    });
+  }
+
+  it("rejects a wrong-digest signature (signed a different transcript)", () => {
+    const key = generateTestDeviceKey();
+    const signedOther = makeTranscript(key, { action: "something-else" });
+    const presented = makeTranscript(key, { action: "owner-claim" });
+    const sig = signTranscriptLowS(key, signedOther);
+    expectReject(verifySigned(key, presented, presented, sig), "signature_mismatch");
+  });
+});
+
+// ─── Key negatives ───
+
+describe("SEC-SETUP-S2a · key binding + possession (zero-effect)", () => {
+  it("rejects a wrong key (signature by another key, hash-bound to presented)", () => {
+    const signer = generateTestDeviceKey();
+    const other = generateTestDeviceKey();
+    // Bind the transcript's key-hash to `other`, but sign with `signer`.
+    const t = makeTranscript(other);
+    const sig = signTranscriptLowS(signer, t);
+    // Present `other`'s public key: hash-binding passes, possession fails.
+    expectReject(
+      verifier.verifyPossession({
+        transcript: t,
+        devicePublicKey: { encoding: "spki-der-base64", value: other.spkiDerBase64 },
+        signature: { encoding: "ieee-p1363-base64", value: sig },
+        nowMs: NOW,
+      }),
+      "signature_mismatch",
+    );
+  });
+
+  it("rejects a public-key-hash mismatch (hash bound to a different key)", () => {
+    const key = generateTestDeviceKey();
+    const other = generateTestDeviceKey();
+    const t = makeTranscript(key, { devicePublicKeyHash: other.publicKeyHash });
+    // Sign so the signature itself is valid over these bytes; hash-binding gates first.
+    expectReject(verifySigned(key, t), "public_key_hash_mismatch");
+  });
+
+  it("rejects a non-P-256 key (secp256k1)", () => {
+    const p256 = generateTestDeviceKey();
+    const t = makeTranscript(p256);
+    const sig = signTranscriptLowS(p256, t);
+    // Wrong-curve EC public key (secp256k1) presented in place of the P-256 key.
+    const wrongCurve = generateKeyPairSync("ec", { namedCurve: "secp256k1" }).publicKey;
+    const spki = Buffer.from(wrongCurve.export({ format: "der", type: "spki" })).toString("base64");
+    expectReject(
+      verifier.verifyPossession({
+        transcript: t,
+        devicePublicKey: { encoding: "spki-der-base64", value: spki },
+        signature: { encoding: "ieee-p1363-base64", value: sig },
+        nowMs: NOW,
+      }),
+      "unsupported_key",
+    );
+  });
+
+  it("rejects an unparseable public key", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const sig = signTranscriptLowS(key, t);
+    expectReject(
+      verifier.verifyPossession({
+        transcript: t,
+        devicePublicKey: { encoding: "spki-der-base64", value: "not-a-real-key!!" },
+        signature: { encoding: "ieee-p1363-base64", value: sig },
+        nowMs: NOW,
+      }),
+      "invalid_public_key",
+    );
+  });
+});
+
+// ─── Expiry ───
+
+describe("SEC-SETUP-S2a · expiry (zero-effect)", () => {
+  it("rejects an expired transcript even with a valid signature", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key, { expiresAt: "2020-01-01T00:00:00.000Z" });
+    // nowMs (2025) is after the (2020) expiry.
+    expectReject(verifySigned(key, t), "expired");
+  });
+
+  it("accepts the SAME transcript+signature when the clock is before expiry", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key, { expiresAt: "2025-06-01T00:00:00.000Z" });
+    const sig = signTranscriptLowS(key, t);
+    // Confirms the rejection above is driven solely by the expiry guard.
+    const before = verifySigned(key, t, t, sig, Date.parse("2025-05-01T00:00:00.000Z"));
+    const after = verifySigned(key, t, t, sig, Date.parse("2025-07-01T00:00:00.000Z"));
+    expect(before.ok).toBe(true);
+    expectReject(after, "expired");
+  });
+
+  it("rejects a malformed expiry string", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key, { expiresAt: "not-a-date" });
+    expectReject(verifySigned(key, t), "malformed_transcript");
+  });
+});
+
+// ─── Algorithm / version allowlist ───
+
+describe("SEC-SETUP-S2a · algorithm + version allowlist (zero-effect)", () => {
+  it("rejects a disallowed algorithm", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key, {
+      algorithm: "ECDSA_P256_SHA512" as OwnerClaimTranscript["algorithm"],
+    });
+    expectReject(verifySigned(key, t), "unsupported_algorithm");
+  });
+
+  it("rejects a disallowed transcript version", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key, {
+      transcriptVersion: "friday-owner-claim-v2" as OwnerClaimTranscript["transcriptVersion"],
+    });
+    expectReject(verifySigned(key, t), "unsupported_transcript_version");
+  });
+
+  it("rejects a wrong kind discriminator", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key, {
+      kind: "install_admin_reset" as OwnerClaimTranscript["kind"],
+    });
+    expectReject(verifySigned(key, t), "malformed_transcript");
+  });
+
+  it("rejects an empty required field", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key, { origin: "" });
+    expectReject(verifySigned(key, t), "malformed_transcript");
+  });
+});
+
+// ─── Signature malleability + malformed encodings ───
+
+describe("SEC-SETUP-S2a · signature malleability + malformed (zero-effect)", () => {
+  it("rejects the high-S malleable twin of a valid signature", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    // Normalize to canonical low-S, then flip to the high-S twin. Both are
+    // ECDSA-valid; only low-S is canonical for this verifier.
+    const highS = toHighSTwin(toLowS(signTranscriptRaw(key, t)));
+    expectReject(
+      verifySigned(key, t, t, highS.toString("base64")),
+      "non_canonical_signature",
+    );
+  });
+
+  it("accepts the low-S form of the same signature (malleability guard is discriminating)", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    // Default helper already normalizes to low-S.
+    expect(verifySigned(key, t).ok).toBe(true);
+  });
+
+  it("rejects an alternate (DER) signature encoding", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const der = signTranscriptDerBase64(key, t);
+    expectReject(verifySigned(key, t, t, der), "malformed_signature");
+  });
+
+  it("rejects a truncated (63-byte) signature", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const raw = signTranscriptRaw(key, t).subarray(0, 63);
+    expectReject(verifySigned(key, t, t, raw.toString("base64")), "malformed_signature");
+  });
+
+  it("rejects an oversized (65-byte) signature", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const raw = Buffer.concat([signTranscriptRaw(key, t), Buffer.from([0x00])]);
+    expectReject(verifySigned(key, t, t, raw.toString("base64")), "malformed_signature");
+  });
+
+  it("rejects an all-zero (out-of-range r/s) signature", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    expectReject(
+      verifySigned(key, t, t, Buffer.alloc(64).toString("base64")),
+      "malformed_signature",
+    );
+  });
+
+  it("rejects a structurally-valid-but-wrong (garbage) signature", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    // Corrupt one byte of r, then normalize to low-S so it clears structural checks
+    // but fails the ECDSA math.
+    const raw = Buffer.from(signTranscriptRaw(key, t));
+    raw[0] = raw[0] ^ 0xff;
+    const low = toLowS(raw);
+    const result = verifySigned(key, t, t, low.toString("base64"));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(["signature_mismatch", "malformed_signature"]).toContain(result.reason);
+    }
+  });
+});
+
+// ─── Replay + restart (composed presentation seam) ───
+
+describe("SEC-SETUP-S2a · replay + restart via single-use nonce seam (zero-effect)", () => {
+  it("accepts once, then rejects a replay of the same nonce", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const consumer = createInMemoryOwnerClaimNonceConsumer();
+    const args = {
+      verifier,
+      nonceConsumer: consumer,
+      transcript: t,
+      devicePublicKey: { encoding: "spki-der-base64" as const, value: key.spkiDerBase64 },
+      signature: { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(key, t) },
+      nowMs: NOW,
+    };
+    const first = verifyOwnerClaimPresentation(args);
+    const second = verifyOwnerClaimPresentation(args);
+    expect(first.ok).toBe(true);
+    if (first.ok) expect(first.nonceConsumed).toBe(true);
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.reason).toBe("nonce_replayed");
+  });
+
+  it("survives restart — replay is still rejected after re-reading persisted consumed state", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const consumer = createInMemoryOwnerClaimNonceConsumer();
+    const sig = signTranscriptLowS(key, t);
+    const base = {
+      verifier,
+      transcript: t,
+      devicePublicKey: { encoding: "spki-der-base64" as const, value: key.spkiDerBase64 },
+      signature: { encoding: "ieee-p1363-base64" as const, value: sig },
+      nowMs: NOW,
+    };
+    expect(verifyOwnerClaimPresentation({ ...base, nonceConsumer: consumer }).ok).toBe(true);
+
+    // Simulate restart: re-read persisted consumed set into a NEW consumer.
+    const snapshot = consumer.snapshot();
+    const rebuilt = createInMemoryOwnerClaimNonceConsumer(snapshot);
+    const afterRestart = verifyOwnerClaimPresentation({ ...base, nonceConsumer: rebuilt });
+    expect(afterRestart.ok).toBe(false);
+    if (!afterRestart.ok) expect(afterRestart.reason).toBe("nonce_replayed");
+  });
+
+  it("presentation with an invalid signature does NOT burn the nonce", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const consumer = createInMemoryOwnerClaimNonceConsumer();
+    const badSig = Buffer.alloc(64).toString("base64");
+    const bad = verifyOwnerClaimPresentation({
+      verifier,
+      nonceConsumer: consumer,
+      transcript: t,
+      devicePublicKey: { encoding: "spki-der-base64", value: key.spkiDerBase64 },
+      signature: { encoding: "ieee-p1363-base64", value: badSig },
+      nowMs: NOW,
+    });
+    expect(bad.ok).toBe(false);
+    // Nonce was never consumed, so a subsequent VALID claim still succeeds.
+    const good = verifyOwnerClaimPresentation({
+      verifier,
+      nonceConsumer: consumer,
+      transcript: t,
+      devicePublicKey: { encoding: "spki-der-base64", value: key.spkiDerBase64 },
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(key, t) },
+      nowMs: NOW,
+    });
+    expect(good.ok).toBe(true);
+  });
+});
+
+// ─── Canonical-encoding properties ───
+
+describe("SEC-SETUP-S2a · canonical encoding properties", () => {
+  it("is deterministic across repeated encodings", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    expect(encodeOwnerClaimTranscript(t).equals(encodeOwnerClaimTranscript(t))).toBe(true);
+  });
+
+  it("has no field-boundary ambiguity (length-prefixing prevents collisions)", () => {
+    const key = generateTestDeviceKey();
+    const a = makeTranscript(key, { hubId: "a", installId: "bc" });
+    const b = makeTranscript(key, { hubId: "ab", installId: "c" });
+    expect(ownerClaimTranscriptDigestHex(a)).not.toBe(ownerClaimTranscriptDigestHex(b));
+  });
+});
+
+// ─── Property fuzz: any single bound-field mutation breaks verification ───
+
+describe("SEC-SETUP-S2a · property — mutation of any bound field fails", () => {
+  const mutable: Array<keyof OwnerClaimTranscript> = [
+    "hubId",
+    "installId",
+    "osUser",
+    "deviceId",
+    "action",
+    "origin",
+    "channel",
+    "nonce",
+  ];
+
+  it("freshly-signed transcripts always verify; single-field tamper always fails", () => {
+    for (let i = 0; i < 40; i++) {
+      const key = generateTestDeviceKey();
+      const signed = makeTranscript(key, {
+        hubId: `hub-${randomBytes(4).toString("hex")}`,
+        installId: `install-${randomBytes(4).toString("hex")}`,
+        nonce: `nonce-${randomBytes(6).toString("hex")}`,
+      });
+      const sig = signTranscriptLowS(key, signed);
+
+      // Positive: the signed transcript verifies.
+      expect(verifySigned(key, signed, signed, sig).ok).toBe(true);
+
+      // Negative: tamper one random bound field → signature_mismatch.
+      const field = mutable[i % mutable.length];
+      const tampered: OwnerClaimTranscript = {
+        ...signed,
+        [field]: `${signed[field]}-tampered`,
+      };
+      const result = verifySigned(key, signed, tampered, sig);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("signature_mismatch");
+    }
+  });
+});

--- a/test/adversarial/secsetup-s2a-red-first-evidence.test.ts
+++ b/test/adversarial/secsetup-s2a-red-first-evidence.test.ts
@@ -1,0 +1,223 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · Slice 2a — §5 red-first evidence ───
+//
+// For each core guard (malleability / transcript-field binding / expiry / replay)
+// this proves the assertion goes RED when the guard is NEUTRALIZED and GREEN with
+// the REAL production guard. The "neutralized" foils reuse production primitives
+// (canonical encoder, Node crypto.verify) minus exactly one guard — they are
+// mutation-testing controls, NOT a re-implementation of ECDSA verification.
+//
+// Evidence artifacts are written to test/adversarial/evidence/secsetup-s2a-*.txt.
+// All keys/signatures are software dev/test material (see helpers).
+
+import { describe, expect, it } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { sign as cryptoSign, verify as cryptoVerify } from "node:crypto";
+import {
+  createFridayOwnerClaimPoPVerifier,
+  createInMemoryOwnerClaimNonceConsumer,
+  encodeOwnerClaimTranscript,
+  verifyOwnerClaimPresentation,
+} from "../../src/api/auth/device-attest/index.js";
+import type { OwnerClaimTranscript } from "../../src/api/auth/device-attest/index.js";
+import {
+  generateTestDeviceKey,
+  makeTranscript,
+  signTranscriptLowS,
+  signTranscriptRaw,
+  toHighSTwin,
+  toLowS,
+} from "./_secsetup-s2a.helpers.js";
+
+const verifier = createFridayOwnerClaimPoPVerifier();
+const NOW = Date.parse("2025-01-01T00:00:00.000Z");
+const EVIDENCE_DIR = resolve("test/adversarial/evidence");
+
+function writeEvidence(name: string, lines: string[]): void {
+  mkdirSync(EVIDENCE_DIR, { recursive: true });
+  const header = [
+    `# ${name}`,
+    `# SEC-SETUP-BOOTSTRAP-001 Slice 2a — red-first (mutation) evidence`,
+    `# generated: ${new Date().toISOString()}`,
+    `# keys/signatures: SOFTWARE dev/test material (Node crypto) — NOT attestation evidence`,
+    "",
+  ];
+  writeFileSync(resolve(EVIDENCE_DIR, name), header.concat(lines).join("\n") + "\n");
+}
+
+// Length-prefixed helper mirroring the production framing, for the neutralized
+// field-binding foil only.
+function lp(value: string): Buffer {
+  const body = Buffer.from(value, "utf8");
+  const prefix = Buffer.alloc(4);
+  prefix.writeUInt32BE(body.byteLength, 0);
+  return Buffer.concat([prefix, body]);
+}
+
+/** NEUTRALIZED encoder: identical to production BUT omits hubId from the bytes. */
+function encodeDroppingHubId(t: OwnerClaimTranscript): Buffer {
+  return Buffer.concat([
+    lp("friday.owner-claim.transcript"),
+    lp(t.transcriptVersion),
+    lp(t.algorithm),
+    lp(t.kind),
+    // hubId intentionally DROPPED — this is the removed guard.
+    lp(t.installId),
+    lp(t.osUser),
+    lp(t.deviceId),
+    lp(t.action),
+    lp(t.origin),
+    lp(t.channel),
+    lp(t.nonce),
+    lp(t.expiresAt),
+    lp(t.devicePublicKeyHash),
+  ]);
+}
+
+describe("SEC-SETUP-S2a · red-first evidence", () => {
+  it("malleability guard: high-S twin is RED (accepted) neutralized, GREEN (rejected) guarded", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const highS = toHighSTwin(toLowS(signTranscriptRaw(key, t)));
+    const canonicalBytes = encodeOwnerClaimTranscript(t);
+
+    // NEUTRALIZED: raw crypto.verify with no low-S check accepts the malleated twin.
+    const neutralizedAccepts = cryptoVerify(
+      "sha256",
+      canonicalBytes,
+      { key: key.publicKey, dsaEncoding: "ieee-p1363" },
+      highS,
+    );
+
+    // GUARDED: the real verifier rejects it as non-canonical.
+    const guarded = verifier.verifyPossession({
+      transcript: t,
+      devicePublicKey: { encoding: "spki-der-base64", value: key.spkiDerBase64 },
+      signature: { encoding: "ieee-p1363-base64", value: highS.toString("base64") },
+      nowMs: NOW,
+    });
+
+    expect(neutralizedAccepts).toBe(true); // RED without the guard
+    expect(guarded.ok).toBe(false); // GREEN with the guard
+    if (!guarded.ok) expect(guarded.reason).toBe("non_canonical_signature");
+
+    writeEvidence("secsetup-s2a-malleability.txt", [
+      "GUARD: low-S canonical-signature enforcement (ECDSA malleability)",
+      "ATTACK: present the high-S twin (r, n-s) of a valid low-S signature",
+      `NEUTRALIZED (no low-S check, raw crypto.verify): accepted=${neutralizedAccepts}  => RED`,
+      `GUARDED   (production verifier)                : ok=${guarded.ok} reason=${guarded.ok ? "-" : guarded.reason}  => GREEN`,
+    ]);
+  });
+
+  it("field-binding guard: cross-hub swap is RED neutralized, GREEN guarded", () => {
+    const key = generateTestDeviceKey();
+    const tA = makeTranscript(key, { hubId: "hub-A" });
+    const tB = makeTranscript(key, { hubId: "hub-B" });
+
+    // NEUTRALIZED: encoder drops hubId, so a signature over tA verifies for tB.
+    const droppedA = encodeDroppingHubId(tA);
+    const droppedB = encodeDroppingHubId(tB);
+    const sigOverDroppedA = signOverBytes(key, droppedA);
+    const neutralizedAccepts = cryptoVerify(
+      "sha256",
+      droppedB,
+      { key: key.publicKey, dsaEncoding: "ieee-p1363" },
+      sigOverDroppedA,
+    );
+
+    // GUARDED: production encoder includes hubId — sign tA, present tB → mismatch.
+    const guarded = verifier.verifyPossession({
+      transcript: tB,
+      devicePublicKey: { encoding: "spki-der-base64", value: key.spkiDerBase64 },
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(key, tA) },
+      nowMs: NOW,
+    });
+
+    expect(neutralizedAccepts).toBe(true); // RED: cross-hub forgery passes without hubId in bytes
+    expect(guarded.ok).toBe(false); // GREEN
+    if (!guarded.ok) expect(guarded.reason).toBe("signature_mismatch");
+    expect(droppedA.equals(droppedB)).toBe(true); // collision proof
+
+    writeEvidence("secsetup-s2a-field-binding.txt", [
+      "GUARD: hubId (and every field) bound into the canonical signed bytes",
+      "ATTACK: sign a claim for hub-A, present it as a claim for hub-B",
+      `NEUTRALIZED (encoder drops hubId): digests collide=${droppedA.equals(droppedB)}, cross-hub accepted=${neutralizedAccepts}  => RED`,
+      `GUARDED   (production encoder)    : ok=${guarded.ok} reason=${guarded.ok ? "-" : guarded.reason}  => GREEN`,
+    ]);
+  });
+
+  it("expiry guard: expired claim is RED neutralized, GREEN guarded", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key, { expiresAt: "2020-01-01T00:00:00.000Z" });
+    const sig = signTranscriptRaw(key, t);
+    const canonicalBytes = encodeOwnerClaimTranscript(t);
+
+    // NEUTRALIZED: verify the signature but skip the expiry gate → expired passes.
+    const neutralizedAccepts = cryptoVerify(
+      "sha256",
+      canonicalBytes,
+      { key: key.publicKey, dsaEncoding: "ieee-p1363" },
+      sig,
+    );
+
+    // GUARDED: real verifier rejects the expired claim (now=2025 > expiry=2020).
+    const guarded = verifier.verifyPossession({
+      transcript: t,
+      devicePublicKey: { encoding: "spki-der-base64", value: key.spkiDerBase64 },
+      signature: { encoding: "ieee-p1363-base64", value: toLowS(sig).toString("base64") },
+      nowMs: NOW,
+    });
+
+    expect(neutralizedAccepts).toBe(true); // RED without expiry gate
+    expect(guarded.ok).toBe(false); // GREEN
+    if (!guarded.ok) expect(guarded.reason).toBe("expired");
+
+    writeEvidence("secsetup-s2a-expiry.txt", [
+      "GUARD: freshness — reject when nowMs >= transcript.expiresAt",
+      "ATTACK: present a signature-valid but EXPIRED transcript",
+      `NEUTRALIZED (skip expiry gate): signature-accepted=${neutralizedAccepts}  => RED`,
+      `GUARDED   (production verifier): ok=${guarded.ok} reason=${guarded.ok ? "-" : guarded.reason}  => GREEN`,
+    ]);
+  });
+
+  it("replay guard: second use is RED without the nonce consumer, GREEN with it", () => {
+    const key = generateTestDeviceKey();
+    const t = makeTranscript(key);
+    const input = {
+      transcript: t,
+      devicePublicKey: { encoding: "spki-der-base64" as const, value: key.spkiDerBase64 },
+      signature: { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(key, t) },
+      nowMs: NOW,
+    };
+
+    // NEUTRALIZED: stateless possession verify has no single-use guard — replays pass.
+    const neutralizedFirst = verifier.verifyPossession(input);
+    const neutralizedSecond = verifier.verifyPossession(input);
+
+    // GUARDED: composed presentation with the single-use nonce consumer.
+    const consumer = createInMemoryOwnerClaimNonceConsumer();
+    const guardedFirst = verifyOwnerClaimPresentation({ ...input, verifier, nonceConsumer: consumer });
+    const guardedSecond = verifyOwnerClaimPresentation({ ...input, verifier, nonceConsumer: consumer });
+
+    expect(neutralizedFirst.ok).toBe(true);
+    expect(neutralizedSecond.ok).toBe(true); // RED: replay accepted without the guard
+    expect(guardedFirst.ok).toBe(true);
+    expect(guardedSecond.ok).toBe(false); // GREEN: replay rejected
+    if (!guardedSecond.ok) expect(guardedSecond.reason).toBe("nonce_replayed");
+
+    writeEvidence("secsetup-s2a-replay.txt", [
+      "GUARD: single-use nonce consumer (replay defense) composed over possession",
+      "ATTACK: present the SAME valid nonce+signature twice",
+      `NEUTRALIZED (possession-only, stateless): 1st ok=${neutralizedFirst.ok}, 2nd ok=${neutralizedSecond.ok}  => RED`,
+      `GUARDED   (with single-use consumer)    : 1st ok=${guardedFirst.ok}, 2nd ok=${guardedSecond.ok} reason=${guardedSecond.ok ? "-" : guardedSecond.reason}  => GREEN`,
+    ]);
+  });
+});
+
+// Local signer over arbitrary bytes (for the field-binding neutralized foil).
+function signOverBytes(
+  key: ReturnType<typeof generateTestDeviceKey>,
+  bytes: Buffer,
+): Buffer {
+  return toLowS(cryptoSign("sha256", bytes, { key: key.privateKey, dsaEncoding: "ieee-p1363" }));
+}


### PR DESCRIPTION
## SEC-SETUP-BOOTSTRAP-001 · Slice 2a — server-side owner-claim proof-of-possession verifier

Independent, **stateless** server-side proof-of-possession (PoP) verifier for the device-bound owner-claim transcript in the operator-locked architecture (signed `Friday.app` → privileged local IPC → hub single-use nonce → native SecKey/Keychain device key → canonical transcript signature → atomic owner/device binding). This slice builds **only** the verifier for that transcript + signature, decoupled from the operator-gated native app.

**Builder PR — do NOT merge. Reviewer signs the final SHA.**

### What this adds (new module `src/api/auth/device-attest/` + tests only)
- **Versioned canonical transcript** (`friday-owner-claim-transcript.ts`): deterministic, length-prefixed binary encoding with a fixed field order + domain separation, binding **all** claim fields — hub / install / os-user / device / action / origin / channel / nonce / expiry / public-key-hash — plus an explicit `transcriptVersion` and an `algorithm`/`version` **allowlist**. The verifier reconstructs bytes from typed fields (never parses an attacker blob), so exactly one valid encoding exists by construction.
- **Production P-256 (secp256r1/prime256v1) ECDSA** verification via `node:crypto` (`createPublicKey` + `crypto.verify`). **No hand-rolled EC math.**
- **Proof-of-possession**: the signature over the nonce-bound transcript proves the signer holds the private key for the presented public key (bound via SPKI-DER hash).
- **Malleability rejection**: canonical IEEE **P-1363 raw** signature only (DER + alternate encodings rejected as malformed) with enforced **low-S**.
- **Typed discriminated failure results** for every rejection reason (no thrown strings).
- **Stable seams**: `FridayOwnerClaimPoPVerifier` + a single-use `OwnerClaimNonceConsumer` seam (in-memory **reference** impl only — production replay/expiry enforcement remains the Slice-1 DB nonce repository, wired by S3) + a composed `verifyOwnerClaimPresentation` plug-point.

### Attestation-theater guardrails (binding)
- `keyProtection` is **NEVER inferred** here — always `"unverified"`. A valid signature proves possession, **not** Secure Enclave / Keychain / attestation. No unverified key gains owner authority; the verifier grants **zero** authority and mutates **no** state.

### Tests (real production verifier; software dev/test keys — NOT attestation evidence)
Happy path + zero-effect adversarial rejections: wrong key · wrong digest · wrong hub · wrong install · wrong os-user · wrong device · wrong action · wrong origin · wrong channel · expired · replay · restart (persisted-state re-read) · high-S + DER malleability · disallowed algorithm/version · truncated/oversized/garbage/out-of-range signature · public-key-hash mismatch · wrong curve.

**§5 red-first mutation evidence** (`test/adversarial/evidence/secsetup-s2a-*.txt`) proves the malleability / field-binding / expiry / replay guards each go RED when neutralized and GREEN with the production guard.

### Scope / safety
- **No DB migration** (stateless crypto). **No `friday-auth-service.ts` owner-claim wiring** (later slice).
- Born-current off `c6b7335aa07f86f4e07aeb13eb342e498a614634`; all files are additive/new.

### Gates (green locally)
- `npx tsc --noEmit` → 0
- `npx eslint src/api/auth/device-attest/` → 0 errors, 0 warnings
- `detect-secrets-hook --baseline .secrets.baseline` → clean (no baseline change)
- new tests → 40 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48
