### PR TITLE
harden(secsetup): positive own-action PoP assertion + narrow readback 409 (#1604 follow-ups)

### DIFF
--- a/src/api/auth/friday-auth-service.ts
+++ b/src/api/auth/friday-auth-service.ts
@@ -131,6 +131,38 @@ function isSqliteConstraintError(error: unknown): boolean {
   return typeof code === "string" && code.startsWith("SQLITE_CONSTRAINT");
 }
 
+/**
+ * The SOLE UNIQUE constraint on friday_device_owner_bindings: the partial index
+ * `idx_friday_device_owner_bindings_active(user_id) WHERE state='active'` (see
+ * migration v104). better-sqlite3 reports its violation as
+ *   code    = "SQLITE_CONSTRAINT_UNIQUE"
+ *   message = "UNIQUE constraint failed: friday_device_owner_bindings.user_id"
+ * on this build; some SQLite builds name the partial index in the message instead,
+ * so both the table.column and the index name are accepted signatures.
+ */
+const ACTIVE_BINDING_UNIQUE_INDEX = "idx_friday_device_owner_bindings_active";
+const ACTIVE_BINDING_UNIQUE_COLUMN = "friday_device_owner_bindings.user_id";
+
+/**
+ * True ONLY for the active-binding uniqueness violation that the provisional→active
+ * readback flip can raise. Deliberately NARROWER than isSqliteConstraintError: a
+ * CHECK / FK / NOT-NULL error, or a UNIQUE on a DIFFERENT (future) column or index,
+ * does NOT match and therefore propagates instead of being mislabelled 409.
+ *
+ * ASSUMPTION: the active-binding partial index is the ONLY UNIQUE constraint on
+ * friday_device_owner_bindings. Any NEW UPDATE-time UNIQUE constraint on that table
+ * (or a rename of the index/user_id column) MUST revisit this mapping.
+ */
+function isActiveBindingUniqueViolation(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as { code?: unknown }).code;
+  if (code !== "SQLITE_CONSTRAINT_UNIQUE") return false;
+  return (
+    error.message.includes(ACTIVE_BINDING_UNIQUE_INDEX) ||
+    error.message.includes(ACTIVE_BINDING_UNIQUE_COLUMN)
+  );
+}
+
 // ─── SEC-SETUP-BOOTSTRAP-001 · Stage 3+4 device-readback hardening follow-ups ───
 
 /**
@@ -141,6 +173,24 @@ function isSqliteConstraintError(error: unknown): boolean {
  * nonce/origin/deviceId — can NEVER be replayed to activate a device binding.
  */
 const READBACK_TRANSCRIPT_ACTION = "owner-readback";
