### PR TITLE
feat(secsetup): harden Stage 3 device-readback — domain-separate action, clamp TTL, graceful 409

### DIFF
--- a/src/api/auth/friday-auth-service.ts
+++ b/src/api/auth/friday-auth-service.ts
@@ -131,6 +131,26 @@ function isSqliteConstraintError(error: unknown): boolean {
   return typeof code === "string" && code.startsWith("SQLITE_CONSTRAINT");
 }
 
+// ─── SEC-SETUP-BOOTSTRAP-001 · Stage 3+4 device-readback hardening follow-ups ───
+
+/**
+ * The canonical transcript `action` a device-readback proof MUST be minted for.
+ * Domain-separates readback from the other PoP legs (owner-claim / owner-migrate):
+ * because `action` is bound INTO the signed transcript bytes, a proof minted for a
+ * DIFFERENT intent — even one that happens to share the readback
+ * nonce/origin/deviceId — can NEVER be replayed to activate a device binding.
+ */
+const READBACK_TRANSCRIPT_ACTION = "owner-readback";
+
+/**
+ * Server-side maximum accepted transcript TTL for a device readback (aligned with
+ * the 300s bootstrap-nonce TTL). The transcript's own `expiresAt` is the freshness
+ * signal, but the PoP verifier imposes NO upper bound — so a client could mint a
+ * far-future transcript once and replay it indefinitely. Clamp the accepted window
+ * so a readback proof is short-lived by construction.
+ */
+const READBACK_MAX_TRANSCRIPT_TTL_MS = 5 * 60 * 1000;
+
 function isLocalhostAddress(addr?: string): boolean {
   return isFridayLoopbackAddress(addr);
 }
@@ -732,6 +752,16 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
           { httpStatus: 401 },
         );
       }
+      // Reverse cross-intent guard: a proof minted FOR device readback
+      // ("owner-readback") must NEVER be replayed into the owner-claim leg. NEGATIVE
+      // guard only — any existing non-canonical claim action still passes.
+      if (proof.transcript.action === READBACK_TRANSCRIPT_ACTION) {
+        throw new FridayDomainError(
+          "AUTH_BOOTSTRAP_POP_INVALID",
+          "Proof-of-possession transcript was minted for device readback, not owner-claim.",
+          { httpStatus: 401 },
+        );
+      }
       const pop = ownerClaimPoPVerifier.verifyPossession({
         transcript: proof.transcript,
         devicePublicKey: { encoding: "spki-der-base64", value: devicePublicKey },
@@ -986,6 +1016,16 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
           { httpStatus: 401 },
         );
       }
+      // Reverse cross-intent guard: a proof minted FOR device readback
+      // ("owner-readback") must NEVER be replayed into the migration leg. NEGATIVE
+      // guard only — any existing non-canonical migration action still passes.
+      if (proof.transcript.action === READBACK_TRANSCRIPT_ACTION) {
+        throw new FridayDomainError(
+          "AUTH_MIGRATE_POP_INVALID",
+          "Proof-of-possession transcript was minted for device readback, not migration.",
+          { httpStatus: 401 },
+        );
+      }
       const pop = ownerClaimPoPVerifier.verifyPossession({
         transcript: proof.transcript,
         devicePublicKey: { encoding: "spki-der-base64", value: devicePublicKey },
@@ -1169,6 +1209,18 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
           { httpStatus: 401 },
         );
       }
+      // ── (a) Domain-separate the readback intent ──
+      // The transcript MUST have been minted FOR device readback. `action` is bound
+      // into the signed bytes, so a proof minted for a different intent (e.g.
+      // "owner-migrate") that happens to share this readback's nonce/origin/deviceId
+      // can NEVER be replayed here to activate the binding.
+      if (proof.transcript.action !== READBACK_TRANSCRIPT_ACTION) {
+        throw new FridayDomainError(
+          "AUTH_READBACK_POP_INVALID",
+          "Proof-of-possession transcript was not minted for device readback.",
+          { httpStatus: 401 },
+        );
+      }
       const pop = ownerClaimPoPVerifier.verifyPossession({
         transcript: proof.transcript,
         devicePublicKey: { encoding: "spki-der-base64", value: devicePublicKey },
@@ -1183,6 +1235,24 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         );
       }
 
