### PR TITLE
feat(secsetup): fail-closed DISABLED device-principal owner data/control plumbing (SEC-SETUP-BOOTSTRAP-001 Slice 3)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -196,7 +196,7 @@
         "filename": "src/api/http/routes/friday-auth-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 164
+        "line_number": 168
       }
     ],
     "src/api/http/routes/friday-provider-routes.ts": [
@@ -611,7 +611,7 @@
         "filename": "test/unit/api/http/routes/friday-auth-routes.test.ts",
         "hashed_secret": "3b5910f25dbc879c344ca806b582efb0da6ffa6f",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 33
       }
     ],
     "test/unit/api/http/routes/friday-multi-tenant-security-routes.test.ts": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-14T03:04:37Z"
+  "generated_at": "2026-07-14T05:28:59Z"
 }

--- a/src/api/auth/friday-auth-service.ts
+++ b/src/api/auth/friday-auth-service.ts
@@ -35,6 +35,17 @@ import { createFridayAuthSessionRepository } from "../persistence/friday-auth-se
 import { createFridaySetupBootstrapNonceRepository } from "../persistence/friday-setup-bootstrap-nonce-repository.js";
 import { isFridayTestSecurityWarningSuppressed } from "#utilities";
 import { isFridayLoopbackAddress } from "../http/friday-http-client-ip.js";
+import {
+  createFridayOwnerClaimPoPVerifier,
+} from "./device-attest/index.js";
+import type {
+  OwnerClaimPresentedSignature,
+  OwnerClaimTranscript,
+} from "./device-attest/index.js";
+import {
+  deriveDeviceKeyProtection,
+  isDeviceOwnerAuthorityEnabled,
+} from "../../security/friday-device-owner-authority-precondition.js";
 
 // ─── Helpers ───
 
@@ -62,6 +73,46 @@ const DEVICE_OWNER_HASH_PREFIX = "device-owner$v1$";
 
 function deviceOwnerSentinel(devicePublicKeyHash: string): string {
   return `${DEVICE_OWNER_HASH_PREFIX}${devicePublicKeyHash}`;
+}
+
+/**
+ * SEC-SETUP-BOOTSTRAP-001 Slice 3: defensively coerce an untrusted request-body
+ * device-claim proof into the strict transcript + signature shape the S2a
+ * verifier consumes. Returns null for any structurally invalid input (→ the
+ * caller fails closed). The literal-typed transcript fields are forwarded
+ * verbatim; the verifier re-validates version/algorithm/kind against its
+ * allowlists and rejects anything malformed — so this coercion grants nothing.
+ */
+function coerceDeviceClaimProof(raw: unknown): {
+  transcript: OwnerClaimTranscript;
+  signature: OwnerClaimPresentedSignature;
+} | null {
+  if (!raw || typeof raw !== "object") return null;
+  const proof = raw as Record<string, unknown>;
+  const t = proof.transcript;
+  const sig = proof.signature;
+  if (!t || typeof t !== "object") return null;
+  if (!sig || typeof sig !== "object") return null;
+  const tr = t as Record<string, unknown>;
+  const sg = sig as Record<string, unknown>;
+  if (sg.encoding !== "ieee-p1363-base64" || typeof sg.value !== "string") return null;
+  const str = (v: unknown): string => (typeof v === "string" ? v : "");
+  const transcript: OwnerClaimTranscript = {
+    transcriptVersion: str(tr.transcriptVersion) as OwnerClaimTranscript["transcriptVersion"],
+    algorithm: str(tr.algorithm) as OwnerClaimTranscript["algorithm"],
+    kind: str(tr.kind) as OwnerClaimTranscript["kind"],
+    hubId: str(tr.hubId),
+    installId: str(tr.installId),
+    osUser: str(tr.osUser),
+    deviceId: str(tr.deviceId),
+    action: str(tr.action),
+    origin: str(tr.origin),
+    channel: str(tr.channel),
+    nonce: str(tr.nonce),
+    expiresAt: str(tr.expiresAt),
+    devicePublicKeyHash: str(tr.devicePublicKeyHash),
+  };
+  return { transcript, signature: { encoding: "ieee-p1363-base64", value: sg.value } };
 }
 
 /** True when the caught error is a better-sqlite3 UNIQUE/constraint violation. */
@@ -227,6 +278,9 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
   const userRepo = createFridayUserRepository();
   const sessionRepo = createFridayAuthSessionRepository();
   const bootstrapNonceRepo = createFridaySetupBootstrapNonceRepository();
+  // SEC-SETUP-BOOTSTRAP-001 Slice 3: the merged S2a proof-of-possession verifier.
+  // Crypto lives entirely in the device-attest seam — never re-implemented here.
+  const ownerClaimPoPVerifier = createFridayOwnerClaimPoPVerifier();
   const bootstrapHubId = deps.hubId ?? "local-hub";
   const bootstrapNonceTtlSec = deps.bootstrapNonceTtlSec ?? 300;
   const generateBootstrapNonce =
@@ -590,6 +644,51 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         );
       }
 
+      // ── SEC-SETUP-BOOTSTRAP-001 Slice 3: proof-of-possession gate ──
+      // Nonce-possession alone no longer suffices: the device MUST prove
+      // possession of the PRIVATE key by signing the canonical transcript. This
+      // runs BEFORE the single-use nonce is consumed (below), so a PoP failure
+      // leaves the nonce un-burned AND the owner slot untouched. Crypto is
+      // delegated ENTIRELY to the merged S2a device-attest verifier.
+      const proof = coerceDeviceClaimProof(request.deviceClaimProof);
+      if (!proof) {
+        throw new FridayDomainError(
+          "AUTH_BOOTSTRAP_POP_REQUIRED",
+          "Device owner-claim requires a proof-of-possession (signed transcript + signature).",
+          { httpStatus: 400 },
+        );
+      }
+      // Bind the signed transcript to THIS claim request: a device may not sign
+      // one transcript and submit a different nonce/origin/device in the claim.
+      if (
+        proof.transcript.nonce !== nonce ||
+        proof.transcript.origin !== origin ||
+        proof.transcript.deviceId !== deviceId
+      ) {
+        throw new FridayDomainError(
+          "AUTH_BOOTSTRAP_POP_INVALID",
+          "Proof-of-possession transcript does not match the claim request.",
+          { httpStatus: 401 },
+        );
+      }
+      const pop = ownerClaimPoPVerifier.verifyPossession({
+        transcript: proof.transcript,
+        devicePublicKey: { encoding: "spki-der-base64", value: devicePublicKey },
+        signature: proof.signature,
+        nowMs: Date.parse(deps.nowIso()),
+      });
+      if (!pop.ok) {
+        // PoP-unverified key ⇒ REFUSAL. No nonce consume, no owner write.
+        throw new FridayDomainError(
+          "AUTH_BOOTSTRAP_POP_INVALID",
+          `Device proof-of-possession failed: ${pop.reason}.`,
+          { httpStatus: 401 },
+        );
+      }
+      // Server-derived key-protection posture (never self-reported). Today the
+      // only reachable value is "unverified" → fail closed for release authority.
+      const keyProtection = deriveDeviceKeyProtection();
+
       const localUser = findLocalUser();
       if (!localUser) {
         throw new FridayDomainError(
@@ -673,6 +772,11 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         userId: localUser.id,
         deviceId,
         devicePublicKeyHash,
+        // Authoritative readback: server-derived posture + the truth that this
+        // device binding carries NO owner authority in release/default (the
+        // device principal stays DISABLED until native-IPC precondition (b)).
+        keyProtection,
+        deviceAuthorityEnabled: isDeviceOwnerAuthorityEnabled(),
       };
     },
 

--- a/src/api/http/routes/friday-auth-routes.ts
+++ b/src/api/http/routes/friday-auth-routes.ts
@@ -134,6 +134,10 @@ export function createFridayAuthRoutes(
           origin: typeof body.origin === "string" ? body.origin : "",
           installId: typeof body.installId === "string" ? body.installId : "",
           osUser: typeof body.osUser === "string" ? body.osUser : "",
+          // SEC-SETUP-BOOTSTRAP-001 Slice 3: forward the untrusted proof-of-
+          // possession envelope; the auth SERVICE defensively validates it and
+          // fails closed on anything malformed.
+          deviceClaimProof: body.deviceClaimProof as FridayAuthDeviceClaimRequest["deviceClaimProof"],
         };
         return deps.authService.claimOwnerWithDeviceKey(request, ctx.ip);
       },

--- a/src/api/model/friday-api-auth.types.ts
+++ b/src/api/model/friday-api-auth.types.ts
@@ -187,10 +187,41 @@ export interface FridayAuthBootstrapChallengeResponse {
   expiresAt: ISODateTime;
 }
 