+
+/**
+ * The canonical transcript `action` an owner-CLAIM proof MUST be minted for. All
+ * first-boot bootstrap challenges are issued with this action (see
+ * issueBootstrapChallenge's default). Because `action` is bound INTO the signed
+ * transcript bytes, requiring an exact match domain-separates the claim leg from
+ * EVERY other intent (migration / readback) — not just the readback case the
+ * negative cross-intent guard covers.
+ */
+const CLAIM_TRANSCRIPT_ACTION = "owner-claim";
+
+/**
+ * The canonical transcript `action` an owner-MIGRATION proof MUST be minted for.
+ * All migration challenges are issued with this action (see
+ * issueMigrationChallenge's default). Same domain-separation rationale as
+ * CLAIM_TRANSCRIPT_ACTION, applied to the migration leg.
+ */
+const MIGRATE_TRANSCRIPT_ACTION = "owner-migrate";
 
 /**
  * Server-side maximum accepted transcript TTL for a device readback (aligned with
@@ -762,6 +812,18 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
           { httpStatus: 401 },
         );
       }
+      // POSITIVE own-action assertion (defence-in-depth, ON TOP of the negative
+      // readback guard above): the transcript MUST have been minted FOR owner-claim.
+      // Because `action` is bound into the signed bytes, a proof minted for ANY other
+      // intent (migration, readback, or an arbitrary label) can never be replayed into
+      // the owner-claim leg — closing the residual gap the negative-only guard left.
+      if (proof.transcript.action !== CLAIM_TRANSCRIPT_ACTION) {
+        throw new FridayDomainError(
+          "AUTH_BOOTSTRAP_POP_INVALID",
+          "Proof-of-possession transcript was not minted for owner-claim.",
+          { httpStatus: 401 },
+        );
+      }
       const pop = ownerClaimPoPVerifier.verifyPossession({
         transcript: proof.transcript,
         devicePublicKey: { encoding: "spki-der-base64", value: devicePublicKey },
@@ -1023,6 +1085,18 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         throw new FridayDomainError(
           "AUTH_MIGRATE_POP_INVALID",
           "Proof-of-possession transcript was minted for device readback, not migration.",
+          { httpStatus: 401 },
+        );
+      }
+      // POSITIVE own-action assertion (defence-in-depth, ON TOP of the negative
+      // readback guard above): the transcript MUST have been minted FOR migration.
+      // Because `action` is bound into the signed bytes, a proof minted for ANY other
+      // intent (owner-claim, readback, or an arbitrary label) can never be replayed
+      // into the migration leg — closing the residual gap the negative-only guard left.
+      if (proof.transcript.action !== MIGRATE_TRANSCRIPT_ACTION) {
+        throw new FridayDomainError(
+          "AUTH_MIGRATE_POP_INVALID",
+          "Proof-of-possession transcript was not minted for migration.",
           { httpStatus: 401 },
         );
       }
@@ -1310,10 +1384,12 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         // The only UNIQUE that can fire is the partial UNIQUE(user_id) WHERE
         // state='active': an existing/concurrent active binding for this owner makes
         // the provisional→active flip a UNIQUE violation. Surface it as a clean
-        // fail-closed 409. The in-txn FridayDomainErrors (tombstone / no-binding /
-        // not-provisional) are NOT constraint errors, so they re-throw unchanged
-        // with their original codes.
-        if (isSqliteConstraintError(error)) {
+        // fail-closed 409. Narrowed to the SPECIFIC active-binding uniqueness
+        // violation (not any SQLITE_CONSTRAINT*) so a future different constraint on
+        // this table is not mismapped to 409 — it propagates. The in-txn
+        // FridayDomainErrors (tombstone / no-binding / not-provisional) are NOT
+        // constraint errors, so they re-throw unchanged with their original codes.
+        if (isActiveBindingUniqueViolation(error)) {
           throw new FridayDomainError(
             "AUTH_READBACK_ALREADY_ACTIVE",
             "A device binding is already active for this owner.",

--- a/test/adversarial/bootstrap-device-claim.test.ts
+++ b/test/adversarial/bootstrap-device-claim.test.ts
@@ -329,6 +329,46 @@ describe("SEC-SETUP-BOOTSTRAP-001: device-bound owner claim", () => {
     expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
   });
 
+  it("(f) cross-intent: a VALID claim PoP whose signed action is 'owner-migrate' is REFUSED (401); ZERO state change", () => {
+    // A fully valid PoP — correct key, fresh, low-S, bound to THIS claim's
+    // nonce/origin/deviceId — that merely carries a DIFFERENT signed intent
+    // ("owner-migrate"). Because `action` is bound INTO the signed bytes, the
+    // positive own-action assertion rejects it: without that assertion this would
+    // successfully claim ownership by cross-intent replay of a migration proof.
+    const nonce = issueNonce(db, { origin: ORIGIN });
+    const transcript = makeTranscript(DEVICE_KEY, {
+      nonce,
+      origin: ORIGIN,
+      deviceId: DEVICE_ID,
+      action: "owner-migrate",
+      installId: "install-1",
+      osUser: "jarvis",
+    });
+    const req = {
+      ...claimReq({ nonce }),
+      deviceClaimProof: {
+        transcript,
+        signature: {
+          encoding: "ieee-p1363-base64" as const,
+          value: signTranscriptLowS(DEVICE_KEY, transcript),
+        },
+      },
+    };
+
+    let caught: unknown;
+    try {
+      makeService(db).claimOwnerWithDeviceKey(req, LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).httpStatus).toBe(401);
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_POP_INVALID");
+    // No ownership claimed; the install nonce is un-burned (fail-closed).
+    expect(readOwnerHash(db)).toBeNull();
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+  });
+
   it("(d) loopback-only: a non-loopback claim / issue fails closed (403)", () => {
     const nonce = issueNonce(db);
 

--- a/test/adversarial/setup-authenticated-migration.test.ts
+++ b/test/adversarial/setup-authenticated-migration.test.ts
@@ -361,6 +361,47 @@ describe("SEC-SETUP-BOOTSTRAP-001 Slice 5: authenticated dual-read migration", (
     expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
   });
 
+  it("cross-intent: a VALID migration PoP whose signed action is 'owner-claim' is REFUSED (401) — nonce un-burned, no binding", () => {
+    seedPassphraseOwner(db);
+    const nonce = issueMigrationNonce(db);
+    // A fully valid PoP — correct key, fresh, low-S, bound to THIS migration's
+    // nonce/origin/deviceId — that merely carries a DIFFERENT signed intent
+    // ("owner-claim"). Because `action` is bound INTO the signed bytes, the positive
+    // own-action assertion rejects it: without that assertion this would successfully
+    // record a migration by cross-intent replay of an owner-claim proof.
+    const transcript = makeTranscript(DEVICE_KEY, {
+      nonce,
+      origin: ORIGIN,
+      deviceId: DEVICE_ID,
+      action: "owner-claim",
+      installId: "install-m1",
+      osUser: "jarvis",
+    });
+    const req = {
+      ...migrateReq({ nonce }),
+      deviceClaimProof: {
+        transcript,
+        signature: {
+          encoding: "ieee-p1363-base64" as const,
+          value: signTranscriptLowS(DEVICE_KEY, transcript),
+        },
+      },
+    };
+
+    let caught: unknown;
+    try {
+      makeService(db).migrateOwnerToDeviceKey(req, ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).httpStatus).toBe(401);
+    expect((caught as FridayDomainError).code).toBe("AUTH_MIGRATE_POP_INVALID");
+    // No binding recorded; the migration nonce is un-burned (fail-closed).
+    expect(readBindings(db)).toHaveLength(0);
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+  });
+
   it("refuses migration against a NULL owner slot — first-boot must NOT reuse the bootstrap leg (409)", () => {
     seedOwner(db); // password_hash NULL, NO passphrase set
     // The challenge itself is refused for a NULL owner, so issue directly via a

--- a/test/adversarial/setup-device-readback-activation.test.ts
+++ b/test/adversarial/setup-device-readback-activation.test.ts
@@ -713,4 +713,38 @@ describe("SEC-SETUP-BOOTSTRAP-001 Stage 3+4: device-readback activation", () => 
     const key2 = readBindings(db).find((b) => b.id === "binding-prov-2");
     expect(key2?.state).toBe("provisional");
   });
+
+  it("(c) narrowed 409: a NON-unique constraint error from the readback write is NOT masked to 409 — it propagates", () => {
+    seedProvisionalBinding(db);
+    // The AUTH_READBACK_ALREADY_ACTIVE 409 mapping is restricted to the SPECIFIC
+    // active-binding UNIQUE violation (SQLITE_CONSTRAINT_UNIQUE on the sole unique
+    // index of friday_device_owner_bindings). Any OTHER constraint on that table —
+    // e.g. a future CHECK — must surface as ITSELF, not be mis-labelled 409. Inject a
+    // synthetic non-unique constraint error at the write-transaction boundary (the
+    // same seam the atomicity crash tests drive).
+    const constraintDb: FridaySqliteLayer = {
+      ...db,
+      withWriteTransaction<T>(): T {
+        const e = new Error(
+          "CHECK constraint failed: friday_device_owner_bindings.some_future_check",
+        );
+        (e as { code?: string }).code = "SQLITE_CONSTRAINT_CHECK";
+        throw e;
+      },
+    };
+
+    let caught: unknown;
+    try {
+      makeService(constraintDb).confirmDeviceReadback(readbackReq(), ownerPrincipal(), LOOPBACK);
+    } catch (err) {
+      caught = err;
+    }
+    // Propagated as the RAW constraint error — NOT masked to a 409 domain error.
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(FridayDomainError);
+    expect((caught as { code?: string }).code).toBe("SQLITE_CONSTRAINT_CHECK");
+    // Real state untouched: the binding is still provisional (the write never ran).
+    expect(readBindings(db)[0].state).toBe("provisional");
+    expect(countActiveBindings(db)).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Two **additive, fail-closed, server-side-TypeScript-only** defence-in-depth follow-ups to the merged Stage-3 device-readback hardening (#1604), each flagged by **both** #1604 reviewers. No behaviour changes for any reachable legitimate flow; both only tighten the fail-closed surface.

Base: `origin/main` @ `9630e72d` (includes #1604).

### Follow-up 1 — positive own-action PoP assertion on the claim/migrate legs (higher risk, red-first)
The merged code only had **negative** cross-intent guards (reject a proof whose `action === "owner-readback"`). That leaves a residual gap: a proof minted for *some other* non-canonical intent still passes. This adds a **positive** own-action assertion, **on top of** the existing negative guards:

- `claimOwnerWithDeviceKey` now requires `proof.transcript.action === "owner-claim"` → else `AUTH_BOOTSTRAP_POP_INVALID` (401).
- `migrateOwnerToDeviceKey` now requires `proof.transcript.action === "owner-migrate"` → else `AUTH_MIGRATE_POP_INVALID` (401).

`action` is bound **into** the signed transcript bytes (canonical encoder), so an exact-match assertion cannot be spoofed and domain-separates each leg from **every** other intent. The two canonical values are defined as shared module-level consts (`CLAIM_TRANSCRIPT_ACTION` / `MIGRATE_TRANSCRIPT_ACTION`) alongside the pre-existing `READBACK_TRANSCRIPT_ACTION`.

**Enumeration result (required before this positive assertion is safe):** I grepped the whole repo (src defaults + every claim/migrate transcript fixture) for the action value used on each leg. Every distinct value found is **canonical**:

| Leg | Distinct `action` values found | Source |
| --- | --- | --- |
| claim | `"owner-claim"` only | `issueBootstrapChallenge` default; `claimReq`/`validProof` helpers (via `makeTranscript` default) in `bootstrap-device-claim`, `bootstrap-nonce-lifecycle`, `secsetup-s3-device-principal-failclosed` |
| migrate | `"owner-migrate"` only | `issueMigrationChallenge` default; `migrateReq` + provisioning helpers in `setup-authenticated-migration`, `setup-device-readback-activation`, `s5-migration-http-proof`, `s3-readback-activation-http-proof` |

No caller/test uses a different or empty action for a legitimate claim/migrate flow → **verdict: PROCEED** (no real caller broken; nothing weakened to make anything pass).

### Follow-up 2 — narrow the `(c)` 409 translation in `confirmDeviceReadback` (zero risk)
Previously the catch mapped **any** `SQLITE_CONSTRAINT*` to `AUTH_READBACK_ALREADY_ACTIVE` (409). Narrowed to the **specific** active-binding uniqueness violation: `SQLITE_CONSTRAINT_UNIQUE` whose message references the sole unique index of `friday_device_owner_bindings` — the partial `idx_friday_device_owner_bindings_active(user_id) WHERE state='active'`. A future *different* constraint on that table (CHECK / FK / a UNIQUE on another column) now **propagates** instead of being mislabelled 409.

Empirical note: on this better-sqlite3 build the violation message is `UNIQUE constraint failed: friday_device_owner_bindings.user_id` (it does **not** contain the index name), so the helper accepts **either** the `table.column` signature **or** the index name (some SQLite builds name the partial index instead). A code comment documents the assumption that the active partial index is the only UNIQUE on that table, and that any new UPDATE-time constraint on it must revisit the mapping. Behaviour for the reachable active-uniqueness case is identical (still 409).

## Test plan (red-first, real production code path against real file-backed SQLite)
All three new tests were confirmed **red** against the base code, then **green** after the fix:
- **claim cross-intent** (`bootstrap-device-claim.test.ts`): a fully valid PoP (correct key, fresh, low-S, bound nonce/origin/deviceId) whose signed `action` is `"owner-migrate"` → 401 `AUTH_BOOTSTRAP_POP_INVALID`, owner slot stays NULL, install nonce un-burned. *(Red: without the assertion this successfully claimed ownership.)*
- **migrate cross-intent** (`setup-authenticated-migration.test.ts`): a valid PoP whose signed `action` is `"owner-claim"` → 401 `AUTH_MIGRATE_POP_INVALID`, no binding, nonce un-burned. *(Red: without the assertion this recorded a migration.)*
- **readback narrowed 409** (`setup-device-readback-activation.test.ts`): a non-unique (`SQLITE_CONSTRAINT_CHECK`) error from the readback write **propagates** as itself, not masked to 409; the existing real active-uniqueness test still yields 409. *(Red: the broad catch masked the CHECK error to 409.)*

### Local gate (all green)
- `npx tsc --noEmit`: **0 errors**
- `npm run lint`: **0 errors** (pre-existing warnings only)
- Broad regression — `test/adversarial` + `test/unit/api/auth` + auth routes + auth integration (secsetup s3/s5 http proofs) + `test/contracts/api` route snapshot: **41 files / 668 tests passed** (665 at base + 3 new, **zero regressions**).
- Route-contract snapshot **unchanged** (no new op/field).
- No forbidden-touch files: no migration / `*.sql` / schema / lockfile / route-contract snapshot / `.secrets.baseline`.

## Properties
- All-additive, fail-closed, **server-side TypeScript only**.
- No migration / schema / schema-handshake / lockfile / route-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48