+      // ── (b) Server-side max-TTL clamp (readback only) ──
+      // Freshness is bound in the transcript's own expiresAt (verified above), but
+      // the PoP verifier imposes NO upper bound. Reject a proof whose expiry is
+      // non-finite or lies further in the future than the maximum allowed readback
+      // TTL, so a far-future transcript can never be minted once and replayed.
+      const readbackNowMs = Date.parse(deps.nowIso());
+      const readbackExpiryMs = Date.parse(proof.transcript.expiresAt);
+      if (
+        !Number.isFinite(readbackExpiryMs) ||
+        readbackExpiryMs - readbackNowMs > READBACK_MAX_TRANSCRIPT_TTL_MS
+      ) {
+        throw new FridayDomainError(
+          "AUTH_READBACK_POP_INVALID",
+          "Proof-of-possession transcript expiry exceeds the maximum allowed TTL.",
+          { httpStatus: 401 },
+        );
+      }
+
       // The binding stores sha256(devicePublicKey base64) — recompute the SAME
       // hash the migrate leg persisted, from the possession-proven presented key,
       // so we activate the exact provisional row that migration created.
@@ -1192,47 +1262,66 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
       // Single write transaction: read-guard + CAS-activate are atomic. NEVER
       // touches users.password_hash (the passphrase stays authoritative — no
       // lockout) and writes NO tombstone (Stage 5 is deferred).
