### PR TITLE
SEC-SETUP-BOOTSTRAP-001 Slice 5: authenticated legacy-passphrase→device migration (additive dual-read) + inactive tombstone scaffolding

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -196,7 +196,7 @@
         "filename": "src/api/http/routes/friday-auth-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 168
+        "line_number": 252
       }
     ],
     "src/api/http/routes/friday-provider-routes.ts": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-14T05:28:59Z"
+  "generated_at": "2026-07-14T06:50:14Z"
 }

--- a/context/MEMORY.md
+++ b/context/MEMORY.md
@@ -18,4 +18,4 @@
 - Tool call summary (`src/agent/services/friday-tool-call-summary.ts`) captures privacy-safe tool execution metadata (arg keys only, no values) for observability and world model training data.
 - Warn-once pattern is used across 7+ modules (hub-bootstrap, auth, memory, system, http-server, workspace-context, unix-socket-bridge) to deduplicate runtime warnings without losing critical signals.
 - OpenAI Responses API (`openai-responses`) streaming is now supported alongside `openai-completions` in the agent LLM client.
-- Database migration count: 103 (latest: v103-setup-bootstrap-device-claim).
+- Database migration count: 104 (latest: v104-setup-bootstrap-migration-state).

--- a/src/api/auth/friday-auth-service.ts
+++ b/src/api/auth/friday-auth-service.ts
@@ -12,6 +12,10 @@ import type {
   FridayAuthDeviceClaimRequest,
   FridayAuthDeviceClaimResponse,
   FridayAuthMeResponse,
+  FridayAuthMigrateChallengeRequest,
+  FridayAuthMigrateChallengeResponse,
+  FridayAuthMigrateDeviceClaimRequest,
+  FridayAuthMigrateDeviceClaimResponse,
   FridayAuthPrincipal,
   FridayLoginRequest,
   FridayLoginResponse,
@@ -33,6 +37,8 @@ import { createFridayUserRepository } from "../persistence/friday-user-repositor
 import type { FridayUserRow } from "../persistence/friday-user-repository.js";
 import { createFridayAuthSessionRepository } from "../persistence/friday-auth-session-repository.js";
 import { createFridaySetupBootstrapNonceRepository } from "../persistence/friday-setup-bootstrap-nonce-repository.js";
+import { createFridayDeviceOwnerBindingRepository } from "../persistence/friday-device-owner-binding-repository.js";
+import { isUnauthenticatedPublicPrincipal } from "../../security/friday-owner-session-channel-capability.js";
 import { isFridayTestSecurityWarningSuppressed } from "#utilities";
 import { isFridayLoopbackAddress } from "../http/friday-http-client-ip.js";
 import {
@@ -198,6 +204,22 @@ function isLegacySha256Hash(hash: string): boolean {
 }
 
 /**
+ * SEC-SETUP-BOOTSTRAP-001 Slice 5: true iff `hash` is a KNOWN passphrase-owner
+ * credential — the only valid migration SOURCE. NULL (first-boot, unclaimed) and
+ * the device-owner sentinel (already device-owned) both return false, so the
+ * authenticated migration can never reuse the first-boot bootstrap leg nor
+ * clobber an existing device owner. The device sentinel
+ * (`device-owner$v1$<64hex>`) is not `scrypt$…` and is longer than 64 chars, so
+ * it fails both branches.
+ */
+function isKnownPassphraseOwnerHash(hash: string | null | undefined): boolean {
+  if (!hash) return false;
+  if (hash.startsWith("scrypt$")) return true;
+  if (isLegacySha256Hash(hash)) return true;
+  return false;
+}
+
+/**
  * Verify a password against a legacy SHA-256 hex hash using constant-time comparison.
  */
 function verifyPasswordLegacySha256(input: string, hash: string): boolean {
@@ -278,6 +300,9 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
   const userRepo = createFridayUserRepository();
   const sessionRepo = createFridayAuthSessionRepository();
   const bootstrapNonceRepo = createFridaySetupBootstrapNonceRepository();
+  // SEC-SETUP-BOOTSTRAP-001 Slice 5: durable dual-read owner↔device binding
+  // record (provisional bind) + INACTIVE tombstone/rollback scaffolding.
+  const bindingRepo = createFridayDeviceOwnerBindingRepository();
   // SEC-SETUP-BOOTSTRAP-001 Slice 3: the merged S2a proof-of-possession verifier.
   // Crypto lives entirely in the device-attest seam — never re-implemented here.
   const ownerClaimPoPVerifier = createFridayOwnerClaimPoPVerifier();
@@ -474,6 +499,39 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
 
     const refreshToken = deps.idGenerator();
     return { accessToken, refreshToken, accessTokenClaims };
+  }
+
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 Slice 5: fail-closed guard that the caller is the
+   * AUTHENTICATED local owner (from a passphrase login). Defence-in-depth on top
+   * of the http-server L1 public-mutation floor: refuse the synthetic public
+   * principal AND any release-disabled device principal, then require the bound
+   * owner identity (principalId === localUser.id) + an owner/admin role. The
+   * authenticated session IS the proof-of-passphrase-possession — the passphrase
+   * is never re-typed into a body, and Origin/UA/bundle-string are never trusted
+   * for identity.
+   */
+  function assertAuthenticatedLocalOwner(
+    principal: FridayAuthPrincipal | null,
+    localUser: FridayUserRow,
+  ): void {
+    if (isUnauthenticatedPublicPrincipal(principal)) {
+      throw new FridayDomainError(
+        "AUTH_MIGRATE_OWNER_REQUIRED",
+        "Migration requires the authenticated local owner; the synthetic public principal cannot migrate ownership.",
+        { httpStatus: 401 },
+      );
+    }
+    const p = principal as FridayAuthPrincipal;
+    const roleOk = p.role === "admin" || p.role === "owner";
+    const identityOk = p.principalId === localUser.id;
+    if (!roleOk || !identityOk) {
+      throw new FridayDomainError(
+        "AUTH_MIGRATE_FORBIDDEN",
+        "Migration requires the authenticated local owner principal (admin/owner bound to the local user).",
+        { httpStatus: 403 },
+      );
+    }
   }
 
   return {
@@ -776,6 +834,270 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         // device binding carries NO owner authority in release/default (the
         // device principal stays DISABLED until native-IPC precondition (b)).
         keyProtection,
+        deviceAuthorityEnabled: isDeviceOwnerAuthorityEnabled(),
+      };
+    },
+
+    issueMigrationChallenge(
+      request: FridayAuthMigrateChallengeRequest,
+      principal: FridayAuthPrincipal | null,
+      ip?: string,
+    ): FridayAuthMigrateChallengeResponse {
+      // Loopback-only, mirroring the bootstrap challenge ingress boundary.
+      if (!isLocalhostAddress(ip)) {
+        throw new FridayDomainError(
+          "AUTH_MIGRATE_NOT_ALLOWED",
+          "Migration challenge is only allowed from localhost.",
+          { httpStatus: 403 },
+        );
+      }
+
+      const localUser = findLocalUser();
+      if (!localUser) {
+        throw new FridayDomainError(
+          "USER_NOT_FOUND",
+          "No local user configured",
+          { httpStatus: 404 },
+        );
+      }
+      // Authenticated-owner gate: only the bound local owner starts a migration.
+      assertAuthenticatedLocalOwner(principal, localUser);
+      // Only a KNOWN passphrase-owner is a valid migration source. NULL
+      // (first-boot) or the device sentinel (already migrated) fail closed — the
+      // migration never reuses the first-boot leg nor re-migrates a device owner.
+      if (!isKnownPassphraseOwnerHash(localUser.password_hash)) {
+        throw new FridayDomainError(
+          "AUTH_MIGRATE_NO_LEGACY_OWNER",
+          "Migration requires an existing passphrase owner; there is no legacy passphrase credential to migrate.",
+          { httpStatus: 409 },
+        );
+      }
+
+      const installId = (request.installId ?? "").trim();
+      const osUser = (request.osUser ?? "").trim();
+      const origin = (request.origin ?? "").trim();
+      const action = (request.action ?? "owner-migrate").trim() || "owner-migrate";
+      if (!installId || !osUser || !origin) {
+        throw new FridayDomainError(
+          "VALIDATION_ERROR",
+          "installId, osUser and origin are required to issue a migration challenge",
+          { httpStatus: 400 },
+        );
+      }
+
+      const now = deps.nowIso();
+      const expiresAt = new Date(
+        new Date(now).getTime() + bootstrapNonceTtlSec * 1000,
+      ).toISOString();
+      const challengeId = deps.idGenerator();
+      const nonce = generateBootstrapNonce();
+      const nonceHash = sha256Hex(nonce);
+
+      deps.db.withWriteTransaction((db) => {
+        bootstrapNonceRepo.insertNonce(db, {
+          id: challengeId,
+          nonceHash,
+          kind: "device_migration_claim",
+          hubId: bootstrapHubId,
+          installId,
+          osUser,
+          origin,
+          action,
+          createdAt: now,
+          expiresAt,
+        });
+      });
+
+      return {
+        challengeId,
+        nonce,
+        kind: "device_migration_claim",
+        hubId: bootstrapHubId,
+        installId,
+        osUser,
+        origin,
+        action,
+        createdAt: now,
+        expiresAt,
+      };
+    },
+
+    migrateOwnerToDeviceKey(
+      request: FridayAuthMigrateDeviceClaimRequest,
+      principal: FridayAuthPrincipal | null,
+      ip?: string,
+    ): FridayAuthMigrateDeviceClaimResponse {
+      // Loopback-only guard.
+      if (!isLocalhostAddress(ip)) {
+        throw new FridayDomainError(
+          "AUTH_MIGRATE_NOT_ALLOWED",
+          "Migration is only allowed from localhost.",
+          { httpStatus: 403 },
+        );
+      }
+
+      const localUser = findLocalUser();
+      if (!localUser) {
+        throw new FridayDomainError(
+          "USER_NOT_FOUND",
+          "No local user configured",
+          { httpStatus: 404 },
+        );
+      }
+      // Authenticated-owner gate (the session is the proof-of-passphrase).
+      assertAuthenticatedLocalOwner(principal, localUser);
+
+      const nonce = (request.nonce ?? "").trim();
+      const devicePublicKey = (request.devicePublicKey ?? "").trim();
+      const deviceId = (request.deviceId ?? "").trim();
+      const origin = (request.origin ?? "").trim();
+      if (!nonce || !devicePublicKey || !deviceId || !origin) {
+        throw new FridayDomainError(
+          "VALIDATION_ERROR",
+          "nonce, devicePublicKey, deviceId and origin are required",
+          { httpStatus: 400 },
+        );
+      }
+
+      // ── Proof-of-possession gate (identical posture to claimOwnerWithDeviceKey) ──
+      // The device MUST prove PRIVATE-key possession by signing the canonical
+      // transcript over the server nonce. Verified BEFORE the nonce is consumed,
+      // so a PoP failure leaves the nonce un-burned and adds NO binding. Crypto is
+      // delegated ENTIRELY to the merged S2a verifier — never re-implemented here.
+      const proof = coerceDeviceClaimProof(request.deviceClaimProof);
+      if (!proof) {
+        throw new FridayDomainError(
+          "AUTH_MIGRATE_POP_REQUIRED",
+          "Device migration requires a proof-of-possession (signed transcript + signature).",
+          { httpStatus: 400 },
+        );
+      }
+      if (
+        proof.transcript.nonce !== nonce ||
+        proof.transcript.origin !== origin ||
+        proof.transcript.deviceId !== deviceId
+      ) {
+        throw new FridayDomainError(
+          "AUTH_MIGRATE_POP_INVALID",
+          "Proof-of-possession transcript does not match the migration request.",
+          { httpStatus: 401 },
+        );
+      }
+      const pop = ownerClaimPoPVerifier.verifyPossession({
+        transcript: proof.transcript,
+        devicePublicKey: { encoding: "spki-der-base64", value: devicePublicKey },
+        signature: proof.signature,
+        nowMs: Date.parse(deps.nowIso()),
+      });
+      if (!pop.ok) {
+        throw new FridayDomainError(
+          "AUTH_MIGRATE_POP_INVALID",
+          `Device proof-of-possession failed: ${pop.reason}.`,
+          { httpStatus: 401 },
+        );
+      }
+      const keyProtection = deriveDeviceKeyProtection();
+
+      // Migration SOURCE gate: CAS from a KNOWN passphrase-owner hash ONLY. NULL
+      // (first-boot) ⇒ refuse (never reuse the bootstrap leg). Device sentinel ⇒
+      // refuse (already migrated). Captured now for the in-txn re-assert below.
+      const observedHash = localUser.password_hash;
+      if (!isKnownPassphraseOwnerHash(observedHash)) {
+        throw new FridayDomainError(
+          "AUTH_MIGRATE_NO_LEGACY_OWNER",
+          "Migration requires an existing passphrase owner; there is no legacy passphrase credential to migrate.",
+          { httpStatus: 409 },
+        );
+      }
+
+      const now = deps.nowIso();
+      const nonceHash = sha256Hex(nonce);
+      const devicePublicKeyHash = sha256Hex(devicePublicKey);
+      const bindingId = deps.idGenerator();
+
+      // ADDITIVE, dual-read, abort-safe: BOTH writes run in ONE transaction. A
+      // crash / thrown error rolls the whole unit back — the nonce stays
+      // unconsumed AND no binding is added. Crucially, users.password_hash is
+      // NEVER written here: the passphrase stays authoritative (NO lockout), the
+      // device binding is only 'provisional', and the tombstone/sentinel flip is
+      // a LATER stage (INACTIVE scaffolding this slice).
+      //   1. CAS-consume the migration nonce (kind='device_migration_claim',
+      //      origin/expiry/single-use). changes=0 ⇒ replay/expired/cross-origin ⇒
+      //      reject, ZERO state change.
+      //   2. Re-assert the observed legacy hash is UNCHANGED inside the txn — a
+      //      concurrent passphrase rotation / re-bootstrap / device-claim aborts
+      //      the migration with ZERO state change (never bind against a moved slot).
+      //   3. Insert the 'provisional' dual-read binding. password_hash UNTOUCHED.
+      try {
+        deps.db.withWriteTransaction((db) => {
+          const consumed = bootstrapNonceRepo.consumeOwnerClaimNonce(db, {
+            nonceHash,
+            kind: "device_migration_claim",
+            origin,
+            nowIso: now,
+            devicePublicKey,
+            devicePublicKeyHash,
+            deviceId,
+            claimedUserId: localUser.id,
+          });
+          if (consumed !== 1) {
+            throw new FridayDomainError(
+              "AUTH_MIGRATE_NONCE_INVALID",
+              "Migration nonce is invalid, expired, cross-origin, or already used.",
+              { httpStatus: 409 },
+            );
+          }
+
+          const current = db
+            .prepare("SELECT password_hash AS h FROM users WHERE id = ?")
+            .get(localUser.id) as { h: string | null } | undefined;
+          if (!current || current.h !== observedHash) {
+            throw new FridayDomainError(
+              "AUTH_MIGRATE_OWNER_CHANGED",
+              "The owner credential changed during migration; aborted with no state change.",
+              { httpStatus: 409 },
+            );
+          }
+
+          bindingRepo.insertProvisionalBinding(db, {
+            id: bindingId,
+            userId: localUser.id,
+            deviceId,
+            devicePublicKey,
+            devicePublicKeyHash,
+            migratedFrom: "passphrase",
+            origin,
+            hubId: bootstrapHubId,
+            createdAt: now,
+          });
+        });
+      } catch (error) {
+        // Defence-in-depth: the partial UNIQUE(kind) WHERE consumed_at IS NOT NULL
+        // makes a second consumed migration nonce a UNIQUE violation. Surface it
+        // as a clean fail-closed 409 rather than a raw SQLite error.
+        if (isSqliteConstraintError(error)) {
+          throw new FridayDomainError(
+            "AUTH_MIGRATE_ALREADY_DONE",
+            "A device migration has already been recorded for this owner.",
+            { httpStatus: 409 },
+          );
+        }
+        throw error;
+      }
+
+      return {
+        migrated: true,
+        state: "provisional",
+        bindingId,
+        migratedAt: now,
+        userId: localUser.id,
+        deviceId,
+        devicePublicKeyHash,
+        // The passphrase is still the working owner credential — no lockout.
+        passphraseStillActive: true,
+        keyProtection,
+        // ALWAYS false in release/default — the provisional device binding
+        // carries ZERO authority until native-IPC precondition (b) lands.
         deviceAuthorityEnabled: isDeviceOwnerAuthorityEnabled(),
       };
     },

--- a/src/api/auth/friday-auth-service.types.ts
+++ b/src/api/auth/friday-auth-service.types.ts
@@ -9,6 +9,10 @@ import type {
   FridayAuthDeviceClaimRequest,
   FridayAuthDeviceClaimResponse,
   FridayAuthMeResponse,
+  FridayAuthMigrateChallengeRequest,
+  FridayAuthMigrateChallengeResponse,
+  FridayAuthMigrateDeviceClaimRequest,
+  FridayAuthMigrateDeviceClaimResponse,
   FridayAuthPrincipal,
   FridayLoginRequest,
   FridayLoginResponse,
@@ -49,6 +53,33 @@ export interface FridayAuthService {
     request: FridayAuthDeviceClaimRequest,
     ip?: string,
   ): FridayAuthDeviceClaimResponse;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 Slice 5: mint a single-use install nonce for an
+   * AUTHENTICATED existing-passphrase-owner → device migration (kind
+   * 'device_migration_claim'). Requires the bound OWNER principal
+   * (principalId === localUser.id, role admin/owner). Loopback-only; the raw
+   * nonce is returned once. ADDITIVE — removes/disables nothing.
+   */
+  issueMigrationChallenge(
+    request: FridayAuthMigrateChallengeRequest,
+    principal: FridayAuthPrincipal | null,
+    ip?: string,
+  ): FridayAuthMigrateChallengeResponse;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 Slice 5: authenticated dual-read migration of an
+   * existing passphrase-owner to a PROVISIONAL device binding. Requires the
+   * bound OWNER principal (the authenticated session IS the proof-of-passphrase
+   * possession) + a valid device proof-of-possession. CAS from a KNOWN
+   * passphrase-owner hash (never NULL / never the device sentinel). Leaves
+   * users.password_hash UNTOUCHED (the passphrase STILL works — no lockout).
+   * Reversible; the device binding carries ZERO authority. Loopback-only,
+   * origin-bound, replay-protected, crash-safe (single txn).
+   */
+  migrateOwnerToDeviceKey(
+    request: FridayAuthMigrateDeviceClaimRequest,
+    principal: FridayAuthPrincipal | null,
+    ip?: string,
+  ): FridayAuthMigrateDeviceClaimResponse;
 }
 
 export interface FridayIssuedAccessTokenRecord {

--- a/src/api/http/routes/friday-auth-routes.ts
+++ b/src/api/http/routes/friday-auth-routes.ts
@@ -8,6 +8,10 @@ import type {
   FridayAuthDeviceClaimRequest,
   FridayAuthDeviceClaimResponse,
   FridayAuthMeResponse,
+  FridayAuthMigrateChallengeRequest,
+  FridayAuthMigrateChallengeResponse,
+  FridayAuthMigrateDeviceClaimRequest,
+  FridayAuthMigrateDeviceClaimResponse,
   FridayLoginRequest,
   FridayLogoutRequest,
   FridayRefreshRequest,
@@ -17,6 +21,7 @@ import {
   FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID,
   FRIDAY_DEFAULT_PUBLIC_HTTP_USER_ID,
 } from "../friday-default-public-principal.js";
+import { assertBoundPrincipalAuthorityForOperation } from "../../../security/friday-owner-session-channel-capability.js";
 import { FridayDomainError } from "#errors";
 
 const FRIDAY_DEFAULT_PUBLIC_HTTP_DISPLAY_NAME = "Friday Public";
@@ -140,6 +145,85 @@ export function createFridayAuthRoutes(
           deviceClaimProof: body.deviceClaimProof as FridayAuthDeviceClaimRequest["deviceClaimProof"],
         };
         return deps.authService.claimOwnerWithDeviceKey(request, ctx.ip);
+      },
+    },
+    {
+      operationId: "auth.migrate.challenge",
+      method: "POST",
+      path: "/v1/auth/migrate/challenge",
+      // SEC-SETUP-BOOTSTRAP-001 Slice 5: mints a single-use migration nonce
+      // (kind='device_migration_claim') the device signs. AUTHENTICATED: NOT
+      // allowUnauthenticatedMutation, so the http-server L1 public-mutation floor
+      // refuses the synthetic public principal (401) — a real OWNER bearer is
+      // required. The handler additionally enforces owner authority, and the auth
+      // SERVICE binds the principal to the local owner (principalId===localUser.id)
+      // and requires an existing passphrase credential. Loopback-only,
+      // rate-limited under auth.login.
+      auth: { public: true },
+      rateLimitPolicyId: "auth.login",
+      async handler(ctx): Promise<FridayAuthMigrateChallengeResponse> {
+        assertBoundPrincipalAuthorityForOperation(
+          ctx.principal,
+          "auth.migrate.challenge",
+          "api",
+          { anyOfRoles: ["owner", "admin"], anyOfScopes: ["security.write"] },
+        );
+        const body = ctx.body as Record<string, unknown> | null;
+        if (!body || typeof body !== "object") {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "Request body is required",
+            { httpStatus: 400 },
+          );
+        }
+        const request: FridayAuthMigrateChallengeRequest = {
+          installId: typeof body.installId === "string" ? body.installId : "",
+          osUser: typeof body.osUser === "string" ? body.osUser : "",
+          origin: typeof body.origin === "string" ? body.origin : "",
+          action: typeof body.action === "string" ? body.action : undefined,
+        };
+        return deps.authService.issueMigrationChallenge(request, ctx.principal, ctx.ip);
+      },
+    },
+    {
+      operationId: "auth.migrate.device.claim",
+      method: "POST",
+      path: "/v1/auth/migrate/device-claim",
+      // SEC-SETUP-BOOTSTRAP-001 Slice 5: authenticated dual-read migration of an
+      // existing passphrase-owner to a PROVISIONAL device binding. ADDITIVE and
+      // reversible: users.password_hash STAYS scrypt$… (the passphrase still
+      // works — NO lockout) and the device binding carries ZERO authority. NOT
+      // allowUnauthenticatedMutation → the L1 floor refuses the synthetic public
+      // principal; the handler enforces owner authority; the auth SERVICE binds
+      // the principal to the local owner (the authenticated session IS the
+      // proof-of-passphrase-possession) + verifies device PoP before any bind.
+      auth: { public: true },
+      rateLimitPolicyId: "auth.login",
+      async handler(ctx): Promise<FridayAuthMigrateDeviceClaimResponse> {
+        assertBoundPrincipalAuthorityForOperation(
+          ctx.principal,
+          "auth.migrate.device.claim",
+          "api",
+          { anyOfRoles: ["owner", "admin"], anyOfScopes: ["security.write"] },
+        );
+        const body = ctx.body as Record<string, unknown> | null;
+        if (!body || typeof body !== "object") {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "Request body is required",
+            { httpStatus: 400 },
+          );
+        }
+        const request: FridayAuthMigrateDeviceClaimRequest = {
+          nonce: typeof body.nonce === "string" ? body.nonce : "",
+          devicePublicKey: typeof body.devicePublicKey === "string" ? body.devicePublicKey : "",
+          deviceId: typeof body.deviceId === "string" ? body.deviceId : "",
+          origin: typeof body.origin === "string" ? body.origin : "",
+          installId: typeof body.installId === "string" ? body.installId : "",
+          osUser: typeof body.osUser === "string" ? body.osUser : "",
+          deviceClaimProof: body.deviceClaimProof as FridayAuthMigrateDeviceClaimRequest["deviceClaimProof"],
+        };
+        return deps.authService.migrateOwnerToDeviceKey(request, ctx.principal, ctx.ip);
       },
     },
     {

--- a/src/api/model/friday-api-auth.types.ts
+++ b/src/api/model/friday-api-auth.types.ts
@@ -259,6 +259,87 @@ export interface FridayAuthDeviceClaimResponse {
   deviceAuthorityEnabled: boolean;
 }
 
+// ─── Authenticated legacy-passphrase → device migration (SEC-SETUP-BOOTSTRAP-001 Slice 5) ───
+//
+// ADDITIVE, dual-read, reversible. Unlike the first-boot device claim (which CAS
+// from password_hash IS NULL), migration moves an ALREADY-authenticated existing
+// passphrase-owner to a PROVISIONAL device binding. The authenticated owner
+// session IS the proof-of-passphrase-possession (never re-typed into a body).
+// After a successful migrate, users.password_hash STAYS scrypt$… (the passphrase
+// STILL works — NO lockout) and a provisional binding row is added. Fully
+// reversible until a later stage proves device readback. The device principal
+// still carries ZERO authority (deviceAuthorityEnabled always false).
+
+export interface FridayAuthMigrateChallengeRequest {
+  /** Stable installation id for this hub install (binds the nonce). */
+  installId: string;
+  /** OS user the install runs as (binds the nonce). */
+  osUser: string;
+  /** Loopback origin the migration claim will be presented from (binds the nonce). */
+  origin: string;
+  /** Optional bound action label; defaults to "owner-migrate". */
+  action?: string;
+}
+
+export interface FridayAuthMigrateChallengeResponse {
+  challengeId: UUID;
+  /** Raw single-use nonce — returned exactly ONCE; only its hash is persisted. */
+  nonce: string;
+  kind: "device_migration_claim";
+  hubId: string;
+  installId: string;
+  osUser: string;
+  origin: string;
+  action: string;
+  createdAt: ISODateTime;
+  expiresAt: ISODateTime;
+}
+
+export interface FridayAuthMigrateDeviceClaimRequest {
+  /** The raw nonce previously issued by the migrate challenge endpoint. */
+  nonce: string;
+  /** Device public key, SPKI DER base64/base64url (P-256), bound to the owner. */
+  devicePublicKey: string;
+  /** Device identifier bound to the owner. */
+  deviceId: string;
+  /** Origin the claim is presented from; MUST equal the bound issue origin. */
+  origin: string;
+  installId: string;
+  osUser: string;
+  /**
+   * REQUIRED proof-of-possession. The device signs the canonical transcript; the
+   * server verifies the signature against the presented public key BEFORE any
+   * binding or nonce consume. A missing/invalid proof fails closed (no binding,
+   * nonce un-burned).
+   */
+  deviceClaimProof?: FridayDeviceClaimProof;
+}
+
+export interface FridayAuthMigrateDeviceClaimResponse {
+  migrated: true;
+  /** Always 'provisional' in Slice 5 — activation is a later stage. */
+  state: "provisional";
+  /** Id of the newly-inserted provisional device-owner binding row. */
+  bindingId: UUID;
+  migratedAt: ISODateTime;
+  userId: UUID;
+  deviceId: string;
+  /** Deterministic hash of the bound device public key (never the private key). */
+  devicePublicKeyHash: string;
+  /**
+   * The passphrase remains the working owner credential after migration
+   * (dual-read window) — ALWAYS true in Slice 5. Positive proof of no-lockout.
+   */
+  passphraseStillActive: true;
+  /** Server-derived key-protection posture (never self-reported). */
+  keyProtection: "secure_enclave_os_verified" | "keychain_acl_verified" | "software_dev_only" | "unverified";
+  /**
+   * Whether this device binding carries owner authority. ALWAYS false in the
+   * release/default profile until native-IPC precondition (b) lands.
+   */
+  deviceAuthorityEnabled: boolean;
+}
+
 // ─── Refresh ───
 
 export interface FridayRefreshRequest {

--- a/src/api/persistence/friday-device-owner-binding-repository.ts
+++ b/src/api/persistence/friday-device-owner-binding-repository.ts
@@ -1,0 +1,220 @@
+import type Database from "better-sqlite3";
+
+// ─── SEC-SETUP-BOOTSTRAP-001 · Slice 5 — dual-read migration persistence ───
+//
+// The durable owner↔device binding record + the (INACTIVE) stage-5 legacy
+// credential tombstone. Stage 2 of the operator-locked FIXED order writes ONLY
+// a `provisional` binding and leaves users.password_hash = scrypt$… untouched
+// (dual-read: the passphrase remains authoritative — no lockout). The activate /
+// revoke / tombstone helpers are SCAFFOLDING for a later stage: they exist and
+// are typed, but NO live Slice-5 code path calls them, and none flips
+// users.password_hash to the device sentinel.
+
+// ─── Binding row + inputs ───
+
+export type FridayDeviceOwnerBindingState = "provisional" | "active" | "revoked";
+export type FridayDeviceOwnerBindingMigratedFrom = "passphrase" | "first_boot";
+
+export interface FridayDeviceOwnerBindingRow {
+  id: string;
+  user_id: string;
+  device_id: string;
+  device_public_key: string;
+  device_public_key_hash: string;
+  state: FridayDeviceOwnerBindingState;
+  migrated_from: FridayDeviceOwnerBindingMigratedFrom;
+  origin: string;
+  hub_id: string;
+  created_at: string;
+  activated_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface InsertProvisionalDeviceOwnerBindingInput {
+  id: string;
+  userId: string;
+  deviceId: string;
+  devicePublicKey: string;
+  devicePublicKeyHash: string;
+  /** Slice 5 only migrates a known passphrase-owner → always 'passphrase'. */
+  migratedFrom: FridayDeviceOwnerBindingMigratedFrom;
+  origin: string;
+  hubId: string;
+  createdAt: string;
+}
+
+// ─── Tombstone row + inputs (INACTIVE scaffolding) ───
+
+export type FridayCredentialTombstoneReason =
+  | "migrated_to_device"
+  | "delete_all"
+  | "release_profile_disable";
+
+export interface FridayCredentialTombstoneRow {
+  id: string;
+  user_id: string;
+  credential_kind: "passphrase";
+  retired_reason: FridayCredentialTombstoneReason;
+  superseded_by_binding_id: string | null;
+  origin: string;
+  hub_id: string;
+  retired_at: string;
+}
+
+export interface InsertCredentialTombstoneInput {
+  id: string;
+  userId: string;
+  credentialKind: "passphrase";
+  retiredReason: FridayCredentialTombstoneReason;
+  supersededByBindingId: string | null;
+  origin: string;
+  hubId: string;
+  retiredAt: string;
+}
+
+// ─── Repository interface ───
+
+export interface FridayDeviceOwnerBindingRepository {
+  /**
+   * ACTIVE in Slice 5. Insert a `provisional` dual-read binding for an
+   * authenticated passphrase-owner migration. Does NOT touch users.password_hash
+   * — the passphrase stays authoritative until a later stage proves device
+   * readback and flips the binding to 'active'.
+   */
+  insertProvisionalBinding(
+    db: Database.Database,
+    input: InsertProvisionalDeviceOwnerBindingInput,
+  ): void;
+  /** All bindings for a user (any state), newest first. */
+  findBindingsByUser(db: Database.Database, userId: string): FridayDeviceOwnerBindingRow[];
+  /** The single active binding for a user, if any (partial-unique enforced). */
+  findActiveBindingByUser(
+    db: Database.Database,
+    userId: string,
+  ): FridayDeviceOwnerBindingRow | null;
+  /**
+   * SCAFFOLDING (stage 3+, INACTIVE in Slice 5). CAS-flip a provisional binding
+   * to 'active'. Not called by any Slice-5 live path. Keyed on the exact
+   * bindingId + state='provisional' so it can never activate a revoked binding.
+   * Returns affected-row count (1 = flipped, 0 = not provisional / not found).
+   */
+  activateBinding(
+    db: Database.Database,
+    bindingId: string,
+    userId: string,
+    activatedAt: string,
+  ): number;
+  /**
+   * SCAFFOLDING (stage 4/5 reversal, INACTIVE in Slice 5). Mark a binding
+   * 'revoked'. Not called by any Slice-5 live path.
+   */
+  revokeBinding(db: Database.Database, bindingId: string, revokedAt: string): number;
+  /**
+   * SCAFFOLDING (stage 5, INACTIVE in Slice 5). Write a legacy-credential
+   * tombstone. Stores NO secret/hash. Not called by any Slice-5 live path.
+   */
+  insertCredentialTombstone(db: Database.Database, input: InsertCredentialTombstoneInput): void;
+  /**
+   * SCAFFOLDING (stage 5 fail-closed login defence, INACTIVE in Slice 5). Find
+   * the authoritative tombstone for a user's passphrase credential. Not consulted
+   * by the Slice-5 login path (the passphrase still works this slice).
+   */
+  findActiveTombstone(
+    db: Database.Database,
+    userId: string,
+  ): FridayCredentialTombstoneRow | null;
+}
+
+// ─── Factory ───
+
+export function createFridayDeviceOwnerBindingRepository(): FridayDeviceOwnerBindingRepository {
+  return {
+    insertProvisionalBinding(db, input) {
+      db.prepare(
+        `INSERT INTO friday_device_owner_bindings (
+           id, user_id, device_id, device_public_key, device_public_key_hash,
+           state, migrated_from, origin, hub_id, created_at, activated_at, revoked_at
+         ) VALUES (?, ?, ?, ?, ?, 'provisional', ?, ?, ?, ?, NULL, NULL)`,
+      ).run(
+        input.id,
+        input.userId,
+        input.deviceId,
+        input.devicePublicKey,
+        input.devicePublicKeyHash,
+        input.migratedFrom,
+        input.origin,
+        input.hubId,
+        input.createdAt,
+      );
+    },
+
+    findBindingsByUser(db, userId) {
+      return db
+        .prepare(
+          "SELECT * FROM friday_device_owner_bindings WHERE user_id = ? ORDER BY created_at DESC",
+        )
+        .all(userId) as FridayDeviceOwnerBindingRow[];
+    },
+
+    findActiveBindingByUser(db, userId) {
+      return (
+        (db
+          .prepare(
+            "SELECT * FROM friday_device_owner_bindings WHERE user_id = ? AND state = 'active'",
+          )
+          .get(userId) as FridayDeviceOwnerBindingRow | undefined) ?? null
+      );
+    },
+
+    activateBinding(db, bindingId, userId, activatedAt) {
+      return db
+        .prepare(
+          `UPDATE friday_device_owner_bindings
+              SET state = 'active', activated_at = ?
+            WHERE id = ? AND user_id = ? AND state = 'provisional'`,
+        )
+        .run(activatedAt, bindingId, userId).changes;
+    },
+
+    revokeBinding(db, bindingId, revokedAt) {
+      return db
+        .prepare(
+          `UPDATE friday_device_owner_bindings
+              SET state = 'revoked', revoked_at = ?
+            WHERE id = ? AND state != 'revoked'`,
+        )
+        .run(revokedAt, bindingId).changes;
+    },
+
+    insertCredentialTombstone(db, input) {
+      db.prepare(
+        `INSERT INTO friday_credential_tombstones (
+           id, user_id, credential_kind, retired_reason, superseded_by_binding_id,
+           origin, hub_id, retired_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        input.id,
+        input.userId,
+        input.credentialKind,
+        input.retiredReason,
+        input.supersededByBindingId,
+        input.origin,
+        input.hubId,
+        input.retiredAt,
+      );
+    },
+
+    findActiveTombstone(db, userId) {
+      return (
+        (db
+          .prepare(
+            `SELECT * FROM friday_credential_tombstones
+              WHERE user_id = ? AND credential_kind = 'passphrase'
+                AND retired_reason = 'migrated_to_device'
+              ORDER BY retired_at DESC LIMIT 1`,
+          )
+          .get(userId) as FridayCredentialTombstoneRow | undefined) ?? null
+      );
+    },
+  };
+}

--- a/src/api/persistence/friday-setup-bootstrap-nonce-repository.ts
+++ b/src/api/persistence/friday-setup-bootstrap-nonce-repository.ts
@@ -20,12 +20,27 @@ export interface FridaySetupBootstrapNonceRow {
   consumed_at: string | null;
 }
 
+// ─── Nonce kinds ───
+
+/**
+ * Ledger `kind` discriminator. `install_owner_claim` is the first-boot
+ * device-bound owner claim (SEC-SETUP-BOOTSTRAP-001 Slice 1). Slice 5 adds
+ * `device_migration_claim` — the SECOND consumer of this same ledger, minted for
+ * an AUTHENTICATED existing-passphrase-owner → device migration. The DB CHECK
+ * (v104) enforces this closed set; the distinct kind keeps a first-boot nonce
+ * from being replayed into a migration and vice-versa (the consume CAS matches
+ * on `kind`).
+ */
+export type FridaySetupBootstrapNonceKind =
+  | "install_owner_claim"
+  | "device_migration_claim";
+
 // ─── Insert / consume inputs ───
 
 export interface InsertFridaySetupBootstrapNonceInput {
   id: string;
   nonceHash: string;
-  kind: "install_owner_claim";
+  kind: FridaySetupBootstrapNonceKind;
   hubId: string;
   installId: string;
   osUser: string;
@@ -37,7 +52,7 @@ export interface InsertFridaySetupBootstrapNonceInput {
 
 export interface ConsumeFridaySetupBootstrapNonceInput {
   nonceHash: string;
-  kind: "install_owner_claim";
+  kind: FridaySetupBootstrapNonceKind;
   /** Origin the claim is presented from; MUST equal the bound issue origin. */
   origin: string;
   /** Wall-clock ISO used for the `expires_at > now` freshness gate. */

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -78,6 +78,11 @@ export type FridayPublicMutationOperation =
   | "task.workflow.cli.handoff.record"
   | "task.workflow.channel.command.issue"
   | "task.workflow.channel.command.confirm"
+  // SEC-SETUP-BOOTSTRAP-001 Slice 5 — authenticated legacy-passphrase → device
+  // migration. Public mutating routes that refuse the synthetic public principal
+  // (only the bound local OWNER may mint a migration nonce / migrate ownership).
+  | "auth.migrate.challenge"
+  | "auth.migrate.device.claim"
   | "runtime.config.update"
   | "runtime.config.revert"
   | "runtime.secret.list"

--- a/src/state/sqlite/migrations/index.ts
+++ b/src/state/sqlite/migrations/index.ts
@@ -102,6 +102,7 @@ import { V100_OPERATION_JOURNAL_MIGRATION } from "./v100-operation-journal.js";
 import { V101_TELEGRAM_INBOX_MIGRATION } from "./v101-telegram-inbox.js";
 import { V102_PROVIDER_CALL_RECEIPT_MIGRATION } from "./v102-provider-call-receipt.js";
 import { V103_SETUP_BOOTSTRAP_DEVICE_CLAIM_MIGRATION } from "./v103-setup-bootstrap-device-claim.js";
+import { V104_SETUP_BOOTSTRAP_MIGRATION_STATE_MIGRATION } from "./v104-setup-bootstrap-migration-state.js";
 
 /**
  * Ordered migration list, always ascending by version.
@@ -210,6 +211,7 @@ export const FRIDAY_SQLITE_MIGRATIONS: readonly FridaySqliteMigration[] = [
   V101_TELEGRAM_INBOX_MIGRATION,
   V102_PROVIDER_CALL_RECEIPT_MIGRATION,
   V103_SETUP_BOOTSTRAP_DEVICE_CLAIM_MIGRATION,
+  V104_SETUP_BOOTSTRAP_MIGRATION_STATE_MIGRATION,
 ];
 
 export { V003_PROVIDER_USAGE_COST_ROUTING_MIGRATION };

--- a/src/state/sqlite/migrations/v104-setup-bootstrap-migration-state.ts
+++ b/src/state/sqlite/migrations/v104-setup-bootstrap-migration-state.ts
@@ -1,0 +1,142 @@
+import { computeFridayMigrationChecksum } from "./friday-migration.types.js";
+import type { FridaySqliteMigration } from "./friday-migration.types.js";
+
+export const V104_SETUP_BOOTSTRAP_MIGRATION_STATE_SQL = `
+-- ============================================================
+-- V104: Authenticated legacy-passphrase → device migration state
+-- (SEC-SETUP-BOOTSTRAP-001 Slice 5). ADDITIVE, dual-read, reversible.
+-- ============================================================
+--
+-- Stage 2 of the operator-locked FIXED order (1 native path → 2 authenticated
+-- existing-user migration → 3 device readback → 4 restart proof → 5 tombstone →
+-- 6 disable legacy login → 7 remove passphrase UI/API). This migration ADDS the
+-- storage the authenticated migration primitive needs and REMOVES / DISABLES
+-- NOTHING:
+--
+--   1. Widen the install-nonce ledger 'kind' CHECK to accept the NEW
+--      'device_migration_claim' value (a SECOND consumer of the same ledger).
+--   2. Add friday_device_owner_bindings — the durable dual-read binding record.
+--      A migrated passphrase-owner keeps users.password_hash = scrypt$… (the
+--      passphrase STILL works, no lockout) AND gains a provisional device
+--      binding row here. Only a later stage flips state='active'.
+--   3. Add friday_credential_tombstones — INACTIVE stage-5 scaffolding. No live
+--      code path writes it in Slice 5; the passphrase remains the working owner
+--      credential throughout.
+--
+-- No users column is altered; v103 is not renumbered; no destructive change. The
+-- whole migration pass runs under one BEGIN IMMEDIATE transaction (the runner),
+-- serialized against all other writers — so the nonce-ledger rebuild below is
+-- atomic and races nothing.
+
+-- ── (1) Widen the nonce 'kind' CHECK (additive value) ──────────────────────
+-- SQLite bakes CHECK into the table definition, so widening it requires a
+-- table rebuild. No table has a FOREIGN KEY into friday_setup_bootstrap_nonces,
+-- so the drop/rename triggers no cascade. All rows + all three single-use
+-- indexes are recreated verbatim; the ONLY change is the widened CHECK, which
+-- accepts a SUPERSET of the previous values (strictly additive).
+
+CREATE TABLE friday_setup_bootstrap_nonces__v104 (
+  id TEXT PRIMARY KEY,
+  nonce_hash TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('install_owner_claim', 'device_migration_claim')),
+  hub_id TEXT NOT NULL,
+  install_id TEXT NOT NULL,
+  os_user TEXT NOT NULL,
+  origin TEXT NOT NULL,
+  action TEXT NOT NULL,
+  device_id TEXT,
+  device_public_key TEXT,
+  device_public_key_hash TEXT,
+  claimed_user_id TEXT,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  consumed_at TEXT
+);
+
+INSERT INTO friday_setup_bootstrap_nonces__v104 (
+  id, nonce_hash, kind, hub_id, install_id, os_user, origin, action,
+  device_id, device_public_key, device_public_key_hash, claimed_user_id,
+  created_at, expires_at, consumed_at
+)
+SELECT
+  id, nonce_hash, kind, hub_id, install_id, os_user, origin, action,
+  device_id, device_public_key, device_public_key_hash, claimed_user_id,
+  created_at, expires_at, consumed_at
+FROM friday_setup_bootstrap_nonces;
+
+DROP TABLE friday_setup_bootstrap_nonces;
+
+ALTER TABLE friday_setup_bootstrap_nonces__v104 RENAME TO friday_setup_bootstrap_nonces;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_friday_setup_bootstrap_nonces_hash
+  ON friday_setup_bootstrap_nonces (nonce_hash);
+
+-- Partial UNIQUE(kind) WHERE consumed_at IS NOT NULL: at most ONE consumed row
+-- PER kind. Preserved verbatim — it now ALSO gives "at most one consumed
+-- device_migration_claim" as a defence-in-depth single-migration belt.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_friday_setup_bootstrap_nonces_single_owner
+  ON friday_setup_bootstrap_nonces (kind)
+  WHERE consumed_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_friday_setup_bootstrap_nonces_expires
+  ON friday_setup_bootstrap_nonces (expires_at, consumed_at);
+
+-- ── (2) Durable dual-read owner↔device binding record ──────────────────────
+-- Separate from the transient nonce ledger. A provisional row is added at
+-- authenticated-migrate time WITHOUT touching users.password_hash (dual-read:
+-- the passphrase stays authoritative). A partial UNIQUE(user_id) WHERE
+-- state='active' enforces at most ONE active device owner per user; the
+-- flip to 'active' is a LATER stage (device readback) — inert in Slice 5.
+
+CREATE TABLE IF NOT EXISTS friday_device_owner_bindings (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  device_public_key TEXT NOT NULL,
+  device_public_key_hash TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('provisional', 'active', 'revoked')),
+  migrated_from TEXT NOT NULL CHECK (migrated_from IN ('passphrase', 'first_boot')),
+  origin TEXT NOT NULL,
+  hub_id TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  activated_at TEXT,
+  revoked_at TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_friday_device_owner_bindings_active
+  ON friday_device_owner_bindings (user_id)
+  WHERE state = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_friday_device_owner_bindings_user_state
+  ON friday_device_owner_bindings (user_id, state);
+
+-- ── (3) Legacy credential tombstone — INACTIVE stage-5 scaffolding ─────────
+-- Durable, fail-closed marker that a passphrase credential existed and was
+-- retired. Stores NO secret and NO recoverable hash. NOT written by any live
+-- Slice-5 code path — the passphrase remains the working owner credential.
+
+CREATE TABLE IF NOT EXISTS friday_credential_tombstones (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  credential_kind TEXT NOT NULL CHECK (credential_kind IN ('passphrase')),
+  retired_reason TEXT NOT NULL CHECK (
+    retired_reason IN ('migrated_to_device', 'delete_all', 'release_profile_disable')
+  ),
+  superseded_by_binding_id TEXT,
+  origin TEXT NOT NULL,
+  hub_id TEXT NOT NULL,
+  retired_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_friday_credential_tombstones_user
+  ON friday_credential_tombstones (user_id, credential_kind);
+`;
+
+const V104_CHECKSUM = computeFridayMigrationChecksum(V104_SETUP_BOOTSTRAP_MIGRATION_STATE_SQL);
+
+export const V104_SETUP_BOOTSTRAP_MIGRATION_STATE_MIGRATION: FridaySqliteMigration = {
+  version: 104,
+  name: "v104-setup-bootstrap-migration-state",
+  sql: V104_SETUP_BOOTSTRAP_MIGRATION_STATE_SQL,
+  checksum: V104_CHECKSUM,
+};

--- a/test/adversarial/setup-authenticated-migration.test.ts
+++ b/test/adversarial/setup-authenticated-migration.test.ts
@@ -1,0 +1,601 @@
+/**
+ * Adversarial Authenticated Legacy-Passphrase → Device Migration
+ * (SEC-SETUP-BOOTSTRAP-001, Slice 5 — stage 2 of the operator-locked FIXED order)
+ *
+ * These tests run the REAL production code path against a REAL file-backed SQLite
+ * layer (createFridaySqliteLayer → real migrations incl. v104 → real WAL), seeded
+ * with admin-001 EXACTLY as src/hub/friday-hub-bootstrap.ts seeds it, then given a
+ * real scrypt passphrase credential via the REAL bootstrapLocalPassphrase path.
+ * No in-memory mock, no route-exists smoke check.
+ *
+ * The migration is ADDITIVE / dual-read / reversible:
+ *   - authenticated OWNER + valid device PoP → a PROVISIONAL device binding is
+ *     added AND users.password_hash STAYS scrypt$… (the passphrase STILL works —
+ *     NO lockout). The device binding carries ZERO authority.
+ *   - it CAS-consumes a SECOND-kind ('device_migration_claim') install nonce.
+ *   - the tombstone/rollback scaffolding is INACTIVE: password_hash is NEVER
+ *     flipped to the device sentinel this slice, and no tombstone row is written.
+ *
+ * Red-first: each assertion targets a real DEFECT that appears when the
+ * corresponding guard is removed (see PR body red→green→revert-red evidence),
+ * not a missing-symbol error.
+ */
+
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type Database from "better-sqlite3";
+
+import { createFridayAuthService } from "#api";
+import { FridayDomainError } from "#errors";
+import { createFridaySqliteLayer } from "#state";
+import type { FridaySqliteLayer } from "#state";
+import type { FridayAuthPrincipal, FridayScope } from "../../src/api/model/friday-api-auth.types.js";
+import { getScopesForRole } from "../../src/api/auth/friday-rbac-policy.js";
+import { isDeviceOwnerAuthorityEnabled } from "../../src/security/friday-device-owner-authority-precondition.js";
+import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "./_secsetup-s2a.helpers.js";
+
+const OWNER_ID = "admin-001";
+const NOW = "2026-07-13T00:00:00.000Z";
+const LATER_AFTER_TTL = "2026-07-13T00:10:00.000Z"; // > NOW + 300s
+const LOOPBACK = "127.0.0.1";
+const ORIGIN = "https://friday.localhost";
+const PASSPHRASE = "owner-passphrase-xyz-123"; // pragma: allowlist secret
+const DEVICE_KEY = generateTestDeviceKey();
+const DEVICE_PUBKEY = DEVICE_KEY.spkiDerBase64;
+const DEVICE_ID = "device-migrate-001";
+const DEVICE_OWNER_SENTINEL_PREFIX = "device-owner$v1$";
+
+function sha256Hex(v: string): string {
+  return crypto.createHash("sha256").update(v).digest("hex");
+}
+
+/** The authenticated LOCAL OWNER principal a passphrase login would mint. */
+function ownerPrincipal(overrides: Partial<FridayAuthPrincipal> = {}): FridayAuthPrincipal {
+  return {
+    principalType: "user",
+    principalId: OWNER_ID,
+    tenantId: OWNER_ID,
+    userId: OWNER_ID,
+    role: "admin",
+    scopes: [...getScopesForRole("admin")] as FridayScope[],
+    tokenId: "tok-owner-0001",
+    tokenKind: "access",
+    issuedAt: NOW,
+    ...overrides,
+  };
+}
+
+/** The synthetic anonymous principal the HTTP server injects for no-auth. */
+function publicPrincipal(): FridayAuthPrincipal {
+  return {
+    principalType: "user",
+    principalId: "public:default",
+    tenantId: "00000000-0000-0000-0000-000000000001",
+    userId: "00000000-0000-0000-0000-000000000001",
+    role: "admin",
+    scopes: [...getScopesForRole("admin")] as FridayScope[],
+    tokenId: "00000000-0000-0000-0000-000000000002",
+    tokenKind: "access",
+    issuedAt: NOW,
+  };
+}
+
+function seedOwner(db: FridaySqliteLayer): void {
+  db.withWriteTransaction((conn) => {
+    conn
+      .prepare(
+        `INSERT INTO users (id, email, display_name, role, password_hash, is_local_only, last_login_at, created_at, updated_at, deleted_at)
+         VALUES (?, ?, ?, ?, NULL, 1, NULL, ?, ?, NULL)`,
+      )
+      .run(OWNER_ID, "admin@friday.dev", "Admin", "admin", NOW, NOW);
+  });
+}
+
+function makeService(db: FridaySqliteLayer, nowIso: string = NOW) {
+  return createFridayAuthService({
+    db,
+    idGenerator: (() => {
+      let n = 0;
+      return () => `id-${String(++n).padStart(4, "0")}`;
+    })(),
+    nowIso: () => nowIso,
+    tokenSecret: "test-secret-key-for-migration-000001", // pragma: allowlist secret
+    accessTokenTtlSec: 900,
+    refreshTokenTtlSec: 604_800,
+    hubId: "test-hub",
+    bootstrapNonceTtlSec: 300,
+    warn: () => {},
+  });
+}
+
+function readOwnerHash(db: FridaySqliteLayer): string | null {
+  return db.withReadConnection((conn) => {
+    const row = conn.prepare("SELECT password_hash AS h FROM users WHERE id = ?").get(OWNER_ID) as
+      | { h: string | null }
+      | undefined;
+    return row?.h ?? null;
+  });
+}
+
+function readBindings(db: FridaySqliteLayer): Record<string, unknown>[] {
+  return db.withReadConnection((conn) =>
+    conn.prepare("SELECT * FROM friday_device_owner_bindings WHERE user_id = ?").all(OWNER_ID) as Record<string, unknown>[],
+  );
+}
+
+function readTombstones(db: FridaySqliteLayer): Record<string, unknown>[] {
+  return db.withReadConnection((conn) =>
+    conn.prepare("SELECT * FROM friday_credential_tombstones WHERE user_id = ?").all(OWNER_ID) as Record<string, unknown>[],
+  );
+}
+
+function readNonceRow(db: FridaySqliteLayer, nonce: string): Record<string, unknown> | null {
+  return db.withReadConnection((conn) => {
+    const row = conn
+      .prepare("SELECT * FROM friday_setup_bootstrap_nonces WHERE nonce_hash = ?")
+      .get(sha256Hex(nonce)) as Record<string, unknown> | undefined;
+    return row ?? null;
+  });
+}
+
+/** Seed admin-001 AND set the real scrypt passphrase credential (the migration source). */
+function seedPassphraseOwner(db: FridaySqliteLayer): void {
+  seedOwner(db);
+  makeService(db).bootstrapLocalPassphrase({ passphrase: PASSPHRASE }, LOOPBACK);
+}
+
+function issueMigrationNonce(
+  db: FridaySqliteLayer,
+  principal: FridayAuthPrincipal = ownerPrincipal(),
+  over?: { origin?: string; nowIso?: string },
+): string {
+  const svc = makeService(db, over?.nowIso ?? NOW);
+  const res = svc.issueMigrationChallenge(
+    { installId: "install-m1", osUser: "jarvis", origin: over?.origin ?? ORIGIN },
+    principal,
+    LOOPBACK,
+  );
+  return res.nonce;
+}
+
+function migrateReq(over?: Partial<{ nonce: string; origin: string; devicePublicKey: string; deviceId: string }>) {
+  const nonce = over?.nonce ?? "";
+  const origin = over?.origin ?? ORIGIN;
+  const deviceId = over?.deviceId ?? DEVICE_ID;
+  const devicePublicKey = over?.devicePublicKey ?? DEVICE_PUBKEY;
+  const transcript = makeTranscript(DEVICE_KEY, {
+    nonce,
+    origin,
+    deviceId,
+    action: "owner-migrate",
+    installId: "install-m1",
+    osUser: "jarvis",
+  });
+  const signature = { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(DEVICE_KEY, transcript) };
+  return {
+    nonce,
+    devicePublicKey,
+    deviceId,
+    origin,
+    installId: "install-m1",
+    osUser: "jarvis",
+    deviceClaimProof: { transcript, signature },
+  };
+}
+
+let db: FridaySqliteLayer;
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-secsetup-s5-"));
+  db = createFridaySqliteLayer({
+    dbPath: path.join(tmpDir, "friday.db"),
+    readPoolSize: 2,
+    pragmas: { busyTimeoutMs: 5_000, synchronous: "NORMAL" },
+  });
+});
+
+afterEach(() => {
+  db.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("SEC-SETUP-BOOTSTRAP-001 Slice 5: authenticated dual-read migration", () => {
+  it("happy path: authenticated owner + valid PoP → provisional bind; passphrase STILL works; ZERO device authority", () => {
+    seedPassphraseOwner(db);
+    const beforeHash = readOwnerHash(db);
+    expect(beforeHash?.startsWith("scrypt$")).toBe(true);
+
+    const nonce = issueMigrationNonce(db);
+    const res = makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce }), ownerPrincipal(), LOOPBACK);
+
+    // Provisional migration succeeded with ZERO authority.
+    expect(res.migrated).toBe(true);
+    expect(res.state).toBe("provisional");
+    expect(res.userId).toBe(OWNER_ID);
+    expect(res.deviceId).toBe(DEVICE_ID);
+    expect(res.devicePublicKeyHash).toBe(sha256Hex(DEVICE_PUBKEY));
+    expect(res.passphraseStillActive).toBe(true);
+    expect(res.deviceAuthorityEnabled).toBe(false);
+    expect(res.keyProtection).toBe("unverified");
+    expect(isDeviceOwnerAuthorityEnabled()).toBe(false);
+
+    // DUAL-READ: password_hash UNCHANGED (still scrypt) — NOT flipped to the sentinel.
+    const afterHash = readOwnerHash(db);
+    expect(afterHash).toBe(beforeHash);
+    expect(afterHash?.startsWith(DEVICE_OWNER_SENTINEL_PREFIX)).toBe(false);
+
+    // A single 'provisional' binding row was added, NOT 'active'.
+    const bindings = readBindings(db);
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0].state).toBe("provisional");
+    expect(bindings[0].migrated_from).toBe("passphrase");
+    expect(bindings[0].device_public_key_hash).toBe(sha256Hex(DEVICE_PUBKEY));
+    expect(bindings[0].activated_at).toBeNull();
+
+    // NO-LOCKOUT: the passphrase login STILL works after migration.
+    const login = makeService(db).login({ localPassphrase: PASSPHRASE }, LOOPBACK);
+    expect(login.accessToken).toBeTruthy();
+    expect(login.user.id).toBe(OWNER_ID);
+
+    // Tombstone scaffolding is INACTIVE — no tombstone written this slice.
+    expect(readTombstones(db)).toHaveLength(0);
+
+    // The migration nonce is durably consumed and carries the binding context.
+    const row = readNonceRow(db, nonce);
+    expect(row?.consumed_at).not.toBeNull();
+    expect(row?.kind).toBe("device_migration_claim");
+    expect(row?.claimed_user_id).toBe(OWNER_ID);
+  });
+
+  it("refuses the synthetic public principal (401) — ZERO state change", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db);
+
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce }), publicPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).httpStatus).toBe(401);
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_OWNER_REQUIRED");
+    expect(readBindings(db)).toHaveLength(0);
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+  });
+
+  it("refuses a null principal (401)", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db);
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce }), null, LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).httpStatus).toBe(401);
+    expect(readBindings(db)).toHaveLength(0);
+  });
+
+  it("refuses a non-owner authenticated principal — wrong identity (403)", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db);
+    // admin role + security.write scope, but principalId is a DIFFERENT user.
+    const notOwner = ownerPrincipal({ principalId: "user:mallory", userId: "user:mallory" });
+
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce }), notOwner, LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).httpStatus).toBe(403);
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_FORBIDDEN");
+    expect(readBindings(db)).toHaveLength(0);
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+  });
+
+  it("refuses a non-owner authenticated principal — wrong role (403)", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db);
+    // Correct local-owner id, but a viewer role (not owner/admin).
+    const viewer = ownerPrincipal({ role: "viewer", scopes: [...getScopesForRole("viewer")] as FridayScope[] });
+
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce }), viewer, LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).httpStatus).toBe(403);
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_FORBIDDEN");
+    expect(readBindings(db)).toHaveLength(0);
+  });
+
+  it("refuses a missing proof-of-possession (400) — nonce un-burned, no binding", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db);
+    const req = migrateReq({ nonce });
+    delete (req as { deviceClaimProof?: unknown }).deviceClaimProof;
+
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(req, ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).httpStatus).toBe(400);
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_POP_REQUIRED");
+    expect(readBindings(db)).toHaveLength(0);
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+  });
+
+  it("refuses a PoP-unverified (wrong-key) claim (401) — nonce un-burned, no binding", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db);
+    // Sign the transcript with an UNRELATED key: possession of the presented key
+    // is NOT proven, so the S2a verifier rejects it.
+    const attacker = generateTestDeviceKey();
+    const transcript = makeTranscript(DEVICE_KEY, { nonce, origin: ORIGIN, deviceId: DEVICE_ID, action: "owner-migrate", installId: "install-m1", osUser: "jarvis" });
+    const forged = {
+      ...migrateReq({ nonce }),
+      deviceClaimProof: {
+        transcript,
+        signature: { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(attacker, transcript) },
+      },
+    };
+
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(forged, ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).httpStatus).toBe(401);
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_POP_INVALID");
+    expect(readBindings(db)).toHaveLength(0);
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+  });
+
+  it("refuses migration against a NULL owner slot — first-boot must NOT reuse the bootstrap leg (409)", () => {
+    seedOwner(db); // password_hash NULL, NO passphrase set
+    // The challenge itself is refused for a NULL owner, so issue directly via a
+    // service that has a passphrase, then clear it to isolate the migrate CAS.
+    // Simpler: assert issueMigrationChallenge refuses NULL, then assert migrate
+    // refuses even if a nonce somehow existed.
+    let challengeErr: unknown;
+    try {
+      issueMigrationNonce(db);
+    } catch (err) {
+      challengeErr = err;
+    }
+    expect((challengeErr as FridayDomainError).httpStatus).toBe(409);
+    expect((challengeErr as FridayDomainError).code).toBe("AUTH_MIGRATE_NO_LEGACY_OWNER");
+
+    // And the migrate primitive itself refuses a NULL owner (defence-in-depth),
+    // regardless of any nonce — proving it never reuses the first-boot leg.
+    let migrateErr: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce: "any-nonce" }), ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      migrateErr = err;
+    }
+    expect((migrateErr as FridayDomainError).code).toBe("AUTH_MIGRATE_NO_LEGACY_OWNER");
+    expect(readOwnerHash(db)).toBeNull();
+    expect(readBindings(db)).toHaveLength(0);
+  });
+
+  it("refuses migration when already device-owned (sentinel) — no re-migration (409)", () => {
+    seedOwner(db);
+    // Simulate a committed device-owner (a later stage's terminal state).
+    db.withWriteTransaction((conn) =>
+      conn
+        .prepare("UPDATE users SET password_hash = ? WHERE id = ?")
+        .run(`${DEVICE_OWNER_SENTINEL_PREFIX}${sha256Hex("some-device")}`, OWNER_ID),
+    );
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce: "any-nonce" }), ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_NO_LEGACY_OWNER");
+    expect(readBindings(db)).toHaveLength(0);
+  });
+
+  it("replay: a consumed migration nonce is rejected (409), no second binding", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db);
+    makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce }), ownerPrincipal(), LOOPBACK);
+    expect(readBindings(db)).toHaveLength(1);
+
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce }), ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_NONCE_INVALID");
+    // Still exactly ONE binding, password_hash still scrypt.
+    expect(readBindings(db)).toHaveLength(1);
+    expect(readOwnerHash(db)?.startsWith("scrypt$")).toBe(true);
+  });
+
+  it("expiry: an expired migration nonce is rejected at the DB CAS (409)", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db, ownerPrincipal(), { nowIso: NOW }); // expires NOW+300s
+    // Present with a clock AFTER expiry.
+    let caught: unknown;
+    try {
+      makeService(db, LATER_AFTER_TTL).migrateOwnerToDeviceKey(migrateReq({ nonce }), ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_NONCE_INVALID");
+    expect(readBindings(db)).toHaveLength(0);
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+  });
+
+  it("cross-origin: a migration nonce presented from a different origin fails at the DB CAS (409)", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db, ownerPrincipal(), { origin: ORIGIN });
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(
+        migrateReq({ nonce, origin: "https://evil.localhost" }),
+        ownerPrincipal(),
+        LOOPBACK,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_NONCE_INVALID");
+    expect(readBindings(db)).toHaveLength(0);
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+  });
+
+  it("cross-kind: an install_owner_claim (first-boot) nonce cannot be consumed by migration (409)", () => {
+    seedPassphraseOwner(db);
+    // Mint a FIRST-BOOT owner-claim nonce (kind install_owner_claim), then try to
+    // spend it on the migration path. The consume CAS matches on kind, so it
+    // fails closed — a first-boot nonce can never be replayed into a migration.
+    const bootstrapNonce = makeService(db).issueBootstrapChallenge(
+      { installId: "install-m1", osUser: "jarvis", origin: ORIGIN },
+      LOOPBACK,
+    ).nonce;
+
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce: bootstrapNonce }), ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_NONCE_INVALID");
+    expect(readBindings(db)).toHaveLength(0);
+    expect(readNonceRow(db, bootstrapNonce)?.consumed_at).toBeNull();
+  });
+
+  it("loopback-only: a non-loopback migrate / challenge fails closed (403)", () => {
+    seedPassphraseOwner(db);
+    let migrateErr: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(migrateReq({ nonce: "any" }), ownerPrincipal(), "10.0.0.5");
+    } catch (err) {
+      migrateErr = err;
+    }
+    expect((migrateErr as FridayDomainError).httpStatus).toBe(403);
+    expect(readBindings(db)).toHaveLength(0);
+
+    let challengeErr: unknown;
+    try {
+      makeService(db).issueMigrationChallenge({ installId: "i", osUser: "u", origin: ORIGIN }, ownerPrincipal(), "10.0.0.5");
+    } catch (err) {
+      challengeErr = err;
+    }
+    expect((challengeErr as FridayDomainError).httpStatus).toBe(403);
+  });
+
+  it("crash/atomicity: a failure AFTER nonce-consume, BEFORE the binding insert leaves NO partial state", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db);
+    const beforeHash = readOwnerHash(db);
+
+    // crashDb runs the migrate inside a REAL write transaction but makes the
+    // binding INSERT throw. Because both writes share one transaction, the
+    // already-run nonce-consume MUST roll back.
+    const crashDb: FridaySqliteLayer = {
+      ...db,
+      withWriteTransaction<T>(fn: (conn: Database.Database) => T): T {
+        const proxy = new Proxy(db.writer, {
+          get(target, prop, receiver) {
+            if (prop === "prepare") {
+              return (sql: string) => {
+                if (sql.includes("INSERT INTO friday_device_owner_bindings")) {
+                  return {
+                    run() {
+                      throw new Error("injected crash mid-migration (binding insert)");
+                    },
+                  } as unknown as Database.Statement;
+                }
+                return target.prepare(sql);
+              };
+            }
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        }) as unknown as Database.Database;
+        const txn = db.writer.transaction(() => fn(proxy));
+        return txn.immediate();
+      },
+    };
+
+    let caught: unknown;
+    try {
+      makeService(crashDb).migrateOwnerToDeviceKey(migrateReq({ nonce }), ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+
+    // Whole unit rolled back: nonce NOT consumed, NO binding, password_hash unchanged.
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+    expect(readBindings(db)).toHaveLength(0);
+    expect(readOwnerHash(db)).toBe(beforeHash);
+  });
+
+  it("concurrent owner-change: password_hash rotated mid-migration aborts with ZERO state change (409)", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db);
+    const rotatedHash = `scrypt$${"a".repeat(64)}$${"b".repeat(128)}`;
+
+    // racyDb rotates the owner's password_hash INSIDE the TOCTOU window (after the
+    // service captured `observedHash` but before/within the migrate txn).
+    let fired = false;
+    const racyDb: FridaySqliteLayer = {
+      ...db,
+      withWriteTransaction<T>(fn: (conn: Database.Database) => T): T {
+        if (!fired) {
+          fired = true;
+          db.writer.prepare("UPDATE users SET password_hash = ? WHERE id = ?").run(rotatedHash, OWNER_ID);
+        }
+        return db.withWriteTransaction(fn);
+      },
+    };
+
+    let caught: unknown;
+    try {
+      makeService(racyDb).migrateOwnerToDeviceKey(migrateReq({ nonce }), ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as FridayDomainError).httpStatus).toBe(409);
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_OWNER_CHANGED");
+    // The rotated hash survives; no binding; the nonce is NOT consumed (rolled back).
+    expect(readOwnerHash(db)).toBe(rotatedHash);
+    expect(readBindings(db)).toHaveLength(0);
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+  });
+
+  it("no-degrade: the passphrase bootstrap + login path is fully intact (regression)", () => {
+    // A fresh machine still bootstraps + logs in by passphrase exactly as before.
+    seedOwner(db);
+    const boot = makeService(db).bootstrapLocalPassphrase({ passphrase: PASSPHRASE }, LOOPBACK);
+    expect(boot.initialized).toBe(true);
+    expect(readOwnerHash(db)?.startsWith("scrypt$")).toBe(true);
+
+    const login = makeService(db).login({ localPassphrase: PASSPHRASE }, LOOPBACK);
+    expect(login.user.id).toBe(OWNER_ID);
+
+    let badErr: unknown;
+    try {
+      makeService(db).login({ localPassphrase: "wrong-passphrase" }, LOOPBACK);
+    } catch (err) {
+      badErr = err;
+    }
+    expect((badErr as FridayDomainError).code).toBe("INVALID_CREDENTIALS");
+  });
+});

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: every public mutating route maps to an accepted gate family 1`] = `
 {
   "classified": {
-    "bound_principal": 66,
+    "bound_principal": 68,
     "channel_signature": 4,
     "hmac_or_bearer_opt_in": 1,
     "public_low_risk": 2,
     "rate_limited_pending": 6,
     "unclassified": 251,
   },
-  "total_public_mutating": 330,
+  "total_public_mutating": 332,
   "unclassified_sample_max_5": [
     "capabilities.acquisition.runs.create",
     "capabilities.acquisition.runs.approve",
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `429`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `431`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -463,6 +463,26 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "authKind": "public",
     "index": 43,
     "method": "POST",
+    "operationId": "auth.migrate.challenge",
+    "path": "/v1/auth/migrate/challenge",
+    "rateLimitPolicyId": "auth.login",
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 44,
+    "method": "POST",
+    "operationId": "auth.migrate.device.claim",
+    "path": "/v1/auth/migrate/device-claim",
+    "rateLimitPolicyId": "auth.login",
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 45,
+    "method": "POST",
     "operationId": "auth.login",
     "path": "/v1/auth/login",
     "rateLimitPolicyId": "auth.login",
@@ -471,7 +491,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 44,
+    "index": 46,
     "method": "POST",
     "operationId": "auth.refresh",
     "path": "/v1/auth/refresh",
@@ -481,7 +501,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 45,
+    "index": 47,
     "method": "POST",
     "operationId": "auth.logout",
     "path": "/v1/auth/logout",
@@ -491,7 +511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 46,
+    "index": 48,
     "method": "GET",
     "operationId": "auth.me",
     "path": "/v1/auth/me",
@@ -501,7 +521,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 47,
+    "index": 49,
     "method": "GET",
     "operationId": "secrets.list",
     "path": "/v1/secrets",
@@ -511,7 +531,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 48,
+    "index": 50,
     "method": "GET",
     "operationId": "secrets.get",
     "path": "/v1/secrets/:secretId",
@@ -521,7 +541,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 49,
+    "index": 51,
     "method": "POST",
     "operationId": "secrets.create",
     "path": "/v1/secrets",
@@ -531,7 +551,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 50,
+    "index": 52,
     "method": "PATCH",
     "operationId": "secrets.update",
     "path": "/v1/secrets/:secretId",
@@ -541,7 +561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 51,
+    "index": 53,
     "method": "DELETE",
     "operationId": "secrets.delete",
     "path": "/v1/secrets/:secretId",
@@ -551,7 +571,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 52,
+    "index": 54,
     "method": "GET",
     "operationId": "workflows.list",
     "path": "/v1/workflows",
@@ -561,7 +581,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 53,
+    "index": 55,
     "method": "POST",
     "operationId": "workflows.create",
     "path": "/v1/workflows",
@@ -571,7 +591,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 54,
+    "index": 56,
     "method": "GET",
     "operationId": "workflows.get",
     "path": "/v1/workflows/:workflowId",
@@ -581,7 +601,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 55,
+    "index": 57,
     "method": "PATCH",
     "operationId": "workflows.update",
     "path": "/v1/workflows/:workflowId",
@@ -591,7 +611,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 56,
+    "index": 58,
     "method": "DELETE",
     "operationId": "workflows.archive",
     "path": "/v1/workflows/:workflowId",
@@ -601,7 +621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 57,
+    "index": 59,
     "method": "POST",
     "operationId": "workflows.publish",
     "path": "/v1/workflows/:workflowId/publish",
@@ -611,7 +631,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 58,
+    "index": 60,
     "method": "GET",
     "operationId": "workflows.list.versions",
     "path": "/v1/workflows/:workflowId/versions",
@@ -621,7 +641,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 59,
+    "index": 61,
     "method": "GET",
     "operationId": "workflow.versions.get",
     "path": "/v1/workflow-versions/:versionId",
@@ -631,7 +651,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 60,
+    "index": 62,
     "method": "GET",
     "operationId": "templates.list",
     "path": "/v1/workflow-builder/templates",
@@ -641,7 +661,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 61,
+    "index": 63,
     "method": "GET",
     "operationId": "templates.get",
     "path": "/v1/workflow-builder/templates/:templateId",
@@ -651,7 +671,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 62,
+    "index": 64,
     "method": "POST",
     "operationId": "templates.instantiate",
     "path": "/v1/workflow-builder/templates/:templateId/instantiate",
@@ -661,7 +681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 63,
+    "index": 65,
     "method": "GET",
     "operationId": "drafts.list",
     "path": "/v1/workflows/:workflowId/drafts",
@@ -671,7 +691,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 64,
+    "index": 66,
     "method": "POST",
     "operationId": "drafts.create",
     "path": "/v1/workflows/:workflowId/drafts",
@@ -681,7 +701,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 65,
+    "index": 67,
     "method": "GET",
     "operationId": "drafts.get",
     "path": "/v1/workflows/:workflowId/drafts/:draftId",
@@ -691,7 +711,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 66,
+    "index": 68,
     "method": "GET",
     "operationId": "drafts.export",
     "path": "/v1/workflows/:workflowId/drafts/:draftId/export",
@@ -701,7 +721,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 67,
+    "index": 69,
     "method": "POST",
     "operationId": "workflows.bundles.import",
     "path": "/v1/workflows/:workflowId/import",
@@ -711,7 +731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 68,
+    "index": 70,
     "method": "PATCH",
     "operationId": "drafts.save",
     "path": "/v1/workflows/:workflowId/drafts/:draftId",
@@ -721,7 +741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 69,
+    "index": 71,
     "method": "POST",
     "operationId": "drafts.autosave",
     "path": "/v1/workflows/:workflowId/drafts/:draftId/autosave",
@@ -731,7 +751,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 70,
+    "index": 72,
     "method": "POST",
     "operationId": "drafts.compile",
     "path": "/v1/workflows/:workflowId/drafts/:draftId/compile",
@@ -741,7 +761,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 71,
+    "index": 73,
     "method": "POST",
     "operationId": "drafts.publish",
     "path": "/v1/workflows/:workflowId/drafts/:draftId/publish",
@@ -751,7 +771,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 72,
+    "index": 74,
     "method": "POST",
     "operationId": "locks.acquire",
     "path": "/v1/workflows/:workflowId/locks/acquire",
@@ -761,7 +781,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 73,
+    "index": 75,
     "method": "POST",
     "operationId": "locks.renew",
     "path": "/v1/workflows/:workflowId/locks/renew",
@@ -771,7 +791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 74,
+    "index": 76,
     "method": "POST",
     "operationId": "locks.release",
     "path": "/v1/workflows/:workflowId/locks/release",
@@ -781,7 +801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 75,
+    "index": 77,
     "method": "GET",
     "operationId": "workflows.overview",
     "path": "/v1/workflows/:workflowId/overview",
@@ -791,7 +811,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 76,
+    "index": 78,
     "method": "GET",
     "operationId": "workflows.visualization",
     "path": "/v1/workflows/:workflowId/visualization",
@@ -801,7 +821,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 77,
+    "index": 79,
     "method": "POST",
     "operationId": "workflows.deploy",
     "path": "/v1/workflows/:workflowId/drafts/:draftId/deploy",
@@ -811,7 +831,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 78,
+    "index": 80,
     "method": "POST",
     "operationId": "runs.start",
     "path": "/v1/workflow-runs",
@@ -821,7 +841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 79,
+    "index": 81,
     "method": "GET",
     "operationId": "runs.get",
     "path": "/v1/workflow-runs/:runId",
@@ -831,7 +851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 80,
+    "index": 82,
     "method": "GET",
     "operationId": "runs.list.nodes",
     "path": "/v1/workflow-runs/:runId/nodes",
@@ -841,7 +861,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 81,
+    "index": 83,
     "method": "GET",
     "operationId": "runs.timeline",
     "path": "/v1/workflow-runs/:runId/timeline",
@@ -851,7 +871,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 82,
+    "index": 84,
     "method": "GET",
     "operationId": "runs.evidence",
     "path": "/v1/workflow-runs/:runId/evidence",
@@ -861,7 +881,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 83,
+    "index": 85,
     "method": "GET",
     "operationId": "runs.evidence.exports.list",
     "path": "/v1/workflow-runs/:runId/evidence/exports",
@@ -871,7 +891,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 84,
+    "index": 86,
     "method": "POST",
     "operationId": "runs.evidence.export",
     "path": "/v1/workflow-runs/:runId/evidence/exports",
@@ -881,7 +901,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 85,
+    "index": 87,
     "method": "GET",
     "operationId": "runs.evidence.exports.get",
     "path": "/v1/workflow-runs/:runId/evidence/exports/:exportId",
@@ -891,7 +911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 86,
+    "index": 88,
     "method": "GET",
     "operationId": "runs.evidence.exports.download",
     "path": "/v1/workflow-runs/:runId/evidence/exports/:exportId/download",
@@ -901,7 +921,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 87,
+    "index": 89,
     "method": "POST",
     "operationId": "runs.cancel",
     "path": "/v1/workflow-runs/:runId/cancel",
@@ -911,7 +931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 88,
+    "index": 90,
     "method": "POST",
     "operationId": "runs.retry",
     "path": "/v1/workflow-runs/:runId/retry",
@@ -921,7 +941,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 89,
+    "index": 91,
     "method": "POST",
     "operationId": "workflows.runs.resume",
     "path": "/v1/workflow-runs/:runId/resume",
@@ -931,7 +951,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 90,
+    "index": 92,
     "method": "GET",
     "operationId": "workflows.approvals.list",
     "path": "/v1/workflow-approvals",
@@ -941,7 +961,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 91,
+    "index": 93,
     "method": "GET",
     "operationId": "workflows.approvals.get",
     "path": "/v1/workflow-approvals/:approvalId",
@@ -951,7 +971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 92,
+    "index": 94,
     "method": "POST",
     "operationId": "workflows.approvals.approve",
     "path": "/v1/workflow-approvals/:approvalId/approve",
@@ -961,7 +981,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 93,
+    "index": 95,
     "method": "POST",
     "operationId": "workflows.approvals.reject",
     "path": "/v1/workflow-approvals/:approvalId/reject",
@@ -971,7 +991,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 94,
+    "index": 96,
     "method": "GET",
     "operationId": "approvals.list",
     "path": "/v1/approvals",
@@ -981,7 +1001,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 95,
+    "index": 97,
     "method": "GET",
     "operationId": "approvals.get",
     "path": "/v1/approvals/:approvalId",
@@ -991,7 +1011,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 96,
+    "index": 98,
     "method": "POST",
     "operationId": "approvals.approve",
     "path": "/v1/approvals/:approvalId/approve",
@@ -1001,7 +1021,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 97,
+    "index": 99,
     "method": "POST",
     "operationId": "approvals.reject",
     "path": "/v1/approvals/:approvalId/reject",
@@ -1011,7 +1031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 98,
+    "index": 100,
     "method": "GET",
     "operationId": "workflows.triggers.list",
     "path": "/v1/workflows/:workflowId/triggers",
@@ -1021,7 +1041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 99,
+    "index": 101,
     "method": "PATCH",
     "operationId": "workflows.triggers.update",
     "path": "/v1/workflow-triggers/:registrationId",
@@ -1031,7 +1051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 100,
+    "index": 102,
     "method": "POST",
     "operationId": "workflows.triggers.resync",
     "path": "/v1/workflows/:workflowId/triggers/resync",
@@ -1041,7 +1061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 101,
+    "index": 103,
     "method": "POST",
     "operationId": "workflows.webhooks.invoke",
     "path": "/v1/workflow-webhooks/:pathToken",
@@ -1051,7 +1071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 102,
+    "index": 104,
     "method": "GET",
     "operationId": "conflicts.list",
     "path": "/v1/workflows/:workflowId/conflicts",
@@ -1061,7 +1081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 103,
+    "index": 105,
     "method": "POST",
     "operationId": "conflicts.resolve",
     "path": "/v1/workflows/:workflowId/conflicts/:conflictId/resolve",
@@ -1071,7 +1091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 104,
+    "index": 106,
     "method": "GET",
     "operationId": "fleet.overview",
     "path": "/v1/fleet/overview",
@@ -1081,7 +1101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 105,
+    "index": 107,
     "method": "GET",
     "operationId": "fleet.list.satellites",
     "path": "/v1/fleet/satellites",
@@ -1091,7 +1111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 106,
+    "index": 108,
     "method": "GET",
     "operationId": "fleet.get.satellite.detail",
     "path": "/v1/fleet/satellites/:satelliteId",
@@ -1101,7 +1121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 107,
+    "index": 109,
     "method": "GET",
     "operationId": "fleet.get.satellite.remediation",
     "path": "/v1/fleet/satellites/:satelliteId/remediation",
@@ -1111,7 +1131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 108,
+    "index": 110,
     "method": "POST",
     "operationId": "fleet.execute.satellite.remediation",
     "path": "/v1/fleet/satellites/:satelliteId/remediation/:actionId/execute",
@@ -1121,7 +1141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 109,
+    "index": 111,
     "method": "GET",
     "operationId": "security.center",
     "path": "/v1/security/center",
@@ -1131,7 +1151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 110,
+    "index": 112,
     "method": "POST",
     "operationId": "security.revoke.token",
     "path": "/v1/security/tokens/revoke",
@@ -1141,7 +1161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 111,
+    "index": 113,
     "method": "POST",
     "operationId": "security.revoke.satellite",
     "path": "/v1/security/satellites/:satelliteId/revoke",
@@ -1151,7 +1171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 112,
+    "index": 114,
     "method": "POST",
     "operationId": "deeplink.preview",
     "path": "/v1/deeplink/preview",
@@ -1161,7 +1181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 113,
+    "index": 115,
     "method": "POST",
     "operationId": "deeplink.apply",
     "path": "/v1/deeplink/apply",
@@ -1171,7 +1191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 114,
+    "index": 116,
     "method": "GET",
     "operationId": "grants.list",
     "path": "/v1/grants",
@@ -1181,7 +1201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 115,
+    "index": 117,
     "method": "POST",
     "operationId": "grants.revoke",
     "path": "/v1/grants/:grantId/revoke",
@@ -1191,7 +1211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 116,
+    "index": 118,
     "method": "GET",
     "operationId": "diagnosis.incidents.list",
     "path": "/v1/diagnosis/incidents",
@@ -1201,7 +1221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 117,
+    "index": 119,
     "method": "GET",
     "operationId": "learning.incidents.list",
     "path": "/v1/learning/incidents",
@@ -1211,7 +1231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 118,
+    "index": 120,
     "method": "GET",
     "operationId": "diagnosis.incidents.get",
     "path": "/v1/diagnosis/incidents/:incidentId",
@@ -1221,7 +1241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 119,
+    "index": 121,
     "method": "GET",
     "operationId": "learning.incidents.get",
     "path": "/v1/learning/incidents/:incidentId",
@@ -1231,7 +1251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 120,
+    "index": 122,
     "method": "GET",
     "operationId": "diagnosis.incidents.diagnosis.get",
     "path": "/v1/diagnosis/incidents/:incidentId/diagnosis",
@@ -1241,7 +1261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 121,
+    "index": 123,
     "method": "GET",
     "operationId": "learning.incidents.diagnosis.get",
     "path": "/v1/learning/incidents/:incidentId/diagnosis",
@@ -1251,7 +1271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 122,
+    "index": 124,
     "method": "GET",
     "operationId": "diagnosis.learning.overview",
     "path": "/v1/diagnosis/learning/overview",
@@ -1261,7 +1281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 123,
+    "index": 125,
     "method": "GET",
     "operationId": "learning.overview.get",
     "path": "/v1/learning/overview",
@@ -1271,7 +1291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 124,
+    "index": 126,
     "method": "POST",
     "operationId": "diagnosis.incidents.manual.resolve",
     "path": "/v1/diagnosis/incidents/:incidentId/manual-resolve",
@@ -1281,7 +1301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 125,
+    "index": 127,
     "method": "POST",
     "operationId": "diagnosis.lessons.enabled.set",
     "path": "/v1/diagnosis/lessons/:lessonId/enabled",
@@ -1291,7 +1311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 126,
+    "index": 128,
     "method": "POST",
     "operationId": "diagnosis.patterns.demote",
     "path": "/v1/diagnosis/patterns/:patternId/demote",
@@ -1301,7 +1321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 127,
+    "index": 129,
     "method": "GET",
     "operationId": "autofix.actions.list",
     "path": "/v1/auto-fix/actions",
@@ -1311,7 +1331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 128,
+    "index": 130,
     "method": "POST",
     "operationId": "autofix.actions.run.ready",
     "path": "/v1/auto-fix/actions/run-ready",
@@ -1321,7 +1341,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 129,
+    "index": 131,
     "method": "GET",
     "operationId": "autofix.actions.get",
     "path": "/v1/auto-fix/actions/:actionId",
@@ -1331,7 +1351,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 130,
+    "index": 132,
     "method": "POST",
     "operationId": "autofix.actions.approve",
     "path": "/v1/auto-fix/actions/:actionId/approve",
@@ -1341,7 +1361,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 131,
+    "index": 133,
     "method": "POST",
     "operationId": "autofix.actions.deny",
     "path": "/v1/auto-fix/actions/:actionId/deny",
@@ -1351,7 +1371,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 132,
+    "index": 134,
     "method": "POST",
     "operationId": "autofix.actions.execute",
     "path": "/v1/auto-fix/actions/:actionId/execute",
@@ -1361,7 +1381,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 133,
+    "index": 135,
     "method": "POST",
     "operationId": "autofix.actions.rollback",
     "path": "/v1/auto-fix/actions/:actionId/rollback",
@@ -1371,7 +1391,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 134,
+    "index": 136,
     "method": "GET",
     "operationId": "autofix.metrics.get",
     "path": "/v1/auto-fix/metrics",
@@ -1381,7 +1401,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 135,
+    "index": 137,
     "method": "POST",
     "operationId": "discovery.scan",
     "path": "/v1/discovery/scan",
@@ -1391,7 +1411,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 136,
+    "index": 138,
     "method": "GET",
     "operationId": "discovery.catalog.get",
     "path": "/v1/discovery/catalog",
@@ -1401,7 +1421,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 137,
+    "index": 139,
     "method": "GET",
     "operationId": "discovery.programs.list",
     "path": "/v1/discovery/programs",
@@ -1411,7 +1431,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 138,
+    "index": 140,
     "method": "GET",
     "operationId": "discovery.recommend",
     "path": "/v1/discovery/recommendations",
@@ -1421,7 +1441,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 139,
+    "index": 141,
     "method": "GET",
     "operationId": "discovery.policy.get",
     "path": "/v1/discovery/policy",
@@ -1431,7 +1451,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 140,
+    "index": 142,
     "method": "PATCH",
     "operationId": "discovery.policy.update",
     "path": "/v1/discovery/policy",
@@ -1441,7 +1461,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 141,
+    "index": 143,
     "method": "GET",
     "operationId": "discovery.status",
     "path": "/v1/discovery/status",
@@ -1451,7 +1471,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 142,
+    "index": 144,
     "method": "POST",
     "operationId": "discovery.integrate",
     "path": "/v1/discovery/integrate",
@@ -1461,7 +1481,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 143,
+    "index": 145,
     "method": "POST",
     "operationId": "mcp.server.rpc",
     "path": "/v1/mcp",
@@ -1471,7 +1491,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 144,
+    "index": 146,
     "method": "POST",
     "operationId": "channels.webhooks.line",
     "path": "/v1/channel-webhooks/line",
@@ -1481,7 +1501,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 145,
+    "index": 147,
     "method": "GET",
     "operationId": "channels.webhooks.whatsapp.verify",
     "path": "/v1/channel-webhooks/whatsapp",
@@ -1491,7 +1511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 146,
+    "index": 148,
     "method": "POST",
     "operationId": "channels.webhooks.whatsapp",
     "path": "/v1/channel-webhooks/whatsapp",
@@ -1501,7 +1521,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 147,
+    "index": 149,
     "method": "POST",
     "operationId": "channels.webhooks.telegram",
     "path": "/v1/channel-webhooks/telegram",
@@ -1511,7 +1531,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 148,
+    "index": 150,
     "method": "POST",
     "operationId": "channels.webhooks.lark",
     "path": "/v1/channel-webhooks/lark",
@@ -1521,7 +1541,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 149,
+    "index": 151,
     "method": "POST",
     "operationId": "packaging.packages.publish",
     "path": "/v1/packages",
@@ -1531,7 +1551,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 150,
+    "index": 152,
     "method": "GET",
     "operationId": "packaging.packages.list",
     "path": "/v1/packages",
@@ -1541,7 +1561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 151,
+    "index": 153,
     "method": "GET",
     "operationId": "packaging.packages.get",
     "path": "/v1/packages/:packageId",
@@ -1551,7 +1571,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 152,
+    "index": 154,
     "method": "GET",
     "operationId": "packaging.packages.versions.list",
     "path": "/v1/packages/:packageName/versions",
@@ -1561,7 +1581,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 153,
+    "index": 155,
     "method": "POST",
     "operationId": "packaging.packages.verify",
     "path": "/v1/packages/:packageId/verify",
@@ -1571,7 +1591,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 154,
+    "index": 156,
     "method": "POST",
     "operationId": "packaging.packages.dependencies.check",
     "path": "/v1/packages/:packageName/check-dependencies",
@@ -1581,7 +1601,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 155,
+    "index": 157,
     "method": "POST",
     "operationId": "packaging.installs.install",
     "path": "/v1/packages/:packageName/install",
@@ -1591,7 +1611,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 156,
+    "index": 158,
     "method": "POST",
     "operationId": "packaging.installs.upgrade",
     "path": "/v1/packages/:packageName/upgrade",
@@ -1601,7 +1621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 157,
+    "index": 159,
     "method": "POST",
     "operationId": "packaging.installs.rollback",
     "path": "/v1/packages/:packageName/rollback",
@@ -1611,7 +1631,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 158,
+    "index": 160,
     "method": "POST",
     "operationId": "packaging.installs.uninstall",
     "path": "/v1/packages/:packageName/uninstall",
@@ -1621,7 +1641,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 159,
+    "index": 161,
     "method": "GET",
     "operationId": "packaging.installs.list",
     "path": "/v1/packages/installs",
@@ -1631,7 +1651,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 160,
+    "index": 162,
     "method": "GET",
     "operationId": "packaging.installs.get",
     "path": "/v1/packages/installs/:installId",
@@ -1641,7 +1661,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 161,
+    "index": 163,
     "method": "GET",
     "operationId": "packaging.lifecycle.list",
     "path": "/v1/packages/lifecycle",
@@ -1651,7 +1671,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 162,
+    "index": 164,
     "method": "GET",
     "operationId": "packaging.keys.list",
     "path": "/v1/packages/keys",
@@ -1661,7 +1681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 163,
+    "index": 165,
     "method": "POST",
     "operationId": "packaging.keys.add",
     "path": "/v1/packages/keys",
@@ -1671,7 +1691,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 164,
+    "index": 166,
     "method": "POST",
     "operationId": "packaging.keys.revoke",
     "path": "/v1/packages/keys/:keyId/revoke",
@@ -1681,7 +1701,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 165,
+    "index": 167,
     "method": "POST",
     "operationId": "packaging.keys.rotate",
     "path": "/v1/packages/keys/:keyId/rotate",
@@ -1691,7 +1711,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 166,
+    "index": 168,
     "method": "GET",
     "operationId": "cloud.workers.catalog.list",
     "path": "/v1/cloud-workers/catalog",
@@ -1701,7 +1721,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 167,
+    "index": 169,
     "method": "GET",
     "operationId": "cloud.workers.preview.get",
     "path": "/v1/cloud-workers/preview/:providerId",
@@ -1711,7 +1731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 168,
+    "index": 170,
     "method": "GET",
     "operationId": "cloud.workers.doctor.run",
     "path": "/v1/cloud-workers/doctor",
@@ -1721,7 +1741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 169,
+    "index": 171,
     "method": "POST",
     "operationId": "cloud.workers.dns.validate",
     "path": "/v1/cloud-workers/dns/validate",
@@ -1731,7 +1751,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 170,
+    "index": 172,
     "method": "POST",
     "operationId": "cloud.workers.package.generate",
     "path": "/v1/cloud-workers/package",
@@ -1741,7 +1761,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 171,
+    "index": 173,
     "method": "POST",
     "operationId": "cloud.workers.teardown.receipt",
     "path": "/v1/cloud-workers/teardown-receipt",
@@ -1751,7 +1771,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 172,
+    "index": 174,
     "method": "GET",
     "operationId": "studio.products.list",
     "path": "/v1/studio/products",
@@ -1761,7 +1781,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 173,
+    "index": 175,
     "method": "POST",
     "operationId": "studio.runs.create",
     "path": "/v1/studio/runs",
@@ -1771,7 +1791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 174,
+    "index": 176,
     "method": "GET",
     "operationId": "studio.runs.get",
     "path": "/v1/studio/runs/:runId",
@@ -1781,7 +1801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 175,
+    "index": 177,
     "method": "GET",
     "operationId": "studio.artifacts.get",
     "path": "/v1/studio/runs/:runId/artifacts/:artifactId",
@@ -1791,7 +1811,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 176,
+    "index": 178,
     "method": "GET",
     "operationId": "studio.runs.export",
     "path": "/v1/studio/runs/:runId/export",
@@ -1801,7 +1821,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 177,
+    "index": 179,
     "method": "POST",
     "operationId": "studio.imports.create",
     "path": "/v1/studio/imports",
@@ -1811,7 +1831,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 178,
+    "index": 180,
     "method": "POST",
     "operationId": "studio.artifacts.validate.candidate",
     "path": "/v1/studio/runs/:runId/validate-candidate",
@@ -1821,7 +1841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 179,
+    "index": 181,
     "method": "GET",
     "operationId": "mission.spine.workbench.get",
     "path": "/v1/mission-spine/workbench",
@@ -1831,7 +1851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 180,
+    "index": 182,
     "method": "POST",
     "operationId": "mission.spine.intake.create",
     "path": "/v1/mission-spine/intake",
@@ -1841,7 +1861,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 181,
+    "index": 183,
     "method": "POST",
     "operationId": "mission.spine.lifecycle.transition",
     "path": "/v1/mission-spine/:missionId/lifecycle",
@@ -1851,7 +1871,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 182,
+    "index": 184,
     "method": "POST",
     "operationId": "mission.spine.workitem.status.transition",
     "path": "/v1/mission-spine/work-items/:workItemId/status",
@@ -1861,7 +1881,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 183,
+    "index": 185,
     "method": "POST",
     "operationId": "mission.spine.routedecision.control",
     "path": "/v1/mission-spine/route-decisions/:decisionId/control",
@@ -1871,7 +1891,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 184,
+    "index": 186,
     "method": "POST",
     "operationId": "memory.spine.decide.apply",
     "path": "/v1/memory-spine/decide",
@@ -1881,7 +1901,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 185,
+    "index": 187,
     "method": "POST",
     "operationId": "run.outcome.learning.decide.apply",
     "path": "/v1/run-outcome-learning/decide",
@@ -1891,7 +1911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 186,
+    "index": 188,
     "method": "POST",
     "operationId": "realtime.subscribe",
     "path": "/v1/realtime/subscriptions",
@@ -1901,7 +1921,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 187,
+    "index": 189,
     "method": "POST",
     "operationId": "realtime.pull",
     "path": "/v1/realtime/pull",
@@ -1911,7 +1931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 188,
+    "index": 190,
     "method": "POST",
     "operationId": "realtime.ack",
     "path": "/v1/realtime/ack",
@@ -1921,7 +1941,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 189,
+    "index": 191,
     "method": "GET",
     "operationId": "providers.usage.get",
     "path": "/v1/providers/usage",
@@ -1931,7 +1951,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 190,
+    "index": 192,
     "method": "GET",
     "operationId": "providers.budget.get",
     "path": "/v1/providers/budget",
@@ -1941,7 +1961,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 191,
+    "index": 193,
     "method": "PUT",
     "operationId": "providers.budget.set",
     "path": "/v1/providers/budget",
@@ -1951,7 +1971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 192,
+    "index": 194,
     "method": "GET",
     "operationId": "providers.templates.list",
     "path": "/v1/providers/templates",
@@ -1961,7 +1981,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 193,
+    "index": 195,
     "method": "GET",
     "operationId": "providers.templates.get",
     "path": "/v1/providers/templates/:templateId",
@@ -1971,7 +1991,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 194,
+    "index": 196,
     "method": "GET",
     "operationId": "providers.list",
     "path": "/v1/providers",
@@ -1981,7 +2001,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 195,
+    "index": 197,
     "method": "GET",
     "operationId": "providers.health.list",
     "path": "/v1/providers/health",
@@ -1991,7 +2011,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 196,
+    "index": 198,
     "method": "GET",
     "operationId": "providers.capability.health.list",
     "path": "/v1/providers/capability-health",
@@ -2001,7 +2021,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 197,
+    "index": 199,
     "method": "POST",
     "operationId": "capabilities.doctor",
     "path": "/v1/capabilities/doctor",
@@ -2011,7 +2031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 198,
+    "index": 200,
     "method": "GET",
     "operationId": "providers.get",
     "path": "/v1/providers/:providerId",
@@ -2021,7 +2041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 199,
+    "index": 201,
     "method": "POST",
     "operationId": "providers.create",
     "path": "/v1/providers",
@@ -2031,7 +2051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 200,
+    "index": 202,
     "method": "PATCH",
     "operationId": "providers.update",
     "path": "/v1/providers/:providerId",
@@ -2041,7 +2061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 201,
+    "index": 203,
     "method": "DELETE",
     "operationId": "providers.delete",
     "path": "/v1/providers/:providerId",
@@ -2051,7 +2071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 202,
+    "index": 204,
     "method": "POST",
     "operationId": "providers.validate",
     "path": "/v1/providers/:providerId/validate",
@@ -2061,7 +2081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 203,
+    "index": 205,
     "method": "GET",
     "operationId": "providers.doctor",
     "path": "/v1/providers/:providerId/doctor",
@@ -2071,7 +2091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 204,
+    "index": 206,
     "method": "GET",
     "operationId": "providers.routing.explain",
     "path": "/v1/providers/routing/explain",
@@ -2081,7 +2101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 205,
+    "index": 207,
     "method": "POST",
     "operationId": "providers.routing.pin",
     "path": "/v1/providers/routing/pin",
@@ -2091,7 +2111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 206,
+    "index": 208,
     "method": "POST",
     "operationId": "providers.routing.penalty.clear",
     "path": "/v1/providers/routing/penalties/clear",
@@ -2101,7 +2121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 207,
+    "index": 209,
     "method": "GET",
     "operationId": "providers.auth.profiles.list",
     "path": "/v1/providers/:providerId/auth-profiles",
@@ -2111,7 +2131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 208,
+    "index": 210,
     "method": "POST",
     "operationId": "providers.auth.profiles.activate",
     "path": "/v1/providers/:providerId/auth-profiles/:profileKey/activate",
@@ -2121,7 +2141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 209,
+    "index": 211,
     "method": "GET",
     "operationId": "providers.routing.get",
     "path": "/v1/model-routing",
@@ -2131,7 +2151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 210,
+    "index": 212,
     "method": "PUT",
     "operationId": "providers.routing.set",
     "path": "/v1/model-routing",
@@ -2141,7 +2161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 211,
+    "index": 213,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.initiate",
     "path": "/v1/auth/oauth/anthropic/initiate",
@@ -2151,7 +2171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 212,
+    "index": 214,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.callback",
     "path": "/v1/auth/oauth/anthropic/callback",
@@ -2161,7 +2181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 213,
+    "index": 215,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.initiate",
     "path": "/v1/auth/oauth/openai-codex/device/initiate",
@@ -2171,7 +2191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 214,
+    "index": 216,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.complete",
     "path": "/v1/auth/oauth/openai-codex/device/complete",
@@ -2181,7 +2201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 215,
+    "index": 217,
     "method": "POST",
     "operationId": "media.understanding.doctor",
     "path": "/v1/media-understanding/doctor",
@@ -2191,7 +2211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 216,
+    "index": 218,
     "method": "POST",
     "operationId": "media.understanding.analyze",
     "path": "/v1/media-understanding/analyze",
@@ -2201,7 +2221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 217,
+    "index": 219,
     "method": "GET",
     "operationId": "task.workflows.boundaries.list",
     "path": "/v1/task-workflows/boundaries",
@@ -2211,7 +2231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 218,
+    "index": 220,
     "method": "GET",
     "operationId": "task.workflows.gates.list",
     "path": "/v1/task-workflows/gates",
@@ -2221,7 +2241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 219,
+    "index": 221,
     "method": "POST",
     "operationId": "task.workflows.preview",
     "path": "/v1/task-workflows/preview",
@@ -2231,7 +2251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 220,
+    "index": 222,
     "method": "POST",
     "operationId": "task.workflows.create",
     "path": "/v1/task-workflows",
@@ -2241,7 +2261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 223,
     "method": "GET",
     "operationId": "task.workflows.list",
     "path": "/v1/task-workflows",
@@ -2251,7 +2271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 224,
     "method": "GET",
     "operationId": "task.workflows.get",
     "path": "/v1/task-workflows/:workflowId",
@@ -2261,7 +2281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 225,
     "method": "POST",
     "operationId": "task.workflows.revise",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2271,7 +2291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 226,
     "method": "GET",
     "operationId": "task.workflows.revisions.list",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2281,7 +2301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 227,
     "method": "POST",
     "operationId": "task.workflows.claims.create",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2291,7 +2311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 228,
     "method": "GET",
     "operationId": "task.workflows.claims.list",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2301,7 +2321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 229,
     "method": "GET",
     "operationId": "task.workflows.claims.get",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId",
@@ -2311,7 +2331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 230,
     "method": "POST",
     "operationId": "task.workflows.claims.evidence.attach",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-ref",
@@ -2321,7 +2341,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 231,
     "method": "GET",
     "operationId": "task.workflows.claims.evidence.list",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-refs",
@@ -2331,7 +2351,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 232,
     "method": "POST",
     "operationId": "task.workflows.claims.verify",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/verify",
@@ -2341,7 +2361,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 233,
     "method": "POST",
     "operationId": "task.workflows.claims.block",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/block",
@@ -2351,7 +2371,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 234,
     "method": "POST",
     "operationId": "task.workflows.closeout",
     "path": "/v1/task-workflows/:workflowId/closeout",
@@ -2361,7 +2381,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 235,
     "method": "POST",
     "operationId": "task.workflows.lanes.executor.open",
     "path": "/v1/task-workflows/:workflowId/lanes/executor",
@@ -2371,7 +2391,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 236,
     "method": "POST",
     "operationId": "task.workflows.lanes.verifier.open",
     "path": "/v1/task-workflows/:workflowId/lanes/verifier",
@@ -2381,7 +2401,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 237,
     "method": "POST",
     "operationId": "task.workflows.lanes.complete",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/complete",
@@ -2391,7 +2411,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 238,
     "method": "POST",
     "operationId": "task.workflows.lanes.verdict",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/verdict",
@@ -2401,7 +2421,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 239,
     "method": "GET",
     "operationId": "task.workflows.lanes.list",
     "path": "/v1/task-workflows/:workflowId/lanes",
@@ -2411,7 +2431,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 240,
     "method": "GET",
     "operationId": "task.workflows.lanes.get",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId",
@@ -2421,7 +2441,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 241,
     "method": "POST",
     "operationId": "task.workflows.lanes.cli.handoff.record",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2431,7 +2451,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 242,
     "method": "GET",
     "operationId": "task.workflows.lanes.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2441,7 +2461,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 243,
     "method": "GET",
     "operationId": "task.workflows.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/cli-handoffs",
@@ -2451,7 +2471,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 244,
     "method": "GET",
     "operationId": "task.workflows.supervisor.read",
     "path": "/v1/task-workflows/:workflowId/supervisor",
@@ -2461,7 +2481,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 245,
     "method": "POST",
     "operationId": "task.workflows.channel.command.issue",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2471,7 +2491,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 246,
     "method": "GET",
     "operationId": "task.workflows.channel.command.list",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2481,7 +2501,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 247,
     "method": "POST",
     "operationId": "task.workflows.channel.command.confirm",
     "path": "/v1/task-workflows/:workflowId/channel-commands/confirm",
@@ -2491,7 +2511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 248,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.query",
     "path": "/v1/task-workflows/evidence",
@@ -2501,7 +2521,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 249,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.raw",
     "path": "/v1/task-workflows/evidence/:evidenceRefId/raw",
@@ -2511,7 +2531,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 250,
     "method": "POST",
     "operationId": "skills.social.import",
     "path": "/v1/skills/social-import",
@@ -2521,7 +2541,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 251,
     "method": "GET",
     "operationId": "setup.status",
     "path": "/v1/setup/status",
@@ -2531,7 +2551,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 252,
     "method": "POST",
     "operationId": "providers.detect",
     "path": "/v1/providers/detect",
@@ -2541,7 +2561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 253,
     "method": "GET",
     "operationId": "setup.network.get",
     "path": "/v1/setup/network",
@@ -2551,7 +2571,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 254,
     "method": "POST",
     "operationId": "setup.network.save",
     "path": "/v1/setup/network",
@@ -2561,7 +2581,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 255,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.begin",
     "path": "/v1/setup/channels/feishu/registration/begin",
@@ -2571,7 +2591,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 256,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.poll",
     "path": "/v1/setup/channels/feishu/registration/poll",
@@ -2581,7 +2601,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 257,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.begin",
     "path": "/v1/setup/channels/telegram/verification/begin",
@@ -2591,7 +2611,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 258,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.poll",
     "path": "/v1/setup/channels/telegram/verification/poll",
@@ -2601,7 +2621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 259,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.begin",
     "path": "/v1/setup/channels/discord/verification/begin",
@@ -2611,7 +2631,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 260,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.complete",
     "path": "/v1/setup/channels/discord/verification/complete",
@@ -2621,7 +2641,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 261,
     "method": "POST",
     "operationId": "setup.channels.test",
     "path": "/v1/setup/channels/test",
@@ -2631,7 +2651,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 262,
     "method": "POST",
     "operationId": "setup.channels.save",
     "path": "/v1/setup/channels",
@@ -2641,7 +2661,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 263,
     "method": "POST",
     "operationId": "setup.complete",
     "path": "/v1/setup/complete",
@@ -2651,7 +2671,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 264,
     "method": "GET",
     "operationId": "skills.list",
     "path": "/v1/skills",
@@ -2661,7 +2681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 265,
     "method": "GET",
     "operationId": "skills.catalog.list",
     "path": "/v1/skills/catalog",
@@ -2671,7 +2691,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 266,
     "method": "GET",
     "operationId": "skills.get",
     "path": "/v1/skills/:skillId",
@@ -2681,7 +2701,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 267,
     "method": "POST",
     "operationId": "skills.install",
     "path": "/v1/skills/install",
@@ -2691,7 +2711,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 268,
     "method": "POST",
     "operationId": "skills.update",
     "path": "/v1/skills/:skillId/update",
@@ -2701,7 +2721,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 269,
     "method": "DELETE",
     "operationId": "skills.delete",
     "path": "/v1/skills/:skillId",
@@ -2711,7 +2731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 270,
     "method": "POST",
     "operationId": "skills.manifest.validate",
     "path": "/v1/skills/validate-manifest",
@@ -2721,7 +2741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 271,
     "method": "POST",
     "operationId": "skills.verify",
     "path": "/v1/skills/:skillId/verify",
@@ -2731,7 +2751,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 272,
     "method": "POST",
     "operationId": "skills.upgrade.analyze",
     "path": "/v1/skills/:skillId/upgrade/analyze",
@@ -2741,7 +2761,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 273,
     "method": "POST",
     "operationId": "skills.upgrade.decide",
     "path": "/v1/skills/:skillId/upgrade/decide",
@@ -2751,7 +2771,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 274,
     "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
@@ -2761,7 +2781,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 275,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2771,7 +2791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 276,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2781,7 +2801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 277,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2791,7 +2811,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 278,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2801,7 +2821,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 279,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2811,7 +2831,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 280,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2821,7 +2841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 281,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2831,7 +2851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 282,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2841,7 +2861,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 283,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2851,7 +2871,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 284,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2861,7 +2881,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 285,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2871,7 +2891,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 286,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2881,7 +2901,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 287,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2891,7 +2911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 288,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2901,7 +2921,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 289,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2911,7 +2931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 290,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2921,7 +2941,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 291,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2931,7 +2951,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 292,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -2941,7 +2961,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 293,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -2951,7 +2971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 294,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -2961,7 +2981,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 295,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -2971,7 +2991,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 296,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -2981,7 +3001,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 297,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -2991,7 +3011,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 298,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -3001,7 +3021,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 299,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -3011,7 +3031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 300,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -3021,7 +3041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 301,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -3031,7 +3051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 302,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -3041,7 +3061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 303,
     "method": "PATCH",
     "operationId": "uix.learnedfacts.update",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3051,7 +3071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 304,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3061,7 +3081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 305,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -3071,7 +3091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 306,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -3081,7 +3101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 307,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -3091,7 +3111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 308,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -3101,7 +3121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 309,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -3111,7 +3131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 310,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -3121,7 +3141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 311,
     "method": "POST",
     "operationId": "packs.cross.border.run.evidence.capture",
     "path": "/v1/packs/cross-border/run-evidence",
@@ -3131,7 +3151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 312,
     "method": "PATCH",
     "operationId": "packs.cross.border.import.stale",
     "path": "/v1/packs/cross-border/imports/:importBatchId/stale",
@@ -3141,7 +3161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 313,
     "method": "POST",
     "operationId": "packs.cross.border.workflows.disable.all",
     "path": "/v1/packs/cross-border/workflows/disable-all",
@@ -3151,7 +3171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 314,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -3161,7 +3181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 315,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -3171,7 +3191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 316,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -3181,7 +3201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 317,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -3191,7 +3211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 318,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -3201,7 +3221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 319,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3211,7 +3231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 320,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -3221,7 +3241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 321,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -3231,7 +3251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 322,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -3241,7 +3261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 323,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -3251,7 +3271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 324,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3261,7 +3281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 325,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -3271,7 +3291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 326,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3281,7 +3301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 327,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -3291,7 +3311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 328,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3301,7 +3321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 329,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -3311,7 +3331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 330,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -3321,7 +3341,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 331,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -3331,7 +3351,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 332,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -3341,7 +3361,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 333,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -3351,7 +3371,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 334,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -3361,7 +3381,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 335,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -3371,7 +3391,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 336,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -3381,7 +3401,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 337,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -3391,7 +3411,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 338,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -3401,7 +3421,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 339,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -3411,7 +3431,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 340,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -3421,7 +3441,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 341,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -3431,7 +3451,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 342,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -3441,7 +3461,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 343,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -3451,7 +3471,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 344,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -3461,7 +3481,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 345,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -3471,7 +3491,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 346,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -3481,7 +3501,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 347,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -3491,7 +3511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 348,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -3501,7 +3521,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 349,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -3511,7 +3531,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 350,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -3521,7 +3541,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 351,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -3531,7 +3551,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 352,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -3541,7 +3561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 353,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -3551,7 +3571,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 354,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -3561,7 +3581,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 355,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -3571,7 +3591,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 356,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -3581,7 +3601,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 357,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -3591,7 +3611,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 358,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3601,7 +3621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 359,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3611,7 +3631,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 360,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3621,7 +3641,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 361,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3631,7 +3651,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 362,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3641,7 +3661,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 363,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3651,7 +3671,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 364,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3661,7 +3681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 365,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3671,7 +3691,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 366,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3681,7 +3701,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 367,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3691,7 +3711,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 368,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3701,7 +3721,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 369,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3711,7 +3731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 370,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3721,7 +3741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 369,
+    "index": 371,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3731,7 +3751,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 370,
+    "index": 372,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3741,7 +3761,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 371,
+    "index": 373,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3751,7 +3771,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 372,
+    "index": 374,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3761,7 +3781,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 373,
+    "index": 375,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3771,7 +3791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 374,
+    "index": 376,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3781,7 +3801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 375,
+    "index": 377,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3791,7 +3811,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 376,
+    "index": 378,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3801,7 +3821,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 377,
+    "index": 379,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3811,7 +3831,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 378,
+    "index": 380,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3821,7 +3841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 379,
+    "index": 381,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3831,7 +3851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 380,
+    "index": 382,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3841,7 +3861,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 381,
+    "index": 383,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3851,7 +3871,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 382,
+    "index": 384,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3861,7 +3881,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 383,
+    "index": 385,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3871,7 +3891,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 384,
+    "index": 386,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3881,7 +3901,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 385,
+    "index": 387,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3891,7 +3911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 386,
+    "index": 388,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3901,7 +3921,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 387,
+    "index": 389,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3911,7 +3931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 388,
+    "index": 390,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3921,7 +3941,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 389,
+    "index": 391,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3931,7 +3951,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 390,
+    "index": 392,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -3941,7 +3961,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 391,
+    "index": 393,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -3951,7 +3971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 392,
+    "index": 394,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -3961,7 +3981,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 393,
+    "index": 395,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -3971,7 +3991,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 394,
+    "index": 396,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -3981,7 +4001,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 395,
+    "index": 397,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -3991,7 +4011,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 396,
+    "index": 398,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -4001,7 +4021,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 397,
+    "index": 399,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -4011,7 +4031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 398,
+    "index": 400,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -4021,7 +4041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 399,
+    "index": 401,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -4031,7 +4051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 400,
+    "index": 402,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -4041,7 +4061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 401,
+    "index": 403,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -4051,7 +4071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 402,
+    "index": 404,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -4061,7 +4081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 403,
+    "index": 405,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -4071,7 +4091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 404,
+    "index": 406,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -4081,7 +4101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 405,
+    "index": 407,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -4091,7 +4111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 406,
+    "index": 408,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -4101,7 +4121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 407,
+    "index": 409,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -4111,7 +4131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 408,
+    "index": 410,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -4121,7 +4141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 411,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -4131,7 +4151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 410,
+    "index": 412,
     "method": "POST",
     "operationId": "agent.runs.resume",
     "path": "/v1/agent/runs/:runId/resume",
@@ -4141,7 +4161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 411,
+    "index": 413,
     "method": "POST",
     "operationId": "agent.d20.worktree.batch.dispatch",
     "path": "/v1/agent/d20/worktree-batches/dispatch",
@@ -4151,7 +4171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 412,
+    "index": 414,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -4161,7 +4181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 413,
+    "index": 415,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -4171,7 +4191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 414,
+    "index": 416,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -4181,7 +4201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 415,
+    "index": 417,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -4191,7 +4211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 416,
+    "index": 418,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4201,7 +4221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 417,
+    "index": 419,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4211,7 +4231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 418,
+    "index": 420,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4221,7 +4241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 419,
+    "index": 421,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4231,7 +4251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 420,
+    "index": 422,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4241,7 +4261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 421,
+    "index": 423,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4251,7 +4271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 422,
+    "index": 424,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4261,7 +4281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 423,
+    "index": 425,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4271,7 +4291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 424,
+    "index": 426,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4281,7 +4301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 425,
+    "index": 427,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4291,7 +4311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 426,
+    "index": 428,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4301,7 +4321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 427,
+    "index": 429,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4311,7 +4331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 428,
+    "index": 430,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -878,6 +878,14 @@ describe("MECHANISM-4 — API Route Contract (Snapshot)", () => {
         // A1 run-outcome learning decision courier. Refuses the synthetic public principal
         // before any dispatch; flag-OFF/503 by default until the Rust arm is configured.
         "run.outcome.learning.decide.apply",
+        // SEC-SETUP-BOOTSTRAP-001 Slice 5: authenticated legacy-passphrase → device
+        // migration. NOT allowUnauthenticatedMutation → the L1 floor refuses the
+        // synthetic public principal; the handler additionally enforces owner
+        // authority via assertBoundPrincipalAuthorityForOperation, and the auth
+        // service binds the principal to the local owner. Additive/reversible;
+        // password_hash is never flipped and the device binding carries zero authority.
+        "auth.migrate.challenge",
+        "auth.migrate.device.claim",
       ]);
       // rate_limited_pending
       const RATE_LIMITED_PENDING: ReadonlySet<string> = new Set([

--- a/test/integration/api/friday-secsetup-s5-migration-http-proof.test.ts
+++ b/test/integration/api/friday-secsetup-s5-migration-http-proof.test.ts
@@ -1,0 +1,275 @@
+/**
+ * SEC-SETUP-BOOTSTRAP-001 · Slice 5 — authenticated migration runtime proof over
+ * REAL HTTP, REAL auth middleware, REAL file-backed SQLite (NODE_ENV=production).
+ *
+ * Drives the FULL production path route → middleware(real token validator + rate
+ * limiter + auth floors) → auth service → sqlite on an ephemeral port > 49152.
+ * The migrate endpoints are `public:true` WITHOUT allowUnauthenticatedMutation,
+ * so the http-server L1 public-mutation floor refuses the synthetic public
+ * principal — a real OWNER bearer (from a passphrase login) is required.
+ *
+ * Proven:
+ *  A. Unauthenticated POST /v1/auth/migrate/{challenge,device-claim} → 401
+ *     (bound-principal floor); no binding, no state change.
+ *  B. Authenticated OWNER → migrate/challenge + migrate/device-claim → 200
+ *     provisional; passphrase login STILL works afterwards (NO lockout);
+ *     password_hash stays scrypt$…; deviceAuthorityEnabled=false.
+ *  C. An authenticated NON-owner (viewer authority) bearer → 403 (authority gate).
+ */
+
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createFridayAuthMiddlewareFactory,
+  createFridayAuthRoutes,
+  createFridayAuthService,
+  createFridayHttpRouteRegistry,
+  createFridayHttpServer,
+  createFridayRateLimitService,
+  createFridayTokenValidator,
+  encodeToken,
+  type FridayHttpServer,
+  type FridayRealtimeWsGateway,
+} from "#api";
+import { createFridaySqliteLayer } from "#state";
+import type { FridaySqliteLayer } from "#state";
+import type { FridayAccessTokenClaims, FridayScope } from "../../../src/api/model/friday-api-auth.types.js";
+import { getScopesForRole } from "../../../src/api/auth/friday-rbac-policy.js";
+import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "../../adversarial/_secsetup-s2a.helpers.js";
+
+const OWNER_ID = "admin-001";
+const NOW = "2026-07-13T00:00:00.000Z";
+const ORIGIN = "https://friday.localhost";
+const PASSPHRASE = "owner-passphrase-http-9988"; // pragma: allowlist secret
+const TOKEN_SECRET = crypto.randomBytes(32).toString("hex"); // pragma: allowlist secret
+const DEVICE_KEY = generateTestDeviceKey();
+const DEVICE_PUBKEY = DEVICE_KEY.spkiDerBase64;
+const DEVICE_ID = "device-s5-http-001";
+
+function sha256Hex(v: string): string {
+  return crypto.createHash("sha256").update(v).digest("hex");
+}
+
+async function findEphemeralPortAbove(min: number): Promise<number> {
+  const lo = Math.max(min + 1, 49153);
+  const hi = 65535;
+  const span = hi - lo + 1;
+  const seed = Math.floor(Math.random() * span);
+  for (let attempt = 0; attempt < 128; attempt += 1) {
+    const candidate = lo + ((seed + attempt * 2861) % span);
+    const bound = await new Promise<number | null>((resolve) => {
+      const srv = net.createServer();
+      srv.once("error", () => resolve(null));
+      srv.listen(candidate, "127.0.0.1", () => {
+        srv.close((e) => resolve(e ? null : candidate));
+      });
+    });
+    if (bound !== null && bound > min) return bound;
+  }
+  throw new Error(`could not allocate an ephemeral port > ${min}`);
+}
+
+function makeStubWsGateway(): FridayRealtimeWsGateway {
+  return {
+    handleClientFrame: () => ({ handled: false }),
+    addConnection: () => {},
+    removeConnection: () => {},
+    broadcastEvent: () => {},
+  } as unknown as FridayRealtimeWsGateway;
+}
+
+describe("S5 runtime proof — authenticated migration over real HTTP (production posture)", () => {
+  let server: FridayHttpServer | null = null;
+  let db: FridaySqliteLayer;
+  let tmpDir: string;
+  let baseUrl = "";
+  let ownerBearer = "";
+  const savedNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = "production";
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-secsetup-s5-http-"));
+    db = createFridaySqliteLayer({
+      dbPath: path.join(tmpDir, "friday.db"),
+      readPoolSize: 2,
+      pragmas: { busyTimeoutMs: 5_000, synchronous: "NORMAL" },
+    });
+    db.withWriteTransaction((conn) => {
+      conn
+        .prepare(
+          `INSERT INTO users (id, email, display_name, role, password_hash, is_local_only, last_login_at, created_at, updated_at, deleted_at)
+           VALUES (?, ?, ?, ?, NULL, 1, NULL, ?, ?, NULL)`,
+        )
+        .run(OWNER_ID, "admin@friday.dev", "Admin", "admin", NOW, NOW);
+    });
+
+    const authService = createFridayAuthService({
+      db,
+      idGenerator: (() => {
+        let n = 0;
+        return () => `id-${String(++n).padStart(4, "0")}`;
+      })(),
+      nowIso: () => new Date().toISOString(),
+      tokenSecret: TOKEN_SECRET,
+      accessTokenTtlSec: 900,
+      refreshTokenTtlSec: 604_800,
+      hubId: "s5-http-hub",
+      bootstrapNonceTtlSec: 300,
+      warn: () => {},
+    });
+
+    // Establish the real passphrase owner credential + mint a real owner bearer.
+    authService.bootstrapLocalPassphrase({ passphrase: PASSPHRASE }, "127.0.0.1");
+    ownerBearer = authService.login({ localPassphrase: PASSPHRASE }, "127.0.0.1").accessToken;
+
+    // REAL auth middleware stack: token validator (same secret) + rate limiter +
+    // the enforcement floors that the http-server consults.
+    const tokenValidator = createFridayTokenValidator({
+      tokenSecret: TOKEN_SECRET,
+      nowMs: () => Date.now(),
+      lookupTokenRevocation: () => false,
+    });
+    const rateLimitService = createFridayRateLimitService({
+      db,
+      nowIso: () => new Date().toISOString(),
+      policyOverrides: { "auth.login": { maxHits: 1000, windowMs: 60_000 } },
+    });
+    const middleware = createFridayAuthMiddlewareFactory({ tokenValidator, rateLimitService });
+
+    const routes = createFridayHttpRouteRegistry();
+    for (const route of createFridayAuthRoutes({ authService })) routes.register(route);
+
+    const port = await findEphemeralPortAbove(49152);
+    baseUrl = `http://127.0.0.1:${port}`;
+    server = createFridayHttpServer({
+      routes,
+      wsGateway: makeStubWsGateway(),
+      middleware,
+      port,
+      host: "127.0.0.1",
+      logRequests: false,
+    });
+    await server.listen();
+  });
+
+  afterEach(async () => {
+    if (server) await server.close();
+    server = null;
+    db.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    process.env.NODE_ENV = savedNodeEnv;
+  });
+
+  async function post(pathname: string, body: unknown, bearer?: string): Promise<{ status: number; json: any }> {
+    const headers: Record<string, string> = { "content-type": "application/json", origin: ORIGIN };
+    if (bearer) headers.authorization = `Bearer ${bearer}`;
+    const res = await fetch(`${baseUrl}${pathname}`, { method: "POST", headers, body: JSON.stringify(body) });
+    let json: any = null;
+    try {
+      json = await res.json();
+    } catch {
+      json = null;
+    }
+    return { status: res.status, json };
+  }
+
+  function ownerHash(): string | null {
+    return db.withReadConnection((conn) => {
+      const row = conn.prepare("SELECT password_hash AS h FROM users WHERE id = ?").get(OWNER_ID) as
+        | { h: string | null }
+        | undefined;
+      return row?.h ?? null;
+    });
+  }
+
+  function bindingCount(): number {
+    return db.withReadConnection((conn) => {
+      const row = conn
+        .prepare("SELECT COUNT(*) AS c FROM friday_device_owner_bindings WHERE user_id = ?")
+        .get(OWNER_ID) as { c: number };
+      return row.c;
+    });
+  }
+
+  async function issueMigrationNonce(bearer: string): Promise<string> {
+    const r = await post("/v1/auth/migrate/challenge", { installId: "install-s5", osUser: "jarvis", origin: ORIGIN }, bearer);
+    expect(r.status).toBe(200);
+    return r.json.data.nonce as string;
+  }
+
+  function migrateBody(nonce: string) {
+    const transcript = makeTranscript(DEVICE_KEY, { nonce, origin: ORIGIN, deviceId: DEVICE_ID, action: "owner-migrate", installId: "install-s5", osUser: "jarvis" });
+    return {
+      nonce,
+      devicePublicKey: DEVICE_PUBKEY,
+      deviceId: DEVICE_ID,
+      origin: ORIGIN,
+      installId: "install-s5",
+      osUser: "jarvis",
+      deviceClaimProof: { transcript, signature: { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(DEVICE_KEY, transcript) } },
+    };
+  }
+
+  it("A: unauthenticated migrate/device-claim → 401 (bound-principal floor); no binding, hash unchanged", async () => {
+    const before = ownerHash();
+    const r = await post("/v1/auth/migrate/device-claim", migrateBody("any-nonce"));
+    expect(r.status).toBe(401);
+    expect(bindingCount()).toBe(0);
+    expect(ownerHash()).toBe(before);
+  });
+
+  it("A: unauthenticated migrate/challenge → 401 (bound-principal floor)", async () => {
+    const r = await post("/v1/auth/migrate/challenge", { installId: "install-s5", osUser: "jarvis", origin: ORIGIN });
+    expect(r.status).toBe(401);
+  });
+
+  it("B: authenticated OWNER → provisional migration; passphrase STILL works; hash stays scrypt; zero device authority", async () => {
+    const before = ownerHash();
+    expect(before?.startsWith("scrypt$")).toBe(true);
+
+    const nonce = await issueMigrationNonce(ownerBearer);
+    const claim = await post("/v1/auth/migrate/device-claim", migrateBody(nonce), ownerBearer);
+    expect(claim.status).toBe(200);
+    expect(claim.json.data.migrated).toBe(true);
+    expect(claim.json.data.state).toBe("provisional");
+    expect(claim.json.data.passphraseStillActive).toBe(true);
+    expect(claim.json.data.deviceAuthorityEnabled).toBe(false);
+    expect(claim.json.data.keyProtection).toBe("unverified");
+    expect(claim.json.data.devicePublicKeyHash).toBe(sha256Hex(DEVICE_PUBKEY));
+
+    // DUAL-READ: password_hash UNCHANGED (still scrypt); exactly one provisional binding.
+    expect(ownerHash()).toBe(before);
+    expect(bindingCount()).toBe(1);
+
+    // NO-LOCKOUT: passphrase login STILL works over the real HTTP login route.
+    const login = await post("/v1/auth/login", { localPassphrase: PASSPHRASE });
+    expect(login.status).toBe(200);
+    expect(login.json.data.user.id).toBe(OWNER_ID);
+  });
+
+  it("C: authenticated NON-owner (viewer authority) bearer → 403 (authority gate); no binding", async () => {
+    const nowSec = Math.floor(Date.now() / 1000);
+    const viewerClaims: FridayAccessTokenClaims = {
+      tokenId: "tok-viewer-0001",
+      principalType: "user",
+      principalId: "user:viewer",
+      tenantId: "user:viewer",
+      userId: "user:viewer",
+      role: "viewer",
+      scopes: [...getScopesForRole("viewer")] as FridayScope[],
+      iat: nowSec,
+      exp: nowSec + 900,
+    };
+    const viewerBearer = encodeToken(viewerClaims, TOKEN_SECRET);
+
+    const r = await post("/v1/auth/migrate/challenge", { installId: "install-s5", osUser: "jarvis", origin: ORIGIN }, viewerBearer);
+    expect(r.status).toBe(403);
+    expect(bindingCount()).toBe(0);
+  });
+});

--- a/test/unit/api/http/routes/friday-auth-routes.test.ts
+++ b/test/unit/api/http/routes/friday-auth-routes.test.ts
@@ -70,8 +70,8 @@ describe("FridayAuthRoutes", () => {
 
   // ─── Route registration ───
 
-  it("registers 8 auth routes", () => {
-    expect(routes).toHaveLength(8);
+  it("registers 10 auth routes", () => {
+    expect(routes).toHaveLength(10);
   });
 
   it("has correct operation IDs", () => {
@@ -80,6 +80,9 @@ describe("FridayAuthRoutes", () => {
     expect(opIds).toContain("auth.bootstrap.local.passphrase");
     expect(opIds).toContain("auth.bootstrap.challenge");
     expect(opIds).toContain("auth.bootstrap.device.claim");
+    // SEC-SETUP-BOOTSTRAP-001 Slice 5: authenticated migration endpoints.
+    expect(opIds).toContain("auth.migrate.challenge");
+    expect(opIds).toContain("auth.migrate.device.claim");
     expect(opIds).toContain("auth.login");
     expect(opIds).toContain("auth.refresh");
     expect(opIds).toContain("auth.logout");


### PR DESCRIPTION
## SEC-SETUP-BOOTSTRAP-001 · Slice 5 — authenticated legacy-passphrase → device migration (additive, dual-read, reversible) + INACTIVE tombstone/rollback scaffolding

**Status: requirement NOT marked passed.** This is **stage 2** of the operator-locked FIXED order (1 native path → **2 authenticated existing-user migration** → 3 device readback → 4 restart proof → 5 tombstone → 6 disable legacy login → 7 remove passphrase UI/API). It is **additive only** — it removes/disables nothing and **cannot lock anyone out**. The passphrase remains the working owner credential throughout; the device principal still carries **zero authority**; and the tombstone/sentinel flip is built but **INACTIVE**.

### What this adds

**Migration `v104` (additive; the whole pass runs under one `BEGIN IMMEDIATE` txn — no writer races):**
- Widens the install-nonce ledger `kind` CHECK to accept a new `device_migration_claim` value (atomic table rebuild — **all rows + all three single-use indexes preserved verbatim**; only the CHECK is widened to a superset). No `users` column altered; v103 not renumbered.
- New `friday_device_owner_bindings` — the durable dual-read owner↔device record. Partial `UNIQUE(user_id) WHERE state='active'`.
- New `friday_credential_tombstones` — **INACTIVE** stage-5 scaffolding (stores NO secret/hash; no live path writes it this slice).

**New authenticated endpoints** (`public:true`, **NOT** `allowUnauthenticatedMutation`):
- `POST /v1/auth/migrate/challenge` (`auth.migrate.challenge`) — mints a single-use `device_migration_claim` nonce the device signs.
- `POST /v1/auth/migrate/device-claim` (`auth.migrate.device.claim`) — the authenticated dual-read migration.
- Because the routes are not `allowUnauthenticatedMutation`, the http-server **L1 public-mutation floor refuses the synthetic public principal (401)** — a real OWNER bearer is required. The handler additionally enforces owner authority via `assertBoundPrincipalAuthorityForOperation`, and the auth **service** binds the principal to the local owner (`principalId === localUser.id`, role admin/owner). The **authenticated passphrase-login session IS the proof-of-passphrase-possession** — the passphrase is never re-typed into a body, and Origin/UA/bundle-string are never trusted for identity. Rate-limited under `auth.login`; loopback-only; origin-bound.

### Migration-flow behaviors (all fail-closed)
- **Device PoP first**: the device proves PRIVATE-key possession by signing the canonical transcript over the server nonce, verified by the merged S2a seam **before** any nonce consume / binding. Crypto is never re-implemented here.
- **CAS from a KNOWN passphrase-owner hash only**: `scrypt$…` / legacy-sha256. Refuses NULL (first-boot — never reuses the bootstrap leg) and the `device-owner$v1$…` sentinel (already migrated).
- **Dual-read provisional bind in ONE txn**: CAS-consume the `device_migration_claim` nonce → re-assert the observed legacy hash is unchanged (a concurrent rotation/re-bootstrap aborts with zero state change) → insert a `state='provisional'` binding. **`users.password_hash` is NEVER written** — the passphrase stays authoritative (**no lockout**).
- **Zero authority**: response `deviceAuthorityEnabled=false`, `keyProtection='unverified'`; the disabled device principal remains refused at L1/L2/L3 (S3 seam unchanged).
- **Distinct kind** blocks cross-replay: a first-boot `install_owner_claim` nonce cannot be spent on migration, and vice-versa (consume CAS matches on `kind`).
- **Tombstone/rollback scaffolding is INACTIVE**: `activateBinding` / `revokeBinding` / `insertCredentialTombstone` / `findActiveTombstone` exist and are typed but **no live path calls them**; `password_hash` is never flipped to the sentinel this slice.

### Red-first evidence (red → green → revert-red)
Each guard I authored was verified by disabling it, watching the matching test go RED, then reverting to green:
- **No-lockout / hash-untouched** — injected the forbidden live sentinel flip → happy-path `afterHash === beforeHash` went RED (hash became `device-owner$v1$…`).
- **Authenticated-owner gate** — disabled `assertAuthenticatedLocalOwner` → all four refusals (synthetic public 401, null 401, wrong-identity 403, wrong-role 403) went RED.
- **Known-passphrase source gate** — forced `isKnownPassphraseOwnerHash` true → NULL-slot (first-boot) and already-device-owned refusals (409) went RED.
- **Device PoP gate** — bypassed the `pop.ok` rejection → the wrong-key claim went RED.
- Replay / expiry / cross-origin are enforced at the shared `consumeOwnerClaimNonce` DB CAS (carried from the proven Slice-1 suite); crash-atomicity and concurrent owner-change are covered by injected-fault tests.

### Tests (real hub route → service → DB, production posture)
- `test/adversarial/setup-authenticated-migration.test.ts` — 17 service-level tests against real file-backed SQLite (real migrations incl. v104, real WAL, real scrypt credential, real PoP/CAS): happy path (provisional bind + **passphrase login still works after** + hash stays scrypt + zero authority + no tombstone), all refusals, replay/expiry/cross-origin/cross-kind, loopback-only, crash-atomicity, concurrent owner-change, no-degrade regression.
- `test/integration/api/friday-secsetup-s5-migration-http-proof.test.ts` — 4 tests over **real HTTP + real auth middleware** (token validator + rate limiter + enforcement floors) in `NODE_ENV=production`: unauthenticated → 401, authenticated owner → provisional (passphrase login still 200 afterwards), non-owner (viewer) → 403.

### No-degrade
The passphrase bootstrap + login path and every shipped negative control are fully intact (regression asserted). Broad regression of the auth/bootstrap/migration/secsetup suites is green; the pre-existing device-claim / S2a / S3 negatives are unchanged. Nothing skipped or weakened.

### Verification
`npx tsc --noEmit` = 0 · `eslint .` = 0 errors · `detect-secrets-hook --baseline .secrets.baseline` clean (test tokens use `// pragma: allowlist secret`; baseline re-added for line-number drift) · S5 tests + broad auth/bootstrap/migration regression green · route-contract snapshot regenerated (routes classified `bound_principal`; count 429→431) · `context/MEMORY.md` migration count updated 103→104.

Deployment restart required: Rust services must be restarted after additive SQLite migration v104 (device-migration-state binding + `friday_device_owner_bindings` + INACTIVE `friday_credential_tombstones`; widened install-nonce `kind` CHECK) lands, so the shared-SQLite readers apply the new schema before the migration routes are exercised in production. Concrete sequence: redeploy the freshly built hub, then kickstart the launchd job with `launchctl kickstart -k gui/$(id -u)/com.friday.hub`, then verify /healthz is up and the migration runner reports version 104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48

