### PR TITLE
test(hub): de-flake channel-natural-trigger teardown ENOTEMPTY race

### DIFF
--- a/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
+++ b/test/unit/hub/friday-channel-natural-trigger-runtime.test.ts
@@ -183,7 +183,7 @@ describe("channel natural-trigger parent runtime resolver", () => {
       hub = null;
     }
     if (stateDir) {
-      await fs.rm(stateDir, { recursive: true, force: true });
+      await fs.rm(stateDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
       stateDir = null;
     }
     if (autoDetectEnvSnapshot) {
@@ -645,7 +645,7 @@ describe("channel session-mirror write guard (G5, default fail-closed)", () => {
       hub = null;
     }
     if (stateDir) {
-      await fs.rm(stateDir, { recursive: true, force: true });
+      await fs.rm(stateDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
       stateDir = null;
     }
     if (autoDetectEnvSnapshot) {
@@ -756,7 +756,7 @@ describe("channel ENGINE control-plane write guard (G5 completeness, default fai
       hub = null;
     }
     if (stateDir) {
-      await fs.rm(stateDir, { recursive: true, force: true });
+      await fs.rm(stateDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
       stateDir = null;
     }
     if (autoDetectEnvSnapshot) {


### PR DESCRIPTION
Test-only teardown hardening. No product code. No migration. No schema change.

## What
Adds Node's built-in `fs.rm` retry (`maxRetries: 10, retryDelay: 50`) to all three `afterEach` teardowns in `test/unit/hub/friday-channel-natural-trigger-runtime.test.ts` that remove the per-test temp state dir.

## Why
CI job `test` intermittently crashed in **afterEach teardown** (not an assertion) with:
`Error: ENOTEMPTY: directory not empty, rmdir '/tmp/friday-channel-engine-failclosed-XXXX/.friday'`

Root cause: the teardown called `fs.rm(stateDir, { recursive: true, force: true })` with Node's default `maxRetries: 0`. A background `.friday/` writer (audit-log / hub persistence) can still be in-flight during teardown, so `rmdir` sees a non-empty dir and throws `ENOTEMPTY` instead of retrying. `maxRetries` makes `fs.rm` retry specifically on `ENOTEMPTY`/`EBUSY`/`EPERM`/`ENOENT` with linear backoff — the canonical fix for a teardown race. This is an environmental flake; the test passes on clean main.

## Scope
- One file changed (test only): `test/unit/hub/friday-channel-natural-trigger-runtime.test.ts`
- No assertions, test bodies, or product source changed. No test skipped/weakened.

## Verification
- Affected file run 20x in a loop: 20/20 GREEN, `14 tests passed` each run, zero ENOTEMPTY.
- `tsc --noEmit`: 0 errors.
- `npm run lint` (eslint .): 0 errors (test/** is intentionally ignore-listed by the repo eslint config; file lints clean under `--no-warn-ignored`).

Fixes intermittent `ENOTEMPTY rmdir .friday` in `friday-channel-natural-trigger-runtime.test.ts`.