### PR TITLE
fix(retention): default-permanent + fail-closed content retention (DATA-RETENTION-001) [R1+R2]

### DIFF
--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -1,11 +1,13 @@
 export type {
+  CategoryRetention,
   FridayRetentionPolicy,
   FridayRetentionJobResult,
 } from "./retention/friday-retention.types.js";
 export {
   FRIDAY_DEFAULT_RETENTION_POLICY,
+  FRIDAY_BOOTSTRAP_NONCE_SWEEP_BATCH_LIMIT,
 } from "./retention/friday-retention.types.js";
-export { createFridayRetentionJob } from "./retention/friday-retention-job.js";
+export { createFridayRetentionJob, resolveCutoff } from "./retention/friday-retention-job.js";
 export type { FridayRetentionJob } from "./retention/friday-retention-job.js";
 
 export type {

--- a/src/jobs/retention/friday-retention-job.ts
+++ b/src/jobs/retention/friday-retention-job.ts
@@ -5,6 +5,7 @@ import type { FridayLearningEventLedger, FridaySkillRunStore } from "#ledger";
 // concrete repo is injected by the wiring layer (see friday-satellite-runtime).
 import type { FridaySetupBootstrapNonceRepository } from "../../api/persistence/friday-setup-bootstrap-nonce-repository.js";
 import type {
+  CategoryRetention,
   FridayRetentionJobResult,
   FridayRetentionPolicy,
 } from "./friday-retention.types.js";
@@ -32,6 +33,45 @@ export interface CreateRetentionJobDeps {
 function subtractDays(isoDate: string, days: number): string {
   const ms = new Date(isoDate).getTime() - days * 24 * 60 * 60 * 1000;
   return new Date(ms).toISOString();
+}
+
+/**
+ * Fail-closed cutoff evaluator for a CONTENT retention category.
+ *
+ * DATA-RETENTION-001 / U9-DATA-RETENTION: content is default-PERMANENT and any
+ * auto-deletion must be explicitly enabled AND well-formed. This is the ONLY
+ * gate the per-category DELETE statements consult.
+ *
+ * Returns:
+ *   - `null` for `{mode:'permanent'}` → caller SKIPS deletion (retain forever).
+ *   - the ISO cutoff string for a valid `{mode:'after_days', days:n}` where `n`
+ *     is a positive finite integer that yields an in-range date.
+ *   - `null` for ANY invalid input — missing/undefined/null, non-object,
+ *     unknown mode, days ≤ 0, non-integer, NaN, Infinity, or an overflowing /
+ *     out-of-range date. Invalid ⇒ treat as PERMANENT (delete nothing) = FAIL
+ *     CLOSED. Never throws; never deletes on uncertainty.
+ */
+export function resolveCutoff(
+  nowIso: string,
+  categoryRetention: CategoryRetention | null | undefined,
+): string | null {
+  if (categoryRetention === null || typeof categoryRetention !== "object") {
+    return null; // missing / non-object → fail closed
+  }
+  const mode = (categoryRetention as { mode?: unknown }).mode;
+  if (mode === "permanent") return null; // retain forever
+  if (mode !== "after_days") return null; // unknown mode → fail closed
+  const days = (categoryRetention as { days?: unknown }).days;
+  if (typeof days !== "number") return null; // missing / non-number → fail closed
+  if (!Number.isInteger(days)) return null; // NaN, Infinity, 1.5, … → fail closed
+  if (days <= 0) return null; // 0 / negative → fail closed
+  const nowMs = new Date(nowIso).getTime();
+  if (!Number.isFinite(nowMs)) return null; // bad nowIso → fail closed
+  const cutoffMs = nowMs - days * 24 * 60 * 60 * 1000;
+  if (!Number.isFinite(cutoffMs)) return null; // overflow → fail closed
+  const cutoff = new Date(cutoffMs);
+  if (Number.isNaN(cutoff.getTime())) return null; // out-of-range date → fail closed
+  return cutoff.toISOString();
 }
 
 export function createFridayRetentionJob(deps: CreateRetentionJobDeps): FridayRetentionJob {
@@ -74,10 +114,14 @@ export function createFridayRetentionJob(deps: CreateRetentionJobDeps): FridayRe
         );
       });
 
-      result.deletedHeartbeats = deps.db.withWriteTransaction((db) => {
-        const heartbeatCutoff = subtractDays(nowIso, policy.heartbeatsDays);
-        return deps.heartbeatRepo.deleteBefore(db, heartbeatCutoff);
-      });
+      // CONTENT category (derived): default-permanent, fail-closed.
+      const heartbeatCutoff = resolveCutoff(nowIso, policy.heartbeats);
+      result.deletedHeartbeats =
+        heartbeatCutoff === null
+          ? 0
+          : deps.db.withWriteTransaction((db) =>
+              deps.heartbeatRepo.deleteBefore(db, heartbeatCutoff),
+            );
 
       result.markedOutboxExpired = deps.db.withWriteTransaction((db) =>
         deps.outboxRepo.expireByTtl(db, nowIso),
@@ -88,48 +132,77 @@ export function createFridayRetentionJob(deps: CreateRetentionJobDeps): FridayRe
         return deps.outboxRepo.deleteTerminalBefore(db, outboxDeleteCutoff);
       });
 