-      const bindingId = deps.db.withWriteTransaction((db) => {
-        // Defence-in-depth (migration-free, writes nothing): if the legacy
-        // credential has already been tombstoned (a later stage's terminal state),
-        // refuse to (re-)activate. This satisfies "tombstoned cannot re-activate"
-        // WITHOUT activating the Stage-5 tombstone-write path.
-        if (bindingRepo.findActiveTombstone(db, localUser.id)) {
-          throw new FridayDomainError(
-            "AUTH_READBACK_TOMBSTONED",
-            "The legacy credential has been retired; the device binding cannot be re-activated.",
-            { httpStatus: 409 },
-          );
-        }
+      let bindingId: string;
+      try {
+        bindingId = deps.db.withWriteTransaction((db) => {
+          // Defence-in-depth (migration-free, writes nothing): if the legacy
+          // credential has already been tombstoned (a later stage's terminal state),
+          // refuse to (re-)activate. This satisfies "tombstoned cannot re-activate"
+          // WITHOUT activating the Stage-5 tombstone-write path.
+          if (bindingRepo.findActiveTombstone(db, localUser.id)) {
+            throw new FridayDomainError(
+              "AUTH_READBACK_TOMBSTONED",
+              "The legacy credential has been retired; the device binding cannot be re-activated.",
+              { httpStatus: 409 },
+            );
+          }
 
-        const binding = bindingRepo.findBindingByUserAndKeyHash(
-          db,
-          localUser.id,
-          devicePublicKeyHash,
-        );
-        if (!binding) {
-          // No binding for this owner+key — cross-owner, unknown key, or migration
-          // never ran. Fail closed with ZERO state change.
-          throw new FridayDomainError(
-            "AUTH_READBACK_NO_BINDING",
-            "No device binding to activate for this owner and device key.",
-            { httpStatus: 409 },
+          const binding = bindingRepo.findBindingByUserAndKeyHash(
+            db,
+            localUser.id,
+            devicePublicKeyHash,
           );
-        }
+          if (!binding) {
+            // No binding for this owner+key — cross-owner, unknown key, or migration
+            // never ran. Fail closed with ZERO state change.
+            throw new FridayDomainError(
+              "AUTH_READBACK_NO_BINDING",
+              "No device binding to activate for this owner and device key.",
+              { httpStatus: 409 },
+            );
+          }
 
-        // Provisional → active compare-and-set. changes===1 only when the row was
-        // provisional; a revoked binding, an already-active binding (replay), or a
-        // concurrent flip all return 0 ⇒ fail closed, NO second active row.
-        const changed = bindingRepo.activateBinding(db, binding.id, localUser.id, now);
-        if (changed !== 1) {
+          // Provisional → active compare-and-set. changes===1 only when the row was
+          // provisional; a revoked binding, an already-active binding (replay), or a
+          // concurrent flip all return 0 ⇒ fail closed, NO second active row.
+          const changed = bindingRepo.activateBinding(db, binding.id, localUser.id, now);
+          if (changed !== 1) {
+            throw new FridayDomainError(
+              "AUTH_READBACK_NOT_PROVISIONAL",
+              "The device binding is not in a provisional state and cannot be activated.",
+              { httpStatus: 409 },
+            );
+          }
+          return binding.id;
+        });
+      } catch (error) {
+        // ── (c) Graceful 409 on the active-binding UNIQUE (never a raw 500) ──
+        // The only UNIQUE that can fire is the partial UNIQUE(user_id) WHERE
+        // state='active': an existing/concurrent active binding for this owner makes
+        // the provisional→active flip a UNIQUE violation. Surface it as a clean
+        // fail-closed 409. The in-txn FridayDomainErrors (tombstone / no-binding /
+        // not-provisional) are NOT constraint errors, so they re-throw unchanged
+        // with their original codes.
+        if (isSqliteConstraintError(error)) {
           throw new FridayDomainError(
-            "AUTH_READBACK_NOT_PROVISIONAL",
-            "The device binding is not in a provisional state and cannot be activated.",
+            "AUTH_READBACK_ALREADY_ACTIVE",
+            "A device binding is already active for this owner.",
             { httpStatus: 409 },
           );
         }
-        return binding.id;
-      });
+        throw error;
+      }
 
       return {
         activated: true,

--- a/test/adversarial/setup-device-readback-activation.test.ts
+++ b/test/adversarial/setup-device-readback-activation.test.ts
@@ -57,6 +57,15 @@ const DEVICE_PUBKEY = DEVICE_KEY.spkiDerBase64;
 const DEVICE_ID = "device-migrate-001";
 const DEVICE_OWNER_SENTINEL_PREFIX = "device-owner$v1$";
 const READBACK_NONCE = "readback-nonce-0001";
+// Follow-up hardening (b): a readback proof's expiry must fall within the
+// server-side max TTL (5 min). The happy/state fixtures use a short, in-window
+// expiry (relative to the fixed test NOW) so they exercise the clamp's PASS side.
+const READBACK_EXPIRES_AT = new Date(Date.parse(NOW) + 4 * 60 * 1000).toISOString();
+// Follow-up hardening (c): a SECOND device key + id used to seed a provisional
+// binding for the same owner alongside an already-active binding.
+const DEVICE_KEY2 = generateTestDeviceKey();
+const DEVICE_PUBKEY2 = DEVICE_KEY2.spkiDerBase64;
+const DEVICE_ID_2 = "device-migrate-002";
 
 function sha256Hex(v: string): string {
   return crypto.createHash("sha256").update(v).digest("hex");
@@ -212,6 +221,7 @@ function readbackReq(
     action: "owner-readback",
     installId: "install-m1",
     osUser: "jarvis",
+    expiresAt: READBACK_EXPIRES_AT,
     ...transcriptOver,
   });
   return {
@@ -595,5 +605,112 @@ describe("SEC-SETUP-BOOTSTRAP-001 Stage 3+4: device-readback activation", () => 
       caught = err;
     }
     expect((caught as FridayDomainError).httpStatus).toBe(401);
+  });
+
+  // ── Follow-up hardening (a): domain-separated transcript.action ──
+
+  it("(a) cross-intent domain separation: a VALID proof whose signed action is 'owner-migrate' — sharing the readback nonce/origin/deviceId — is REFUSED (401); binding stays provisional", () => {
+    seedProvisionalBinding(db);
+    // readbackReq re-signs over the overridden transcript, so this is a fully valid
+    // PoP (correct key, fresh, low-S) that merely carries a DIFFERENT signed intent.
+    // Without domain separation it would activate the binding by cross-intent replay.
+    const req = readbackReq({}, { action: "owner-migrate" });
+    let caught: unknown;
+    try {
+      makeService(db).confirmDeviceReadback(req, ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).httpStatus).toBe(401);
+    expect((caught as FridayDomainError).code).toBe("AUTH_READBACK_POP_INVALID");
+    expect(readBindings(db)[0].state).toBe("provisional");
+    expect(countActiveBindings(db)).toBe(0);
+  });
+
+  // ── Follow-up hardening (b): server-side max-TTL clamp (readback only) ──
+
+  it("(b) max-TTL clamp: a far-future (NOW + 24h) transcript expiry is REFUSED (401); binding stays provisional", () => {
+    seedProvisionalBinding(db);
+    // Not expired (NOW < expiry) so the freshness gate passes — but the expiry lies
+    // FAR beyond the 5-minute readback max TTL, so the clamp fails it closed.
+    const farFuture = new Date(Date.parse(NOW) + 24 * 60 * 60 * 1000).toISOString();
+    const req = readbackReq({}, { expiresAt: farFuture });
+    let caught: unknown;
+    try {
+      makeService(db).confirmDeviceReadback(req, ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).httpStatus).toBe(401);
+    expect((caught as FridayDomainError).code).toBe("AUTH_READBACK_POP_INVALID");
+    expect(readBindings(db)[0].state).toBe("provisional");
+    expect(countActiveBindings(db)).toBe(0);
+  });
+
+  // ── Follow-up hardening (c): graceful 409 on the active-binding UNIQUE, not 500 ──
+
+  it("(c) already-active owner: activating a second device key's provisional binding is a clean 409 AUTH_READBACK_ALREADY_ACTIVE (NOT a raw 500); exactly ONE active row remains", () => {
+    seedPassphraseOwner(db);
+    // ONE already-active binding (device key #1) + a second PROVISIONAL binding for a
+    // DIFFERENT device key (#2), same owner. The partial UNIQUE(user_id) WHERE
+    // state='active' allows this at rest but rejects flipping #2 to active.
+    db.withWriteTransaction((conn) => {
+      conn
+        .prepare(
+          `INSERT INTO friday_device_owner_bindings (
+             id, user_id, device_id, device_public_key, device_public_key_hash,
+             state, migrated_from, origin, hub_id, created_at, activated_at, revoked_at
+           ) VALUES (?, ?, ?, ?, ?, 'active', 'passphrase', ?, 'test-hub', ?, ?, NULL)`,
+        )
+        .run("binding-active-1", OWNER_ID, DEVICE_ID, DEVICE_PUBKEY, sha256Hex(DEVICE_PUBKEY), ORIGIN, NOW, NOW);
+      conn
+        .prepare(
+          `INSERT INTO friday_device_owner_bindings (
+             id, user_id, device_id, device_public_key, device_public_key_hash,
+             state, migrated_from, origin, hub_id, created_at, activated_at, revoked_at
+           ) VALUES (?, ?, ?, ?, ?, 'provisional', 'passphrase', ?, 'test-hub', ?, NULL, NULL)`,
+        )
+        .run("binding-prov-2", OWNER_ID, DEVICE_ID_2, DEVICE_PUBKEY2, sha256Hex(DEVICE_PUBKEY2), ORIGIN, NOW);
+    });
+
+    // A fresh, valid readback PoP over device key #2 (the provisional one).
+    const nonce = "readback-nonce-key2";
+    const transcript = makeTranscript(DEVICE_KEY2, {
+      nonce,
+      origin: ORIGIN,
+      deviceId: DEVICE_ID_2,
+      action: "owner-readback",
+      installId: "install-m1",
+      osUser: "jarvis",
+      expiresAt: READBACK_EXPIRES_AT,
+    });
+    const req = {
+      nonce,
+      devicePublicKey: DEVICE_PUBKEY2,
+      deviceId: DEVICE_ID_2,
+      origin: ORIGIN,
+      installId: "install-m1",
+      osUser: "jarvis",
+      deviceClaimProof: {
+        transcript,
+        signature: { encoding: "ieee-p1363-base64" as const, value: signTranscriptLowS(DEVICE_KEY2, transcript) },
+      },
+    };
+
+    let caught: unknown;
+    try {
+      makeService(db).confirmDeviceReadback(req, ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).httpStatus).toBe(409);
+    expect((caught as FridayDomainError).code).toBe("AUTH_READBACK_ALREADY_ACTIVE");
+    // The failed flip rolled back: exactly ONE active row (#1), #2 stayed provisional.
+    expect(countActiveBindings(db)).toBe(1);
+    const key2 = readBindings(db).find((b) => b.id === "binding-prov-2");
+    expect(key2?.state).toBe("provisional");
   });
 });

