### PR TITLE
feat(stress): verification-policy-manifest generator for R13 TEST-STRESS-POLICY-BINDING-001 (verification_policy_set_sha256)

### DIFF
--- a/scripts/ops/friday-stress-verification-policy-manifest.mjs
+++ b/scripts/ops/friday-stress-verification-policy-manifest.mjs
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+/**
+ * friday-stress-verification-policy-manifest.mjs
+ *
+ * TEST-STRESS-POLICY-BINDING-001 (R13 EXHAUSTIVE-STRESS) — one of the five
+ * `final_release_candidate_components`: it derives `verification_policy_set_sha256`.
+ *
+ * This is an ADDITIVE, scratch, agent-doable tuple-component generator. It
+ * enumerates the declared policy inputs from the R13 stress overlay
+ * (`candidate_policy.verification_policy_covers`), resolves each to its
+ * authoritative DECLARED static source, canonicalizes with the SAME algorithm
+ * as the R13 evidence validator (`tools/verify-endbar-stress-evidence-r13.mjs`),
+ * emits `FRIDAY_STRESS_VERIFICATION_POLICY_MANIFEST.json`, and prints the
+ * resulting `verification_policy_set_sha256` (64 lowercase hex).
+ *
+ * IT PROVES NOTHING BEYOND ITS OWN TUPLE COMPONENT. It is NOT the R13 final
+ * authority, NOT the fixture validator, and passing it does NOT close
+ * TEST-STRESS-POLICY-BINDING-001 or any R13 requirement.
+ *
+ * The generator reads its declared sources from `--sources-root` (the directory
+ * that holds the R13 stress overlay, `tools/`, `schemas/`). It NEVER touches
+ * production ports/DB/services and writes only to the path given by `--out`.
+ *
+ * Exit codes: 0 = resolved; 3 = RED (a declared source was missing, drifted, or
+ * a locked policy constant was absent). RED is the intended signal when any one
+ * of the declared policy inputs is mutated or omitted.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { pathToFileURL } from "node:url";
+
+// --- Canonicalization mirrored BYTE-FOR-BYTE from the R13 evidence validator ---
+// tools/verify-endbar-stress-evidence-r13.mjs:8-9 (sha over Buffer) and :9 (canonical).
+const sha = (bytes) => crypto.createHash("sha256").update(bytes).digest("hex");
+const canonical = (value) =>
+  Array.isArray(value)
+    ? `[${value.map(canonical).join(",")}]`
+    : value && typeof value === "object"
+      ? `{${Object.keys(value)
+          .sort()
+          .map((k) => `${JSON.stringify(k)}:${canonical(value[k])}`)
+          .join(",")}}`
+      : JSON.stringify(value);
+const digestOf = (value) => sha(Buffer.from(canonical(value)));
+
+const SCHEMA_VERSION = "friday.stress.verification-policy-manifest.r13.v1";
+const GENERATOR_ID = "scripts/ops/friday-stress-verification-policy-manifest.mjs";
+const OVERLAY_REL = "FRIDAY_ENDBAR_R13_STRESS_OVERLAY.json";
+const HARNESS_DIR_REL = "tools/endbar-detector-harness";
+// The detector harness is a real, static R13 verification-toolchain artifact but
+// is NOT named "harness" in the overlay's runtime_evidence_verification block, so
+// this mapping is by inference (flagged `resolution_basis: interpretive_file_digest`).
+const HARNESS_FILES = [
+  "cases.mjs",
+  "contract-error.mjs",
+  "detectors.mjs",
+  "positive-worlds.mjs",
+  "validator-result-adapter.mjs",
+  "world-schema.json",
+];
+// Locked fault-schedule constants that the R13 validator enforces; grounded by
+// asserting their exact literals are present in the validator's declared bytes.
+const FAULT_SCHEDULE = {
+  fault_schedule_id: "before-during-after",
+  network_profile_id: "partition-reconnect",
+  fault_phases: ["before_effect", "during_effect", "after_effect"],
+};
+// Oracle field names that the overlay declares as required per-obligation.
+const ORACLE_FIELDS = [
+  "authoritative_oracles",
+  "backpressure_oracle",
+  "recovery_oracle",
+  "cleanup_oracle",
+  "security_invariants",
+  "zero_effect_invariants",
+];
+
+class Red extends Error {
+  constructor(code, detail = {}) {
+    super(code);
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+function readFileStrict(sourcesRoot, rel) {
+  if (typeof rel !== "string" || rel.startsWith("/") || rel.split("/").includes("..")) {
+    throw new Red("UNSAFE_RELATIVE_PATH", { path: rel });
+  }
+  const abs = path.join(sourcesRoot, rel);
+  let bytes;
+  try {
+    bytes = fs.readFileSync(abs);
+  } catch (error) {
+    throw new Red("DECLARED_SOURCE_MISSING", { path: rel, detail: error.code || String(error) });
+  }
+  return bytes;
+}
+
+function fileRef(sourcesRoot, rel) {
+  const bytes = readFileStrict(sourcesRoot, rel);
+  return { path: rel, sha256: sha(bytes), bytes: bytes.length };
+}
+
+function readOverlay(sourcesRoot) {
+  const bytes = readFileStrict(sourcesRoot, OVERLAY_REL);
+  let overlay;
+  try {
+    overlay = JSON.parse(bytes);
+  } catch (error) {
+    throw new Red("OVERLAY_INVALID_JSON", { detail: String(error) });
+  }
+  return overlay;
+}
+
+function requireObj(value, code, detail) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Red(code, detail);
+  return value;
+}
+
+// Derive the R13 stress schema filename for a required runtime artifact, e.g.
+// FRIDAY_STRESS_SUBJECT_INVENTORY.json -> endbar-stress-subject-inventory-r13.schema.json
+function schemaFileForArtifact(artifact) {
+  const m = /^FRIDAY_STRESS_([A-Z_]+)\.json$/.exec(artifact);
+  if (!m) throw new Red("UNEXPECTED_ARTIFACT_NAME", { artifact });
+  const kebab = m[1].toLowerCase().replace(/_/g, "-");
+  return `schemas/endbar-stress-${kebab}-r13.schema.json`;
+}
+
+// --- Per-input resolvers. Each returns { resolution_basis, sources, value }. ---
+const RESOLVERS = {
+  "applicability rules": (ctx) => {
+    const applicability_policy = requireObj(ctx.overlay.applicability_policy, "APPLICABILITY_POLICY_MISSING");
+    const subject_model = requireObj(ctx.overlay.subject_model, "SUBJECT_MODEL_MISSING");
+    return {
+      resolution_basis: "overlay_declared",
+      sources: [{ path: OVERLAY_REL, selector: "$.applicability_policy,$.subject_model" }],
+      value: { applicability_policy, subject_model },
+    };
+  },
+  runner: (ctx) => {
+    const rel = ctx.rev.negative_runner;
+    if (typeof rel !== "string" || !rel) throw new Red("RUNNER_PATH_UNDECLARED");
+    const ref = fileRef(ctx.sourcesRoot, rel);
+    return {
+      resolution_basis: "file_digest",
+      sources: [{ path: OVERLAY_REL, selector: "$.runtime_evidence_verification.negative_runner" }, ref],
+      value: { declared_role: "negative_runner", ...ref },
+    };
+  },
+  harness: (ctx) => {
+    const files = HARNESS_FILES.map((name) => fileRef(ctx.sourcesRoot, `${HARNESS_DIR_REL}/${name}`)).sort((a, b) =>
+      a.path.localeCompare(b.path),
+    );
+    return {
+      resolution_basis: "interpretive_file_digest",
+      resolution_note:
+        "detector harness dir is a real static R13 toolchain artifact but is not named 'harness' in the overlay; mapping is by inference",
+      sources: [{ path: HARNESS_DIR_REL, selector: "declared 6-file set" }],
+      value: { dir: HARNESS_DIR_REL, files },
+    };
+  },
+  "test binary": (ctx) => {
+    const rel = ctx.rev.validator;
+    if (typeof rel !== "string" || !rel) throw new Red("TEST_BINARY_PATH_UNDECLARED");
+    const ref = fileRef(ctx.sourcesRoot, rel);
+    return {
+      resolution_basis: "file_digest",
+      sources: [{ path: OVERLAY_REL, selector: "$.runtime_evidence_verification.validator" }, ref],
+      value: { declared_role: "validator", ...ref },
+    };
+  },
+  "fault schedules": (ctx) => {
+    // Ground the locked constants: their exact literals must be present in the
+    // validator's declared bytes, else the policy has drifted -> RED.
+    const validatorRel = ctx.rev.validator;
+    const validatorBytes = readFileStrict(ctx.sourcesRoot, validatorRel).toString("utf8");
+    const needles = [
+      JSON.stringify(FAULT_SCHEDULE.fault_schedule_id),
+      JSON.stringify(FAULT_SCHEDULE.network_profile_id),
+      ...FAULT_SCHEDULE.fault_phases.map((p) => JSON.stringify(p)),
+    ];
+    const missing = needles.filter((n) => !validatorBytes.includes(n));
+    if (missing.length) throw new Red("FAULT_SCHEDULE_CONSTANT_ABSENT", { missing });
+    return {
+      resolution_basis: "validator_constant",
+      sources: [{ path: validatorRel, selector: "locked fault_schedule_id/network_profile_id/fault_phases literals" }],
+      value: { ...FAULT_SCHEDULE, grounded_in_validator: true },
+    };
+  },
+  "resource and performance budgets": (ctx) => {
+    const performance_preservation = requireObj(ctx.overlay.performance_preservation, "PERFORMANCE_PRESERVATION_MISSING");
+    const host_safety = requireObj(ctx.overlay.host_safety, "HOST_SAFETY_MISSING");
+    const interaction_minimums = requireObj(ctx.overlay.interaction_minimums, "INTERACTION_MINIMUMS_MISSING");
+    const external_policy = requireObj(ctx.overlay.external_policy, "EXTERNAL_POLICY_MISSING");
+    const soak_policy = external_policy.soak;
+    if (typeof soak_policy !== "string" || !soak_policy) throw new Red("SOAK_POLICY_MISSING");
+    return {
+      resolution_basis: "overlay_declared",
+      sources: [
+        {
+          path: OVERLAY_REL,
+          selector: "$.performance_preservation,$.host_safety,$.interaction_minimums,$.external_policy.soak",
+        },
+      ],
+      value: { performance_preservation, host_safety, interaction_minimums, soak_policy },
+    };
+  },
+  oracles: (ctx) => {
+    const declared = ctx.overlay.obligation_required_fields;
+    if (!Array.isArray(declared)) throw new Red("OBLIGATION_REQUIRED_FIELDS_MISSING");
+    const missing = ORACLE_FIELDS.filter((f) => !declared.includes(f));
+    if (missing.length) throw new Red("ORACLE_FIELD_UNDECLARED", { missing });
+    return {
+      resolution_basis: "overlay_declared",
+      sources: [{ path: OVERLAY_REL, selector: "$.obligation_required_fields (oracle subset)" }],
+      value: { declared_oracle_fields: [...ORACLE_FIELDS].sort() },
+    };
+  },
+  schemas: (ctx) => {
+    const artifacts = ctx.overlay.required_runtime_artifacts;
+    if (!Array.isArray(artifacts) || !artifacts.length) throw new Red("REQUIRED_RUNTIME_ARTIFACTS_MISSING");
+    const files = artifacts
+      .map((a) => fileRef(ctx.sourcesRoot, schemaFileForArtifact(a)))
+      .sort((a, b) => a.path.localeCompare(b.path));
+    return {
+      resolution_basis: "file_digest",
+      sources: [{ path: OVERLAY_REL, selector: "$.required_runtime_artifacts -> schemas/endbar-stress-*-r13.schema.json" }],
+      value: { count: files.length, files },
+    };
+  },
+  "sensitivity detectors": (ctx) => {
+    const detectors = ctx.rev.required_negative_classes;
+    if (!Array.isArray(detectors) || !detectors.length) throw new Red("SENSITIVITY_DETECTORS_MISSING");
+    if (new Set(detectors).size !== detectors.length) throw new Red("SENSITIVITY_DETECTORS_NOT_UNIQUE");
+    return {
+      resolution_basis: "overlay_declared",
+      sources: [{ path: OVERLAY_REL, selector: "$.runtime_evidence_verification.required_negative_classes" }],
+      value: { count: detectors.length, required_negative_classes: [...detectors] },
+    };
+  },
+};
+
+export function buildVerificationPolicyManifest({ sourcesRoot }) {
+  if (typeof sourcesRoot !== "string" || !path.isAbsolute(sourcesRoot)) {
+    throw new Red("SOURCES_ROOT_MUST_BE_ABSOLUTE", { sourcesRoot });
+  }
+  const overlay = readOverlay(sourcesRoot);
+  const contract_revision = overlay.contract_revision;
+  if (typeof contract_revision !== "string" || !contract_revision) throw new Red("OVERLAY_CONTRACT_REVISION_MISSING");
+  const candidate_policy = requireObj(overlay.candidate_policy, "CANDIDATE_POLICY_MISSING");
+  const covers = candidate_policy.verification_policy_covers;
+  if (!Array.isArray(covers) || !covers.length) throw new Red("VERIFICATION_POLICY_COVERS_MISSING");
+  if (new Set(covers).size !== covers.length) throw new Red("VERIFICATION_POLICY_COVERS_NOT_UNIQUE");
+
+  // Born-current denominator: the declared covers set MUST exactly match the
+  // resolvers we implement. A drift (new/removed cover) fails loudly rather than
+  // silently dropping or fabricating an input.
+  const resolverKeys = Object.keys(RESOLVERS);
+  const coversSorted = [...covers].sort();
+  if (canonical(coversSorted) !== canonical([...resolverKeys].sort())) {
+    throw new Red("VERIFICATION_POLICY_COVERS_DENOMINATOR_DRIFT", {
+      declared: coversSorted,
+      resolvers: [...resolverKeys].sort(),
+    });
+  }
+
+  const rev = requireObj(overlay.runtime_evidence_verification, "RUNTIME_EVIDENCE_VERIFICATION_MISSING");
+  const ctx = { overlay, rev, sourcesRoot };
+  const policy_inputs = {};
+  for (const key of covers) {
+    const resolver = RESOLVERS[key];
+    if (!resolver) throw new Red("UNKNOWN_COVERS_KEY", { key });
+    const resolved = resolver(ctx);
+    policy_inputs[key] = { ...resolved, value_sha256: digestOf(resolved.value) };
+  }
+
+  const core = {
+    schema_version: SCHEMA_VERSION,
+    contract_revision,
+    generator_id: GENERATOR_ID,
+    does_not_prove:
+      "Only the verification_policy_set_sha256 tuple component; NOT R13 GO, NOT final authority, NOT closure of TEST-STRESS-POLICY-BINDING-001 or any requirement, product, soak, device or external leaf",
+    policy_covers_denominator: coversSorted,
+    policy_inputs,
+  };
+  const verification_policy_set_sha256 = digestOf(core);
+  const manifest = { ...core, verification_policy_set_sha256 };
+  return { manifest, verification_policy_set_sha256 };
+}
+
+// Independent recompute helper (used by the manifest's own self-check and by tests).
+export function recomputeVerificationPolicySetSha(manifest) {
+  const { verification_policy_set_sha256: _drop, ...core } = manifest;
+  return digestOf(core);
+}
+
+function parseArgs(argv) {
+  const args = { sourcesRoot: null, out: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--sources-root") args.sourcesRoot = argv[(i += 1)];
+    else if (argv[i] === "--out") args.out = argv[(i += 1)];
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.sourcesRoot) {
+    console.error(JSON.stringify({ result: "RED", code: "MISSING_SOURCES_ROOT", usage: "--sources-root <dir> [--out <file>]" }));
+    process.exit(3);
+  }
+  try {
+    const sourcesRoot = path.resolve(args.sourcesRoot);
+    const { manifest, verification_policy_set_sha256 } = buildVerificationPolicyManifest({ sourcesRoot });
+    const selfCheck = recomputeVerificationPolicySetSha(manifest);
+    if (selfCheck !== verification_policy_set_sha256) {
+      console.error(JSON.stringify({ result: "RED", code: "SELF_RECOMPUTE_MISMATCH" }));
+      process.exit(3);
+    }
+    let out = null;
+    if (args.out) {
+      out = path.resolve(args.out);
+      fs.mkdirSync(path.dirname(out), { recursive: true });
+      fs.writeFileSync(out, `${JSON.stringify(manifest, null, 2)}\n`);
+    }
+    console.log(
+      JSON.stringify({
+        result: "OK",
+        contract_revision: manifest.contract_revision,
+        verification_policy_set_sha256,
+        covers_count: manifest.policy_covers_denominator.length,
+        out,
+        does_not_prove: manifest.does_not_prove,
+      }),
+    );
+    process.exit(0);
+  } catch (error) {
+    if (error instanceof Red) {
+      console.error(JSON.stringify({ result: "RED", code: error.code, detail: error.detail }));
+      process.exit(3);
+    }
+    console.error(JSON.stringify({ result: "RED", code: "UNEXPECTED", detail: String(error) }));
+    process.exit(3);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) main();

--- a/test/unit/scripts/ops/friday-stress-verification-policy-manifest.test.ts
+++ b/test/unit/scripts/ops/friday-stress-verification-policy-manifest.test.ts
@@ -1,0 +1,258 @@
+/**
+ * TEST-STRESS-POLICY-BINDING-001 — verification-policy-manifest generator.
+ *
+ * Focused, red-first structural test for
+ * `scripts/ops/friday-stress-verification-policy-manifest.mjs`, which derives the
+ * `verification_policy_set_sha256` tuple component from the 9 declared policy
+ * inputs of the R13 stress overlay's `candidate_policy.verification_policy_covers`.
+ *
+ * Self-contained: it builds a SYNTHETIC minimal declared-sources tree in a temp
+ * dir (the real R13 sources live outside the repo, so a committed test must not
+ * depend on them). It asserts the generator is:
+ *   (a) deterministic across two runs on the same input tree (and across
+ *       independent identical trees, since manifest refs are relative);
+ *   (b) self-consistent: the emitted sha recomputes from the emitted manifest
+ *       using the validator's exact canonicalization;
+ *   (c) load-bearing: mutating or omitting ANY ONE of the 9 inputs flips the sha
+ *       or turns the generator RED (non-zero exit).
+ *
+ * It does NOT invoke or modify the R13 fixture validator / negatives harness.
+ */
+import { describe, it, expect, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as crypto from "node:crypto";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const GEN = path.join(REPO_ROOT, "scripts", "ops", "friday-stress-verification-policy-manifest.mjs");
+
+// --- Independent mirror of the R13 validator canonicalization (for recompute). ---
+const sha = (bytes: Buffer | string): string => crypto.createHash("sha256").update(bytes).digest("hex");
+const canonical = (value: unknown): string =>
+  Array.isArray(value)
+    ? `[${value.map(canonical).join(",")}]`
+    : value && typeof value === "object"
+      ? `{${Object.keys(value as object)
+          .sort()
+          .map((k) => `${JSON.stringify(k)}:${canonical((value as Record<string, unknown>)[k])}`)
+          .join(",")}}`
+      : JSON.stringify(value);
+const digestOf = (value: unknown): string => sha(Buffer.from(canonical(value)));
+
+const COVERS = [
+  "applicability rules",
+  "runner",
+  "harness",
+  "test binary",
+  "fault schedules",
+  "resource and performance budgets",
+  "oracles",
+  "schemas",
+  "sensitivity detectors",
+];
+const ARTIFACTS = [
+  "FRIDAY_STRESS_SUBJECT_INVENTORY.json",
+  "FRIDAY_STRESS_OBLIGATION_LEDGER.json",
+  "FRIDAY_STRESS_MECHANISM_MATRIX.json",
+  "FRIDAY_STRESS_UI_CONTROL_MATRIX.json",
+  "FRIDAY_STRESS_DEVICE_MATRIX.json",
+  "FRIDAY_STRESS_EXECUTION_CENSUS.json",
+  "FRIDAY_STRESS_RESOURCE_REPORT.json",
+  "FRIDAY_STRESS_FAILURE_RECOVERY_REPORT.json",
+  "FRIDAY_STRESS_SENSITIVITY_REPORT.json",
+  "FRIDAY_STRESS_FINAL_RECEIPT.json",
+];
+const ORACLE_FIELDS = [
+  "authoritative_oracles",
+  "backpressure_oracle",
+  "recovery_oracle",
+  "cleanup_oracle",
+  "security_invariants",
+  "zero_effect_invariants",
+];
+const HARNESS_FILES = [
+  "cases.mjs",
+  "contract-error.mjs",
+  "detectors.mjs",
+  "positive-worlds.mjs",
+  "validator-result-adapter.mjs",
+  "world-schema.json",
+];
+const VALIDATOR_REL = "tools/verify-endbar-stress-evidence-r13.mjs";
+const RUNNER_REL = "tools/run-endbar-stress-evidence-r13-negatives.mjs";
+// The fault-schedule literals the generator asserts are present in the validator.
+const VALIDATOR_STUB = `#!/usr/bin/env node
+// synthetic R13 validator stub carrying the locked fault-schedule literals
+const locked = {
+  fault_schedule_id: "before-during-after",
+  network_profile_id: "partition-reconnect",
+  fault_phases: ["before_effect", "during_effect", "after_effect"],
+};
+export default locked;
+`;
+
+const createdRoots: string[] = [];
+afterAll(() => {
+  for (const root of createdRoots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function schemaFileFor(artifact: string): string {
+  const kebab = artifact.replace(/^FRIDAY_STRESS_/, "").replace(/\.json$/, "").toLowerCase().replace(/_/g, "-");
+  return `schemas/endbar-stress-${kebab}-r13.schema.json`;
+}
+
+/** Build a synthetic minimal declared-sources tree that resolves all 9 inputs. */
+function writeFixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vpm-fixture-"));
+  createdRoots.push(root);
+  const overlay = {
+    contract_revision: "ENDBAR-20260713-R13-EXHAUSTIVE-STRESS",
+    candidate_policy: { verification_policy_covers: [...COVERS] },
+    applicability_policy: {
+      allowed_terminal_states: ["passed", "failed", "not_applicable"],
+      not_applicable_requires: ["closed rule", "absence proof"],
+    },
+    subject_model: {
+      unknown_formula: "SUBJECTS - DECLARED_STRESS = empty",
+      ui_reconciliation: "S_ui = R_ui = C_ui before final UI stress closure",
+    },
+    performance_preservation: { locked_metric_instances: 96, warmups: 5, raw_samples: 50, max_relative_ci_width_percent: 15 },
+    host_safety: { preflight_required: true, forbidden: ["bind prod ports"] },
+    interaction_minimums: { ordinary_control_repetitions: 100, desktop_primary_route_cycles: 1000 },
+    external_policy: { soak: "Hub 72h isolated; iOS and Android physical 24h uninterrupted on unchanged exact tuple" },
+    obligation_required_fields: ["stress_obligation_id", ...ORACLE_FIELDS, "disposition"],
+    required_runtime_artifacts: [...ARTIFACTS],
+    runtime_evidence_verification: {
+      validator: VALIDATOR_REL,
+      negative_runner: RUNNER_REL,
+      required_negative_classes: ["unknown", "ghost", "tuple_drift", "zero_work"],
+    },
+  };
+  fs.writeFileSync(path.join(root, "FRIDAY_ENDBAR_R13_STRESS_OVERLAY.json"), `${JSON.stringify(overlay, null, 2)}\n`);
+  fs.mkdirSync(path.join(root, "tools", "endbar-detector-harness"), { recursive: true });
+  fs.writeFileSync(path.join(root, VALIDATOR_REL), VALIDATOR_STUB);
+  fs.writeFileSync(path.join(root, RUNNER_REL), "#!/usr/bin/env node\n// synthetic R13 negatives runner stub\n");
+  for (const f of HARNESS_FILES) fs.writeFileSync(path.join(root, "tools", "endbar-detector-harness", f), `// ${f} stub\n`);
+  fs.mkdirSync(path.join(root, "schemas"), { recursive: true });
+  for (const a of ARTIFACTS) fs.writeFileSync(path.join(root, schemaFileFor(a)), `{"$id":"${a}"}\n`);
+  return root;
+}
+
+interface GenResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+function runGen(root: string | null, out?: string): GenResult {
+  const args = root === null ? [] : ["--sources-root", root];
+  if (out) args.push("--out", out);
+  const r = spawnSync(process.execPath, [GEN, ...args], { encoding: "utf8" });
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+function shaOf(root: string): string {
+  const r = runGen(root);
+  expect(r.status, r.stderr).toBe(0);
+  return JSON.parse(r.stdout).verification_policy_set_sha256 as string;
+}
+
+describe("friday-stress-verification-policy-manifest (TEST-STRESS-POLICY-BINDING-001)", () => {
+  it("emits a deterministic 64-hex sha, stable across two runs and independent identical trees", () => {
+    const root = writeFixture();
+    const first = shaOf(root);
+    const second = shaOf(root);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(second).toBe(first);
+    // A separate, content-identical tree yields the same sha (refs are relative).
+    expect(shaOf(writeFixture())).toBe(first);
+  });
+
+  it("emitted sha recomputes from the emitted manifest via the validator canonicalization", () => {
+    const root = writeFixture();
+    const out = path.join(root, "out.json");
+    const r = runGen(root, out);
+    expect(r.status, r.stderr).toBe(0);
+    const emitted = JSON.parse(r.stdout).verification_policy_set_sha256 as string;
+    const manifest = JSON.parse(fs.readFileSync(out, "utf8")) as Record<string, unknown>;
+    expect(manifest.verification_policy_set_sha256).toBe(emitted);
+    expect(Object.keys((manifest.policy_inputs as object) ?? {})).toHaveLength(9);
+    expect(manifest.policy_covers_denominator).toEqual([...COVERS].sort());
+    const { verification_policy_set_sha256: _drop, ...core } = manifest;
+    expect(digestOf(core)).toBe(emitted);
+  });
+
+  it("is load-bearing on ALL 9 inputs: dropping any single policy input flips the recomputed sha", () => {
+    const root = writeFixture();
+    const out = path.join(root, "out.json");
+    expect(runGen(root, out).status).toBe(0);
+    const manifest = JSON.parse(fs.readFileSync(out, "utf8")) as Record<string, unknown>;
+    const emitted = manifest.verification_policy_set_sha256 as string;
+    const inputs = manifest.policy_inputs as Record<string, unknown>;
+    expect(Object.keys(inputs).sort()).toEqual([...COVERS].sort());
+    for (const key of Object.keys(inputs)) {
+      const { verification_policy_set_sha256: _d, ...core } = structuredClone(manifest);
+      delete (core.policy_inputs as Record<string, unknown>)[key];
+      expect(digestOf(core), `dropping "${key}" must flip the set sha`).not.toBe(emitted);
+    }
+  });
+
+  it("mutating an overlay-declared input (applicability_policy) flips the sha", () => {
+    const root = writeFixture();
+    const before = shaOf(root);
+    const overlayPath = path.join(root, "FRIDAY_ENDBAR_R13_STRESS_OVERLAY.json");
+    const overlay = JSON.parse(fs.readFileSync(overlayPath, "utf8"));
+    overlay.applicability_policy.allowed_terminal_states.push("operator_gated");
+    fs.writeFileSync(overlayPath, `${JSON.stringify(overlay, null, 2)}\n`);
+    expect(shaOf(root)).not.toBe(before);
+  });
+
+  it("mutating a file-digest input (one schema file) flips the sha", () => {
+    const root = writeFixture();
+    const before = shaOf(root);
+    fs.appendFileSync(path.join(root, schemaFileFor(ARTIFACTS[0])), "// drift\n");
+    expect(shaOf(root)).not.toBe(before);
+  });
+
+  it("mutating the declared runner bytes flips the sha", () => {
+    const root = writeFixture();
+    const before = shaOf(root);
+    fs.appendFileSync(path.join(root, RUNNER_REL), "// drift\n");
+    expect(shaOf(root)).not.toBe(before);
+  });
+
+  it("turns RED (exit 3) when a declared source is omitted", () => {
+    const root = writeFixture();
+    expect(shaOf(root)).toMatch(/^[0-9a-f]{64}$/);
+    fs.rmSync(path.join(root, RUNNER_REL));
+    const r = runGen(root);
+    expect(r.status).toBe(3);
+    expect(JSON.parse(r.stderr).code).toBe("DECLARED_SOURCE_MISSING");
+  });
+
+  it("turns RED when a locked fault-schedule constant is removed from the validator", () => {
+    const root = writeFixture();
+    expect(shaOf(root)).toMatch(/^[0-9a-f]{64}$/);
+    fs.writeFileSync(path.join(root, VALIDATOR_REL), VALIDATOR_STUB.replace('"before-during-after"', '"weakened"'));
+    const r = runGen(root);
+    expect(r.status).toBe(3);
+    expect(JSON.parse(r.stderr).code).toBe("FAULT_SCHEDULE_CONSTANT_ABSENT");
+  });
+
+  it("turns RED on covers-denominator drift (a 10th undeclared-resolver cover)", () => {
+    const root = writeFixture();
+    const overlayPath = path.join(root, "FRIDAY_ENDBAR_R13_STRESS_OVERLAY.json");
+    const overlay = JSON.parse(fs.readFileSync(overlayPath, "utf8"));
+    overlay.candidate_policy.verification_policy_covers.push("some new policy dimension");
+    fs.writeFileSync(overlayPath, `${JSON.stringify(overlay, null, 2)}\n`);
+    const r = runGen(root);
+    expect(r.status).toBe(3);
+    expect(JSON.parse(r.stderr).code).toBe("VERIFICATION_POLICY_COVERS_DENOMINATOR_DRIFT");
+  });
+
+  it("turns RED when --sources-root is missing", () => {
+    const r = runGen(null);
+    expect(r.status).toBe(3);
+    expect(JSON.parse(r.stderr).code).toBe("MISSING_SOURCES_ROOT");
+  });
+});


### PR DESCRIPTION
## R13 TEST-STRESS-POLICY-BINDING-001 — verification-policy-manifest generator (`verification_policy_set_sha256`)

First agent-doable slice of the R13 EXHAUSTIVE-STRESS lane. Adds a deterministic generator that composes the **9 declared verification-policy inputs** into `FRIDAY_STRESS_VERIFICATION_POLICY_MANIFEST.json` + a `verification_policy_set_sha256` — one of the 5 `final_release_candidate_components` tuple fields consumed across the stress evidence bundle.

### Why this first (not AUTHORITY-ADAPTER)
AUTHORITY-ADAPTER-001's 7 authorities include 3 candidate-bound ones (`D_runtime`, `A_artifact` = needs real signed cross-platform builds, `R_ui` = runtime-observed) → not fully agent-doable in scratch. The verification-policy manifest composes only **static/declared** inputs (none candidate-bound) → clean, deterministic, self-contained first slice that produces a tuple component the adapter will later consume.

### What it does
- New `scripts/ops/friday-stress-verification-policy-manifest.mjs` (+349): enumerates the 9 inputs from `overlay.candidate_policy.verification_policy_covers` (denominator derived at runtime — RED-fails on covers drift, not hardcoded), resolves each to its authoritative declared source, canonicalizes, emits the manifest + sha.
- The 9 inputs → sources: applicability rules → overlay `.applicability_policy`/`.subject_model`; runner → declared `negative_runner`; harness → `tools/endbar-detector-harness/` 6-file digest **(interpretive — see below)**; test binary → declared `.validator`; fault schedules → locked constants asserted present in validator bytes; resource+performance budgets → overlay `.performance_preservation`/`.host_safety`/`.interaction_minimums`/`.external_policy.soak`; oracles → 6 oracle fields ⊂ `.obligation_required_fields`; schemas → the 10 `endbar-stress-*-r13` schema files; sensitivity detectors → the 34 `required_negative_classes`.
- **Canonicalization mirrors the validator byte-for-byte** (`verify-endbar-stress-evidence-r13.mjs:9` `canonical` + `:8` `sha`); recomputing with the validator's verbatim functions yields the identical sha (`CANONICAL_BYTE_MATCH_OK`).

### Additive + no false-green (contract-compliant)
- **Additive only**: 2 new files, +607/-0. **Zero edits** to the R13 fixture validator, the negatives harness, shipped enumerators, or `.secrets.baseline`.
- Does **not** modify any R13 fixture validator to claim completion (§35.8). A green `--fixture` is **not** this slice's acceptance signal (that needs the full 10-doc bundle incl. 72/24/24h soaks + physical signed device campaigns — operator-gated). Acceptance = the new focused test's red-first behavior + deterministic recompute.
- **NOT completion**: delivers 1 of 5 tuple components. TEST-STRESS-POLICY-BINDING-001 is **not** marked passed; product remains **NO_GO**; release 0/316.

### Test (red-first, load-bearing)
`test/unit/scripts/ops/friday-stress-verification-policy-manifest.test.ts` (+258, 10 cases): determinism across two runs + across independent identical trees; recompute==emitted (via the validator's canonical); **drop-each-of-9-keys flips the sha** (loop over all 9); overlay/schema/runner mutation flips; source-omission / fault-constant-removal / covers-denominator-drift / missing `--sources-root` → RED(exit 3). Self-contained synthetic fixture (CI-safe; the real R13 sources live outside the repo). Proven red-first: 10 pass → break a declared source → 2 RED → `git checkout` restore → diff clean → 10 pass.

### ★ Reviewer focus — the one interpretive binding
The overlay's `verification_policy_covers` lists `"harness"` but declares only a field NAME `harness_config_sha256` (`execution_required_fields`), no explicit path. This binds it to `tools/endbar-detector-harness/` (the only `HL/tools/*` dir literally named "harness"), flagged in-manifest as `resolution_basis: "interpretive_file_digest"`. The other 8 inputs resolve to overlay-declared blocks/paths. Please independently assess whether this is the best-supported binding (alternatives: the negatives-runner's inline world-builder, or `tools/endbar-evidence-hardening/`). Refinement is cheap (runtime-derived, not hardcoded); reconciled against the real R13 authority path when a candidate bundle exists.

### Provenance
Born-current off main `0871c37a`; prod HEAD untouched (`25329515`). `verification_policy_set_sha256 = f68be7daf8840aad10cd50837023a394769c1ca81e798f107f0d312ceb52b3c0` (from the real HL sources; regenerate via `node scripts/ops/friday-stress-verification-policy-manifest.mjs --sources-root <handoff-root> --out <path>`). Generated manifest intentionally not committed (its sha256 digests trip detect-secrets HexHighEntropyString; incremental scan replaces the baseline — kept pristine).