+// SEC-SETUP-BOOTSTRAP-001 Slice 3 — proof-of-possession (PoP) over the server
+// nonce. The device MUST prove possession of the PRIVATE key by signing the
+// canonical owner-claim transcript; nonce-possession alone no longer suffices.
+// The transcript + signature are verified by the merged S2a device-attest seam
+// BEFORE the single-use nonce is consumed, so a PoP failure leaves the nonce
+// un-burned and the owner slot untouched.
+
+/** Canonical owner-claim transcript the device signed (S2a shape). */
+export interface FridayDeviceClaimTranscript {
+  transcriptVersion: "friday-owner-claim-v1";
+  algorithm: "ECDSA_P256_SHA256";
+  kind: "install_owner_claim";
+  hubId: string;
+  installId: string;
+  osUser: string;
+  deviceId: string;
+  action: string;
+  origin: string;
+  channel: string;
+  nonce: string;
+  expiresAt: ISODateTime;
+  /** SHA-256 hex of the canonical SPKI DER of the device public key. */
+  devicePublicKeyHash: string;
+}
+
+export interface FridayDeviceClaimProof {
+  transcript: FridayDeviceClaimTranscript;
+  /** IEEE P-1363 raw (r‖s, 64 bytes) ECDSA signature, base64/base64url. */
+  signature: { encoding: "ieee-p1363-base64"; value: string };
+}
+
 export interface FridayAuthDeviceClaimRequest {
   /** The raw nonce previously issued by the challenge endpoint. */
   nonce: string;
-  /** Device public key (opaque bytes, base64url) bound to the owner. */
+  /** Device public key, SPKI DER base64/base64url (P-256), bound to the owner. */
   devicePublicKey: string;
   /** Device identifier bound to the owner. */
   deviceId: string;
@@ -198,6 +229,13 @@ export interface FridayAuthDeviceClaimRequest {
   origin: string;
   installId: string;
   osUser: string;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 Slice 3: REQUIRED proof-of-possession. The device
+   * signs the canonical transcript; the server verifies the signature against the
+   * presented public key before consuming the nonce. A missing/invalid proof
+   * fails closed (owner slot untouched, nonce un-burned).
+   */
+  deviceClaimProof?: FridayDeviceClaimProof;
 }
 
 export interface FridayAuthDeviceClaimResponse {
@@ -207,6 +245,18 @@ export interface FridayAuthDeviceClaimResponse {
   deviceId: string;
   /** Deterministic hash of the bound device public key (never the private key). */
   devicePublicKeyHash: string;
+  /**
+   * Server-derived key-protection posture. Never self-reported. Today the only
+   * reachable value is `unverified` (no OS attestation bridge), which is
+   * fail-closed for release authority.
+   */
+  keyProtection: "secure_enclave_os_verified" | "keychain_acl_verified" | "software_dev_only" | "unverified";
+  /**
+   * Authoritative readback: whether this device binding carries owner authority.
+   * ALWAYS `false` in the release/default profile until native-IPC precondition
+   * (b) lands — so a caller can positively confirm the device has NO authority.
+   */
+  deviceAuthorityEnabled: boolean;
 }
 
 // ─── Refresh ───

--- a/src/api/model/friday-api-principal.types.ts
+++ b/src/api/model/friday-api-principal.types.ts
@@ -1,1 +1,7 @@
-export type FridayPrincipalType = "user" | "satellite" | "service" | "workflow-runner";
+// `device` (SEC-SETUP-BOOTSTRAP-001 Slice 3) is a fail-closed, DISABLED
+// device-bound owner principal. It carries ZERO owner data/control authority in
+// the release/default profile: the enforcement floors treat it exactly like the
+// synthetic anonymous principal until the server-derived device-authority switch
+// flips (which requires native-IPC caller-identity — absent today). It is added
+// here to the deny path first; the allow path lands only post-preconditions.
+export type FridayPrincipalType = "user" | "satellite" | "service" | "workflow-runner" | "device";

--- a/src/security/friday-device-owner-authority-precondition.ts
+++ b/src/security/friday-device-owner-authority-precondition.ts
@@ -1,0 +1,211 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · Slice 3 — device-principal fail-closed precondition ───
+//
+// This module is the SINGLE server-derived source of truth for whether a
+// device-bound owner principal may carry ANY real owner data/control authority
+// in the release/default profile. It is deliberately additive and fail-closed:
+// it grants nothing, mints no token, and treats every device principal as
+// DISABLED until BOTH preconditions land —
+//   (a) S2a proof-of-possession verify  [MERGED — src/api/auth/device-attest]
+//   (b) trusted native-app IPC caller-identity  [ABSENT today]
+//
+// Because (b) is absent, the switch below is HARD-WIRED off (a config flag
+// cannot flip it) and the only reachable keyProtection state is "unverified" —
+// which fails closed. NOTHING here labels an arbitrary key as Secure Enclave,
+// hardcodes attestation-passed, or lets nonce/config/request facts assert a
+// trusted device. See the types file in device-attest for the crypto contract.
+
+import type { FridayAuthPrincipal } from "../api/model/friday-api-auth.types.js";
+import type { FridayScope } from "../api/model/friday-api-auth.types.js";
+
+// ─── Device principal identity constants ───
+
+/**
+ * The principal-type discriminator for a device-bound owner principal. The
+ * enforcement floors key on THIS value (not on "the id is not public:default")
+ * so a device principal cannot slip through by merely being non-synthetic.
+ */
+export const DEVICE_OWNER_PRINCIPAL_TYPE = "device" as const;
+
+/**
+ * Stable principalId prefix for a device-bound owner principal. The
+ * conversational session-dispatch gate (which only sees a string actorId) refuses
+ * any actor id carrying this prefix while the device authority switch is off.
+ */
+export const DEVICE_OWNER_PRINCIPAL_ID_PREFIX = "device-owner:";
+
+export function deviceOwnerPrincipalId(devicePublicKeyHash: string): string {
+  return `${DEVICE_OWNER_PRINCIPAL_ID_PREFIX}${devicePublicKeyHash}`;
+}
+
+export function isDeviceOwnerPrincipalId(actorId: string | null | undefined): boolean {
+  return typeof actorId === "string" && actorId.startsWith(DEVICE_OWNER_PRINCIPAL_ID_PREFIX);
+}
+
+// ─── (b) native-IPC caller-identity precondition (ABSENT today) ───
+//
+// This is a compile-time constant, NOT a config flag. It flips to `true` ONLY in
+// the future slice that lands a trusted native-app IPC caller-identity bridge
+// (SO_PEERCRED / signed-shell attestation). Until then, no amount of env / header
+// / request / loopback fact can make a device principal trusted.
+export const NATIVE_IPC_ATTESTATION_AVAILABLE = false as const;
+
+// ─── Server-derived, off-by-default authority switch ───
+
+/**
+ * Explicit server-side opt-in env var. Even when set, it does NOT enable device
+ * authority on its own — precondition (b) (`NATIVE_IPC_ATTESTATION_AVAILABLE`)
+ * must ALSO be present. This var is read ONLY from the process environment; it is
+ * never derived from a request body, header, Origin, cookie, User-Agent,
+ * bundle-id, loopback fact, or any nonce-holding process.
+ */
+export const DEVICE_OWNER_AUTHORITY_ENABLED_ENV = "FRIDAY_DEVICE_OWNER_AUTHORITY_ENABLED";
+
+/**
+ * True IFF a device-bound owner principal may carry release-profile owner
+ * authority. Server-derived and fail-closed: requires BOTH the explicit
+ * server-side env opt-in AND the native-IPC precondition (b). Because (b) is a
+ * hard-wired `false` today, this ALWAYS returns `false` in the current build —
+ * the truthful state of the requirement (NOT "passed").
+ *
+ * Takes NO request-derived input by design: there is structurally no way for a
+ * caller to flip it via request data.
+ */
+export function isDeviceOwnerAuthorityEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!NATIVE_IPC_ATTESTATION_AVAILABLE) {
+    // Precondition (b) absent — fail closed regardless of any config.
+    return false;
+  }
+  return env[DEVICE_OWNER_AUTHORITY_ENABLED_ENV] === "1";
+}
+
+// ─── keyProtection — server-derived 4-state (NEVER request-reported) ───
+
+/**
+ * Device key-protection posture, derived SERVER-SIDE only. NEVER read from the
+ * request body / self-reported by the caller.
+ *   - `secure_enclave_os_verified` / `keychain_acl_verified` — release-trusted,
+ *     but UNREACHABLE today (no OS attestation bridge exists yet).
+ *   - `software_dev_only` / `unverified` — fail closed in the release profile.
+ */
+export type FridayDeviceKeyProtection =
+  | "secure_enclave_os_verified"
+  | "keychain_acl_verified"
+  | "software_dev_only"
+  | "unverified";
+
+const RELEASE_TRUSTED_KEY_PROTECTION: ReadonlySet<FridayDeviceKeyProtection> = new Set<
+  FridayDeviceKeyProtection
+>(["secure_enclave_os_verified", "keychain_acl_verified"]);
+
+/**
+ * True iff the derived key-protection posture is release-trusted. `unverified`
+ * and `software_dev_only` return `false` (fail closed).
+ */
+export function isReleaseTrustedKeyProtection(kp: FridayDeviceKeyProtection): boolean {
+  return RELEASE_TRUSTED_KEY_PROTECTION.has(kp);
+}
+
+/**
+ * Derive the device key-protection posture SERVER-SIDE. Today there is no OS
+ * attestation bridge, so the only honest, reachable value is `"unverified"` —
+ * which fails closed. A FUTURE native slice sets the hardware-backed states here
+ * from a verified OS attestation, never from the request.
+ */
+export function deriveDeviceKeyProtection(): FridayDeviceKeyProtection {
+  return "unverified";
+}
+
+// ─── Fail-closed device-owner mint seam ───
+//
+// The seam a future slice would call (AFTER PoP-verify) to mint a device-bound
+// owner principal. Today it ALWAYS fails closed: it issues no token and returns
+// no authority-bearing principal, because the switch is off and keyProtection is
+// not release-trusted. It never fabricates a Secure-Enclave label or authority.
+
+export interface DeviceOwnerMintInput {
+  readonly deviceId: string;
+  /** Canonical (SPKI-DER) hash of the verified device public key. */
+  readonly devicePublicKeyHash: string;
+  readonly ownerUserId: string;
+  readonly tenantId: string;
+  /** Server-derived posture (never from the request). */
+  readonly keyProtection: FridayDeviceKeyProtection;
+  /** Result of the S2a PoP verifier — possession of the private key was proven. */
+  readonly popVerified: boolean;
+  /** Owner scopes the device WOULD receive once enabled (post-preconditions). */
+  readonly ownerScopes: readonly FridayScope[];
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+export type DeviceOwnerMintDisabledReason =
+  | "pop-unverified"
+  | "device-owner-authority-disabled-pending-native-ipc"
+  | "key-protection-not-release-trusted";
+
+export interface DeviceOwnerMintDisabled {
+  readonly ok: false;
+  readonly disabled: true;
+  readonly reason: DeviceOwnerMintDisabledReason;
+  readonly keyProtection: FridayDeviceKeyProtection;
+  /** Always false in the release/default profile — the requirement is NOT passed. */
+  readonly deviceAuthorityEnabled: false;
+}
+
+export interface DeviceOwnerMintEnabled {
+  readonly ok: true;
+  readonly principal: FridayAuthPrincipal;
+  readonly deviceAuthorityEnabled: true;
+}
+
+export type DeviceOwnerMintResult = DeviceOwnerMintDisabled | DeviceOwnerMintEnabled;
+
+function disabled(
+  reason: DeviceOwnerMintDisabledReason,
+  keyProtection: FridayDeviceKeyProtection,
+): DeviceOwnerMintDisabled {
+  return { ok: false, disabled: true, reason, keyProtection, deviceAuthorityEnabled: false };
+}
+
+/**
+ * Fail-closed device-owner mint seam. Returns a DISABLED result (no token, no
+ * authority) unless EVERY precondition holds:
+ *   1. PoP was verified (possession of the private key proven — S2a).
+ *   2. The server-derived authority switch is enabled (requires (b) native IPC).
+ *   3. keyProtection is release-trusted (hardware-backed, OS-verified).
+ * In the current build (2) is impossible ((b) absent) and (3) is unreachable, so
+ * this NEVER returns an authority-bearing principal. The enabled branch is the
+ * future plug point; it grants authority only when all three hold.
+ */
+export function mintDeviceOwnerPrincipal(input: DeviceOwnerMintInput): DeviceOwnerMintResult {
+  const { keyProtection } = input;
+
+  // Defense-in-depth: never mint from mere nonce/claim possession.
+  if (!input.popVerified) {
+    return disabled("pop-unverified", keyProtection);
+  }
+  // (b) native-IPC + explicit server opt-in — off by default, hard-wired off today.
+  if (!isDeviceOwnerAuthorityEnabled(input.env)) {
+    return disabled("device-owner-authority-disabled-pending-native-ipc", keyProtection);
+  }
+  // keyProtection must be hardware-backed + OS-verified (unreachable today).
+  if (!isReleaseTrustedKeyProtection(keyProtection)) {
+    return disabled("key-protection-not-release-trusted", keyProtection);
+  }
+
+  // Future plug point (post-preconditions): mint the device-bound owner principal.
+  // Reached ONLY when all three fail-closed gates above pass — never in this build.
+  const principal: FridayAuthPrincipal = {
+    principalType: DEVICE_OWNER_PRINCIPAL_TYPE,
+    principalId: deviceOwnerPrincipalId(input.devicePublicKeyHash),
+    tenantId: input.tenantId,
+    userId: input.ownerUserId,
+    role: "owner",
+    scopes: [...input.ownerScopes],
+    tokenId: input.devicePublicKeyHash,
+    tokenKind: "access",
+    issuedAt: new Date().toISOString(),
+  };
+  return { ok: true, principal, deviceAuthorityEnabled: true };
+}

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -6,6 +6,11 @@ import {
   FRIDAY_DEFAULT_PUBLIC_HTTP_USER_ID,
 } from "../api/http/friday-default-public-principal.js";
 import type { FridayAuthPrincipal, FridayRole, FridayScope } from "../api/model/friday-api-auth.types.js";
+import {
+  DEVICE_OWNER_PRINCIPAL_TYPE,
+  isDeviceOwnerAuthorityEnabled,
+  isDeviceOwnerPrincipalId,
+} from "./friday-device-owner-authority-precondition.js";
 
 // Phase 14.5A — module_28a owner/session/channel capability gate.
 // Source-aware boundary above high-risk public mutating operations.
@@ -108,7 +113,7 @@ export type FridayPublicMutationOperation =
   // owning principal).
   | "memory.spine.decide";
 
-export type FridayBoundPrincipalSource = "api" | "session" | "channel" | "satellite";
+export type FridayBoundPrincipalSource = "api" | "session" | "channel" | "satellite" | "device";
 
 export const ERROR_CODE_BOUND_PRINCIPAL_REQUIRED = "OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED";
 const ERROR_CODE_BOUND_PRINCIPAL_AUTHORITY_REQUIRED = "OWNER_SESSION_CHANNEL_AUTHORITY_REQUIRED";
@@ -129,6 +134,25 @@ const SENSITIVE_HEADER_PATTERNS: ReadonlyArray<RegExp> = [
   /^x-csrf-token$/i,
 ];
 
+/**
+ * SEC-SETUP-BOOTSTRAP-001 Slice 3 — a device-bound owner principal that is
+ * DISABLED in the release/default profile (the server-derived device-authority
+ * switch is off, which is ALWAYS the case until native-IPC caller-identity (b)
+ * lands). Such a principal MUST be treated exactly like the synthetic anonymous
+ * principal by every floor. This is keyed on the principal TYPE + the
+ * server-derived switch — NOT on "the id is not public:default" — so a device
+ * principal minted non-synthetic with owner scopes cannot slip through L1/L2/L3.
+ */
+export function isReleaseDisabledDevicePrincipal(
+  principal: FridayAuthPrincipal | null | undefined,
+): boolean {
+  if (!principal) return false;
+  if (principal.principalType !== DEVICE_OWNER_PRINCIPAL_TYPE) return false;
+  // Fail closed: the device principal carries authority ONLY when the
+  // server-derived switch is on. Off (today) ⇒ treat as unauthenticated.
+  return !isDeviceOwnerAuthorityEnabled();
+}
+
 export function isUnauthenticatedPublicPrincipal(
   principal: FridayAuthPrincipal | null | undefined,
 ): boolean {
@@ -141,6 +165,9 @@ export function isUnauthenticatedPublicPrincipal(
   ) {
     return true;
   }
+  // Additive fail-closed refusal: a release-disabled device principal is refused
+  // exactly like the synthetic anonymous principal across L1/L2/L3.
+  if (isReleaseDisabledDevicePrincipal(principal)) return true;
   return false;
 }
 
@@ -221,10 +248,17 @@ export function assertBoundActorForSessionOperation(
   // (which is truthy in JavaScript) cannot pass the bound-principal gate or be
   // propagated downstream as an audit identity.
   const normalized = typeof actorId === "string" ? actorId.trim() : "";
+  // SEC-SETUP-BOOTSTRAP-001 Slice 3: a device-owner actor id is refused here
+  // exactly like the synthetic public actor while the server-derived
+  // device-authority switch is off (always, today) — conversational dispatch
+  // never grants owner authority from a disabled device identity.
+  const isDisabledDeviceActor =
+    isDeviceOwnerPrincipalId(normalized) && !isDeviceOwnerAuthorityEnabled();
   if (
     normalized.length === 0 ||
     normalized === FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID ||
-    normalized === "system"
+    normalized === "system" ||
+    isDisabledDeviceActor
   ) {
     throw new FridayDomainError(
       ERROR_CODE_BOUND_PRINCIPAL_REQUIRED,

--- a/test/adversarial/bootstrap-device-claim.test.ts
+++ b/test/adversarial/bootstrap-device-claim.test.ts
@@ -36,12 +36,21 @@ import { FridayDomainError } from "#errors";
 import { createFridaySqliteLayer } from "#state";
 import type { FridaySqliteLayer } from "#state";
 
+// SEC-SETUP-BOOTSTRAP-001 Slice 3: the device-claim now REQUIRES a real
+// proof-of-possession (signed transcript). These slice-1 negative controls are
+// preserved verbatim; each claim just additionally carries a valid signed
+// transcript so the flow reaches the same nonce/owner/atomicity branches. The
+// transcript's expiresAt is far-future so the AUTHORITATIVE single-use + TTL gate
+// stays server-side at nonce-consume — keeping every error code unchanged.
+import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "./_secsetup-s2a.helpers.js";
+
 const OWNER_ID = "admin-001";
 const NOW = "2026-07-13T00:00:00.000Z";
 const LATER_AFTER_TTL = "2026-07-13T00:10:00.000Z"; // > NOW + 300s
 const LOOPBACK = "127.0.0.1";
 const ORIGIN = "https://friday.localhost";
-const DEVICE_PUBKEY = crypto.randomBytes(32).toString("base64url");
+const DEVICE_KEY = generateTestDeviceKey();
+const DEVICE_PUBKEY = DEVICE_KEY.spkiDerBase64;
 const DEVICE_ID = "device-abc-001";
 const OWNER_HASH_PREFIX = "device-owner$v1$";
 
@@ -105,13 +114,29 @@ function issueNonce(db: FridaySqliteLayer, over?: { origin?: string; nowIso?: st
 }
 
 function claimReq(over?: Partial<{ nonce: string; origin: string; devicePublicKey: string; deviceId: string }>) {
-  return {
-    nonce: over?.nonce ?? "",
-    devicePublicKey: over?.devicePublicKey ?? DEVICE_PUBKEY,
-    deviceId: over?.deviceId ?? DEVICE_ID,
-    origin: over?.origin ?? ORIGIN,
+  const nonce = over?.nonce ?? "";
+  const origin = over?.origin ?? ORIGIN;
+  const deviceId = over?.deviceId ?? DEVICE_ID;
+  const devicePublicKey = over?.devicePublicKey ?? DEVICE_PUBKEY;
+  // Sign a transcript BOUND to this claim (nonce/origin/deviceId) with far-future
+  // expiry so PoP freshness passes and the server nonce store remains the
+  // authoritative TTL/single-use gate (error codes unchanged from slice 1).
+  const transcript = makeTranscript(DEVICE_KEY, {
+    nonce,
+    origin,
+    deviceId,
     installId: "install-1",
     osUser: "jarvis",
+  });
+  const signature = { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(DEVICE_KEY, transcript) };
+  return {
+    nonce,
+    devicePublicKey,
+    deviceId,
+    origin,
+    installId: "install-1",
+    osUser: "jarvis",
+    deviceClaimProof: { transcript, signature },
   };
 }
 

--- a/test/adversarial/bootstrap-nonce-lifecycle.test.ts
+++ b/test/adversarial/bootstrap-nonce-lifecycle.test.ts
@@ -33,13 +33,16 @@ import { createFridayAuthService, createFridaySetupBootstrapNonceRepository } fr
 import { FridayDomainError } from "#errors";
 import { createFridaySqliteLayer } from "#state";
 import type { FridaySqliteLayer } from "#state";
+// SEC-SETUP-BOOTSTRAP-001 Slice 3: device-claim now requires proof-of-possession.
+import { generateTestDeviceKey, makeTranscript, signTranscriptLowS, type TestDeviceKey } from "./_secsetup-s2a.helpers.js";
 
 const OWNER_ID = "admin-001";
 const NOW = "2026-07-13T00:00:00.000Z";
 const AFTER_TTL = "2026-07-13T00:10:00.000Z"; // > NOW + 300s (nonce TTL)
 const LOOPBACK = "127.0.0.1";
 const ORIGIN = "https://friday.localhost";
-const DEVICE_PUBKEY = crypto.randomBytes(32).toString("base64url");
+const DEVICE_KEY = generateTestDeviceKey();
+const DEVICE_PUBKEY = DEVICE_KEY.spkiDerBase64;
 const DEVICE_ID = "device-abc-001";
 const OWNER_HASH_PREFIX = "device-owner$v1$";
 const BOOTSTRAP_TTL_SEC = 300;
@@ -111,14 +114,25 @@ function issueNonce(db: FridaySqliteLayer, over?: { origin?: string; nowIso?: st
   return res.nonce;
 }
 
-function claimReq(over?: Partial<{ nonce: string; origin: string; devicePublicKey: string; deviceId: string }>) {
+function claimReq(over?: Partial<{ nonce: string; origin: string; deviceId: string; key: TestDeviceKey }>) {
+  const key = over?.key ?? DEVICE_KEY;
+  const nonce = over?.nonce ?? "";
+  const origin = over?.origin ?? ORIGIN;
+  const deviceId = over?.deviceId ?? DEVICE_ID;
+  // Far-future transcript expiry so the server nonce store stays the authoritative
+  // TTL/single-use gate (slice-1 error codes unchanged); PoP proves key possession.
+  const transcript = makeTranscript(key, { nonce, origin, deviceId, installId: "install-1", osUser: "jarvis" });
   return {
-    nonce: over?.nonce ?? "",
-    devicePublicKey: over?.devicePublicKey ?? DEVICE_PUBKEY,
-    deviceId: over?.deviceId ?? DEVICE_ID,
-    origin: over?.origin ?? ORIGIN,
+    nonce,
+    devicePublicKey: key.spkiDerBase64,
+    deviceId,
+    origin,
     installId: "install-1",
     osUser: "jarvis",
+    deviceClaimProof: {
+      transcript,
+      signature: { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(key, transcript) },
+    },
   };
 }
 
@@ -340,11 +354,11 @@ describe("SEC-SETUP-BOOTSTRAP-001 s4: crash / restart recovery", () => {
     // A retried claim after restart — even with a FRESH nonce and a DIFFERENT
     // device — cannot re-own: it fails closed (409) and leaves the owner intact.
     const nonceB = issueNonce(db);
-    const otherKey = crypto.randomBytes(32).toString("base64url");
+    const otherKey = generateTestDeviceKey(); // a DIFFERENT real device (valid PoP)
     let caught: unknown;
     try {
       makeService(db).claimOwnerWithDeviceKey(
-        claimReq({ nonce: nonceB, devicePublicKey: otherKey, deviceId: "device-other" }),
+        claimReq({ nonce: nonceB, key: otherKey, deviceId: "device-other" }),
         LOOPBACK,
       );
     } catch (err) {

--- a/test/adversarial/secsetup-s3-device-principal-failclosed.test.ts
+++ b/test/adversarial/secsetup-s3-device-principal-failclosed.test.ts
@@ -1,0 +1,421 @@
+/**
+ * SEC-SETUP-BOOTSTRAP-001 · Slice 3 — fail-closed DISABLED device-principal
+ * owner data/control plumbing (adversarial, service + floor level).
+ *
+ * This proves the DISABLED device principal is refused everywhere and that S1
+ * claim/nonce-possession confers ZERO authority — WITHOUT granting any device
+ * real owner authority. Every device path here is fail-closed because the
+ * server-derived device-authority switch is OFF (native-IPC precondition (b) is
+ * ABSENT) and keyProtection is `unverified`.
+ *
+ * Red-first: each guard is load-bearing — reverting it flips a MUST-REFUSE row
+ * from 401/403 back to allow (see PR body red→green→revert-red evidence).
+ *
+ * Groups (inventory §3.1/§3.2, §4):
+ *   A — device mint seam fails closed; the switch is server-derived only.
+ *   B — floors refuse a (synthesized) device principal exactly like anonymous.
+ *   E1 — conversational session-dispatch refuses a device-owner actor id.
+ *   PoP — device-claim requires proof-of-possession; nonce not burned on failure.
+ */
+
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createFridayAuthService } from "#api";
+import { FridayDomainError } from "#errors";
+import { createFridaySqliteLayer } from "#state";
+import type { FridaySqliteLayer } from "#state";
+
+import type { FridayAuthPrincipal, FridayScope } from "../../src/api/model/friday-api-auth.types.js";
+import {
+  assertBoundActorForSessionOperation,
+  assertBoundPrincipalAuthorityForOperation,
+  assertBoundPrincipalForOperation,
+  isReleaseDisabledDevicePrincipal,
+  isUnauthenticatedPublicPrincipal,
+} from "../../src/security/friday-owner-session-channel-capability.js";
+import {
+  DEVICE_OWNER_AUTHORITY_ENABLED_ENV,
+  DEVICE_OWNER_PRINCIPAL_TYPE,
+  NATIVE_IPC_ATTESTATION_AVAILABLE,
+  deriveDeviceKeyProtection,
+  deviceOwnerPrincipalId,
+  isDeviceOwnerAuthorityEnabled,
+  isReleaseTrustedKeyProtection,
+  mintDeviceOwnerPrincipal,
+  type FridayDeviceKeyProtection,
+} from "../../src/security/friday-device-owner-authority-precondition.js";
+import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "./_secsetup-s2a.helpers.js";
+
+const OWNER_ID = "admin-001";
+const NOW = "2026-07-13T00:00:00.000Z";
+const LOOPBACK = "127.0.0.1";
+const ORIGIN = "https://friday.localhost";
+const DEVICE_KEY = generateTestDeviceKey();
+const DEVICE_PUBKEY = DEVICE_KEY.spkiDerBase64;
+const DEVICE_ID = "device-s3-001";
+const OWNER_SCOPES: FridayScope[] = ["workflow.read", "security.read", "session.read"];
+
+function sha256Hex(v: string): string {
+  return crypto.createHash("sha256").update(v).digest("hex");
+}
+
+/** A NON-synthetic device principal carrying owner scopes — the danger surface. */
+function makeDevicePrincipal(over: Partial<FridayAuthPrincipal> = {}): FridayAuthPrincipal {
+  return {
+    principalType: DEVICE_OWNER_PRINCIPAL_TYPE,
+    principalId: deviceOwnerPrincipalId(sha256Hex("device-key")),
+    tenantId: "11111111-1111-1111-1111-111111111111",
+    userId: "22222222-2222-2222-2222-222222222222",
+    role: "owner",
+    scopes: [...OWNER_SCOPES],
+    tokenId: "33333333-3333-3333-3333-333333333333",
+    tokenKind: "access",
+    issuedAt: NOW,
+    ...over,
+  };
+}
+
+// ── SQLite harness (mirrors the slice-1 adversarial suite) ──
+
+function seedOwner(db: FridaySqliteLayer): void {
+  db.withWriteTransaction((conn) => {
+    conn
+      .prepare(
+        `INSERT INTO users (id, email, display_name, role, password_hash, is_local_only, last_login_at, created_at, updated_at, deleted_at)
+         VALUES (?, ?, ?, ?, NULL, 1, NULL, ?, ?, NULL)`,
+      )
+      .run(OWNER_ID, "admin@friday.dev", "Admin", "admin", NOW, NOW);
+  });
+}
+
+function makeService(db: FridaySqliteLayer) {
+  return createFridayAuthService({
+    db,
+    idGenerator: (() => {
+      let n = 0;
+      return () => `id-${String(++n).padStart(4, "0")}`;
+    })(),
+    nowIso: () => NOW,
+    tokenSecret: "test-secret-key-for-device-claim-s3-00", // pragma: allowlist secret
+    accessTokenTtlSec: 900,
+    refreshTokenTtlSec: 604_800,
+    hubId: "test-hub",
+    bootstrapNonceTtlSec: 300,
+  });
+}
+
+function readOwnerHash(db: FridaySqliteLayer): string | null {
+  return db.withReadConnection((conn) => {
+    const row = conn.prepare("SELECT password_hash AS h FROM users WHERE id = ?").get(OWNER_ID) as
+      | { h: string | null }
+      | undefined;
+    return row?.h ?? null;
+  });
+}
+
+function readNonceConsumedAt(db: FridaySqliteLayer, nonce: string): unknown {
+  return db.withReadConnection((conn) => {
+    const row = conn
+      .prepare("SELECT consumed_at FROM friday_setup_bootstrap_nonces WHERE nonce_hash = ?")
+      .get(sha256Hex(nonce)) as { consumed_at: unknown } | undefined;
+    return row?.consumed_at ?? null;
+  });
+}
+
+function issueNonce(db: FridaySqliteLayer): string {
+  return makeService(db).issueBootstrapChallenge(
+    { installId: "install-1", osUser: "jarvis", origin: ORIGIN },
+    LOOPBACK,
+  ).nonce;
+}
+
+function validProof(nonce: string, over: { origin?: string; deviceId?: string } = {}) {
+  const transcript = makeTranscript(DEVICE_KEY, {
+    nonce,
+    origin: over.origin ?? ORIGIN,
+    deviceId: over.deviceId ?? DEVICE_ID,
+    installId: "install-1",
+    osUser: "jarvis",
+  });
+  return {
+    transcript,
+    signature: { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(DEVICE_KEY, transcript) },
+  };
+}
+
+function baseClaim(nonce: string, over: Partial<{ origin: string; deviceId: string; devicePublicKey: string }> = {}) {
+  return {
+    nonce,
+    devicePublicKey: over.devicePublicKey ?? DEVICE_PUBKEY,
+    deviceId: over.deviceId ?? DEVICE_ID,
+    origin: over.origin ?? ORIGIN,
+    installId: "install-1",
+    osUser: "jarvis",
+  };
+}
+
+let db: FridaySqliteLayer;
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-secsetup-s3-"));
+  db = createFridaySqliteLayer({
+    dbPath: path.join(tmpDir, "friday.db"),
+    readPoolSize: 2,
+    pragmas: { busyTimeoutMs: 5_000, synchronous: "NORMAL" },
+  });
+  seedOwner(db);
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── Group A — device mint seam fails closed; switch is server-derived ───
+
+describe("S3 Group A — device mint seam + authority switch (fail-closed)", () => {
+  it("RF-A1: mint seam issues NO token/principal while preconditions unmet (PoP-verified, unverified keyProtection)", () => {
+    const result = mintDeviceOwnerPrincipal({
+      deviceId: DEVICE_ID,
+      devicePublicKeyHash: DEVICE_KEY.publicKeyHash,
+      ownerUserId: OWNER_ID,
+      tenantId: "t-1",
+      keyProtection: deriveDeviceKeyProtection(), // "unverified"
+      popVerified: true,
+      ownerScopes: OWNER_SCOPES,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("mint seam MUST NOT grant authority");
+    expect(result.disabled).toBe(true);
+    expect(result.deviceAuthorityEnabled).toBe(false);
+    // Off because the switch is off (b absent) — never a Secure-Enclave label.
+    expect(result.reason).toBe("device-owner-authority-disabled-pending-native-ipc");
+    expect(result.keyProtection).toBe("unverified");
+  });
+
+  it("RF-A1: even a (hypothetical) hardware-backed keyProtection is disabled while the switch is off", () => {
+    const result = mintDeviceOwnerPrincipal({
+      deviceId: DEVICE_ID,
+      devicePublicKeyHash: DEVICE_KEY.publicKeyHash,
+      ownerUserId: OWNER_ID,
+      tenantId: "t-1",
+      keyProtection: "secure_enclave_os_verified",
+      popVerified: true,
+      ownerScopes: OWNER_SCOPES,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("switch off ⇒ never mint");
+    expect(result.reason).toBe("device-owner-authority-disabled-pending-native-ipc");
+  });
+
+  it("RF-A1: mere nonce/claim possession (no PoP) is disabled at the seam", () => {
+    const result = mintDeviceOwnerPrincipal({
+      deviceId: DEVICE_ID,
+      devicePublicKeyHash: DEVICE_KEY.publicKeyHash,
+      ownerUserId: OWNER_ID,
+      tenantId: "t-1",
+      keyProtection: "unverified",
+      popVerified: false,
+      ownerScopes: OWNER_SCOPES,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("no PoP ⇒ never mint");
+    expect(result.reason).toBe("pop-unverified");
+  });
+
+  it("switch is server-derived + hard-wired off: native-IPC precondition (b) is absent", () => {
+    expect(NATIVE_IPC_ATTESTATION_AVAILABLE).toBe(false);
+    expect(isDeviceOwnerAuthorityEnabled()).toBe(false);
+    // Cannot be flipped by config while (b) is absent.
+    expect(isDeviceOwnerAuthorityEnabled({ [DEVICE_OWNER_AUTHORITY_ENABLED_ENV]: "1" })).toBe(false);
+    // keyProtection derives to a fail-closed state server-side (never trusted).
+    const kp: FridayDeviceKeyProtection = deriveDeviceKeyProtection();
+    expect(kp).toBe("unverified");
+    expect(isReleaseTrustedKeyProtection(kp)).toBe(false);
+  });
+
+  it("the switch takes NO request-derived input (cannot be flipped by request-body/header/Origin/loopback facts)", () => {
+    // The function's ONLY input is the process env. Passing request-shaped facts
+    // as an env-like object does nothing — there is structurally no request path.
+    const hostileEnvs: NodeJS.ProcessEnv[] = [
+      { origin: "https://friday.localhost" } as unknown as NodeJS.ProcessEnv,
+      { "user-agent": "Friday-Native/1.0" } as unknown as NodeJS.ProcessEnv,
+      { "x-forwarded-for": "127.0.0.1" } as unknown as NodeJS.ProcessEnv,
+      { nonce: "attacker-nonce" } as unknown as NodeJS.ProcessEnv,
+      { bundleId: "com.friday.native" } as unknown as NodeJS.ProcessEnv,
+    ];
+    for (const env of hostileEnvs) {
+      expect(isDeviceOwnerAuthorityEnabled(env)).toBe(false);
+    }
+  });
+});
+
+// ─── Group B — floors refuse a device principal exactly like anonymous ───
+
+describe("S3 Group B — enforcement floors refuse the DISABLED device principal", () => {
+  it("RF-A2: isUnauthenticatedPublicPrincipal treats a non-synthetic device principal as unauthenticated", () => {
+    const device = makeDevicePrincipal();
+    expect(isReleaseDisabledDevicePrincipal(device)).toBe(true);
+    // The danger surface: device principal is non-synthetic + owner-scoped, yet
+    // still refused — proving the floor consults TYPE + switch, not the id shape.
+    expect(isUnauthenticatedPublicPrincipal(device)).toBe(true);
+  });
+
+  it("positive control: a NON-device principal of identical shape is NOT refused (it is the type+switch, not the shape)", () => {
+    const userLike = makeDevicePrincipal({ principalType: "user", principalId: "user:alice" });
+    expect(isReleaseDisabledDevicePrincipal(userLike)).toBe(false);
+    expect(isUnauthenticatedPublicPrincipal(userLike)).toBe(false);
+  });
+
+  it("RF-C1: assertBoundPrincipalForOperation refuses the device principal on a high-risk owner op (401)", () => {
+    const device = makeDevicePrincipal();
+    let caught: unknown;
+    try {
+      assertBoundPrincipalForOperation(device, "workflow.run.start", "device");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).code).toBe("OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED");
+    expect((caught as FridayDomainError).httpStatus).toBe(401);
+  });
+
+  it("RF-C1: assertBoundPrincipalAuthorityForOperation refuses the device principal BEFORE scope evaluation (401)", () => {
+    const device = makeDevicePrincipal({ scopes: ["runtime.secret.read"] as FridayScope[] });
+    let caught: unknown;
+    try {
+      assertBoundPrincipalAuthorityForOperation(device, "runtime.secret.read", "device", {
+        anyOfScopes: ["runtime.secret.read"] as FridayScope[],
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    // Bound-principal check fires first → PRINCIPAL_REQUIRED, not AUTHORITY_REQUIRED.
+    expect((caught as FridayDomainError).code).toBe("OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED");
+    expect((caught as FridayDomainError).httpStatus).toBe(401);
+  });
+});
+
+// ─── Group E1 — conversational session-dispatch parity ───
+
+describe("S3 Group E1 — session-text dispatch refuses a disabled device actor", () => {
+  it("RF-E1: refuses '', whitespace, public:default, system, AND a device-owner actor id", () => {
+    const refused = ["", "   ", "public:default", "system", deviceOwnerPrincipalId(sha256Hex("device-key"))];
+    for (const actorId of refused) {
+      let caught: unknown;
+      try {
+        assertBoundActorForSessionOperation(actorId, "memory.spine.decide");
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught, `actorId=${JSON.stringify(actorId)} must be refused`).toBeInstanceOf(FridayDomainError);
+      expect((caught as FridayDomainError).code).toBe("OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED");
+    }
+  });
+
+  it("positive control: a bound owner/session actor id is accepted", () => {
+    expect(assertBoundActorForSessionOperation("owner-session:alice", "memory.spine.decide")).toBe(
+      "owner-session:alice",
+    );
+  });
+});
+
+// ─── PoP — device-claim requires proof-of-possession (nonce not burned on failure) ───
+
+describe("S3 PoP — device-claim refuses a PoP-unverified key (nonce-possession ⇏ authority)", () => {
+  it("RF-B: a claim with NO proof is refused (400 POP_REQUIRED); owner NULL, nonce unconsumed", () => {
+    const nonce = issueNonce(db);
+    let caught: unknown;
+    try {
+      makeService(db).claimOwnerWithDeviceKey(baseClaim(nonce), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_POP_REQUIRED");
+    expect((caught as FridayDomainError).httpStatus).toBe(400);
+    expect(readOwnerHash(db)).toBeNull();
+    expect(readNonceConsumedAt(db, nonce)).toBeNull(); // nonce NOT burned
+  });
+
+  it("RF-B3: a signature from a DIFFERENT key (nonce-possession, no private-key possession) is refused (401); nonce unconsumed", () => {
+    const nonce = issueNonce(db);
+    const attackerKey = generateTestDeviceKey();
+    // Transcript binds the REAL device key hash + the real nonce/origin/deviceId,
+    // but the signature is produced by the attacker key → possession NOT proven.
+    const transcript = makeTranscript(DEVICE_KEY, { nonce, origin: ORIGIN, deviceId: DEVICE_ID });
+    const forged = {
+      transcript,
+      signature: { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(attackerKey, transcript) },
+    };
+    let caught: unknown;
+    try {
+      makeService(db).claimOwnerWithDeviceKey({ ...baseClaim(nonce), deviceClaimProof: forged }, LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_POP_INVALID");
+    expect((caught as FridayDomainError).httpStatus).toBe(401);
+    expect(readOwnerHash(db)).toBeNull();
+    expect(readNonceConsumedAt(db, nonce)).toBeNull(); // nonce NOT burned on failed possession
+  });
+
+  it("RF-B3: a tampered signature is refused (401); nonce unconsumed", () => {
+    const nonce = issueNonce(db);
+    const good = validProof(nonce);
+    // Flip the base64 payload so the signature no longer verifies.
+    const tampered = {
+      transcript: good.transcript,
+      signature: { encoding: "ieee-p1363-base64" as const, value: Buffer.from(crypto.randomBytes(64)).toString("base64") },
+    };
+    let caught: unknown;
+    try {
+      makeService(db).claimOwnerWithDeviceKey({ ...baseClaim(nonce), deviceClaimProof: tampered }, LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_POP_INVALID");
+    expect(readOwnerHash(db)).toBeNull();
+    expect(readNonceConsumedAt(db, nonce)).toBeNull();
+  });
+
+  it("RF-B3: a proof whose transcript does not bind THIS claim (origin mismatch) is refused (401); nonce unconsumed", () => {
+    const nonce = issueNonce(db);
+    // Sign a valid transcript for a DIFFERENT origin, but submit origin=ORIGIN.
+    const mismatched = validProof(nonce, { origin: "https://evil.localhost" });
+    let caught: unknown;
+    try {
+      makeService(db).claimOwnerWithDeviceKey(
+        { ...baseClaim(nonce, { origin: ORIGIN }), deviceClaimProof: mismatched },
+        LOOPBACK,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_POP_INVALID");
+    expect(readOwnerHash(db)).toBeNull();
+    expect(readNonceConsumedAt(db, nonce)).toBeNull();
+  });
+
+  it("positive: a valid PoP claim succeeds but grants ZERO authority (deviceAuthorityEnabled=false, keyProtection=unverified)", () => {
+    const nonce = issueNonce(db);
+    const res = makeService(db).claimOwnerWithDeviceKey(
+      { ...baseClaim(nonce), deviceClaimProof: validProof(nonce) },
+      LOOPBACK,
+    );
+    expect(res.claimed).toBe(true);
+    expect(res.deviceAuthorityEnabled).toBe(false);
+    expect(res.keyProtection).toBe("unverified");
+    // Owner slot bound to the device sentinel; nonce consumed.
+    expect(readOwnerHash(db)).toBe(`device-owner$v1$${sha256Hex(DEVICE_PUBKEY)}`);
+    expect(readNonceConsumedAt(db, nonce)).not.toBeNull();
+  });
+});

--- a/test/integration/api/friday-secsetup-s3-device-principal-http-proof.test.ts
+++ b/test/integration/api/friday-secsetup-s3-device-principal-http-proof.test.ts
@@ -1,0 +1,398 @@
+/**
+ * SEC-SETUP-BOOTSTRAP-001 · Slice 3 — runtime proof over REAL HTTP.
+ *
+ * Two production-posture proofs that the DISABLED device principal carries ZERO
+ * owner data/control authority:
+ *
+ *  A. The device-claim endpoint now REQUIRES proof-of-possession: a missing or
+ *     PoP-unverified key is refused (owner slot untouched, nonce un-burned) —
+ *     driven over a real TCP socket against a real file-backed SQLite hub in
+ *     NODE_ENV=production on an ephemeral port > 49152 (no allowTestOnly).
+ *
+ *  B. The real http-server enforcement floors (L1 public-mutation, L2
+ *     sensitive-read) refuse a device principal EXACTLY like the synthetic
+ *     anonymous principal, while a NON-device principal of identical shape is
+ *     allowed — proving the floor consults the principal TYPE + the server-derived
+ *     switch, not the id/scope shape (the central attestation-theater trap).
+ */
+
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createFridayAuthRoutes,
+  createFridayAuthService,
+  createFridayHttpRouteRegistry,
+  createFridayHttpServer,
+  type FridayAuthMiddlewareFactory,
+  type FridayHttpServer,
+  type FridayRealtimeWsGateway,
+} from "#api";
+import { createFridaySqliteLayer } from "#state";
+import type { FridaySqliteLayer } from "#state";
+
+import type { FridayAuthPrincipal, FridayScope } from "../../../src/api/model/friday-api-auth.types.js";
+import { FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID } from "../../../src/api/http/friday-default-public-principal.js";
+import { ERROR_CODE_BOUND_PRINCIPAL_REQUIRED } from "../../../src/security/friday-owner-session-channel-capability.js";
+import {
+  DEVICE_OWNER_PRINCIPAL_TYPE,
+  deviceOwnerPrincipalId,
+} from "../../../src/security/friday-device-owner-authority-precondition.js";
+import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "../../adversarial/_secsetup-s2a.helpers.js";
+
+const OWNER_ID = "admin-001";
+const NOW = "2026-07-13T00:00:00.000Z";
+const ORIGIN = "https://friday.localhost";
+const DEVICE_KEY = generateTestDeviceKey();
+const DEVICE_PUBKEY = DEVICE_KEY.spkiDerBase64;
+const DEVICE_ID = "device-s3-http-001";
+const OWNER_SCOPES: FridayScope[] = ["workflow.read", "security.read", "session.read"];
+
+function sha256Hex(v: string): string {
+  return crypto.createHash("sha256").update(v).digest("hex");
+}
+
+async function findEphemeralPortAbove(min: number): Promise<number> {
+  const lo = Math.max(min + 1, 49153);
+  const hi = 65535;
+  const span = hi - lo + 1;
+  // Random per-call seed so consecutive servers in the same worker never reuse a
+  // just-closed port (which can be in TIME_WAIT and race the first request).
+  const seed = Math.floor(Math.random() * span);
+  for (let attempt = 0; attempt < 128; attempt += 1) {
+    const candidate = lo + ((seed + attempt * 2861) % span);
+    const bound = await new Promise<number | null>((resolve) => {
+      const srv = net.createServer();
+      srv.once("error", () => resolve(null));
+      srv.listen(candidate, "127.0.0.1", () => {
+        srv.close((e) => resolve(e ? null : candidate));
+      });
+    });
+    if (bound !== null && bound > min) return bound;
+  }
+  throw new Error(`could not allocate an ephemeral port > ${min}`);
+}
+
+function makeStubWsGateway(): FridayRealtimeWsGateway {
+  return {
+    handleClientFrame: () => ({ handled: false }),
+    addConnection: () => {},
+    removeConnection: () => {},
+    broadcastEvent: () => {},
+  } as unknown as FridayRealtimeWsGateway;
+}
+
+function makePassthroughMiddleware(): FridayAuthMiddlewareFactory {
+  return {
+    requireAuth: () => ({ passed: true as const }),
+    requireAnyScope: () => ({ passed: true as const }),
+    requireAnyRole: () => ({ passed: true as const }),
+    enforceRateLimit: () => ({ passed: true as const }),
+  } as unknown as FridayAuthMiddlewareFactory;
+}
+
+/** Bearer-stub middleware that hydrates a FULL principal (incl. principalType). */
+function makePrincipalBearerMiddleware(
+  tokens: Record<string, FridayAuthPrincipal>,
+): FridayAuthMiddlewareFactory {
+  return {
+    requireAuth: (ctx: { principal?: unknown; headers: Record<string, string | undefined> }) => {
+      if (ctx.principal) return { passed: true as const };
+      const auth = ctx.headers["authorization"] ?? ctx.headers["Authorization"];
+      if (!auth) return { passed: false as const, statusCode: 401, code: "UNAUTHORIZED", message: "missing token" };
+      const [scheme, token] = auth.split(" ");
+      if (scheme !== "Bearer" || !token || !tokens[token]) {
+        return { passed: false as const, statusCode: 401, code: "UNAUTHORIZED", message: "invalid token" };
+      }
+      (ctx as { principal: unknown }).principal = tokens[token];
+      return { passed: true as const };
+    },
+    requireAnyScope: () => ({ passed: true as const }),
+    requireAnyRole: () => ({ passed: true as const }),
+    enforceRateLimit: () => ({ passed: true as const }),
+  } as unknown as FridayAuthMiddlewareFactory;
+}
+
+function claimBody(nonce: string, over: Partial<{ origin: string; withProof: boolean; badSig: boolean }> = {}): Record<string, unknown> {
+  const origin = over.origin ?? ORIGIN;
+  const base = {
+    nonce,
+    devicePublicKey: DEVICE_PUBKEY,
+    deviceId: DEVICE_ID,
+    origin,
+    installId: "install-s3",
+    osUser: "jarvis",
+  };
+  if (over.withProof === false) return base; // no proof at all
+  const transcript = makeTranscript(DEVICE_KEY, { nonce, origin, deviceId: DEVICE_ID, installId: "install-s3", osUser: "jarvis" });
+  const value = over.badSig
+    ? Buffer.from(crypto.randomBytes(64)).toString("base64")
+    : signTranscriptLowS(DEVICE_KEY, transcript);
+  return { ...base, deviceClaimProof: { transcript, signature: { encoding: "ieee-p1363-base64", value } } };
+}
+
+// ─── A. device-claim PoP enforcement over real HTTP + sqlite ───
+
+describe("S3 runtime proof A — device-claim requires PoP (real HTTP, production posture)", () => {
+  let server: FridayHttpServer | null = null;
+  let db: FridaySqliteLayer;
+  let tmpDir: string;
+  let baseUrl = "";
+  const savedNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = "production";
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-secsetup-s3-http-"));
+    db = createFridaySqliteLayer({
+      dbPath: path.join(tmpDir, "friday.db"),
+      readPoolSize: 2,
+      pragmas: { busyTimeoutMs: 5_000, synchronous: "NORMAL" },
+    });
+    db.withWriteTransaction((conn) => {
+      conn
+        .prepare(
+          `INSERT INTO users (id, email, display_name, role, password_hash, is_local_only, last_login_at, created_at, updated_at, deleted_at)
+           VALUES (?, ?, ?, ?, NULL, 1, NULL, ?, ?, NULL)`,
+        )
+        .run(OWNER_ID, "admin@friday.dev", "Admin", "admin", NOW, NOW);
+    });
+
+    const authService = createFridayAuthService({
+      db,
+      idGenerator: (() => {
+        let n = 0;
+        return () => `id-${String(++n).padStart(4, "0")}`;
+      })(),
+      nowIso: () => NOW,
+      tokenSecret: crypto.randomBytes(32).toString("hex"), // pragma: allowlist secret
+      accessTokenTtlSec: 900,
+      refreshTokenTtlSec: 604_800,
+      hubId: "s3-http-hub",
+      bootstrapNonceTtlSec: 300,
+      warn: () => {},
+    });
+    const routes = createFridayHttpRouteRegistry();
+    for (const route of createFridayAuthRoutes({ authService })) routes.register(route);
+
+    const port = await findEphemeralPortAbove(49152);
+    baseUrl = `http://127.0.0.1:${port}`;
+    server = createFridayHttpServer({
+      routes,
+      wsGateway: makeStubWsGateway(),
+      middleware: makePassthroughMiddleware(),
+      port,
+      host: "127.0.0.1",
+      logRequests: false,
+    });
+    await server.listen();
+  });
+
+  afterEach(async () => {
+    if (server) await server.close();
+    server = null;
+    db.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    process.env.NODE_ENV = savedNodeEnv;
+  });
+
+  async function post(body: unknown): Promise<{ status: number; json: any }> {
+    const res = await fetch(`${baseUrl}/v1/auth/bootstrap/device-claim`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: ORIGIN },
+      body: JSON.stringify(body),
+    });
+    let json: any = null;
+    try {
+      json = await res.json();
+    } catch {
+      json = null;
+    }
+    return { status: res.status, json };
+  }
+
+  function ownerHash(): string | null {
+    return db.withReadConnection((conn) => {
+      const row = conn.prepare("SELECT password_hash AS h FROM users WHERE id = ?").get(OWNER_ID) as
+        | { h: string | null }
+        | undefined;
+      return row?.h ?? null;
+    });
+  }
+
+  function nonceConsumedAt(nonce: string): unknown {
+    return db.withReadConnection((conn) => {
+      const row = conn
+        .prepare("SELECT consumed_at FROM friday_setup_bootstrap_nonces WHERE nonce_hash = ?")
+        .get(sha256Hex(nonce)) as { consumed_at: unknown } | undefined;
+      return row?.consumed_at ?? null;
+    });
+  }
+
+  async function issue(): Promise<string> {
+    const res = await fetch(`${baseUrl}/v1/auth/bootstrap/challenge`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: ORIGIN },
+      body: JSON.stringify({ installId: "install-s3", osUser: "jarvis", origin: ORIGIN }),
+    });
+    const json = (await res.json()) as any;
+    return json.data.nonce as string;
+  }
+
+  it("MUST-REFUSE: a claim with NO proof → 400 POP_REQUIRED; owner NULL, nonce un-burned", async () => {
+    const nonce = await issue();
+    const r = await post(claimBody(nonce, { withProof: false }));
+    expect(r.status).toBe(400);
+    expect(r.json?.error?.code).toBe("AUTH_BOOTSTRAP_POP_REQUIRED");
+    expect(ownerHash()).toBeNull();
+    expect(nonceConsumedAt(nonce)).toBeNull();
+  });
+
+  it("MUST-REFUSE: a PoP-unverified (bad signature) key → 401 POP_INVALID; owner NULL, nonce un-burned", async () => {
+    const nonce = await issue();
+    const r = await post(claimBody(nonce, { badSig: true }));
+    expect(r.status).toBe(401);
+    expect(r.json?.error?.code).toBe("AUTH_BOOTSTRAP_POP_INVALID");
+    expect(ownerHash()).toBeNull();
+    expect(nonceConsumedAt(nonce)).toBeNull();
+  });
+
+  it("ALLOW (owner-slot binding only): a valid PoP claim → 200 claimed, deviceAuthorityEnabled=false", async () => {
+    const nonce = await issue();
+    const r = await post(claimBody(nonce));
+    expect(r.status).toBe(200);
+    expect(r.json.data.claimed).toBe(true);
+    expect(r.json.data.deviceAuthorityEnabled).toBe(false);
+    expect(r.json.data.keyProtection).toBe("unverified");
+  });
+});
+
+// ─── B. http-server floors refuse the DISABLED device principal ───
+
+describe("S3 runtime proof B — L1/L2 floors refuse a device principal (real http-server)", () => {
+  let server: FridayHttpServer | null = null;
+  let baseUrl = "";
+  let handlerCalls = 0;
+
+  const devicePrincipal: FridayAuthPrincipal = {
+    principalType: DEVICE_OWNER_PRINCIPAL_TYPE,
+    principalId: deviceOwnerPrincipalId(sha256Hex("device-key")),
+    tenantId: "11111111-1111-1111-1111-111111111111",
+    userId: "22222222-2222-2222-2222-222222222222",
+    role: "owner",
+    scopes: [...OWNER_SCOPES],
+    tokenId: "33333333-3333-3333-3333-333333333333",
+    tokenKind: "access",
+    issuedAt: NOW,
+  };
+  // Identical shape (id/scopes/role), but a NON-device type → allowed.
+  const userPrincipal: FridayAuthPrincipal = { ...devicePrincipal, principalType: "user", principalId: "user:alice" };
+
+  beforeEach(async () => {
+    handlerCalls = 0;
+    const routes = createFridayHttpRouteRegistry();
+    routes.register({
+      operationId: "test.s3.mutate",
+      method: "POST",
+      path: "/v1/test/s3/mutate",
+      auth: { public: true },
+      async handler() {
+        handlerCalls += 1;
+        return { handlerRan: true };
+      },
+    });
+    routes.register({
+      operationId: "test.s3.sensitive.read",
+      method: "GET",
+      path: "/v1/memory/items/s3", // under the /v1/memory sensitive-read prefix
+      auth: { public: true },
+      async handler() {
+        handlerCalls += 1;
+        return { ownerData: "owner-only" };
+      },
+    });
+
+    const port = await findEphemeralPortAbove(49152);
+    baseUrl = `http://127.0.0.1:${port}`;
+    server = createFridayHttpServer({
+      routes,
+      wsGateway: makeStubWsGateway(),
+      middleware: makePrincipalBearerMiddleware({ "device-token": devicePrincipal, "user-token": userPrincipal }),
+      port,
+      host: "127.0.0.1",
+      logRequests: false,
+    });
+    await server.listen();
+  });
+
+  afterEach(async () => {
+    if (server) await server.close();
+    server = null;
+  });
+
+  async function req(method: "POST" | "GET", pathname: string, token?: string): Promise<{ status: number; code?: string }> {
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const res = await fetch(`${baseUrl}${pathname}`, {
+      method,
+      headers,
+      body: method === "POST" ? JSON.stringify({}) : undefined,
+    });
+    let code: string | undefined;
+    try {
+      const j = (await res.json()) as any;
+      code = j?.error?.code;
+    } catch {
+      code = undefined;
+    }
+    return { status: res.status, code };
+  }
+
+  it("RF-C1 (L1): POST mutating public route with the device principal → 401 BOUND_PRINCIPAL_REQUIRED; handler not run", async () => {
+    const r = await req("POST", "/v1/test/s3/mutate", "device-token");
+    expect(r.status).toBe(401);
+    expect(r.code).toBe(ERROR_CODE_BOUND_PRINCIPAL_REQUIRED);
+    expect(handlerCalls).toBe(0);
+  });
+
+  it("positive control (L1): the SAME shape as a NON-device principal → 200 (handler runs)", async () => {
+    const r = await req("POST", "/v1/test/s3/mutate", "user-token");
+    expect(r.status).toBe(200);
+    expect(handlerCalls).toBe(1);
+  });
+
+  it("regression (L1): anonymous (no bearer) → 401 BOUND_PRINCIPAL_REQUIRED (existing floor intact)", async () => {
+    const r = await req("POST", "/v1/test/s3/mutate");
+    expect(r.status).toBe(401);
+    expect(r.code).toBe(ERROR_CODE_BOUND_PRINCIPAL_REQUIRED);
+    expect(handlerCalls).toBe(0);
+  });
+
+  it("RF-C2 (L2): GET sensitive-read route with the device principal → 401; handler not run", async () => {
+    const r = await req("GET", "/v1/memory/items/s3", "device-token");
+    expect(r.status).toBe(401);
+    expect(r.code).toBe(ERROR_CODE_BOUND_PRINCIPAL_REQUIRED);
+    expect(handlerCalls).toBe(0);
+  });
+
+  it("positive control (L2): the SAME shape as a NON-device principal → 200 (sensitive read allowed)", async () => {
+    const r = await req("GET", "/v1/memory/items/s3", "user-token");
+    expect(r.status).toBe(200);
+    expect(handlerCalls).toBe(1);
+  });
+
+  it("regression (L2): anonymous (no bearer) → 401 (existing sensitive-read floor intact)", async () => {
+    const r = await req("GET", "/v1/memory/items/s3");
+    expect(r.status).toBe(401);
+    expect(r.code).toBe(ERROR_CODE_BOUND_PRINCIPAL_REQUIRED);
+    expect(handlerCalls).toBe(0);
+  });
+
+  it("sanity: the device principalId is non-synthetic (proves the danger surface is real, not a public:default alias)", () => {
+    expect(devicePrincipal.principalId).not.toBe(FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID);
+  });
+});

--- a/test/integration/api/friday-setup-device-claim-http-proof.test.ts
+++ b/test/integration/api/friday-setup-device-claim-http-proof.test.ts
@@ -31,13 +31,40 @@ import {
 } from "#api";
 import { createFridaySqliteLayer } from "#state";
 import type { FridaySqliteLayer } from "#state";
+// SEC-SETUP-BOOTSTRAP-001 Slice 3: device-claim now requires a real PoP. Reuse
+// the S2a signing helpers so this runtime proof drives the REAL verifier.
+import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "../../adversarial/_secsetup-s2a.helpers.js";
 
 const OWNER_ID = "admin-001";
 const NOW = "2026-07-13T00:00:00.000Z";
 const ORIGIN = "https://friday.localhost";
 const EVIL_ORIGIN = "https://evil.localhost";
-const DEVICE_PUBKEY = crypto.randomBytes(32).toString("base64url");
+const DEVICE_KEY = generateTestDeviceKey();
+const DEVICE_PUBKEY = DEVICE_KEY.spkiDerBase64;
 const DEVICE_ID = "device-http-proof-001";
+
+/** Build a device-claim body carrying a valid PoP bound to (nonce, origin). */
+function claimBody(nonce: string, origin: string): Record<string, unknown> {
+  const transcript = makeTranscript(DEVICE_KEY, {
+    nonce,
+    origin,
+    deviceId: DEVICE_ID,
+    installId: "install-http-1",
+    osUser: "jarvis",
+  });
+  return {
+    nonce,
+    devicePublicKey: DEVICE_PUBKEY,
+    deviceId: DEVICE_ID,
+    origin,
+    installId: "install-http-1",
+    osUser: "jarvis",
+    deviceClaimProof: {
+      transcript,
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(DEVICE_KEY, transcript) },
+    },
+  };
+}
 // Evidence is written to a scratch path (NOT into the repo tree) so CI never
 // dirties the working tree. A representative captured run is committed at
 // test/adversarial/evidence/secsetup-device-claim-runtime-proof.txt.
@@ -220,14 +247,7 @@ describe("SEC-SETUP-BOOTSTRAP-001 runtime proof: device claim over real HTTP + r
     evidence.push(`   persisted row: nonce_hash=${nonceRow(nonce)?.nonce_hash} consumed_at=${nonceRow(nonce)?.consumed_at}`);
 
     // 2. Cross-origin claim MUST fail closed; owner NULL; nonce unconsumed.
-    const evil = await post("/v1/auth/bootstrap/device-claim", {
-      nonce,
-      devicePublicKey: DEVICE_PUBKEY,
-      deviceId: DEVICE_ID,
-      origin: EVIL_ORIGIN,
-      installId: "install-http-1",
-      osUser: "jarvis",
-    });
+    const evil = await post("/v1/auth/bootstrap/device-claim", claimBody(nonce, EVIL_ORIGIN));
     expect(evil.status).toBe(409);
     expect(ownerHash()).toBeNull();
     expect(nonceRow(nonce)?.consumed_at).toBeNull();
@@ -235,17 +255,13 @@ describe("SEC-SETUP-BOOTSTRAP-001 runtime proof: device claim over real HTTP + r
     evidence.push(`   owner password_hash=${ownerHash()} (unchanged) nonce consumed_at=${nonceRow(nonce)?.consumed_at}`);
 
     // 3. Correct-origin claim wins: owner sentinel set, nonce consumed + bound.
-    const ok = await post("/v1/auth/bootstrap/device-claim", {
-      nonce,
-      devicePublicKey: DEVICE_PUBKEY,
-      deviceId: DEVICE_ID,
-      origin: ORIGIN,
-      installId: "install-http-1",
-      osUser: "jarvis",
-    });
+    const ok = await post("/v1/auth/bootstrap/device-claim", claimBody(nonce, ORIGIN));
     expect(ok.status).toBe(200);
     expect(ok.json.data.claimed).toBe(true);
     expect(ok.json.data.devicePublicKeyHash).toBe(sha256Hex(DEVICE_PUBKEY));
+    // Slice 3 authoritative readback: the device binding carries ZERO authority.
+    expect(ok.json.data.deviceAuthorityEnabled).toBe(false);
+    expect(ok.json.data.keyProtection).toBe("unverified");
     const claimedHash = ownerHash();
     expect(claimedHash).toBe(`device-owner$v1$${sha256Hex(DEVICE_PUBKEY)}`);
     const consumedRow = nonceRow(nonce);
@@ -257,14 +273,7 @@ describe("SEC-SETUP-BOOTSTRAP-001 runtime proof: device claim over real HTTP + r
     evidence.push(`   consumed row: consumed_at=${consumedRow?.consumed_at} device_id=${consumedRow?.device_id} device_public_key_hash=${consumedRow?.device_public_key_hash} claimed_user_id=${consumedRow?.claimed_user_id}`);
 
     // 4. Replay the same nonce MUST fail closed; sentinel unchanged.
-    const replay = await post("/v1/auth/bootstrap/device-claim", {
-      nonce,
-      devicePublicKey: DEVICE_PUBKEY,
-      deviceId: DEVICE_ID,
-      origin: ORIGIN,
-      installId: "install-http-1",
-      osUser: "jarvis",
-    });
+    const replay = await post("/v1/auth/bootstrap/device-claim", claimBody(nonce, ORIGIN));
     expect(replay.status).toBe(409);
     expect(ownerHash()).toBe(claimedHash);
     evidence.push(`4) POST /v1/auth/bootstrap/device-claim (replay same nonce) -> HTTP ${replay.status} code=${replay.json?.error?.code ?? replay.json?.code}`);

--- a/test/unit/api/http/routes/friday-auth-routes.test.ts
+++ b/test/unit/api/http/routes/friday-auth-routes.test.ts
@@ -4,6 +4,26 @@ import { createTestDb } from "../../../satellites/_helpers/create-test-db.helper
 import { createFridayAuthRoutes, createFridayAuthService } from "#api";
 import type { FridayAuthService } from "#api";
 import type { FridayRouteDefinition, FridayHttpContext } from "#api";
+// SEC-SETUP-BOOTSTRAP-001 Slice 3: device-claim now requires proof-of-possession.
+import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "../../../../adversarial/_secsetup-s2a.helpers.js";
+
+const ROUTE_DEVICE_KEY = generateTestDeviceKey();
+/** Build a device-claim body carrying a valid PoP bound to (nonce, origin, deviceId). */
+function deviceClaimBody(nonce: string, origin: string, deviceId: string) {
+  const transcript = makeTranscript(ROUTE_DEVICE_KEY, { nonce, origin, deviceId, installId: "i-1", osUser: "u" });
+  return {
+    nonce,
+    devicePublicKey: ROUTE_DEVICE_KEY.spkiDerBase64,
+    deviceId,
+    origin,
+    installId: "i-1",
+    osUser: "u",
+    deviceClaimProof: {
+      transcript,
+      signature: { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(ROUTE_DEVICE_KEY, transcript) },
+    },
+  };
+}
 
 describe("FridayAuthRoutes", () => {
   let db: FridaySqliteLayer;
@@ -139,14 +159,7 @@ describe("FridayAuthRoutes", () => {
     const claim = await findRoute("auth.bootstrap.device.claim").handler(
       makeCtx({
         ip: "127.0.0.1",
-        body: {
-          nonce: challenge.nonce,
-          devicePublicKey: "device-pubkey-b64u",
-          deviceId: "device-1",
-          origin,
-          installId: "i-1",
-          osUser: "u",
-        },
+        body: deviceClaimBody(challenge.nonce, origin, "device-1"),
       }),
     ) as { claimed: boolean; userId: string };
     expect(claim.claimed).toBe(true);
@@ -157,14 +170,7 @@ describe("FridayAuthRoutes", () => {
       findRoute("auth.bootstrap.device.claim").handler(
         makeCtx({
           ip: "127.0.0.1",
-          body: {
-            nonce: challenge.nonce,
-            devicePublicKey: "device-pubkey-b64u",
-            deviceId: "device-1",
-            origin,
-            installId: "i-1",
-            osUser: "u",
-          },
+          body: deviceClaimBody(challenge.nonce, origin, "device-1"),
         }),
       ),
     ).rejects.toThrow("already been completed");


### PR DESCRIPTION
## SEC-SETUP-BOOTSTRAP-001 · Slice 3 — fail-closed DISABLED device-principal owner data/control plumbing

**Truth label (binding):** this is **additive, fail-closed plumbing**. A device-bound owner principal carries **ZERO owner data/control authority** in the release/default profile. This slice does **NOT** mark the SEC-SETUP requirement "passed" — it builds the deny path and the fail-closed seam pending native-IPC precondition **(b)**, which is **absent today**.

### The hard dependency
A device principal gets no real owner authority until **both** (a) S2a proof-of-possession verify [MERGED] **and** (b) trusted native-app IPC caller-identity [ABSENT] land. Because (b) is absent, the device principal stays **DISABLED/fail-closed** even though (a) exists. The server-derived authority switch is **hard-wired off** (a compile-time `NATIVE_IPC_ATTESTATION_AVAILABLE = false` gates it; an env opt-in alone cannot flip it), and it takes **no request-derived input** — no request-body/header/Origin/loopback/nonce fact can enable it.

### MUST-REFUSE behaviors covered (inventory §3.1/§3.2), with red→green→revert-red evidence
Every row asserts **both** the status/error code **and** the absence of side effect (owner slot unchanged, nonce un-burned, handler not run).

| MUST-REFUSE | Verdict | Proof |
|---|---|---|
| anonymous / `public:default` on mutating public route (L1) | 401 `OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED` | HTTP proof B (regression) + existing floor tests intact |
| anonymous / `public:default` on sensitive read (L2) | 401 | HTTP proof B (regression) |
| **DISABLED device principal** on L1 mutating route | 401, handler not run | HTTP proof B (real http-server + injected device bearer) |
| **DISABLED device principal** on L2 sensitive read | 401, handler not run | HTTP proof B |
| device principal shape fed to per-op gates (RF-A2) | 401 (bound-check before scope-check) | adversarial Group B |
| **positive control**: identical shape as a NON-device (`user`) principal | ALLOWED (200) | HTTP proof B + adversarial Group B — proves the floor consults **type + switch**, not the id/scope shape |
| device mint seam, preconditions unmet (RF-A1) | disabled, **no token / no principal** | adversarial Group A |
| unverified device (nonce-possession, no PoP) → device-claim | REFUSED (400 `AUTH_BOOTSTRAP_POP_REQUIRED`) | adversarial PoP + HTTP proof A |
| **PoP-unverified key** on device-claim (wrong key / tampered sig) | REFUSED (401 `AUTH_BOOTSTRAP_POP_INVALID`), **nonce un-burned** | adversarial PoP (RF-B3) + HTTP proof A |
| proof transcript not bound to the claim (nonce/origin/device mismatch) | REFUSED (401) | adversarial PoP |
| session-text dispatch: `''`/whitespace/`public:default`/`system`/**device-owner actor id** | REFUSED (401) | adversarial Group E1 |
| precondition switch cannot be flipped by any request fact | switch stays off | adversarial Group A (hostile env/request-shaped inputs) |

**Revert-red (load-bearing) verified:**
- Removing the device-refusal clause in `isUnauthenticatedPublicPrincipal` → **5 floor tests flip RED** (RF-A2, both per-op assert refusals, L1 + L2 HTTP). Restored → GREEN.
- Neutralizing the `if (!pop.ok)` refusal in `claimOwnerWithDeviceKey` → the **wrong-key + tampered PoP tests flip RED** (proves nonce-possession ≠ private-key-possession is enforced there). Restored → GREEN.

Tests run the **real** hub route → service → floor path in production posture (`NODE_ENV=production`, ephemeral port > 49152, real file-backed SQLite, no `allowTestOnly`).

### What changed
- `friday-api-principal.types.ts` — `device` added to `FridayPrincipalType`.
- `friday-owner-session-channel-capability.ts` — `device` added to `FridayBoundPrincipalSource`; new `isReleaseDisabledDevicePrincipal`; `isUnauthenticatedPublicPrincipal` + the session-actor gate now refuse a disabled device principal.
- `friday-device-owner-authority-precondition.ts` (**new**) — the server-derived switch, 4-state keyProtection (`secure_enclave_os_verified` / `keychain_acl_verified` / `software_dev_only` / `unverified`; only `unverified` reachable today → fail closed), device-principal identifiers, and the fail-closed `mintDeviceOwnerPrincipal` seam.
- `friday-auth-service.ts` / `friday-auth-routes.ts` / `friday-api-auth.types.ts` — device-claim now REQUIRES a PoP (calls the merged S2a `verifyPossession` before nonce-consume); response echoes authoritative readback (`keyProtection`, `deviceAuthorityEnabled: false`).

### Live-contract note (please review)
`POST /v1/auth/bootstrap/device-claim` now **requires** `deviceClaimProof` (signed transcript + signature); a missing/PoP-unverified proof fails closed. There is no signing native client today (that is precondition (b)), so no real flow depends on the old no-PoP contract; the passphrase bootstrap path is untouched. All shipped slice-1 device-claim tests were **adapted (not weakened)** to supply a valid signed transcript — every negative control (cross-origin, replay, expiry, loopback, atomicity, no-degrade, hash-only) keeps its exact error code (the transcript's `expiresAt` is far-future so the authoritative TTL/single-use gate stays server-side at nonce-consume).

### NO-DEGRADE
Only ADDs refusals + the fail-closed seam. No existing floor, refusal, or negative control relaxed or removed; no existing test weakened or skipped (proved via broad regression: 2018 tests across security/api-http/api-auth/adversarial/integration/contract suites green).

### Migration
**None.** The device principal type is a code enum; the device binding record already exists as the consumed nonce row + the `device-owner$v1$<hash>` sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48
