### PR TITLE
fix(memory-guard): redact full-width PII on the memory egress path incl. appended learned facts

### DIFF
--- a/src/api/http/routes/friday-memory-routes.ts
+++ b/src/api/http/routes/friday-memory-routes.ts
@@ -22,7 +22,7 @@ import {
 } from "../../../learning/services/friday-learned-fact-memory-view.js";
 import { isFridayReflexConfirmationRequiredKey } from "../../../reflex/services/friday-reflex-preference-sensitivity.js";
 import { FridayDomainError } from "#errors";
-import { FRIDAY_MEMORY_ERROR_CODES, FRIDAY_MEMORY_MAX_LIMIT } from "#memory";
+import { createFridayMemoryOutputFilter, FRIDAY_MEMORY_ERROR_CODES, FRIDAY_MEMORY_MAX_LIMIT } from "#memory";
 import {
   hashIdempotencyPayload,
   readIdempotencyKeyHeader,
@@ -349,6 +349,13 @@ function validatePruneBody(body: unknown): asserts body is FridayMemoryPruneRequ
 export function createFridayMemoryRoutes(
   deps: FridayMemoryRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
+  // Single egress PII filter for list/search. The guard service already filters items it
+  // returns, but learned facts are appended in these route handlers AFTER the guard has run
+  // (deps.listLearnedFacts). Re-applying the SAME production output filter to the FINAL
+  // merged result guarantees no returned field — including appended learned-fact content,
+  // metadata, tags, and snippet — can bypass PII redaction. It is idempotent on the
+  // already-filtered stored items.
+  const outputFilter = createFridayMemoryOutputFilter();
   return [
     // ─── Store ───
     {
@@ -533,7 +540,9 @@ export function createFridayMemoryRoutes(
         return {
           items: [...items, ...learnedItems]
             .sort((a, b) => b.score - a.score)
-            .slice(0, body.limit ?? FRIDAY_MEMORY_MAX_LIMIT),
+            .slice(0, body.limit ?? FRIDAY_MEMORY_MAX_LIMIT)
+            // Egress PII filter over the merged result (stored + appended learned facts).
+            .map((result) => outputFilter.filterSearchResult(result)),
         };
       },
     },
@@ -593,7 +602,9 @@ export function createFridayMemoryRoutes(
           : [];
         const combined = [...items, ...learnedItems]
           .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-        return { items: typeof limit === "number" ? combined.slice(0, limit) : combined };
+        const sliced = typeof limit === "number" ? combined.slice(0, limit) : combined;
+        // Egress PII filter over the merged result (stored + appended learned facts).
+        return { items: sliced.map((item) => outputFilter.filterItem(item)) };
       },
     },
 

--- a/src/memory/guard/model/friday-memory-guard.types.ts
+++ b/src/memory/guard/model/friday-memory-guard.types.ts
@@ -136,6 +136,13 @@ export interface FridayMemoryGuardPiiGuard {
 export interface FridayMemoryGuardOutputFilter {
   filterItem(item: FridayMemoryItem): FridayMemoryItem;
   filterSearchResults(results: FridayMemorySearchResult[]): FridayMemorySearchResult[];
+  /**
+   * Redact + truncate a single search result (item content/metadata/tags + snippet) WITHOUT
+   * applying the result-count cap. Use at an egress boundary where results from multiple
+   * sources are merged (e.g. stored items + appended learned facts) so every returned
+   * result passes the same PII filter regardless of the total count.
+   */
+  filterSearchResult(result: FridayMemorySearchResult): FridayMemorySearchResult;
 }
 
 // ─── Guard service ───

--- a/src/memory/guard/services/friday-memory-output-filter.ts
+++ b/src/memory/guard/services/friday-memory-output-filter.ts
@@ -30,29 +30,31 @@ function dropPiiTags(tags: string[]): string[] {
   return tags.filter((tag) => piiRedactor.scanAndTransform(tag).matches.length === 0);
 }
 
+function filterItemImpl(item: FridayMemoryItem): FridayMemoryItem {
+  return {
+    ...item,
+    content: redactAndTruncate(item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
+    metadata: redactMetadata(item.metadata),
+    tags: dropPiiTags(item.tags),
+  };
+}
+
+function filterSearchResultImpl(result: FridayMemorySearchResult): FridayMemorySearchResult {
+  return {
+    ...result,
+    item: filterItemImpl(result.item),
+    snippet: redactAndTruncate(result.snippet, FRIDAY_MEMORY_GUARD_MAX_RESULT_SNIPPET_CHARS),
+  };
+}
+
 export function createFridayMemoryOutputFilter(): FridayMemoryGuardOutputFilter {
   return {
-    filterItem(item: FridayMemoryItem): FridayMemoryItem {
-      return {
-        ...item,
-        content: redactAndTruncate(item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
-        metadata: redactMetadata(item.metadata),
-        tags: dropPiiTags(item.tags),
-      };
-    },
-
+    filterItem: filterItemImpl,
+    filterSearchResult: filterSearchResultImpl,
     filterSearchResults(results: FridayMemorySearchResult[]): FridayMemorySearchResult[] {
-      const capped = results.slice(0, FRIDAY_MEMORY_GUARD_MAX_SEARCH_RESULTS);
-      return capped.map((result) => ({
-        ...result,
-        item: {
-          ...result.item,
-          content: redactAndTruncate(result.item.content, FRIDAY_MEMORY_GUARD_MAX_RESULT_CONTENT_CHARS),
-          metadata: redactMetadata(result.item.metadata),
-          tags: dropPiiTags(result.item.tags),
-        },
-        snippet: redactAndTruncate(result.snippet, FRIDAY_MEMORY_GUARD_MAX_RESULT_SNIPPET_CHARS),
-      }));
+      return results
+        .slice(0, FRIDAY_MEMORY_GUARD_MAX_SEARCH_RESULTS)
+        .map(filterSearchResultImpl);
     },
   };
 }

--- a/src/memory/guard/services/friday-memory-pii-guard.ts
+++ b/src/memory/guard/services/friday-memory-pii-guard.ts
@@ -27,6 +27,38 @@ const PII_PATTERNS: PiiPattern[] = [
   { type: "credit_card", regex: FRIDAY_MEMORY_GUARD_CREDIT_CARD_REGEX },
 ];
 
+/**
+ * Length-preserving width fold used ONLY for matching. Folds full-width decimal digits
+ * (U+FF10–FF19) → 0–9 plus the full-width number separators/format chars used by phone and
+ * card formats: hyphen-minus U+FF0D → '-', plus U+FF0B → '+', left/right paren U+FF08/FF09
+ * → '(' / ')', and full stop U+FF0E → '.'. Every mapped code unit is a single BMP code unit
+ * replaced by exactly one ASCII code unit, so `String.length` and every offset stay
+ * identical to the original — a match found in the folded view maps to the SAME
+ * [start, end) in the ORIGINAL string.
+ *
+ * Deliberate scope decisions (only ADD detection, never over-redact):
+ *  - NFKC is NOT used: it can change string length (ligatures / compatibility forms) and
+ *    would break index alignment.
+ *  - U+3000 (ideographic space) and U+FF0C (full-width comma) are NOT folded. The card
+ *    regex's `[ -]` class would otherwise bridge two distinct full-width number groups
+ *    separated only by such a char into one false card (over-redaction of legitimate
+ *    content).
+ *
+ * NOTE: folding a full-width DIGIT (a non-word char) into an ASCII digit (a word char) can
+ * merge it with an adjacent ASCII digit run and destroy a `\b` the ASCII-only regexes rely
+ * on. `findMatches` therefore uses this fold ADDITIVELY — detection also runs on the
+ * original string — so a match the unfolded scan would find is never lost.
+ */
+function foldWidthForMatching(content: string): string {
+  return content.replace(/[\uFF08\uFF09\uFF0B\uFF0D\uFF0E\uFF10-\uFF19]/g, (ch) =>
+    // Every mapped code unit maps to exactly one ASCII code unit via (code − 0xFEE0):
+    //   U+FF08→'(' U+FF09→')' U+FF0B→'+' U+FF0D→'-' U+FF0E→'.' U+FF10–FF19→'0'–'9'.
+    // Only digits are word chars (their `\b` effect is handled by the additive union in
+    // findMatches); the separators/parens fold to non-word ASCII, so they never perturb `\b`.
+    String.fromCharCode(ch.charCodeAt(0) - 0xfee0),
+  );
+}
+
 function luhnCheck(digits: string): boolean {
   let sum = 0;
   let alternate = false;
@@ -59,7 +91,13 @@ function isCreditCardIdentifierFalsePositive(content: string, match: RegExpExecA
   return CREDIT_CARD_IDENTIFIER_PREFIX.test(before) || CREDIT_CARD_IDENTIFIER_SUFFIX.test(after);
 }
 
-function findMatches(content: string): FridayMemoryGuardPiiMatch[] {
+/**
+ * Run every PII pattern against `scan` (which must be length-aligned with `original`),
+ * applying the credit-card Luhn + false-positive gates per pass. Because `scan` and
+ * `original` share a coordinate system, every match offset is valid in `original`, so the
+ * reported value/start/end reference the ORIGINAL text.
+ */
+function detectMatches(scan: string, original: string): FridayMemoryGuardPiiMatch[] {
   const matches: FridayMemoryGuardPiiMatch[] = [];
 
   for (const pattern of PII_PATTERNS) {
@@ -67,41 +105,84 @@ function findMatches(content: string): FridayMemoryGuardPiiMatch[] {
     const regex = new RegExp(pattern.regex.source, pattern.regex.flags);
     let match: RegExpExecArray | null;
 
-    while ((match = regex.exec(content)) !== null) {
+    while ((match = regex.exec(scan)) !== null) {
       // For credit card matches, validate with Luhn algorithm
       if (pattern.type === "credit_card") {
         const digits = match[0].replace(/[^0-9]/g, "");
         if (digits.length < 13 || digits.length > 19 || !luhnCheck(digits)) {
           continue;
         }
-        if (isCreditCardIdentifierFalsePositive(content, match)) {
+        if (isCreditCardIdentifierFalsePositive(scan, match)) {
           continue;
         }
       }
 
       matches.push({
         type: pattern.type,
-        value: match[0],
+        value: original.slice(match.index, match.index + match[0].length),
         start: match.index,
         end: match.index + match[0].length,
       });
     }
   }
 
+  return matches;
+}
+
+/**
+ * Additive two-pass detection. The ORIGINAL pass reproduces the pre-width-fold behavior
+ * exactly (pure-ASCII PII with correct `\b` boundaries); the FOLDED pass adds full-width
+ * PII. Both scans are length-preserving and index-aligned with `content`, so their match
+ * spans live in one coordinate system. The union is a strict SUPERSET of the original pass:
+ * every span the unfolded scan finds is retained, so no pre-existing match can be lost by
+ * the fold — full-width detection only ever ADDS redactions.
+ */
+function findMatches(content: string): FridayMemoryGuardPiiMatch[] {
+  const originalPass = detectMatches(content, content);
+  const foldedPass = detectMatches(foldWidthForMatching(content), content);
+
+  // Dedupe exact duplicates (a pure-ASCII region is found identically by both passes) so
+  // downstream match counts / distinct types / tags are not inflated.
+  const seen = new Set<string>();
+  const matches: FridayMemoryGuardPiiMatch[] = [];
+  for (const m of [...originalPass, ...foldedPass]) {
+    const key = `${m.type}:${m.start}:${m.end}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    matches.push(m);
+  }
+
   // Sort by start position for deterministic ordering
-  matches.sort((a, b) => a.start - b.start);
+  matches.sort((a, b) => a.start - b.start || a.end - b.end);
   return matches;
 }
 
 function redactContent(content: string, matches: FridayMemoryGuardPiiMatch[]): string {
   if (matches.length === 0) return content;
 
-  // Process matches from end to start to preserve indices
-  const sorted = [...matches].sort((a, b) => b.start - a.start);
-  let result = content;
+  // Merge overlapping spans into non-overlapping segments before replacing. The two-pass
+  // union can yield overlapping spans (e.g. a mixed ASCII/full-width number matched at
+  // slightly different extents), and replacing overlapping ranges independently would
+  // corrupt indices. Non-overlapping (merely adjacent) matches are kept separate so their
+  // individual labels are preserved.
+  const sorted = [...matches].sort((a, b) => a.start - b.start || a.end - b.end);
+  const segments: Array<{ start: number; end: number; type: FridayMemoryGuardPiiType }> = [];
   for (const m of sorted) {
-    const redacted = `[${m.type.toUpperCase()}]`;
-    result = result.substring(0, m.start) + redacted + result.substring(m.end);
+    const last = segments[segments.length - 1];
+    if (last && m.start < last.end) {
+      // Overlap: extend the segment; keep the earliest contributor's label (cosmetic only —
+      // the whole span is redacted regardless of label).
+      if (m.end > last.end) last.end = m.end;
+    } else {
+      segments.push({ start: m.start, end: m.end, type: m.type });
+    }
+  }
+
+  // Process segments from end to start to preserve indices
+  let result = content;
+  for (const s of [...segments].reverse()) {
+    const redacted = `[${s.type.toUpperCase()}]`;
+    result = result.substring(0, s.start) + redacted + result.substring(s.end);
   }
   return result;
 }

--- a/test/unit/api/http/routes/friday-memory-routes-learned-fact-pii.test.ts
+++ b/test/unit/api/http/routes/friday-memory-routes-learned-fact-pii.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createFridayMemoryRoutes } from "#api";
+import type { FridayRouteDefinition, FridayHttpContext } from "#api";
+import type {
+  FridayMemoryItem,
+  FridayMemorySearchResult,
+  FridayMemoryService,
+  FridayMemoryGuardServiceFactory,
+} from "#memory";
+
+// ─── Regression: learned facts appended AFTER the memory guard/output-filter must still be
+//     PII-redacted at the route egress. Full-width (U+FF10–FF19) credit-card digits in a
+//     learned fact were returned verbatim through GET /v1/memory/items (list) and
+//     POST /v1/memory/search (content + snippet). These route-level tests exercise the real
+//     route handler and assert on the returned JSON. ───
+
+const NOW = "2026-02-18T10:00:00.000Z";
+// toFullwidth("4111111111111111") — Luhn-valid Visa test number in full-width digits.
+const FULLWIDTH_CARD = "４１１１１１１１１１１１１１１１";
+
+describe("FridayMemoryRoutes — learned-fact PII egress (full-width)", () => {
+  let memoryService: FridayMemoryService;
+  let memoryGuardFactory: FridayMemoryGuardServiceFactory;
+  let routes: FridayRouteDefinition<unknown, unknown, unknown, unknown>[];
+
+  function makeCtx(
+    overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {},
+  ): FridayHttpContext<unknown, unknown, unknown> {
+    return {
+      requestId: "req-1",
+      receivedAt: NOW,
+      params: {},
+      query: {},
+      body: {},
+      headers: {},
+      principal: {
+        principalType: "user" as const,
+        principalId: "user-1",
+        userId: "user-1",
+        role: "admin" as const,
+        scopes: ["hub.admin" as const],
+        tokenId: "tok-1",
+        tokenKind: "access" as const,
+        issuedAt: NOW,
+      },
+      ...overrides,
+    };
+  }
+
+  function findRoute(operationId: string) {
+    return routes.find((r) => r.operationId === operationId)!;
+  }
+
+  // A learned fact whose value is a full-width credit card (the leaking payload).
+  const learnedFacts = [
+    {
+      key: "card",
+      value: `カード番号は${FULLWIDTH_CARD}です`,
+      confidence: 0.9,
+      evidenceCount: 3,
+      lastConfirmedAt: NOW,
+    },
+  ];
+
+  beforeEach(() => {
+    memoryService = {
+      store: vi.fn(),
+      // No stored items — the payload under test is the appended learned fact.
+      search: vi.fn().mockResolvedValue([] as FridayMemorySearchResult[]),
+      get: vi.fn(),
+      list: vi.fn().mockResolvedValue([] as FridayMemoryItem[]),
+      delete: vi.fn(),
+      prune: vi.fn(),
+    } as unknown as FridayMemoryService;
+    memoryGuardFactory = {
+      forPrincipal: vi.fn().mockReturnValue(memoryService),
+      forContext: vi.fn().mockReturnValue(memoryService),
+    } as unknown as FridayMemoryGuardServiceFactory;
+    routes = createFridayMemoryRoutes({
+      memoryGuardFactory,
+      listLearnedFacts: () => learnedFacts,
+    });
+  });
+
+  it("memory.search redacts full-width card in appended learned-fact content AND snippet", async () => {
+    const route = findRoute("memory.search");
+    const res = (await route.handler(makeCtx({ body: { query: "card" } }))) as {
+      items: FridayMemorySearchResult[];
+    };
+    expect(res.items.length).toBeGreaterThanOrEqual(1);
+    const learned = res.items[0];
+    expect(learned.item.content).toContain("[CREDIT_CARD]");
+    expect(learned.item.content).not.toContain(FULLWIDTH_CARD);
+    expect(learned.snippet).toContain("[CREDIT_CARD]");
+    expect(learned.snippet).not.toContain(FULLWIDTH_CARD);
+  });
+
+  it("memory.list redacts full-width card in appended learned-fact content", async () => {
+    const route = findRoute("memory.list");
+    const res = (await route.handler(makeCtx({ query: {} }))) as { items: FridayMemoryItem[] };
+    expect(res.items.length).toBeGreaterThanOrEqual(1);
+    const learned = res.items[0];
+    expect(learned.content).toContain("[CREDIT_CARD]");
+    expect(learned.content).not.toContain(FULLWIDTH_CARD);
+  });
+
+  it("memory.search does not leak the raw full-width digits in ANY returned field", async () => {
+    const route = findRoute("memory.search");
+    const res = (await route.handler(makeCtx({ body: { query: "card" } }))) as {
+      items: FridayMemorySearchResult[];
+    };
+    expect(JSON.stringify(res)).not.toContain(FULLWIDTH_CARD);
+  });
+
+  it("memory.list does not leak the raw full-width digits in ANY returned field", async () => {
+    const route = findRoute("memory.list");
+    const res = (await route.handler(makeCtx({ query: {} }))) as { items: FridayMemoryItem[] };
+    expect(JSON.stringify(res)).not.toContain(FULLWIDTH_CARD);
+  });
+});

--- a/test/unit/memory/guard/friday-memory-pii-guard-superset-fuzz.test.ts
+++ b/test/unit/memory/guard/friday-memory-pii-guard-superset-fuzz.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import {
+  createFridayMemoryPiiGuard,
+  FRIDAY_MEMORY_GUARD_EMAIL_REGEX,
+  FRIDAY_MEMORY_GUARD_US_PHONE_REGEX,
+  FRIDAY_MEMORY_GUARD_US_SSN_REGEX,
+  FRIDAY_MEMORY_GUARD_CREDIT_CARD_REGEX,
+} from "#memory";
+
+// ─── Reference: the ORIGINAL (pre-width-fold) detection, run on the raw input string. ───
+function luhnCheck(digits: string): boolean {
+  let sum = 0;
+  let alt = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let n = parseInt(digits[i], 10);
+    if (alt) { n *= 2; if (n > 9) n -= 9; }
+    sum += n; alt = !alt;
+  }
+  return sum % 10 === 0;
+}
+const CTX_BEFORE =
+  /(?:credit\s*card|card(?:\s*number)?|cc|visa|mastercard|master\s*card|amex|american\s*express|discover|payment|billing|account)\s*(?:number|no\.?)?\s*[:#=-]?\s*$/i;
+const ID_PREFIX = /[A-Za-z][A-Za-z0-9]{1,31}[-_:]$/;
+const ID_SUFFIX = /^[-_:][A-Za-z][A-Za-z0-9]{1,31}/;
+function fpCard(content: string, m: RegExpExecArray): boolean {
+  const before = content.slice(Math.max(0, m.index - 48), m.index);
+  if (CTX_BEFORE.test(before)) return false;
+  const after = content.slice(m.index + m[0].length, m.index + m[0].length + 48);
+  return ID_PREFIX.test(before) || ID_SUFFIX.test(after);
+}
+const PATTERNS: Array<{ type: string; regex: RegExp }> = [
+  { type: "email", regex: FRIDAY_MEMORY_GUARD_EMAIL_REGEX },
+  { type: "phone_us", regex: FRIDAY_MEMORY_GUARD_US_PHONE_REGEX },
+  { type: "ssn_us", regex: FRIDAY_MEMORY_GUARD_US_SSN_REGEX },
+  { type: "credit_card", regex: FRIDAY_MEMORY_GUARD_CREDIT_CARD_REGEX },
+];
+function referenceSpans(content: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+  for (const p of PATTERNS) {
+    const re = new RegExp(p.regex.source, p.regex.flags);
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(content)) !== null) {
+      if (m[0].length === 0) { re.lastIndex++; continue; }
+      if (p.type === "credit_card") {
+        const digits = m[0].replace(/[^0-9]/g, "");
+        if (digits.length < 13 || digits.length > 19 || !luhnCheck(digits)) continue;
+        if (fpCard(content, m)) continue;
+      }
+      spans.push([m.index, m.index + m[0].length]);
+    }
+  }
+  return spans;
+}
+
+// ─── Deterministic PRNG (LCG) for reproducibility. ───
+function makeRng(seed: number) {
+  let s = seed >>> 0;
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+function toFullwidth(str: string): string {
+  return [...str].map((ch) => {
+    const c = ch.charCodeAt(0);
+    if (c === 0x20) return "　";
+    if (c >= 0x21 && c <= 0x7e) return String.fromCharCode(c + 0xfee0);
+    return ch;
+  }).join("");
+}
+
+// Alphabet of tokens the generator stitches together — heavy on the risky adjacency cases
+// (full-width digits next to ASCII digits, mixed separators, U+3000/commas).
+const KNOWN = [
+  "4111111111111111", // luhn-valid card
+  "5500005555555559", // luhn-valid card
+  "123-45-6789",      // ssn
+  "234-567-8901",     // phone
+  "(234)567-8901",
+  "234.567.8901",
+  "user@example.com",
+];
+const NOISE = [
+  " ", "-", ".", "(", ")", "+", ",", "　", "0", "1", "9", "5",
+  "abc", "カード", "です", "_x-", ":", "BARB-", "credit card ",
+];
+
+function randomInput(rng: () => number): string {
+  const parts: string[] = [];
+  const n = 1 + Math.floor(rng() * 8);
+  for (let i = 0; i < n; i++) {
+    const pick = rng();
+    if (pick < 0.4) {
+      let tok = KNOWN[Math.floor(rng() * KNOWN.length)];
+      const form = rng();
+      if (form < 0.33) tok = toFullwidth(tok);
+      else if (form < 0.5) {
+        // mixed: fold a random half to full-width
+        const cut = Math.floor(rng() * tok.length);
+        tok = tok.slice(0, cut) + toFullwidth(tok.slice(cut));
+      }
+      parts.push(tok);
+    } else {
+      parts.push(NOISE[Math.floor(rng() * NOISE.length)]);
+    }
+    // Occasionally jam a stray full-width digit directly against the previous token.
+    if (rng() < 0.35) parts.push(toFullwidth(String(Math.floor(rng() * 10))));
+  }
+  return parts.join("");
+}
+
+describe("width-fold superset fuzz (200k)", () => {
+  it("union redaction covers every span the original-only ASCII detection finds", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+    const rng = makeRng(0x9e3779b9);
+    const ITER = 200_000;
+    let violations = 0;
+    let firstViolation = "";
+    let refMatchInputs = 0;
+    for (let i = 0; i < ITER; i++) {
+      const input = randomInput(rng);
+      const ref = referenceSpans(input);
+      if (ref.length === 0) continue;
+      refMatchInputs++;
+      // Coverage set from the NEW union matches.
+      const covered = new Set<number>();
+      for (const m of guard.scanAndTransform(input).matches) {
+        for (let k = m.start; k < m.end; k++) covered.add(k);
+      }
+      for (const [s, e] of ref) {
+        for (let k = s; k < e; k++) {
+          if (!covered.has(k)) {
+            violations++;
+            if (!firstViolation) {
+              firstViolation = `idx ${k} of [${s},${e}) uncovered in ${JSON.stringify(input)}`;
+            }
+            break;
+          }
+        }
+      }
+    }
+    // The union redaction must never leave un-redacted a span the original-only detection
+    // finds (strict superset). `firstViolation` names the first counter-example if any.
+    expect(firstViolation).toBe("");
+    expect(violations).toBe(0);
+    // Non-vacuity: a "0 violations" result is only meaningful if the generator actually
+    // produced many PII-bearing inputs (deterministic seed → ~99.7k of 200k).
+    expect(refMatchInputs).toBeGreaterThan(20_000);
+  });
+});

--- a/test/unit/memory/guard/services/friday-memory-guard-service-output-filter.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-output-filter.test.ts
@@ -129,6 +129,30 @@ describe("FridayMemoryOutputFilter", () => {
     expect(filtered[0].snippet).not.toContain("user@example.com");
   });
 
+  it("redacts a FULL-WIDTH credit card on the egress read path (filterItem)", () => {
+    // Full-width digits (U+FF10–FF19) previously bypassed the ASCII-only regex and leaked
+    // through the live GET /v1/memory/items(/:id) + POST /v1/memory/search read path.
+    const fullwidthCard = "４１１１１１１１１１１１１１１１"; // toFullwidth("4111111111111111"), Luhn-valid
+    const item = makeItem({ content: `カード番号は${fullwidthCard}です` });
+    const filtered = filter.filterItem(item);
+    expect(filtered.content).toContain("[CREDIT_CARD]");
+    expect(filtered.content).not.toContain(fullwidthCard);
+    expect(filtered.content).toBe("カード番号は[CREDIT_CARD]です");
+  });
+
+  it("redacts a FULL-WIDTH credit card in search result content and snippet (filterSearchResults)", () => {
+    const fullwidthCard = "４１１１１１１１１１１１１１１１";
+    const results = [makeSearchResult({
+      item: makeItem({ content: `card ${fullwidthCard}` }),
+      snippet: `snippet ${fullwidthCard}`,
+    })];
+    const filtered = filter.filterSearchResults(results);
+    expect(filtered[0].item.content).toContain("[CREDIT_CARD]");
+    expect(filtered[0].item.content).not.toContain(fullwidthCard);
+    expect(filtered[0].snippet).toContain("[CREDIT_CARD]");
+    expect(filtered[0].snippet).not.toContain(fullwidthCard);
+  });
+
   it("preserves score and matchedBy", () => {
     const results = [makeSearchResult({ score: 0.95, matchedBy: ["fts", "semantic"] })];
     const filtered = filter.filterSearchResults(results);

--- a/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
@@ -161,6 +161,214 @@ describe("FridayMemoryPiiGuard", () => {
     expect(result.distinctTypes).toContain("phone_us");
   });
 
+  // ─── Full-width / width-folding (egress PII correctness) ───
+  //
+  // The redaction regexes are ASCII-only (\d = [0-9], no `u` flag). Full-width digit
+  // (U+FF10–FF19) and separator forms bypassed them, so a Luhn-valid card in full-width
+  // form was returned UNREDACTED through the live memory egress/read path. The guard now
+  // matches against a *length-preserving* width-folded view (each full-width code unit maps
+  // to exactly one ASCII code unit at the SAME index), then redacts the ORIGINAL string at
+  // the matched offsets — so match offsets stay valid and surrounding text is untouched.
+
+  // Map ASCII printable + space to its full-width / ideographic-space counterpart.
+  function toFullwidth(s: string): string {
+    return [...s]
+      .map((ch) => {
+        const c = ch.charCodeAt(0);
+        if (c === 0x20) return "　"; // space → ideographic space
+        if (c >= 0x21 && c <= 0x7e) return String.fromCharCode(c + 0xfee0);
+        return ch;
+      })
+      .join("");
+  }
+
+  describe("full-width width-fold", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    it("redacts a full-width Luhn-valid card and preserves surrounding text byte-for-byte", () => {
+      const card = toFullwidth("4111111111111111"); // ４１１１…, Luhn-valid Visa test number
+      const result = guard.scanAndTransform(`カード番号は${card}です`);
+      // Exact-equality proves index alignment: only the card span is replaced, the
+      // Japanese context is preserved unchanged.
+      expect(result.transformedContent).toBe("カード番号は[CREDIT_CARD]です");
+      expect(result.distinctTypes).toContain("credit_card");
+      expect(result.tagsToAdd).toContain("pii.credit_card");
+      // The reported match must span exactly the full-width card (length-preserving fold).
+      const cc = result.matches.find((m) => m.type === "credit_card");
+      expect(cc?.value).toBe(card);
+    });
+
+    it("redacts a full-width US phone number", () => {
+      const result = guard.scanAndTransform(`電話は${toFullwidth("555-234-5678")}まで`);
+      expect(result.transformedContent).toBe("電話は[PHONE_US]まで");
+      expect(result.distinctTypes).toContain("phone_us");
+    });
+
+    it("redacts a full-width US SSN", () => {
+      const result = guard.scanAndTransform(`SSN ${toFullwidth("123-45-6789")}`);
+      expect(result.transformedContent).toContain("[SSN_US]");
+      expect(result.transformedContent).not.toContain(toFullwidth("123-45-6789"));
+    });
+
+    it("redacts full-width digit groups separated by ASCII spaces", () => {
+      // ASCII space is a genuine, unambiguous separator (unlike U+3000 — see the
+      // ideographic-space non-bridge test); the card regex's `[ -]` class bridges the groups.
+      const card = [
+        toFullwidth("4111"),
+        toFullwidth("1111"),
+        toFullwidth("1111"),
+        toFullwidth("1111"),
+      ].join(" ");
+      const result = guard.scanAndTransform(card);
+      expect(result.transformedContent).toBe("[CREDIT_CARD]");
+      expect(result.distinctTypes).toContain("credit_card");
+    });
+
+    it("redacts a full-width card with full-width hyphen separators", () => {
+      const result = guard.scanAndTransform(toFullwidth("4111-1111-1111-1111"));
+      expect(result.transformedContent).toBe("[CREDIT_CARD]");
+      expect(result.distinctTypes).toContain("credit_card");
+    });
+
+    it("redacts a card mixing ASCII and full-width digits", () => {
+      const mixed = "4111" + toFullwidth("1111") + "11111111"; // 4111111111111111, Luhn-valid
+      const result = guard.scanAndTransform(mixed);
+      expect(result.transformedContent).toBe("[CREDIT_CARD]");
+      expect(result.distinctTypes).toContain("credit_card");
+    });
+
+    it("does NOT redact a full-width NON-Luhn card (Luhn still gates; fold did not over-match)", () => {
+      const nonLuhn = toFullwidth("4111111111111112"); // last digit broken → Luhn-invalid
+      const result = guard.scanAndTransform(nonLuhn);
+      expect(result.matches.filter((m) => m.type === "credit_card")).toHaveLength(0);
+      expect(result.distinctTypes).not.toContain("credit_card");
+      expect(result.transformedContent).toBe(nonLuhn); // returned unchanged
+    });
+
+    it("redacts a folded card at the very start and end of the string", () => {
+      const card = toFullwidth("4111111111111111");
+      const result = guard.scanAndTransform(card);
+      expect(result.transformedContent).toBe("[CREDIT_CARD]");
+      const cc = result.matches.find((m) => m.type === "credit_card");
+      expect(cc?.start).toBe(0);
+      expect(cc?.end).toBe(card.length);
+    });
+
+    it("redacts two adjacent PII spans without corrupting the boundary between them", () => {
+      const card = toFullwidth("4111111111111111");
+      const ssn = toFullwidth("123-45-6789");
+      const result = guard.scanAndTransform(`${card} / ${ssn}`);
+      expect(result.transformedContent).toBe("[CREDIT_CARD] / [SSN_US]");
+    });
+
+    it("redacts full-width PII inside metadata values and tags (redactDeep egress path)", () => {
+      const { value, tagsToAdd } = guard.redactDeep({
+        note: `card ${toFullwidth("4111111111111111")}`,
+        tag: toFullwidth("123-45-6789"),
+      });
+      const meta = value as { note: string; tag: string };
+      expect(meta.note).toContain("[CREDIT_CARD]");
+      expect(meta.note).not.toContain(toFullwidth("4111111111111111"));
+      expect(meta.tag).toContain("[SSN_US]");
+      expect(tagsToAdd).toEqual(expect.arrayContaining(["pii.credit_card", "pii.ssn_us"]));
+    });
+  });
+
+  // ─── Full-width adjacency: UNION / no-regression (a full-width digit next to an ASCII
+  //     PII run must NOT make the ASCII PII vanish) ───
+  //
+  // A full-width digit is a NON-word char, so in the ORIGINAL string it forms a \b that
+  // correctly delimits an adjacent ASCII PII run. Folding it to an ASCII digit turns it into
+  // a word char, merging the runs and destroying that \b — the extended run overflows the
+  // card length/Luhn gate (or breaks SSN/phone exact-length anchoring) and the match
+  // vanishes. Detection must therefore be ADDITIVE: run on the ORIGINAL string too so no
+  // pre-existing ASCII match is ever lost.
+
+  describe("full-width adjacency (union superset)", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    it("still redacts an ASCII card immediately followed by a full-width digit", () => {
+      const result = guard.scanAndTransform("my card 4111111111111111１ thanks");
+      expect(result.transformedContent).toContain("[CREDIT_CARD]");
+      expect(result.transformedContent).not.toContain("4111111111111111");
+      expect(result.distinctTypes).toContain("credit_card");
+    });
+
+    it("still redacts an ASCII card immediately preceded by a full-width digit", () => {
+      const result = guard.scanAndTransform("１4111111111111111");
+      expect(result.transformedContent).toContain("[CREDIT_CARD]");
+      expect(result.transformedContent).not.toContain("4111111111111111");
+    });
+
+    it("still redacts an ASCII SSN immediately followed by a full-width digit", () => {
+      const result = guard.scanAndTransform("SSN: 123-45-6789１");
+      expect(result.transformedContent).toContain("[SSN_US]");
+      expect(result.transformedContent).not.toContain("123-45-6789");
+    });
+
+    it("still redacts an ASCII phone immediately followed by a full-width digit", () => {
+      const result = guard.scanAndTransform("call 234-5678１ now");
+      expect(result.transformedContent).toContain("[PHONE_US]");
+      expect(result.transformedContent).not.toContain("234-5678");
+    });
+
+    it("SUPERSET: the pre-fold (original-string) match span is always still redacted", () => {
+      // For each input, the character range the ASCII regex matches on the ORIGINAL string
+      // must be fully redacted after the union fix (old redaction span ⊆ new redaction span).
+      const cases: Array<{ input: string; leaked: string }> = [
+        { input: "my card 4111111111111111１ thanks", leaked: "4111111111111111" },
+        { input: "１4111111111111111", leaked: "4111111111111111" },
+        { input: "SSN: 123-45-6789１", leaked: "123-45-6789" },
+        { input: "call 234-5678１ now", leaked: "234-5678" },
+      ];
+      for (const c of cases) {
+        const out = guard.scanAndTransform(c.input).transformedContent;
+        expect(out).not.toContain(c.leaked);
+      }
+    });
+  });
+
+  // ─── U+3000 (ideographic space) must NOT bridge two distinct full-width groups ───
+
+  describe("full-width ideographic-space non-bridge", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    it("does NOT bridge two full-width digit groups joined only by U+3000 into a false card", () => {
+      // Bridged, these 8+8 digits would be a Luhn-valid 16-digit card; the ideographic space
+      // must keep them separate so legitimate non-card content is not over-redacted.
+      const g1 = toFullwidth("41111111");
+      const g2 = toFullwidth("11111111");
+      const result = guard.scanAndTransform(`${g1}　${g2}`);
+      expect(result.distinctTypes).not.toContain("credit_card");
+      expect(result.transformedContent).not.toContain("[CREDIT_CARD]");
+    });
+  });
+
+  // ─── Full-width phone-format chars: period (U+FF0E), parens (U+FF08/FF09) ───
+  //
+  // Phone/number formats use '.', '(', ')' (and '+') as separators. Folding their full-width
+  // forms lets the ASCII phone regex match full-width-formatted numbers. Additive union still
+  // applies, so nothing pre-existing is lost.
+
+  describe("full-width phone-format chars", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    it("redacts a full-width phone using full-width PERIOD separators (U+FF0E)", () => {
+      // Without folding U+FF0E there is no 7+ contiguous-digit run, so nothing matches → leak.
+      const result = guard.scanAndTransform(`電話 ${toFullwidth("234.567.8901")}`);
+      expect(result.transformedContent).toContain("[PHONE_US]");
+      expect(result.distinctTypes).toContain("phone_us");
+    });
+
+    it("redacts the AREA CODE of a full-width parenthesized phone (U+FF08/FF09)", () => {
+      // Without folding the full-width parens, only the local `567-8901` matches and the
+      // area code `234` LEAKS; folding U+FF09 lets `\)?` extend the match over the area code.
+      const result = guard.scanAndTransform(toFullwidth("(234)567-8901"));
+      expect(result.transformedContent).toContain("[PHONE_US]");
+      expect(result.transformedContent).not.toContain(toFullwidth("234")); // area code redacted
+    });
+  });
+
   // ─── redactDeep (metadata + tags) ───
 
   describe("redactDeep", () => {


### PR DESCRIPTION
## Requirement
No PII on the memory read/egress path (`GET /v1/memory/items[/:id]`, `POST /v1/memory/search`): credit cards, phones, SSNs must be redacted in the returned HTTP JSON across **content, metadata, tags, AND snippet** — including **full-width** forms and including **appended learned facts** — with **no regression** (never redact fewer chars than before).

## Frozen head SHA
`c851a6350aaeaf39cddf7dbaa6adca1cbe0c11b5` (base `d7bb8dc7513f9e33131f0947d754cb7217e02748` = current origin/main). Supersedes `496e0d27`/`a2049bd2`, whose evidence is void.

## LIVE production seam (egress / read path)
`GET /v1/memory/items/:id`, `GET /v1/memory/items` (list), `POST /v1/memory/search` (`friday-memory-routes.ts`) → the guard service output filter (`filterItem`/`filterSearchResults` → `piiRedactor`). These READ paths are **not** gated by `tsMemoryWritesEnabled`, so leaks here are live.

## Two leaks fixed
**Leak A — full-width forms bypass the ASCII-only regexes.** `\d = [0-9]` (no `u` flag) and `luhnCheck` strips to `[0-9]`, so a Luhn-valid card in full-width digits (U+FF10–FF19) was returned verbatim.

**Leak B (HIGH, found by review) — learned facts appended after the filter.** `memory.list` (`:594`) and `memory.search` (`:534`) append `deps.listLearnedFacts(...)` to the result **after** the guard's output filter has already run, so learned-fact `content` / `metadata` / `tags` / `snippet` skipped PII redaction entirely (any PII, full-width or ASCII, leaked in the JSON).

## Fixes
**Width fold — additive UNION, strict superset.** `findMatches()` detects on **both** the ORIGINAL string (reproduces pre-fold behavior exactly, correct `\b`) **and** a length-preserving width-folded scan, then unions the validated spans and redacts the ORIGINAL at the merged spans. A full-width digit is a non-word char whose `\b` delimits an adjacent ASCII run; folding it alone would merge the runs and make mixed-form PII **vanish** (the regression fixed in the prior revision), so the original pass is always retained → the redacted span set is a strict superset of pre-fold behavior. Fold set: digits U+FF10–FF19 plus the number-format chars **U+FF0D `-`, U+FF0B `+`, U+FF08/FF09 `(` `)`, U+FF0E `.`** (each a single BMP code unit → one ASCII code unit). **U+3000 (ideographic space) and U+FF0C (comma) are NOT folded** (they would bridge two distinct full-width groups into a false card). No NFKC (length-changing → breaks index alignment).

**Single egress filter for learned facts.** `createFridayMemoryRoutes` now applies the **same production output filter** to the FINAL merged list: `memory.list` maps every returned item through `filterItem`; `memory.search` maps every returned result through a new `filterSearchResult` (per-result; redacts item content/metadata/tags + snippet; **no result-count cap**, so sort/slice semantics are preserved). It is idempotent on the already-filtered stored items, so no returned field — including appended learned-fact content/metadata/tags/snippet — can bypass redaction. `filterSearchResults` (plural) now delegates to `filterSearchResult`, behavior-preserving.

**Where the unified filter sits:** the route handlers for `memory.list` and `memory.search` are the single egress boundary through which all returned content (stored items + appended learned facts) passes before serialization.

## Red-first (against the prior fix `496e0d27`, reverting each fix in isolation)
Learned-facts leak (route JSON, real handler + appended learned fact with full-width card):
```
× memory.search redacts full-width card in appended learned-fact content AND snippet
   expected 'カード番号は４１１１１１１１１１１１１１１１です' to contain '[CREDIT_CARD]'
× memory.list redacts full-width card in appended learned-fact content
× memory.search does not leak the raw full-width digits in ANY returned field
× memory.list does not leak the raw full-width digits in ANY returned field
 Tests  4 failed
```
New fold forms (fold narrowed back to digits+hyphen):
```
× redacts a full-width phone using full-width PERIOD separators (U+FF0E)
   expected '電話 ２３４．５６７．８９０１' to contain '[PHONE_US]'
× redacts the AREA CODE of a full-width parenthesized phone (U+FF08/FF09)
   expected '（２３４）[PHONE_US]' not to contain '２３４'
 Tests  2 failed
```

## Verify (all green post-fix)
- **200k superset fuzz** (deterministic seed): `inputs-with-ref-PII=99,714 / 200,000`, **violations=0** — the union redaction covers every span the original-only ASCII detection finds (committed as `friday-memory-pii-guard-superset-fuzz.test.ts`, ~0.66s).
- **Route-level JSON tests** (`memory.list` + `memory.search`, real handler): stored + appended full-width learned-fact PII comes back redacted across list, search, content, and snippet — 4 tests green.
- **Full memory-guard suite + all memory route tests**: 240 tests, 14 files, all green.
- `npm run typecheck` → **0 errors**. `npm run lint` → **0 errors** in changed source (only pre-existing baseline warnings).

## does_not_prove / remaining live leaves (NOT closed)
- **Realtime payload redactor** `src/api/realtime/friday-event-payload-redactor.ts` — untouched, still ASCII-only. **OPEN live leaf.**
- **Other Unicode digit scripts** (Arabic-Indic U+0660–0669, Extended-Arabic, Devanagari, fullwidth already covered) — not folded. **OPEN live leaf.**
- **Write-scan path is dark / not-live** (store/delete/prune are gated by `tsMemoryWritesEnabled`); live justification is egress only.
- **Code-path + unit/route evidence only** — no runtime/prod HTTP request was made.
- **U+FF0B `+` fold** is included for normalization completeness though the phone regex's `\b`-anchored `\+1` prefix is effectively unreachable at string start today (harmless, additive).

This PR closes: **full-width digit/separator PII, and appended learned-fact PII, on the memory egress path (list/search; content/metadata/tags/snippet).** It does NOT close the overall PII requirement (see open leaves above).

## Files changed (vs base)
- `src/memory/guard/services/friday-memory-pii-guard.ts` (+101/−…): additive two-pass union `findMatches`, extended `foldWidthForMatching`, overlap-merging `redactContent`.
- `src/memory/guard/services/friday-memory-output-filter.ts`: add `filterSearchResult`; `filterSearchResults` delegates.
- `src/memory/guard/model/friday-memory-guard.types.ts`: add `filterSearchResult` to the interface.
- `src/api/http/routes/friday-memory-routes.ts`: single egress filter over merged list/search results.
- `test/.../friday-memory-pii-guard.test.ts` (+208), `friday-memory-guard-service-output-filter.test.ts` (+24), `friday-memory-routes-learned-fact-pii.test.ts` (+120, new), `friday-memory-pii-guard-superset-fuzz.test.ts` (+150, new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48