-      result.deletedLearningEvents = deps.db.withWriteTransaction((db) => {
-        const learningCutoff = subtractDays(nowIso, policy.learningEventsDays);
-        return db
-          .prepare("DELETE FROM learning_events WHERE ts < ?")
-          .run(learningCutoff).changes;
-      });
+      // CONTENT category (canonical): default-permanent, fail-closed.
+      const learningCutoff = resolveCutoff(nowIso, policy.learningEvents);
+      result.deletedLearningEvents =
+        learningCutoff === null
+          ? 0
+          : deps.db.withWriteTransaction(
+              (db) =>
+                db
+                  .prepare("DELETE FROM learning_events WHERE ts < ?")
+                  .run(learningCutoff).changes,
+            );
 
-      const skillRunCutoff = subtractDays(nowIso, policy.skillRunTerminalDays);
+      // CONTENT category (canonical): default-permanent, fail-closed.
+      const skillRunCutoff = resolveCutoff(nowIso, policy.skillRunTerminal);
       result.deletedSkillRuns =
-        deps.skillRunStore.pruneTerminalRunsBefore(skillRunCutoff);
+        skillRunCutoff === null
+          ? 0
+          : deps.skillRunStore.pruneTerminalRunsBefore(skillRunCutoff);
 
-      result.deletedAuditLogs = deps.db.withWriteTransaction((db) => {
-        const auditCutoff = subtractDays(nowIso, policy.auditLogsDays);
-        return db
-          .prepare("DELETE FROM audit_logs WHERE ts < ?")
-          .run(auditCutoff).changes;
-      });
+      // CONTENT category (canonical): default-permanent, fail-closed.
+      // audit_logs permanence is a hard requirement — never auto-delete by default.
+      const auditCutoff = resolveCutoff(nowIso, policy.auditLogs);
+      result.deletedAuditLogs =
+        auditCutoff === null
+          ? 0
+          : deps.db.withWriteTransaction(
+              (db) =>
+                db
+                  .prepare("DELETE FROM audit_logs WHERE ts < ?")
+                  .run(auditCutoff).changes,
+            );
 
-      result.deletedAgentRuns = deps.db.withWriteTransaction((db) => {
-        const agentRunCutoff = subtractDays(nowIso, policy.agentRunsDays);
-        return db
-          .prepare(
-            "DELETE FROM friday_agent_runs WHERE created_at < ? AND status IN ('completed', 'failed', 'cancelled')",
-          )
-          .run(agentRunCutoff).changes;
-      });
+      // CONTENT category (canonical): default-permanent, fail-closed.
+      const agentRunCutoff = resolveCutoff(nowIso, policy.agentRuns);
+      result.deletedAgentRuns =
+        agentRunCutoff === null
+          ? 0
+          : deps.db.withWriteTransaction(
+              (db) =>
+                db
+                  .prepare(
+                    "DELETE FROM friday_agent_runs WHERE created_at < ? AND status IN ('completed', 'failed', 'cancelled')",
+                  )
+                  .run(agentRunCutoff).changes,
+            );
 
-      result.deletedLlmUsageRecords = deps.db.withWriteTransaction((db) => {
-        const llmUsageCutoff = subtractDays(nowIso, policy.llmUsageRecordsDays);
-        return db
-          .prepare("DELETE FROM llm_usage_records WHERE created_at < ?")
-          .run(llmUsageCutoff).changes;
-      });
+      // CONTENT category (canonical): default-permanent, fail-closed.
+      const llmUsageCutoff = resolveCutoff(nowIso, policy.llmUsageRecords);
+      result.deletedLlmUsageRecords =
+        llmUsageCutoff === null
+          ? 0
+          : deps.db.withWriteTransaction(
+              (db) =>
+                db
+                  .prepare("DELETE FROM llm_usage_records WHERE created_at < ?")
+                  .run(llmUsageCutoff).changes,
+            );
 
-      result.deletedErrorIncidents = deps.db.withWriteTransaction((db) => {
-        const errorCutoff = subtractDays(nowIso, policy.errorIncidentsDays);
-        return db
-          .prepare(
-            "DELETE FROM error_incidents WHERE status = 'resolved' AND updated_at < ?",
-          )
-          .run(errorCutoff).changes;
-      });
+      // CONTENT category (canonical): default-permanent, fail-closed.
+      const errorCutoff = resolveCutoff(nowIso, policy.errorIncidents);
+      result.deletedErrorIncidents =
+        errorCutoff === null
+          ? 0
+          : deps.db.withWriteTransaction(
+              (db) =>
+                db
+                  .prepare(
+                    "DELETE FROM error_incidents WHERE status = 'resolved' AND updated_at < ?",
+                  )
+                  .run(errorCutoff).changes,
+            );
 
       // Setup-bootstrap install-nonce reaper (OBS-2). Bounded per pass; reaps
       // expired UNCONSUMED nonces (dead weight / DoS vector) and CONSUMED nonces