--- a/test/integration/api/friday-secsetup-s3-readback-activation-http-proof.test.ts
+++ b/test/integration/api/friday-secsetup-s3-readback-activation-http-proof.test.ts
@@ -235,7 +235,11 @@ describe("S3 runtime proof — device-readback activation over real HTTP (produc
 
   function readbackBody() {
     const nonce = "readback-http-0001";
-    const transcript = makeTranscript(DEVICE_KEY, { nonce, origin: ORIGIN, deviceId: DEVICE_ID, action: "owner-readback", installId: "install-s3", osUser: "jarvis" });
+    // Follow-up hardening (b): the readback proof's expiry must fall within the
+    // server-side max TTL (5 min). The service's clock is real time here, so mint a
+    // short, in-window expiry relative to now.
+    const expiresAt = new Date(Date.now() + 4 * 60 * 1000).toISOString();
+    const transcript = makeTranscript(DEVICE_KEY, { nonce, origin: ORIGIN, deviceId: DEVICE_ID, action: "owner-readback", installId: "install-s3", osUser: "jarvis", expiresAt });
     return {
       nonce,
       devicePublicKey: DEVICE_PUBKEY,


### PR DESCRIPTION
## Summary

Three additive, fail-closed, **server-side TypeScript-only** auth-hardening follow-ups to SEC-SETUP-BOOTSTRAP-001 Stage 3+4 `confirmDeviceReadback` (`src/api/auth/friday-auth-service.ts`). No DTO/request-response shape change, no new endpoint, no route-contract change, no migration/schema/lockfile change.

### (a) Domain-separate `transcript.action` (cross-intent replay)

`confirmDeviceReadback` matched only `nonce`/`origin`/`deviceId` and **never asserted the signed `transcript.action`**, and the readback consumes no single-use nonce — so a transcript minted for a *different* intent that shares the readback nonce/origin/deviceId could activate the binding.

- **Red-first result: the gap was EMPIRICALLY EXPLOITABLE pre-fix.** A fully valid PoP (correct key, fresh, low-S) whose signed `action` is `"owner-migrate"` — sharing the readback `nonce`/`origin`/`deviceId` — **activated the provisional binding with no 401** (the adversarial test's `confirmDeviceReadback` returned normally, `state: "active"`). Confirmed by running the new test against unmodified product code (it did **not** throw); it passes after the fix.
- **Fix:** module-level `READBACK_TRANSCRIPT_ACTION = "owner-readback"` + a positive equality assertion in readback (immediately after the nonce/origin/deviceId match block) → `FridayDomainError("AUTH_READBACK_POP_INVALID", …, { httpStatus: 401 })`.
- **Reverse guard:** in `migrateOwnerToDeviceKey` and `claimOwnerWithDeviceKey`, reject `action === "owner-readback"` (401, each leg's own POP-invalid code). This is a **NEGATIVE guard only** — no positive equality assertion on migrate/claim, so any non-canonical existing caller is unaffected.

### (b) Server-side max-TTL clamp (readback only)

The PoP verifier treats the transcript's `expiresAt` as freshness with **no upper bound**, so a far-future (`"2999-…"`) transcript could be minted once and replayed indefinitely.

- **Fix:** module-level `READBACK_MAX_TRANSCRIPT_TTL_MS = 5 * 60 * 1000` (aligned with `bootstrapNonceTtlSec` 300s). Immediately after `verifyPossession` succeeds, reject when the expiry is non-finite **or** `(expiryMs - nowMs) > READBACK_MAX_TRANSCRIPT_TTL_MS` → `AUTH_READBACK_POP_INVALID` (401), using `deps.nowIso()` for now.

### (c) Graceful 409 instead of raw 500

`confirmDeviceReadback`'s write transaction had no `try/catch`, so a UNIQUE violation surfaced as a raw 500.

- **Fix:** wrap the `withWriteTransaction` block in `try/catch`. On `isSqliteConstraintError(error)` (the partial `UNIQUE(user_id) WHERE state='active'` — the only UNIQUE that can fire) throw `FridayDomainError("AUTH_READBACK_ALREADY_ACTIVE", …, { httpStatus: 409 })`; otherwise **re-throw unchanged** so the in-transaction `FridayDomainError`s (tombstone / no-binding / not-provisional 409s) propagate with their original codes. `AUTH_READBACK_ALREADY_ACTIVE` is a free-string code with explicit `httpStatus` (consistent with the other `AUTH_READBACK_*` codes) — no error-enum registration required.

## Test plan (red-first, precision)

New adversarial tests in `test/adversarial/setup-device-readback-activation.test.ts`, all confirmed **RED against unmodified product code, GREEN after the fix**:

- **(a)** cross-intent `"owner-migrate"` proof sharing the readback nonce/origin/deviceId → `401 AUTH_READBACK_POP_INVALID`, binding stays `provisional`, zero active rows. *(pre-fix: activated with no throw)*
- **(b)** `NOW + 24h` expiry (not expired, but beyond the 5-min max TTL) → `401 AUTH_READBACK_POP_INVALID`, binding stays `provisional`. *(pre-fix: activated with no throw)*
- **(c)** one already-active binding + a second provisional binding for a different device key, then readback over the second key → clean `409 AUTH_READBACK_ALREADY_ACTIVE` (not a raw 500); exactly **one** active row remains, the failed flip rolled back. *(pre-fix: raw `SqliteError`)*

Fixture note: the readback happy/state fixtures in both the adversarial and the HTTP integration suites previously signed the `makeTranscript` default `expiresAt = "2999-…"`, which the new (b) clamp correctly rejects. They were moved to a **short in-window expiry** (relative to the suite's now) so they exercise the clamp's PASS side; the migrate transcripts keep their far-future default (migrate has no clamp).

Gates run locally from the worktree:

- `tsc --noEmit` — clean (exit 0).
- `eslint` on the changed files — **0 errors** (only a pre-existing `max-lines-per-function` warning on `createFridayAuthService`, present on base; CI runs `eslint .` with no `--max-warnings`).
- Both touched suites green: `test/adversarial/setup-device-readback-activation.test.ts` (20) + `test/integration/api/friday-secsetup-s3-readback-activation-http-proof.test.ts` (4).
- Broad auth regression: **701 tests across 43 files green** — all adversarial claim/migrate/bootstrap legs, `test/unit/api/auth`, auth routes, all auth integration, and the **route-contract snapshot (`test/contracts/api`) — unchanged**, confirming no contract drift.

No migration (`src/state/sqlite/migrations/**`, `*.sql`), schema (`schema.rs` / `friday-rust-hub-schema-handshake.ts`), or lockfile (`package-lock.json` / `pnpm-lock.yaml` / `Cargo.lock`) was touched, and the route-contract snapshot is unchanged — so **no "Deployment restart required:" line is needed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48