--- a/src/jobs/retention/friday-retention.types.ts
+++ b/src/jobs/retention/friday-retention.types.ts
@@ -1,13 +1,43 @@
+/**
+ * Per-category retention configuration for a CONTENT category.
+ *
+ * DATA-RETENTION-001 / U9-DATA-RETENTION: local data is default-PERMANENT until
+ * the user deletes it; automatic time-based cleanup is default-OFF and opt-in
+ * per category. `permanent` (the default) means "never auto-delete". `after_days`
+ * is the ONLY way to enable a time-based sweep for a content category, and the
+ * evaluator (`resolveCutoff`) fails closed — treats any invalid config as
+ * permanent — so a corrupt policy can never trigger a silent deletion.
+ */
+export type CategoryRetention =
+  | { mode: "permanent" }
+  | { mode: "after_days"; days: number };
+
 export interface FridayRetentionPolicy {
-  learningEventsDays: number;
-  heartbeatsDays: number;
+  // ── CONTENT categories (canonical + derived-content) ──────────────────────
+  // Default PERMANENT. Auto-deletion is opt-in per category via `after_days`;
+  // any invalid config fails closed to permanent (see resolveCutoff).
+  learningEvents: CategoryRetention;
+  /** Derived telemetry; per operator, default no-delete until an authority exemption is proven. */
+  heartbeats: CategoryRetention;
+  skillRunTerminal: CategoryRetention;
+  auditLogs: CategoryRetention;
+  agentRuns: CategoryRetention;
+  llmUsageRecords: CategoryRetention;
+  errorIncidents: CategoryRetention;
+
+  // ── SECURITY-LIFECYCLE terminal TTLs (EXEMPT from default-permanent) ───────
+  // These are NOT canonical content-retention: each deletes a row only once it
+  // is TERMINAL / state-invalidated, and the deletion is a security-hygiene /
+  // anti-replay lifecycle (not content retention). They therefore remain plain
+  // numeric day-windows and are intentionally left ON:
+  //   - pairingRequestsDays: hard-delete of RESOLVED pairing-request rows.
+  //   - outboxTerminalDays:  hard-delete of TERMINAL (acked/failed) outbox rows.
+  //   - bootstrapNoncesConsumedDays: retention horizon for CONSUMED install
+  //     nonces (an anti-replay / defence-in-depth record whose authoritative
+  //     binding lives on users.password_hash). Expired UNCONSUMED nonces are
+  //     always reaped (unusable) with no policy knob.
   pairingRequestsDays: number;
   outboxTerminalDays: number;
-  skillRunTerminalDays: number;
-  auditLogsDays: number;
-  agentRunsDays: number;
-  llmUsageRecordsDays: number;
-  errorIncidentsDays: number;
   /**
    * Retention horizon for CONSUMED setup-bootstrap install-nonce rows. Expired
    * UNCONSUMED nonces are always reaped once past `expires_at` (no policy knob —
@@ -19,15 +49,17 @@ export interface FridayRetentionPolicy {
 }
 
 export const FRIDAY_DEFAULT_RETENTION_POLICY: FridayRetentionPolicy = {
-  learningEventsDays: 90,
-  heartbeatsDays: 7,
+  // Content categories: PERMANENT by default (DATA-RETENTION-001).
+  learningEvents: { mode: "permanent" },
+  heartbeats: { mode: "permanent" },
+  skillRunTerminal: { mode: "permanent" },
+  auditLogs: { mode: "permanent" },
+  agentRuns: { mode: "permanent" },
+  llmUsageRecords: { mode: "permanent" },
+  errorIncidents: { mode: "permanent" },
+  // Security-lifecycle terminal TTLs (unchanged; not content retention).
   pairingRequestsDays: 7,
   outboxTerminalDays: 14,
-  skillRunTerminalDays: 30,
-  auditLogsDays: 90,
-  agentRunsDays: 90,
-  llmUsageRecordsDays: 180,
-  errorIncidentsDays: 90,
   bootstrapNoncesConsumedDays: 365,
 };
 

--- a/test/unit/jobs/retention/friday-retention-job.test.ts
+++ b/test/unit/jobs/retention/friday-retention-job.test.ts
@@ -7,6 +7,7 @@ import { createFridayLearningEventLedger } from "#ledger";
 import { createFridaySkillRunStore } from "#ledger";
 import { createFridaySetupBootstrapNonceRepository } from "#api";
 import { createFridayRetentionJob } from "#jobs";
+import type { FridayRetentionPolicy } from "#jobs";
 import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
 
 describe("FridayRetentionJob", () => {
@@ -69,18 +70,13 @@ describe("FridayRetentionJob", () => {
     db.close();
   });
 
-  function createJob(policy?: Partial<{
-    learningEventsDays: number;
-    heartbeatsDays: number;
-    pairingRequestsDays: number;
-    outboxTerminalDays: number;
-    skillRunTerminalDays: number;
-    auditLogsDays: number;
-    agentRunsDays: number;
-    llmUsageRecordsDays: number;
-    errorIncidentsDays: number;
-    bootstrapNoncesConsumedDays: number;
-  }>) {
+  // Content categories are now default-PERMANENT in production
+  // (FRIDAY_DEFAULT_RETENTION_POLICY — proven in
+  // friday-retention-policy-core.test.ts). The deletion-asserting tests below
+  // exercise the *enable* path, so this helper injects each content category
+  // explicitly ENABLED at its historical day-window as a discriminated
+  // {mode:'after_days'} config. Security-lifecycle TTLs stay numeric.
+  function createJob(policy?: Partial<FridayRetentionPolicy>) {
     return createFridayRetentionJob({
       db,
       pairingRequestRepo,
@@ -91,15 +87,15 @@ describe("FridayRetentionJob", () => {
       bootstrapNonceRepo,
       nowIso: () => NOW,
       policy: {
-        learningEventsDays: 90,
-        heartbeatsDays: 7,
+        learningEvents: { mode: "after_days", days: 90 },
+        heartbeats: { mode: "after_days", days: 7 },
+        skillRunTerminal: { mode: "after_days", days: 30 },
+        auditLogs: { mode: "after_days", days: 90 },
+        agentRuns: { mode: "after_days", days: 90 },
+        llmUsageRecords: { mode: "after_days", days: 180 },
+        errorIncidents: { mode: "after_days", days: 90 },
         pairingRequestsDays: 7,
         outboxTerminalDays: 14,
-        skillRunTerminalDays: 30,
-        auditLogsDays: 90,
-        agentRunsDays: 90,
-        llmUsageRecordsDays: 180,
-        errorIncidentsDays: 90,
         bootstrapNoncesConsumedDays: 365,
         ...policy,
       },

--- a/test/unit/jobs/retention/friday-retention-policy-core.test.ts
+++ b/test/unit/jobs/retention/friday-retention-policy-core.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridaySatellitePairingRequestRepository,
+  createFridaySatelliteHeartbeatRepository,
+  createFridayOutboxMessageRepository,
+} from "#satellites";
+import { createFridayLearningEventLedger, createFridaySkillRunStore } from "#ledger";
+import { createFridaySetupBootstrapNonceRepository } from "#api";
+import { createFridayRetentionJob, FRIDAY_DEFAULT_RETENTION_POLICY } from "#jobs";
+import type { FridayRetentionPolicy } from "#jobs";
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * RETENTION-POLICY-CORE (R1+R2) matrix.
+ *
+ * Requirement anchors: DATA-RETENTION-001 / U9-DATA-RETENTION (all local data
+ * default-PERMANENT until the user deletes; automatic time-based cleanup
+ * default-OFF; user-controlled per category; fail-closed on bad config).
+ *
+ * Production seam: retention-sweep job (registered unconditionally,
+ * friday-hub-bootstrap.ts) -> satelliteRuntime.retention.run() ->
+ * friday-retention-job.ts -> per-category DELETE.
+ */
+describe("FridayRetentionJob — RETENTION-POLICY-CORE", () => {
+  let db: FridaySqliteLayer;
+
+  // Reference "now" used by seed timestamps.
+  const NOW = "2025-06-15T10:00:00.000Z";
+  // A "far future" now: every seeded row is older than any conceivable window.
+  const FAR_FUTURE = "2099-01-01T00:00:00.000Z";
+
+  const pairingRequestRepo = createFridaySatellitePairingRequestRepository();
+  const heartbeatRepo = createFridaySatelliteHeartbeatRepository();
+  const outboxRepo = createFridayOutboxMessageRepository();
+  const bootstrapNonceRepo = createFridaySetupBootstrapNonceRepository();
+
+  function insertSatellite(id: string) {
+    db.writer
+      .prepare(
+        `INSERT INTO satellites (id, type, display_name, pairing_status, trust_level, public_key,
+         token_version, transport, platform, arch, app_version, node_version, tags_json, created_at, updated_at)
+         VALUES (?, 'phone', 'Test', 'online', 'restricted', 'pk', 1, 'ws', 'linux', 'arm64', '1.0', '22.0', '[]', ?, ?)`,
+      )
+      .run(id, NOW, NOW);
+  }
+
+  beforeEach(() => {
+    db = createTestDb();
+    insertSatellite("sat-1");
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ── seed helpers (one aged row per CONTENT category) ─────────────────────
+  const AGED = "2024-01-01T00:00:00.000Z";
+
+  function seedAgedAuditLog(id = "al-old") {
+    db.writer
+      .prepare(
+        `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+         VALUES (?, ?, 'user', 'u1', 'create', 'skill', 's1')`,
+      )
+      .run(id, AGED);
+  }
+
+  function seedAgedAgentRun(id = "run-old") {
+    db.writer
+      .prepare(
+        `INSERT INTO friday_agent_runs (id, session_key, task, status, created_at)
+         VALUES (?, 'cli:u1:chat', 'old task', 'completed', ?)`,
+      )
+      .run(id, AGED);
+  }
+
+  function seedAgedSkillRun(runId = "srun-old") {
+    createFridaySkillRunStore({ db }).upsertRun({
+      runId,
+      skillId: "s",
+      version: "1.0",
+      status: "completed",
+      currentStepId: "step",
+      attemptsByStep: {},
+      state: {},
+      startedAt: AGED,
+      updatedAt: AGED,
+      sessionId: "sess",
+      userId: "test-user",
+      channel: "discord",
+      lastTransitionAt: AGED,
+    });
+  }
+
+  function seedAgedLearningEvent(id = "evt-old") {
+    db.writer
+      .prepare(
+        `INSERT INTO learning_events (event_id, ts, user_id, kind, payload_json, created_at)
+         VALUES (?, ?, 'test-user', 'user_message', '{}', ?)`,
+      )
+      .run(id, AGED, AGED);
+  }
+
+  function seedAgedLlmUsage(id = "llm-old") {
+    db.writer
+      .prepare(
+        `INSERT INTO llm_usage_records (id, occurred_at, usage_day, usage_month, provider_id, provider_kind, provider_api, model,
+         route_strategy, task_complexity, input_tokens, output_tokens, total_tokens, cost_usd, created_at)
+         VALUES (?, ?, '2024-01-01', '2024-01', 'p1', 'api', 'anthropic', 'm1',
+         'configured', 'simple', 100, 50, 150, 0.01, ?)`,
+      )
+      .run(id, AGED, AGED);
+  }
+
+  function seedAgedErrorIncident(id = "ei-old") {
+    db.writer
+      .prepare(
+        `INSERT INTO error_incidents (incident_id, user_id, ts, category, severity, signature, context_json, status, created_at, updated_at)
+         VALUES (?, 'test-user', ?, 'tool', 'low', 'sig1', '{}', 'resolved', ?, ?)`,
+      )
+      .run(id, AGED, AGED, AGED);
+  }
+
+  function seedAgedHeartbeat(id = "hb-old") {
+    db.writer
+      .prepare(
+        `INSERT INTO satellite_heartbeats (id, satellite_id, ts, status)
+         VALUES (?, 'sat-1', ?, 'online')`,
+      )
+      .run(id, AGED);
+  }
+
+  function seedAllContentCategories() {
+    seedAgedAuditLog();
+    seedAgedAgentRun();
+    seedAgedSkillRun();
+    seedAgedLearningEvent();
+    seedAgedLlmUsage();
+    seedAgedErrorIncident();
+    seedAgedHeartbeat();
+  }
+
+  function makeJob(policy?: FridayRetentionPolicy) {
+    return createFridayRetentionJob({
+      db,
+      pairingRequestRepo,
+      heartbeatRepo,
+      outboxRepo,
+      learningLedger: createFridayLearningEventLedger({ db }),
+      skillRunStore: createFridaySkillRunStore({ db }),
+      bootstrapNonceRepo,
+      nowIso: () => NOW,
+      ...(policy ? { policy } : {}),
+    });
+  }
+
+  // ── 1. DEFAULT-PERMANENT: every content category keeps rows forever ──────
+  it("DEFAULT policy deletes 0 in EVERY content category at far-future NOW", () => {
+    seedAllContentCategories();
+
+    // Use the exported production default explicitly (no injected override).
+    const job = makeJob();
+    const result = job.run(FAR_FUTURE);
+
+    expect(result.deletedAuditLogs).toBe(0);
+    expect(result.deletedAgentRuns).toBe(0);
+    expect(result.deletedSkillRuns).toBe(0);
+    expect(result.deletedLearningEvents).toBe(0);
+    expect(result.deletedLlmUsageRecords).toBe(0);
+    expect(result.deletedErrorIncidents).toBe(0);
+    expect(result.deletedHeartbeats).toBe(0);
+
+    // Rows physically survive.
+    const count = (sql: string) =>
+      (db.writer.prepare(sql).get() as { c: number }).c;
+    expect(count("SELECT COUNT(*) c FROM audit_logs")).toBe(1);
+    expect(count("SELECT COUNT(*) c FROM friday_agent_runs")).toBe(1);
+    expect(count("SELECT COUNT(*) c FROM learning_events")).toBe(1);
+    expect(count("SELECT COUNT(*) c FROM llm_usage_records")).toBe(1);
+    expect(count("SELECT COUNT(*) c FROM error_incidents")).toBe(1);
+    expect(count("SELECT COUNT(*) c FROM satellite_heartbeats")).toBe(1);
+  });
+
+  it("audit_logs are NEVER deleted under DEFAULT even at extreme NOW", () => {
+    seedAgedAuditLog("al-ancient");
+    const job = makeJob();
+    const result = job.run("9999-12-31T23:59:59.000Z");
+    expect(result.deletedAuditLogs).toBe(0);
+    const row = db.writer
+      .prepare("SELECT id FROM audit_logs WHERE id = 'al-ancient'")
+      .get();
+    expect(row).toBeDefined();
+  });
+
+  // ── 2. FAIL-CLOSED: any invalid category config => delete 0 ──────────────
+  const invalidConfigs: Array<[string, unknown]> = [
+    ["missing/undefined", undefined],
+    ["unknown mode", { mode: "forever" }],
+    ["days = 0", { mode: "after_days", days: 0 }],
+    ["days = -1", { mode: "after_days", days: -1 }],
+    ["days = 1.5", { mode: "after_days", days: 1.5 }],
+    ["days = NaN", { mode: "after_days", days: Number.NaN }],
+    ["days = Infinity", { mode: "after_days", days: Number.POSITIVE_INFINITY }],
+    ["days = huge-overflow", { mode: "after_days", days: Number.MAX_SAFE_INTEGER }],
+    ["non-object (number)", 90],
+    ["non-object (string)", "90"],
+    ["null", null],
+  ];
+
+  it.each(invalidConfigs)(
+    "FAIL-CLOSED: auditLogs config %s => deletes 0",
+    (_label, badValue) => {
+      seedAgedAuditLog();
+      // All-permanent baseline with only auditLogs corrupted.
+      const policy = {
+        ...FRIDAY_DEFAULT_RETENTION_POLICY,
+        auditLogs: badValue,
+      } as unknown as FridayRetentionPolicy;
+      const job = makeJob(policy);
+      const result = job.run(FAR_FUTURE);
+      expect(result.deletedAuditLogs).toBe(0);
+      expect(
+        (db.writer.prepare("SELECT COUNT(*) c FROM audit_logs").get() as { c: number }).c,
+      ).toBe(1);
+    },
+  );
+
+  it("FAIL-CLOSED: a wholly non-object category never throws / aborts the sweep", () => {
+    seedAllContentCategories();
+    const policy = {
+      ...FRIDAY_DEFAULT_RETENTION_POLICY,
+      auditLogs: 90, // corrupt one
+      learningEvents: "nonsense", // corrupt another
+    } as unknown as FridayRetentionPolicy;
+    const job = makeJob(policy);
+    // Must not throw; other lifecycle steps still run.
+    expect(() => job.run(FAR_FUTURE)).not.toThrow();
+    const result = job.run(FAR_FUTURE);
+    expect(result.deletedAuditLogs).toBe(0);
+    expect(result.deletedLearningEvents).toBe(0);
+  });
+
+  // ── 3. EXPLICIT ENABLE: only the enabled category deletes; boundary `<` ──
+  it("explicit after_days enables ONLY that category; others untouched", () => {
+    seedAllContentCategories();
+    const policy = {
+      ...FRIDAY_DEFAULT_RETENTION_POLICY,
+      auditLogs: { mode: "after_days", days: 90 },
+    } as unknown as FridayRetentionPolicy;
+    const job = makeJob(policy);
+    const result = job.run(NOW); // AGED (2024-01-01) is > 90d before NOW
+
+    expect(result.deletedAuditLogs).toBe(1);
+    // Every other content category remains permanent -> 0 deleted.
+    expect(result.deletedAgentRuns).toBe(0);
+    expect(result.deletedSkillRuns).toBe(0);
+    expect(result.deletedLearningEvents).toBe(0);
+    expect(result.deletedLlmUsageRecords).toBe(0);
+    expect(result.deletedErrorIncidents).toBe(0);
+    expect(result.deletedHeartbeats).toBe(0);
+  });
+
+  it("boundary: row exactly at cutoff is NOT deleted ( `<` semantics )", () => {
+    const days = 90;
+    const cutoffIso = new Date(
+      new Date(NOW).getTime() - days * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const justBefore = new Date(new Date(cutoffIso).getTime() - 1).toISOString();
+
+    // Row exactly AT cutoff -> survives; row 1ms older -> deleted.
+    db.writer
+      .prepare(
+        `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+         VALUES ('al-at', ?, 'user', 'u1', 'create', 'skill', 's1')`,
+      )
+      .run(cutoffIso);
+    db.writer
+      .prepare(
+        `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+         VALUES ('al-before', ?, 'user', 'u1', 'create', 'skill', 's2')`,
+      )
+      .run(justBefore);
+
+    const policy = {
+      ...FRIDAY_DEFAULT_RETENTION_POLICY,
+      auditLogs: { mode: "after_days", days },
+    } as unknown as FridayRetentionPolicy;
+    const result = makeJob(policy).run(NOW);
+
+    expect(result.deletedAuditLogs).toBe(1);
+    const remaining = db.writer
+      .prepare("SELECT id FROM audit_logs ORDER BY id")
+      .all() as Array<{ id: string }>;
+    expect(remaining).toEqual([{ id: "al-at" }]);
+  });
+
+  // ── 4. SECURITY-LIFECYCLE non-degraded ───────────────────────────────────
+  it("pairing expiry status-flip still fires under DEFAULT policy", () => {
+    db.writer
+      .prepare(
+        `INSERT INTO satellite_pairing_requests (id, satellite_id, code, nonce, status, expires_at, created_at, updated_at)
+         VALUES ('req-exp', 'sat-1', '123456', 'nonce', 'pending', '2025-06-14T00:00:00.000Z', ?, ?)`,
+      )
+      .run(NOW, NOW);
+
+    const result = makeJob().run(NOW);
+    expect(result.markedPairingExpired).toBe(1);
+    const req = db.writer
+      .prepare("SELECT status FROM satellite_pairing_requests WHERE id = 'req-exp'")
+      .get() as { status: string };
+    expect(req.status).toBe("expired");
+  });
+
+  it("resolved pairing-request terminal cleanup still deletes under DEFAULT", () => {
+    db.writer
+      .prepare(
+        `INSERT INTO satellite_pairing_requests (id, satellite_id, code, nonce, status, expires_at, created_at, updated_at)
+         VALUES ('req-old', 'sat-1', '123456', 'nonce', 'approved', ?, ?, ?)`,
+      )
+      .run(AGED, AGED, AGED);
+    const result = makeJob().run(NOW);
+    expect(result.deletedPairingRequests).toBe(1);
+  });
+
+  it("outbox TTL expiry status-flip still fires under DEFAULT", () => {
+    db.withWriteTransaction((d) => {
+      outboxRepo.insertMessage(
+        d,
+        "msg-expired",
+        {
+          satelliteId: "sat-1",
+          queueKey: "commands",
+          messageType: "test",
+          payloadCiphertext: "data",
+          nonce: "n",
+          keyId: "k",
+          idempotencyKey: "idem-exp",
+          expiresAt: "2025-06-14T00:00:00.000Z",
+        },
+        NOW,
+      );
+    });
+    const result = makeJob().run(NOW);
+    expect(result.markedOutboxExpired).toBe(1);
+  });
+
+  it("terminal outbox cleanup still deletes under DEFAULT", () => {
+    db.withWriteTransaction((d) => {
+      outboxRepo.insertMessage(
+        d,
+        "msg-old",
+        {
+          satelliteId: "sat-1",
+          queueKey: "commands",
+          messageType: "test",
+          payloadCiphertext: "data",
+          nonce: "n",
+          keyId: "k",
+          idempotencyKey: "idem-term",
+        },
+        AGED,
+      );
+    });
+    db.writer
+      .prepare(
+        "UPDATE outbox_messages SET status = 'acked', updated_at = ? WHERE id = 'msg-old'",
+      )
+      .run(AGED);
+    const result = makeJob().run(NOW);
+    expect(result.deletedOutboxTerminal).toBe(1);
+  });
+
+  // ── 5. SENSITIVITY: default MUST be permanent for content categories ─────
+  it("SENSITIVITY: production default has every content category set to permanent", () => {
+    // If someone re-introduces a hardcoded numeric window (e.g. auditLogs 90d)
+    // in place of {mode:'permanent'} this guard goes RED.
+    const contentCategories = [
+      "auditLogs",
+      "agentRuns",
+      "skillRunTerminal",
+      "learningEvents",
+      "llmUsageRecords",
+      "errorIncidents",
+      "heartbeats",
+    ] as const;
+    const policy = FRIDAY_DEFAULT_RETENTION_POLICY as unknown as Record<
+      string,
+      { mode?: string }
+    >;
+    for (const cat of contentCategories) {
+      expect(policy[cat]).toBeDefined();
+      expect(policy[cat].mode).toBe("permanent");
+    }
+  });
+
+  // ── 6. CONCURRENCY (light): a post-cutoff row inserted mid-sweep survives ─
+  it("CONCURRENCY: a just-inserted post-cutoff row is not deleted by an enabled sweep", () => {
+    // better-sqlite3 is synchronous; we model a concurrent writer by inserting a
+    // fresh (post-cutoff) row immediately before the sweep, alongside an aged row.
+    seedAgedAuditLog("al-aged"); // should be deleted
+    db.writer
+      .prepare(
+        `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+         VALUES ('al-fresh', ?, 'user', 'u1', 'create', 'skill', 's-fresh')`,
+      )
+      .run(NOW); // post-cutoff -> must survive
+
+    const policy = {
+      ...FRIDAY_DEFAULT_RETENTION_POLICY,
+      auditLogs: { mode: "after_days", days: 90 },
+    } as unknown as FridayRetentionPolicy;
+    const result = makeJob(policy).run(NOW);
+
+    expect(result.deletedAuditLogs).toBe(1);
+    const remaining = db.writer
+      .prepare("SELECT id FROM audit_logs ORDER BY id")
+      .all() as Array<{ id: string }>;
+    expect(remaining).toEqual([{ id: "al-fresh" }]);
+  });
+});


### PR DESCRIPTION
## RETENTION-POLICY-CORE (R1+R2) — default-permanent + fail-closed content retention

**Requirement IDs:** `DATA-RETENTION-001`, `U9-DATA-RETENTION` (local data default-PERMANENT until the user deletes; automatic time-based cleanup default-OFF; user-controlled per category; fail-closed on bad config).

**Frozen head SHA:** `f5db482b5c441e91199910ed218545cf271adfaa` (base `72af57c3277455d26ae919213c0c0995a5e00061` = origin/main at authoring).

### Problem (factual)
Current-main code **default-deletes canonical categories**: the TS retention-sweep job is registered unconditionally (default-ON, hourly) and `FRIDAY_DEFAULT_RETENTION_POLICY` uses hardcoded numeric day-windows that hard-delete canonical user content (`audit_logs`, `friday_agent_runs`, skill runs, `learning_events`, `llm_usage_records`, `error_incidents`) plus derived `heartbeats`. This is a code-path violation of DATA-RETENTION-001. (No runtime/prod state was inspected; this is not a claim that prod is currently deleting.)

### Production seam
`retention-sweep` job (registered unconditionally, `friday-hub-bootstrap.ts`) → `satelliteRuntime.retention.run()` → `src/jobs/retention/friday-retention-job.ts` → per-category `DELETE`.

### Change
1. **Discriminated policy schema** (`friday-retention.types.ts`): every CONTENT category (canonical `auditLogs`, `agentRuns`, `skillRunTerminal`, `learningEvents`, `llmUsageRecords`, `errorIncidents`; derived `heartbeats`) becomes `CategoryRetention = {mode:'permanent'} | {mode:'after_days', days:number}`. `FRIDAY_DEFAULT_RETENTION_POLICY` sets **every** content category to `{mode:'permanent'}`.
2. **Security-lifecycle KEPT exactly as today** (exempt from default-permanent; they delete only TERMINAL / state-invalidated rows, not canonical content, so they stay plain numeric day-windows):
   - `pairing` expiry status-flip (unconditional) — unchanged.
   - `outbox` TTL expiry status-flip (unconditional) — unchanged.
   - `pairingRequestsDays` (hard-delete of RESOLVED pairing rows) — unchanged numeric.
   - `outboxTerminalDays` (hard-delete of TERMINAL outbox rows) — unchanged numeric.
   - `bootstrapNoncesConsumedDays` + the OBS-2 bootstrap-nonce reaper (expired-unconsumed always reaped; consumed past horizon reaped) — unchanged numeric. Anti-replay / defence-in-depth lifecycle; authoritative binding lives on `users.password_hash`.
3. **Fail-closed evaluator** `resolveCutoff(nowIso, category): string | null` in `friday-retention-job.ts`:
   - `{mode:'permanent'}` → `null` ⇒ SKIP deletion (delete 0).
   - valid `{mode:'after_days', days:n}` (positive finite integer, in-range date) → ISO cutoff.
   - ANY invalid input (missing/undefined/null, non-object, unknown mode, `days<=0`, non-integer, `NaN`, `Infinity`, overflow/out-of-range date) → `null` = **FAIL CLOSED** (delete 0). Never throws; never deletes on uncertainty.
   - Each content `DELETE` runs only when `resolveCutoff` returns a non-null cutoff. Security-lifecycle status-flips + terminal cleanups + `db.optimize()` intact.

### Red-first (final new test file run against UNMODIFIED source)
```
 Test Files  1 failed (1)
      Tests  15 failed | 7 passed (22)
```
Representative failures (default deletes canonical rows; fail-closed configs ignored; sensitivity guard red):
```
× DEFAULT policy deletes 0 in EVERY content category at far-future NOW
    AssertionError: expected 1 to be +0 // Object.is equality
× audit_logs are NEVER deleted under DEFAULT even at extreme NOW
    AssertionError: expected 1 to be +0
× FAIL-CLOSED: auditLogs config days = 0 => deletes 0        (expected 1 to be +0)
× FAIL-CLOSED: auditLogs config unknown mode => deletes 0    (expected 1 to be +0)
× FAIL-CLOSED: auditLogs config null => deletes 0            (expected 1 to be +0)
× SENSITIVITY: production default has every content category set to permanent
    AssertionError: expected undefined to be defined
```
The 7 that passed pre-change are the security-lifecycle paths (unchanged) plus a couple whose still-present numeric field produced the same cutoff — expected.

### Negative controls (the matrix)
`test/unit/jobs/retention/friday-retention-policy-core.test.ts`:
- **Default-permanent:** aged rows seeded in every content category, DEFAULT policy at far-future NOW → 0 deleted in each; rows physically survive.
- **Fail-closed x11:** `{undefined, unknown mode, days=0, days=-1, days=1.5, NaN, Infinity, huge-overflow, non-object(number), non-object(string), null}` → 0 deleted; plus a "never throws / aborts sweep" case.
- **Explicit enable:** inject `{after_days,90}` for one category → only that category deletes, others untouched; `<` boundary row exactly at cutoff survives, 1ms-older deleted.
- **Security-lifecycle non-degraded:** pairing expiry status-flip fires; resolved-pairing terminal cleanup deletes; outbox TTL expiry fires; terminal outbox cleanup deletes — all under DEFAULT policy.
- **audit_logs permanence:** explicit assertion that DEFAULT never deletes `audit_logs` at extreme NOW.
- **Sensitivity guard:** fails RED if any content category default is not `{mode:'permanent'}`.
- **Concurrency (light):** a just-inserted post-cutoff row survives an enabled sweep (better-sqlite3 is synchronous; modeled by inserting a fresh row before the sweep).

### Checks (tails)
- `npx vitest run test/unit/jobs/retention/` → **41 passed (2 files)**, Type Errors: no errors.
- `npm run typecheck:src` (`tsc --noEmit` x3) → **exit 0, 0 errors**; `typecheck:contracts` → no errors.
- `eslint` on the 3 changed source files → **0 errors, 0 warnings** (the 2 test files are ignored by the repo eslint config — pre-existing).
- e2e/ui: not run (per instruction).

### does_not_prove
- No persisted user-control / API / UI / restart-readback yet — that is **R3** (later PR). The enable path is exercised only via injected `deps.policy` in tests.
- Rust sweeps (`friday-storage/retention.rs`, `session_lifecycle.rs`) unaddressed — **R-Rust** (Rust owner, before any Rust reaper flag is enabled).
- Code-path only; **no runtime/prod evidence** — this changes source defaults, not observed prod behavior.

### Remaining operator leaves
- **R3:** user-control surface (persist per-category policy + API + UI + readback + disk-growth warning).
- **R-Rust:** same default-permanent + fail-closed for the Rust reapers before flags are ever enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48
