### PR TITLE
feat(retention): default-permanent + fail-closed for DARK Rust sweep_retention + sweep_lifecycle

### DIFF
--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -3718,9 +3718,16 @@ mod tests {
     }
 
     #[test]
-    fn retention_sweep_runs_only_on_enabled_reaper_tick() {
+    fn retention_sweep_is_default_permanent_even_when_the_flag_is_enabled() {
+        // DATA-RETENTION-001 (R-Rust): the reaper tick passes `RetentionWindows::default()`, which
+        // is now PERMANENT for every user-data category. So even with the retention flag ENABLED,
+        // the sweep deletes NOTHING — local canonical user data is retained until the user
+        // explicitly enables a per-category window. This is the tick-level mirror of #1608's
+        // default-permanent policy; flipping the flag alone can never silently prune content.
         let (rt, _ws) = mock_runtime("retention-reaper-tick", OWNER);
         let now = 2_000 * 24 * 60 * 60 * 1000_i64;
+        // A token_ledger row far older than the (opt-in) 90-day window — maximally eligible IF a
+        // window were enabled; under the permanent default it must survive regardless.
         let old = now - friday_storage::retention::TOKEN_LEDGER_MAX_AGE_MS - 1;
         rt.db()
             .conn()
@@ -3751,8 +3758,9 @@ mod tests {
         run_session_reaper_tick(rt.db(), true, now);
         assert_eq!(
             count(),
-            0,
-            "retention flag ON runs artifact retention on the same tick"
+            1,
+            "retention flag ON still deletes NOTHING: the default policy is PERMANENT \
+             (DATA-RETENTION-001)"
         );
         assert_eq!(
             rt.db()

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -69,8 +69,8 @@ pub use provider_timeline_store::{
     StoredPendingAction, StoredTimeline, StoredTimelineEvent, TimelineEventRow, TimelineState,
 };
 pub use retention::{
-    insert_retention_log, insert_retention_log_in, sweep_retention, RetentionOutcome,
-    RetentionWindows,
+    insert_retention_log, insert_retention_log_in, resolve_cutoff, sweep_retention,
+    CategoryRetention, RetentionOutcome, RetentionWindows,
 };
 pub use run_result::{
     get_run_answer_for_principal, get_run_result, get_run_result_ref, persist_run_result,
@@ -80,7 +80,7 @@ pub use run_result::{
 pub use schema::{
     hub_code_max, hub_migrations, phone_migrations, HUB_ONLY_TABLES, PHONE_ONLY_TABLES,
 };
-pub use session_lifecycle::{sweep_lifecycle, SweepOutcome};
+pub use session_lifecycle::{sweep_lifecycle, sweep_lifecycle_with_policy, SweepOutcome};
 pub use trust_grant::{
     active_grant, authorize_agent_action, grant_trust, latest_grant_any_state, revoke_trust,
     AgentActionContext,

--- a/rust-core/crates/friday-storage/src/retention.rs
+++ b/rust-core/crates/friday-storage/src/retention.rs
@@ -74,60 +74,183 @@ use rusqlite::params;
 use rusqlite::Connection;
 use rusqlite::Transaction;
 
-// ─── Operator-approved default retention windows (ms) ───
+// ─── DATA-RETENTION-001 policy primitive (default-permanent + fail-closed) ───
+//
+// This module MIRRORS the TS retention policy landed in PR #1608
+// (`src/jobs/retention/friday-retention.types.ts` + `resolveCutoff`) INTO the Rust sweep.
+// DATA-RETENTION-001 / U9-DATA-RETENTION: local user data is PERMANENT by default until the user
+// explicitly deletes it; automatic time-based cleanup is DEFAULT-OFF and opt-in per category; any
+// invalid/missing/corrupt config FAILS CLOSED (delete nothing). Every CONTENT category below is
+// therefore a discriminated policy that DEFAULTS to `Permanent`; `AfterDays(n>0)` is the ONLY way
+// to enable a time-based sweep, and [`resolve_cutoff`] is the single fail-closed gate every DELETE
+// consults. A magic sentinel (e.g. an "infinite" numeric window) is deliberately NOT used — "off"
+// is a clean, structurally-distinct `Permanent` variant, so a corrupt/unknown config can never be
+// misread as "delete after N days".
 
-/// `token_ledger` rows older than 90 days are pruned (keyed on `created_at`).
-pub const TOKEN_LEDGER_MAX_AGE_MS: i64 = 90 * 24 * 60 * 60 * 1000;
-/// `run_result` rows older than 365 days are pruned (keyed on `created_at`).
-pub const RUN_RESULT_MAX_AGE_MS: i64 = 365 * 24 * 60 * 60 * 1000;
-/// `surface_event` rows older than 90 days are pruned (keyed on `created_at_ms`).
-pub const SURFACE_EVENT_MAX_AGE_MS: i64 = 90 * 24 * 60 * 60 * 1000;
-/// `provider_session_event` rows older than 90 days are pruned (keyed on `observed_at`).
-pub const PROVIDER_SESSION_EVENT_MAX_AGE_MS: i64 = 90 * 24 * 60 * 60 * 1000;
-/// Terminal `agent_run` rows older than 365 days are pruned after their events/results are gone.
-pub const AGENT_RUN_MAX_AGE_MS: i64 = 365 * 24 * 60 * 60 * 1000;
-/// Terminal `mission` rows older than 365 days are pruned (keyed on `updated_at_ms`).
-pub const MISSION_MAX_AGE_MS: i64 = 365 * 24 * 60 * 60 * 1000;
-/// Terminal `work_item` rows older than 365 days are pruned (keyed on `updated_at_ms`).
-pub const WORK_ITEM_MAX_AGE_MS: i64 = 365 * 24 * 60 * 60 * 1000;
-/// Rejected/expired memory CANDIDATES older than 30 days are pruned (keyed on `created_at`).
-/// CONFIRMED memory is NEVER pruned regardless of age.
-pub const MEMORY_CANDIDATE_MAX_AGE_MS: i64 = 30 * 24 * 60 * 60 * 1000;
+/// One CONTENT category's retention policy. `Permanent` (the default) means "never auto-delete".
+/// `AfterDays(n)` enables a time-based sweep that deletes rows older than `n` days — but ONLY when
+/// `n` is a positive integer whose cutoff is in range; anything else fails closed via
+/// [`resolve_cutoff`]. Mirrors the TS `CategoryRetention` union (`{mode:"permanent"} |
+/// {mode:"after_days",days:n}`) from PR #1608.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CategoryRetention {
+    /// Retain forever (DATA-RETENTION-001 default). The sweep skips this category entirely.
+    Permanent,
+    /// Opt-in: delete rows older than `days` days. A non-positive or overflowing `days` fails
+    /// closed (see [`resolve_cutoff`]) — it is NEVER treated as "delete everything".
+    AfterDays(i64),
+}
+
+impl CategoryRetention {
+    /// FAIL-CLOSED constructor from a serialized `(mode, days)` pair — the Rust mirror of the TS
+    /// `resolveCutoff` input validation (#1608). This is the boundary where an untrusted/persisted
+    /// config (env / JSON / DB) becomes a typed policy. ANY unrecognized/empty mode, or
+    /// `after_days` with a missing / zero / negative `days`, yields `Permanent` (delete nothing).
+    /// Only a well-formed `("after_days", Some(n>0))` enables a sweep.
+    pub fn from_config(mode: &str, days: Option<i64>) -> CategoryRetention {
+        match mode {
+            "after_days" => match days {
+                Some(d) if d > 0 => CategoryRetention::AfterDays(d),
+                // missing / zero / negative days ⇒ fail closed.
+                _ => CategoryRetention::Permanent,
+            },
+            "permanent" => CategoryRetention::Permanent,
+            // unknown / corrupt / empty mode ⇒ fail closed.
+            _ => CategoryRetention::Permanent,
+        }
+    }
+}
+
+/// One day in milliseconds. The sweep keys on epoch-ms timestamps.
+pub const DAY_MS: i64 = 24 * 60 * 60 * 1000;
+
+/// FAIL-CLOSED cutoff evaluator — the single gate every per-category DELETE consults. Returns
+/// `Some(cutoff_ms)` ONLY for an explicitly-enabled, well-formed `AfterDays(n>0)` whose cutoff is
+/// representable; `Permanent` and ANY invalid input (n ≤ 0, or a multiply/subtract that overflows
+/// `i64`) return `None`, which the caller treats as "skip this category (delete 0)". NEVER panics.
+/// This is the Rust mirror of the TS `resolveCutoff` (#1608): invalid ⇒ permanent ⇒ delete nothing.
+pub fn resolve_cutoff(now_ms: i64, policy: CategoryRetention) -> Option<i64> {
+    match policy {
+        CategoryRetention::Permanent => None,
+        CategoryRetention::AfterDays(days) => {
+            if days <= 0 {
+                return None; // zero / negative ⇒ fail closed
+            }
+            // Compute in i128 then range-check back to i64 so an overflowing window fails closed
+            // (returns None) instead of wrapping into a bogus (possibly future) cutoff.
+            let age_ms = (days as i128).checked_mul(DAY_MS as i128)?;
+            let cutoff = (now_ms as i128).checked_sub(age_ms)?;
+            if cutoff < i64::MIN as i128 || cutoff > i64::MAX as i128 {
+                return None; // out-of-range ⇒ fail closed
+            }
+            Some(cutoff as i64)
+        }
+    }
+}
+
+// ─── Operator-approved OPT-IN retention windows (day counts) ───
+//
+// These are NOT the default (the default is `Permanent`); they are the values an operator would set
+// if they DELIBERATELY enable per-category time-based cleanup (surfaced via
+// [`RetentionWindows::operator_windows`]). The `*_MAX_AGE_MS` constants are derived from the day
+// counts so existing age-boundary tests keep a single source of truth.
+
+/// `token_ledger`: opt-in window is 90 days (keyed on `created_at`).
+pub const TOKEN_LEDGER_MAX_AGE_DAYS: i64 = 90;
+/// `run_result`: opt-in window is 365 days (keyed on `created_at`).
+pub const RUN_RESULT_MAX_AGE_DAYS: i64 = 365;
+/// `surface_event`: opt-in window is 90 days (keyed on `created_at_ms`).
+pub const SURFACE_EVENT_MAX_AGE_DAYS: i64 = 90;
+/// `provider_session_event`: opt-in window is 90 days (keyed on `observed_at`).
+pub const PROVIDER_SESSION_EVENT_MAX_AGE_DAYS: i64 = 90;
+/// Terminal `agent_run`: opt-in window is 365 days.
+pub const AGENT_RUN_MAX_AGE_DAYS: i64 = 365;
+/// Terminal `mission`: opt-in window is 365 days (keyed on `updated_at_ms`).
+pub const MISSION_MAX_AGE_DAYS: i64 = 365;
+/// Terminal `work_item`: opt-in window is 365 days (keyed on `updated_at_ms`).
+pub const WORK_ITEM_MAX_AGE_DAYS: i64 = 365;
+/// Rejected/expired memory CANDIDATES: opt-in window is 30 days. CONFIRMED memory is NEVER pruned.
+pub const MEMORY_CANDIDATE_MAX_AGE_DAYS: i64 = 30;
+
+/// `token_ledger` opt-in window in ms (keyed on `created_at`).
+pub const TOKEN_LEDGER_MAX_AGE_MS: i64 = TOKEN_LEDGER_MAX_AGE_DAYS * DAY_MS;
+/// `run_result` opt-in window in ms (keyed on `created_at`).
+pub const RUN_RESULT_MAX_AGE_MS: i64 = RUN_RESULT_MAX_AGE_DAYS * DAY_MS;
+/// `surface_event` opt-in window in ms (keyed on `created_at_ms`).
+pub const SURFACE_EVENT_MAX_AGE_MS: i64 = SURFACE_EVENT_MAX_AGE_DAYS * DAY_MS;
+/// `provider_session_event` opt-in window in ms (keyed on `observed_at`).
+pub const PROVIDER_SESSION_EVENT_MAX_AGE_MS: i64 = PROVIDER_SESSION_EVENT_MAX_AGE_DAYS * DAY_MS;
+/// Terminal `agent_run` opt-in window in ms.
+pub const AGENT_RUN_MAX_AGE_MS: i64 = AGENT_RUN_MAX_AGE_DAYS * DAY_MS;
+/// Terminal `mission` opt-in window in ms (keyed on `updated_at_ms`).
+pub const MISSION_MAX_AGE_MS: i64 = MISSION_MAX_AGE_DAYS * DAY_MS;
+/// Terminal `work_item` opt-in window in ms (keyed on `updated_at_ms`).
+pub const WORK_ITEM_MAX_AGE_MS: i64 = WORK_ITEM_MAX_AGE_DAYS * DAY_MS;
+/// Rejected/expired memory CANDIDATE opt-in window in ms (keyed on `created_at`).
+pub const MEMORY_CANDIDATE_MAX_AGE_MS: i64 = MEMORY_CANDIDATE_MAX_AGE_DAYS * DAY_MS;
 
 /// Default max rows deleted per table per sweep (bounds the per-tick work / lock time). At the
 /// 120s reaper cadence this drains a large backlog over successive ticks without ever holding a
 /// long write lock.
 pub const DEFAULT_BATCH_LIMIT: i64 = 5_000;
 
-/// The retention windows + batch cap, passed to [`sweep_retention`]. Constructed from the
-/// operator-approved constants via [`RetentionWindows::default`]; exposed as named fields so the
-/// windows are trivially adjustable (e.g. in a test) without touching the sweep logic.
+/// The per-category retention POLICIES + batch cap, passed to [`sweep_retention`]. Each content
+/// category is a [`CategoryRetention`] that DEFAULTS to `Permanent` (DATA-RETENTION-001): the
+/// runtime default deletes NOTHING. [`RetentionWindows::operator_windows`] gives the explicit
+/// opt-in after-days windows. Exposed as named fields so a category can be enabled individually
+/// (e.g. in a test) without touching the sweep logic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RetentionWindows {
-    pub token_ledger_max_age_ms: i64,
-    pub run_result_max_age_ms: i64,
-    pub surface_event_max_age_ms: i64,
-    pub provider_session_event_max_age_ms: i64,
-    pub agent_run_max_age_ms: i64,
-    pub mission_max_age_ms: i64,
-    pub work_item_max_age_ms: i64,
-    pub memory_candidate_max_age_ms: i64,
+    pub token_ledger: CategoryRetention,
+    pub run_result: CategoryRetention,
+    pub surface_event: CategoryRetention,
+    pub provider_session_event: CategoryRetention,
+    pub agent_run: CategoryRetention,
+    pub mission: CategoryRetention,
+    pub work_item: CategoryRetention,
+    pub memory_candidate: CategoryRetention,
     /// Max rows deleted per table per sweep (`> 0`; a non-positive value disables that table's
     /// delete, since the `LIMIT` would select nothing).
     pub batch_limit: i64,
 }
 
 impl Default for RetentionWindows {
+    /// DATA-RETENTION-001: every user-data CONTENT category defaults to `Permanent` (never
+    /// auto-delete). This is what the runtime reaper uses, so deploying/enabling the sweep flag
+    /// deletes NOTHING until a category is explicitly opted in.
     fn default() -> Self {
         RetentionWindows {
-            token_ledger_max_age_ms: TOKEN_LEDGER_MAX_AGE_MS,
-            run_result_max_age_ms: RUN_RESULT_MAX_AGE_MS,
-            surface_event_max_age_ms: SURFACE_EVENT_MAX_AGE_MS,
-            provider_session_event_max_age_ms: PROVIDER_SESSION_EVENT_MAX_AGE_MS,
-            agent_run_max_age_ms: AGENT_RUN_MAX_AGE_MS,
-            mission_max_age_ms: MISSION_MAX_AGE_MS,
-            work_item_max_age_ms: WORK_ITEM_MAX_AGE_MS,
-            memory_candidate_max_age_ms: MEMORY_CANDIDATE_MAX_AGE_MS,
+            token_ledger: CategoryRetention::Permanent,
+            run_result: CategoryRetention::Permanent,
+            surface_event: CategoryRetention::Permanent,
+            provider_session_event: CategoryRetention::Permanent,
+            agent_run: CategoryRetention::Permanent,
+            mission: CategoryRetention::Permanent,
+            work_item: CategoryRetention::Permanent,
+            memory_candidate: CategoryRetention::Permanent,
+            batch_limit: DEFAULT_BATCH_LIMIT,
+        }
+    }
+}
+
+impl RetentionWindows {
+    /// The operator-approved OPT-IN windows: every content category set to its `AfterDays(n)`
+    /// value. This is NOT a default — it is what an operator would choose if they DELIBERATELY
+    /// enable per-category time-based cleanup. It is never wired as the runtime default (the
+    /// runtime default is [`RetentionWindows::default`] = all-`Permanent`); it exists so the
+    /// deletion mechanism can be exercised (tests, or a future operator-supplied policy).
+    pub fn operator_windows() -> Self {
+        RetentionWindows {
+            token_ledger: CategoryRetention::AfterDays(TOKEN_LEDGER_MAX_AGE_DAYS),
+            run_result: CategoryRetention::AfterDays(RUN_RESULT_MAX_AGE_DAYS),
+            surface_event: CategoryRetention::AfterDays(SURFACE_EVENT_MAX_AGE_DAYS),
+            provider_session_event: CategoryRetention::AfterDays(
+                PROVIDER_SESSION_EVENT_MAX_AGE_DAYS,
+            ),
+            agent_run: CategoryRetention::AfterDays(AGENT_RUN_MAX_AGE_DAYS),
+            mission: CategoryRetention::AfterDays(MISSION_MAX_AGE_DAYS),
+            work_item: CategoryRetention::AfterDays(WORK_ITEM_MAX_AGE_DAYS),
+            memory_candidate: CategoryRetention::AfterDays(MEMORY_CANDIDATE_MAX_AGE_DAYS),
             batch_limit: DEFAULT_BATCH_LIMIT,
         }
     }
@@ -203,50 +326,63 @@ pub fn sweep_retention(
     windows: RetentionWindows,
 ) -> RetentionOutcome {
     let mut out = RetentionOutcome::default();
-    let work_item_cutoff = now_ms - windows.work_item_max_age_ms;
-    let mission_cutoff = now_ms - windows.mission_max_age_ms;
+
+    // Resolve every content category to a FAIL-CLOSED cutoff. `None` = `Permanent` OR an invalid
+    // config ⇒ that category's DELETE is SKIPPED entirely (deletes 0). Under the DEFAULT policy
+    // every category resolves to `None`, so the whole sweep is a no-op regardless of how far
+    // `now_ms` is advanced — the DATA-RETENTION-001 default-permanent guarantee (constraint #3).
+    let token_cutoff = resolve_cutoff(now_ms, windows.token_ledger);
+    let run_result_cutoff = resolve_cutoff(now_ms, windows.run_result);
+    let agent_run_cutoff = resolve_cutoff(now_ms, windows.agent_run);
+    let surface_cutoff = resolve_cutoff(now_ms, windows.surface_event);
+    let provider_session_cutoff = resolve_cutoff(now_ms, windows.provider_session_event);
+    let memory_cutoff = resolve_cutoff(now_ms, windows.memory_candidate);
+    let mission_cutoff = resolve_cutoff(now_ms, windows.mission);
+    let work_item_cutoff = resolve_cutoff(now_ms, windows.work_item);
 
     // 1. token_ledger — pure age on created_at. Leaf w.r.t. these FKs (nothing references it).
-    let token_cutoff = now_ms - windows.token_ledger_max_age_ms;
-    match delete_bounded(
-        conn,
-        "DELETE FROM token_ledger
+    if let Some(token_cutoff) = token_cutoff {
+        match delete_bounded(
+            conn,
+            "DELETE FROM token_ledger
           WHERE rowid IN (
               SELECT rowid FROM token_ledger WHERE created_at < ?1
                ORDER BY created_at LIMIT ?2
           )",
-        token_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.token_ledger_deleted = n,
-        Err(_e) => out.table_errors += 1,
+            token_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.token_ledger_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
     }
 
     // 2. run_result — pure age on created_at. Leaf w.r.t. hard FKs (audit_ref/run_id are soft
     //    refs), and rows exist only for terminal run outcomes, so no state guard is needed.
-    let run_result_cutoff = now_ms - windows.run_result_max_age_ms;
-    match delete_bounded(
-        conn,
-        "DELETE FROM run_result
+    if let Some(run_result_cutoff) = run_result_cutoff {
+        match delete_bounded(
+            conn,
+            "DELETE FROM run_result
           WHERE rowid IN (
               SELECT rowid FROM run_result WHERE created_at < ?1
                ORDER BY created_at LIMIT ?2
           )",
-        run_result_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.run_result_deleted = n,
-        Err(_e) => out.table_errors += 1,
+            run_result_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.run_result_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
     }
 
     // 3. agent_run_event — old events for hard-terminal+aged runs, before deleting the run row.
     //    Events for a live hold (`awaiting_clarification`), approval states, or recent terminal
     //    runs stay intact. Orphaned old events are safe to remove because no parent can need them
     //    for a coherent run projection.
-    let agent_run_cutoff = now_ms - windows.agent_run_max_age_ms;
-    match delete_bounded(
-        conn,
-        "DELETE FROM agent_run_event
+    if let Some(agent_run_cutoff) = agent_run_cutoff {
+        match delete_bounded(
+            conn,
+            "DELETE FROM agent_run_event
           WHERE rowid IN (
               SELECT e.rowid FROM agent_run_event e
                WHERE e.created_at < ?1
@@ -263,17 +399,17 @@ pub fn sweep_retention(
                  )
                ORDER BY e.created_at LIMIT ?2
           )",
-        agent_run_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.agent_run_event_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            agent_run_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.agent_run_event_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
 
-    // 4. agent_run — parent row last, after event rows and any still-retained run_result are gone.
-    match delete_bounded(
-        conn,
-        "DELETE FROM agent_run
+        // 4. agent_run — parent row last, after event rows and any still-retained run_result gone.
+        match delete_bounded(
+            conn,
+            "DELETE FROM agent_run
           WHERE rowid IN (
               SELECT ar.rowid FROM agent_run ar
                WHERE ar.state IN
@@ -284,71 +420,80 @@ pub fn sweep_retention(
                  AND NOT EXISTS (SELECT 1 FROM run_result r WHERE r.run_id = ar.run_id)
                ORDER BY ar.updated_at LIMIT ?2
           )",
-        agent_run_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.agent_run_deleted = n,
-        Err(_e) => out.table_errors += 1,
+            agent_run_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.agent_run_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
     }
 
     // 5. surface_event — pure age on created_at_ms. Leaf (no table references surface_event).
     //    Deleted BEFORE work_item/mission so this tick can also free those parents.
-    let surface_cutoff = now_ms - windows.surface_event_max_age_ms;
-    match delete_bounded(
-        conn,
-        "DELETE FROM surface_event
+    if let Some(surface_cutoff) = surface_cutoff {
+        match delete_bounded(
+            conn,
+            "DELETE FROM surface_event
           WHERE rowid IN (
               SELECT rowid FROM surface_event WHERE created_at_ms < ?1
                ORDER BY created_at_ms LIMIT ?2
           )",
-        surface_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.surface_event_deleted = n,
-        Err(_e) => out.table_errors += 1,
+            surface_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.surface_event_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
     }
 
-    // 6. provider_session_event — pure age on observed_at. This is the provider app-server
-    //    observation firehose (metadata/delta receipts), not the token ledger. It is a leaf w.r.t.
-    //    Friday's core mission/work_item FKs, so a bounded age sweep cannot orphan mission state.
-    let provider_session_cutoff = now_ms - windows.provider_session_event_max_age_ms;
-    match delete_bounded(
-        conn,
-        "DELETE FROM provider_session_event
+    // 6. provider_session_event + process_observation — the two firehose leaves, both keyed on the
+    //    provider_session category window. This is the provider app-server observation firehose
+    //    (metadata/delta receipts), not the token ledger; a leaf w.r.t. Friday's core mission/
+    //    work_item FKs, so a bounded age sweep cannot orphan mission state.
+    if let Some(provider_session_cutoff) = provider_session_cutoff {
+        match delete_bounded(
+            conn,
+            "DELETE FROM provider_session_event
           WHERE rowid IN (
               SELECT rowid FROM provider_session_event WHERE observed_at < ?1
                ORDER BY observed_at LIMIT ?2
           )",
-        provider_session_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.provider_session_event_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            provider_session_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.provider_session_event_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
 
-    // 5. process_observation — process-discovery firehose, pure age on observed_at_ms. It is
-    //    deleted before workspace_claim so old matched observations do not pin old released claims.
-    match delete_bounded(
-        conn,
-        "DELETE FROM process_observation
+        // process_observation — process-discovery firehose, pure age on observed_at_ms. Deleted
+        // before workspace_claim so old matched observations do not pin old released claims.
+        match delete_bounded(
+            conn,
+            "DELETE FROM process_observation
           WHERE rowid IN (
               SELECT rowid FROM process_observation WHERE observed_at_ms < ?1
                ORDER BY observed_at_ms LIMIT ?2
           )",
-        provider_session_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.process_observation_deleted = n,
-        Err(_e) => out.table_errors += 1,
+            provider_session_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.process_observation_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
     }
 
-    // 6. route_decision_control — terminal route trace child rows only. The join back to the
-    //    matching route_decision prevents a mismatched but FK-valid control row from being treated
-    //    as terminal trace debris for an unrelated parent.
-    let route_trace_cutoff = work_item_cutoff.min(mission_cutoff);
-    match delete_bounded4(
-        conn,
-        "DELETE FROM route_decision_control
+    // Blocks 6–11: mission/work_item route-trace + child rows. ALL require BOTH the mission AND
+    // work_item categories to be explicitly enabled (fail-closed): a permanent/invalid PARENT
+    // category ⇒ its trace/child debris is retained too. Under the default policy both resolve to
+    // None ⇒ the whole group is skipped.
+    if let (Some(mission_cutoff), Some(work_item_cutoff)) = (mission_cutoff, work_item_cutoff) {
+        let route_trace_cutoff = work_item_cutoff.min(mission_cutoff);
+        // 6. route_decision_control — terminal route trace child rows only. The join back to the
+        //    matching route_decision prevents a mismatched but FK-valid control row from being treated
+        //    as terminal trace debris for an unrelated parent.
+        match delete_bounded4(
+            conn,
+            "DELETE FROM route_decision_control
           WHERE rowid IN (
               SELECT c.rowid
                 FROM route_decision_control c
@@ -366,19 +511,19 @@ pub fn sweep_retention(
                  AND w.updated_at_ms < ?3
                ORDER BY c.created_at_ms LIMIT ?4
           )",
-        route_trace_cutoff,
-        mission_cutoff,
-        work_item_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.route_decision_control_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            route_trace_cutoff,
+            mission_cutoff,
+            work_item_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.route_decision_control_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
 
-    // 7. route_decision — terminal route trace rows after their controls are gone.
-    match delete_bounded4(
-        conn,
-        "DELETE FROM route_decision
+        // 7. route_decision — terminal route trace rows after their controls are gone.
+        match delete_bounded4(
+            conn,
+            "DELETE FROM route_decision
           WHERE rowid IN (
               SELECT r.rowid
                 FROM route_decision r
@@ -396,20 +541,20 @@ pub fn sweep_retention(
                  )
                ORDER BY r.created_at_ms LIMIT ?4
           )",
-        route_trace_cutoff,
-        mission_cutoff,
-        work_item_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.route_decision_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            route_trace_cutoff,
+            mission_cutoff,
+            work_item_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.route_decision_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
 
-    // 8. mission_link — only route-decision trace links are swept here; proof receipts and other
-    //    product evidence links keep their retention semantics and can still pin the parent.
-    match delete_bounded4(
-        conn,
-        "DELETE FROM mission_link
+        // 8. mission_link — only route-decision trace links are swept here; proof receipts and other
+        //    product evidence links keep their retention semantics and can still pin the parent.
+        match delete_bounded4(
+            conn,
+            "DELETE FROM mission_link
           WHERE rowid IN (
               SELECT l.rowid
                 FROM mission_link l
@@ -427,19 +572,19 @@ pub fn sweep_retention(
                  )
                ORDER BY l.created_at_ms LIMIT ?4
           )",
-        route_trace_cutoff,
-        mission_cutoff,
-        work_item_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.mission_link_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            route_trace_cutoff,
+            mission_cutoff,
+            work_item_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.mission_link_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
 
-    // 9. mission_body_snapshot — full-text body snapshot attached to terminal+aged parents.
-    match delete_bounded4(
-        conn,
-        "DELETE FROM mission_body_snapshot
+        // 9. mission_body_snapshot — full-text body snapshot attached to terminal+aged parents.
+        match delete_bounded4(
+            conn,
+            "DELETE FROM mission_body_snapshot
           WHERE rowid IN (
               SELECT b.rowid
                 FROM mission_body_snapshot b
@@ -453,19 +598,19 @@ pub fn sweep_retention(
                  AND w.updated_at_ms < ?3
                ORDER BY b.created_at_ms LIMIT ?4
           )",
-        route_trace_cutoff,
-        mission_cutoff,
-        work_item_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.mission_body_snapshot_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            route_trace_cutoff,
+            mission_cutoff,
+            work_item_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.mission_body_snapshot_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
 
-    // 10. process_lease — terminal process ownership rows attached to terminal+aged parents.
-    match delete_bounded4(
-        conn,
-        "DELETE FROM process_lease
+        // 10. process_lease — terminal process ownership rows attached to terminal+aged parents.
+        match delete_bounded4(
+            conn,
+            "DELETE FROM process_lease
           WHERE rowid IN (
               SELECT p.rowid
                 FROM process_lease p
@@ -483,19 +628,19 @@ pub fn sweep_retention(
                  )
                ORDER BY p.updated_at_ms LIMIT ?4
           )",
-        route_trace_cutoff,
-        mission_cutoff,
-        work_item_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.process_lease_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            route_trace_cutoff,
+            mission_cutoff,
+            work_item_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.process_lease_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
 
-    // 11. workspace_claim — released/stale claims after process observations and leases are gone.
-    match delete_bounded4(
-        conn,
-        "DELETE FROM workspace_claim
+        // 11. workspace_claim — released/stale claims after process observations and leases are gone.
+        match delete_bounded4(
+            conn,
+            "DELETE FROM workspace_claim
           WHERE rowid IN (
               SELECT c.rowid
                 FROM workspace_claim c
@@ -519,20 +664,23 @@ pub fn sweep_retention(
                  )
                ORDER BY c.updated_at_ms LIMIT ?4
           )",
-        route_trace_cutoff,
-        mission_cutoff,
-        work_item_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.workspace_claim_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            route_trace_cutoff,
+            mission_cutoff,
+            work_item_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.workspace_claim_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
+    } // end mission/work_item route-trace group (blocks 6–11)
 
     // 12. provider_session_link — session mirror rows after old event children and process leases
     //    are gone. A NULL last sighting is kept; only an explicitly old sighting can age out.
-    match delete_bounded(
-        conn,
-        "DELETE FROM provider_session_link
+    //    Keyed on the provider_session category (with process_lease already gone above).
+    if let Some(provider_session_cutoff) = provider_session_cutoff {
+        match delete_bounded(
+            conn,
+            "DELETE FROM provider_session_link
           WHERE rowid IN (
               SELECT l.rowid FROM provider_session_link l
                WHERE l.last_provider_seen_at IS NOT NULL
@@ -547,18 +695,20 @@ pub fn sweep_retention(
                  )
                ORDER BY l.last_provider_seen_at LIMIT ?2
           )",
-        provider_session_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.provider_session_link_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            provider_session_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.provider_session_link_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
+    } // end provider_session_link (block 12)
 
     // 13. surface_thread — old terminal-mission threads only, after surface events and process
-    //    leases are gone.
-    match delete_bounded3(
-        conn,
-        "DELETE FROM surface_thread
+    //    leases are gone. Keyed on the mission category only.
+    if let Some(mission_cutoff) = mission_cutoff {
+        match delete_bounded3(
+            conn,
+            "DELETE FROM surface_thread
           WHERE rowid IN (
               SELECT t.rowid
                 FROM surface_thread t
@@ -576,37 +726,40 @@ pub fn sweep_retention(
                  )
                ORDER BY t.updated_at_ms LIMIT ?3
           )",
-        mission_cutoff,
-        mission_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.surface_thread_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            mission_cutoff,
+            mission_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.surface_thread_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
+    } // end surface_thread (block 13)
 
     // 14. memory_item — rejected/expired CANDIDATES only, by created_at. CONFIRMED is excluded by
     //    state, so durable memory is NEVER deleted regardless of age. Leaf (no FK refs into it).
-    let memory_cutoff = now_ms - windows.memory_candidate_max_age_ms;
-    match delete_bounded(
-        conn,
-        "DELETE FROM memory_item
+    if let Some(memory_cutoff) = memory_cutoff {
+        match delete_bounded(
+            conn,
+            "DELETE FROM memory_item
           WHERE rowid IN (
               SELECT rowid FROM memory_item
                WHERE state IN ('candidate', 'rejected')
                  AND created_at < ?1
                ORDER BY created_at LIMIT ?2
           )",
-        memory_cutoff,
-        windows.batch_limit,
-    ) {
-        Ok(n) => out.memory_item_deleted = n,
-        Err(_e) => out.table_errors += 1,
-    }
+            memory_cutoff,
+            windows.batch_limit,
+        ) {
+            Ok(n) => out.memory_item_deleted = n,
+            Err(_e) => out.table_errors += 1,
+        }
+    } // end memory_item (block 14)
 
     // 15. work_item — terminal status AND aged on updated_at_ms, AND FK-safe (no surviving child
     //    in any table that RESTRICT-references work_item). A non-terminal work_item can never
     //    match the status set. Deleted BEFORE mission so an aged-out work_item frees its mission.
-    match delete_bounded(
+    if let Some(work_item_cutoff) = work_item_cutoff {
+        match delete_bounded(
         conn,
         "DELETE FROM work_item
           WHERE rowid IN (
@@ -629,11 +782,13 @@ pub fn sweep_retention(
         Ok(n) => out.work_item_deleted = n,
         Err(_e) => out.table_errors += 1,
     }
+    } // end work_item (block 15)
 
     // 16. mission — terminal status AND aged on updated_at_ms, AND FK-safe (no surviving child in
     //    ANY table that RESTRICT-references mission). A non-terminal (active/waiting/blocked/
     //    paused) mission can never match the status set.
-    match delete_bounded(
+    if let Some(mission_cutoff) = mission_cutoff {
+        match delete_bounded(
         conn,
         "DELETE FROM mission
           WHERE rowid IN (
@@ -657,6 +812,7 @@ pub fn sweep_retention(
         Ok(n) => out.mission_deleted = n,
         Err(_e) => out.table_errors += 1,
     }
+    } // end mission (block 16)
 
     // M3 receipt: record a CONTENT-FREE, counts-only summary of this sweep into `retention_log`
     // (a SEPARATE table, NOT the hash-chained `audit_ledger`). Written ONLY when the sweep actually
@@ -1066,7 +1222,7 @@ mod tests {
         .unwrap();
         assert_eq!(count(&db, "run_result"), 3);
 
-        let out = sweep_retention(db.conn(), now, RetentionWindows::default());
+        let out = sweep_retention(db.conn(), now, RetentionWindows::operator_windows());
         assert_eq!(out.table_errors, 0);
         assert_eq!(out.run_result_deleted, 1);
 
@@ -1091,7 +1247,7 @@ mod tests {
         let now = 2_000 * 24 * 60 * 60 * 1000_i64;
         let windows = RetentionWindows {
             batch_limit: 2,
-            ..RetentionWindows::default()
+            ..RetentionWindows::operator_windows()
         };
 
         for idx in 0..5 {
@@ -1124,7 +1280,7 @@ mod tests {
     fn flag_on_sweep_prunes_only_old_terminal_rows_others_untouched() {
         let db = Db::open_hub(&tmp("e2e-on")).unwrap();
         let now = 2_000 * 24 * 60 * 60 * 1000_i64; // ~2000 days, far past every window
-        let w = RetentionWindows::default();
+        let w = RetentionWindows::operator_windows();
 
         seed_conversation(&db, "fconv_1");
 
@@ -1397,7 +1553,7 @@ mod tests {
         let db = Db::open_hub(&tmp("error-only-receipt")).unwrap();
         let now = 2_000 * 24 * 60 * 60 * 1000_i64;
         db.conn().execute_batch("DROP TABLE mission").unwrap();
-        let out = sweep_retention(db.conn(), now, RetentionWindows::default());
+        let out = sweep_retention(db.conn(), now, RetentionWindows::operator_windows());
         assert!(out.table_errors >= 1, "the dropped-table DELETE must error");
         assert_eq!(out.mission_deleted, 0, "nothing was deleted");
         assert_eq!(
@@ -1417,7 +1573,7 @@ mod tests {
         // age+terminal window) so the whole progression is driven by the sweep, not test surgery.
         let db = Db::open_hub(&tmp("fk-safe")).unwrap();
         let now = 2_000 * 24 * 60 * 60 * 1000_i64;
-        let w = RetentionWindows::default();
+        let w = RetentionWindows::operator_windows();
         seed_conversation(&db, "fconv_1");
 
         // Terminal + very old mission whose ONLY child is a NON-terminal work_item (never
@@ -1477,7 +1633,7 @@ mod tests {
         // parent sweep must skip instead of relying on the route_decision guard alone.
         let db = Db::open_hub(&tmp("rd-control-fk-safe")).unwrap();
         let now = 2_000 * 24 * 60 * 60 * 1000_i64;
-        let w = RetentionWindows::default();
+        let w = RetentionWindows::operator_windows();
         seed_conversation(&db, "fconv_1");
         seed_mission(
             &db,
@@ -1541,7 +1697,7 @@ mod tests {
         );
         seed_agent_run_with_event(&db, "run_recent_done", "ev_recent_done", "finished", recent);
 
-        let out = sweep_retention(db.conn(), now, RetentionWindows::default());
+        let out = sweep_retention(db.conn(), now, RetentionWindows::operator_windows());
         assert_eq!(out.table_errors, 0);
 
         assert!(
@@ -1566,7 +1722,7 @@ mod tests {
     fn f2_aged_observe_and_terminal_child_rows_are_reaped_before_parents() {
         let db = Db::open_hub(&tmp("f2-child-reap")).unwrap();
         let now = 2_000 * 24 * 60 * 60 * 1000_i64;
-        let w = RetentionWindows::default();
+        let w = RetentionWindows::operator_windows();
         let old_session_seen = now - PROVIDER_SESSION_EVENT_MAX_AGE_MS - 1;
         let old_parent_seen = now - MISSION_MAX_AGE_MS - 1;
         seed_conversation(&db, "fconv_f2");
@@ -1709,7 +1865,7 @@ mod tests {
     fn empty_db_and_boundary_are_noops() {
         let db = Db::open_hub(&tmp("empty")).unwrap();
         let now = 2_000 * 24 * 60 * 60 * 1000_i64;
-        let w = RetentionWindows::default();
+        let w = RetentionWindows::operator_windows();
         // Empty DB: nothing to prune.
         assert!(sweep_retention(db.conn(), now, w).is_empty());
 
@@ -1746,7 +1902,7 @@ mod tests {
     fn second_back_to_back_sweep_is_a_noop() {
         let db = Db::open_hub(&tmp("idem")).unwrap();
         let now = 2_000 * 24 * 60 * 60 * 1000_i64;
-        let w = RetentionWindows::default();
+        let w = RetentionWindows::operator_windows();
         seed_conversation(&db, "fconv_1");
         seed_token_ledger(&db, "tl_old", now - TOKEN_LEDGER_MAX_AGE_MS - 1);
         seed_provider_session_link(&db, "ps_idem", now);
@@ -1792,7 +1948,7 @@ mod tests {
         let db = Db::open_hub(&tmp("non-terminal")).unwrap();
         let ancient = 1_i64; // updated_at_ms = 1 → maximally old
         let now = 5_000 * 24 * 60 * 60 * 1000_i64;
-        let w = RetentionWindows::default();
+        let w = RetentionWindows::operator_windows();
         seed_conversation(&db, "fconv_1");
 
         // Every NON-terminal mission status.
@@ -1840,7 +1996,7 @@ mod tests {
         let now = 2_000 * 24 * 60 * 60 * 1000_i64;
         let w = RetentionWindows {
             batch_limit: 2,
-            ..RetentionWindows::default()
+            ..RetentionWindows::operator_windows()
         };
         for i in 0..5 {
             seed_token_ledger(&db, &format!("tl{i}"), now - TOKEN_LEDGER_MAX_AGE_MS - 1);
@@ -1871,21 +2027,258 @@ mod tests {
         assert_eq!(count(&db, "provider_session_event"), 0);
     }
 
-    // --- the default windows ARE the operator-approved constants ---
+    // --- DATA-RETENTION-001: the DEFAULT policy is PERMANENT (deletes nothing) ---
+
+    /// Seed one AGED canonical/user-data row in every category the sweep can touch, at a `now`
+    /// far past every operator window, so that under an ENABLED (after-days) policy EVERYTHING
+    /// would be eligible for deletion. The default-permanent test asserts that under the DEFAULT
+    /// (permanent) policy NONE of it is deleted even with this extreme time-travel.
+    fn seed_all_aged_canonical(db: &Db, now: i64) {
+        seed_conversation(db, "fconv_1");
+        seed_token_ledger(db, "tl_old", now - 10_000 * 24 * 60 * 60 * 1000_i64);
+        persist_run_result(
+            db.conn(),
+            "rr_old",
+            &RunResult::new("finished", "OLD-CANONICAL-ANSWER-BODY", None),
+            1,
+        )
+        .unwrap();
+        seed_memory(db, "mem_rejected_old", "rejected", "candidate", 1);
+        seed_memory(db, "mem_confirmed_old", "confirmed", "confirmed", 1);
+        // A terminal+aged mission with a terminal+aged work_item child (both leaf under the FK
+        // guards after each other), an aged surface_event, and an aged provider firehose row.
+        seed_mission(db, "miss_term_old", "fconv_1", "done", 1);
+        seed_mission(db, "miss_for_wi", "fconv_1", "merged", 1);
+        seed_work_item(db, "wi_term_old", "miss_for_wi", "completed_with_proof", 1);
+        seed_surface_thread(db, "st_1", "fconv_1", "miss_term_old");
+        seed_surface_event(db, "se_old", "fconv_1", "miss_term_old", None, "st_1", 1);
+        seed_provider_session_link(db, "ps_1", 1);
+        seed_provider_session_event(db, "ps_1", "pse_old", 1);
+        seed_agent_run_with_event(db, "run_old", "ev_old", "finished", 1);
+    }
 
     #[test]
-    fn default_windows_are_the_operator_approved_values() {
-        let w = RetentionWindows::default();
-        assert_eq!(w.token_ledger_max_age_ms, 90 * 24 * 60 * 60 * 1000);
-        assert_eq!(w.surface_event_max_age_ms, 90 * 24 * 60 * 60 * 1000);
-        assert_eq!(
-            w.provider_session_event_max_age_ms,
-            90 * 24 * 60 * 60 * 1000
+    fn default_policy_deletes_nothing_even_under_far_future_time_travel() {
+        // DATA-RETENTION-001 (constraint #3): under the DEFAULT retention policy AND arbitrary
+        // long time-travel, ZERO canonical user-data rows are deleted. Local user data is
+        // PERMANENT by default until the user explicitly enables per-category cleanup.
+        //
+        // RED-FIRST: against the pre-fix code (default = operator after-days windows) this sweep
+        // deletes the aged rows, so `is_empty()` is FALSE and this test FAILS. After the fix
+        // (default = permanent, fail-closed) the sweep deletes nothing and it PASSES.
+        let db = Db::open_hub(&tmp("default-permanent")).unwrap();
+        let now = 1_000_000 * 24 * 60 * 60 * 1000_i64; // ~1e6 days into the future
+        seed_all_aged_canonical(&db, now);
+
+        let out = sweep_retention(db.conn(), now, RetentionWindows::default());
+
+        assert!(
+            out.is_empty(),
+            "DEFAULT policy is PERMANENT: no user-data row may be deleted even far in the future \
+             (got {out:?})"
         );
-        assert_eq!(w.agent_run_max_age_ms, 365 * 24 * 60 * 60 * 1000);
-        assert_eq!(w.mission_max_age_ms, 365 * 24 * 60 * 60 * 1000);
-        assert_eq!(w.work_item_max_age_ms, 365 * 24 * 60 * 60 * 1000);
-        assert_eq!(w.memory_candidate_max_age_ms, 30 * 24 * 60 * 60 * 1000);
+        // Every seeded canonical row still present.
+        assert!(exists(&db, "token_ledger", "ledger_id", "tl_old"));
+        assert!(exists(&db, "run_result", "run_id", "rr_old"));
+        assert!(exists(&db, "memory_item", "memory_id", "mem_rejected_old"));
+        assert!(exists(&db, "memory_item", "memory_id", "mem_confirmed_old"));
+        assert!(exists(&db, "mission", "mission_id", "miss_term_old"));
+        assert!(exists(&db, "work_item", "work_item_id", "wi_term_old"));
+        assert!(exists(&db, "surface_event", "surface_event_id", "se_old"));
+        assert!(exists(
+            &db,
+            "provider_session_event",
+            "provider_event_id",
+            "pse_old"
+        ));
+        assert!(exists(&db, "agent_run", "run_id", "run_old"));
+        // No receipt row: nothing was deleted.
+        assert_eq!(
+            count(&db, "retention_log"),
+            0,
+            "a permanent-default sweep deletes nothing and writes no receipt"
+        );
+    }
+
+    // --- DEFAULT = permanent for every category; operator_windows = the opt-in day counts ---
+
+    #[test]
+    fn default_windows_are_permanent_and_operator_windows_are_the_approved_values() {
+        // DEFAULT = permanent for every content category (DATA-RETENTION-001).
+        let d = RetentionWindows::default();
+        for cat in [
+            d.token_ledger,
+            d.run_result,
+            d.surface_event,
+            d.provider_session_event,
+            d.agent_run,
+            d.mission,
+            d.work_item,
+            d.memory_candidate,
+        ] {
+            assert_eq!(
+                cat,
+                CategoryRetention::Permanent,
+                "every content category defaults to PERMANENT"
+            );
+        }
+        assert_eq!(d.batch_limit, DEFAULT_BATCH_LIMIT);
+
+        // operator_windows() = the explicit opt-in after-days values (NOT a default).
+        let w = RetentionWindows::operator_windows();
+        assert_eq!(w.token_ledger, CategoryRetention::AfterDays(90));
+        assert_eq!(w.surface_event, CategoryRetention::AfterDays(90));
+        assert_eq!(w.provider_session_event, CategoryRetention::AfterDays(90));
+        assert_eq!(w.agent_run, CategoryRetention::AfterDays(365));
+        assert_eq!(w.run_result, CategoryRetention::AfterDays(365));
+        assert_eq!(w.mission, CategoryRetention::AfterDays(365));
+        assert_eq!(w.work_item, CategoryRetention::AfterDays(365));
+        assert_eq!(w.memory_candidate, CategoryRetention::AfterDays(30));
         assert_eq!(w.batch_limit, DEFAULT_BATCH_LIMIT);
+    }
+
+    // --- fail-closed: resolve_cutoff / from_config reject every invalid config ---
+
+    #[test]
+    fn resolve_cutoff_and_from_config_fail_closed_on_every_invalid_input() {
+        let now = 1_000_000 * 24 * 60 * 60 * 1000_i64;
+        // permanent → None (skip).
+        assert_eq!(resolve_cutoff(now, CategoryRetention::Permanent), None);
+        // zero-days → None.
+        assert_eq!(resolve_cutoff(now, CategoryRetention::AfterDays(0)), None);
+        // negative-days → None.
+        assert_eq!(resolve_cutoff(now, CategoryRetention::AfterDays(-5)), None);
+        // overflow-days → None (does not panic).
+        assert_eq!(
+            resolve_cutoff(now, CategoryRetention::AfterDays(i64::MAX)),
+            None
+        );
+        assert_eq!(
+            resolve_cutoff(i64::MIN, CategoryRetention::AfterDays(i64::MAX)),
+            None
+        );
+        // a valid positive window resolves to now - n*day.
+        assert_eq!(
+            resolve_cutoff(now, CategoryRetention::AfterDays(90)),
+            Some(now - 90 * DAY_MS)
+        );
+
+        // from_config fail-closes on missing / unknown-mode / corrupt / non-positive inputs.
+        assert_eq!(
+            CategoryRetention::from_config("permanent", None),
+            CategoryRetention::Permanent
+        );
+        assert_eq!(
+            CategoryRetention::from_config("after_days", None), // missing days
+            CategoryRetention::Permanent
+        );
+        assert_eq!(
+            CategoryRetention::from_config("after_days", Some(0)), // zero
+            CategoryRetention::Permanent
+        );
+        assert_eq!(
+            CategoryRetention::from_config("after_days", Some(-3)), // negative
+            CategoryRetention::Permanent
+        );
+        assert_eq!(
+            CategoryRetention::from_config("garbage_mode", Some(30)), // unknown / corrupt mode
+            CategoryRetention::Permanent
+        );
+        assert_eq!(
+            CategoryRetention::from_config("", None), // empty / missing mode
+            CategoryRetention::Permanent
+        );
+        // only a well-formed after_days enables it.
+        assert_eq!(
+            CategoryRetention::from_config("after_days", Some(30)),
+            CategoryRetention::AfterDays(30)
+        );
+    }
+
+    #[test]
+    fn invalid_per_category_config_deletes_zero_for_that_category() {
+        // Enable ONE category (token_ledger) with each invalid config in turn; each must delete 0
+        // (fail-closed) while an aged row sits ready. Every OTHER category stays permanent.
+        let now = 1_000_000 * 24 * 60 * 60 * 1000_i64;
+        for bad in [
+            CategoryRetention::AfterDays(0),
+            CategoryRetention::AfterDays(-1),
+            CategoryRetention::AfterDays(i64::MAX),
+            CategoryRetention::from_config("unknown", Some(90)),
+            CategoryRetention::from_config("after_days", None),
+        ] {
+            let db = Db::open_hub(&tmp("failclosed")).unwrap();
+            seed_token_ledger(&db, "tl_old", 1);
+            let w = RetentionWindows {
+                token_ledger: bad,
+                ..RetentionWindows::default()
+            };
+            let out = sweep_retention(db.conn(), now, w);
+            assert_eq!(
+                out.token_ledger_deleted, 0,
+                "invalid config {bad:?} must fail closed (delete 0)"
+            );
+            assert!(exists(&db, "token_ledger", "ledger_id", "tl_old"));
+            assert_eq!(count(&db, "retention_log"), 0);
+        }
+    }
+
+    // --- positive control: an EXPLICIT opt-in deletes exactly that category, nothing else ---
+
+    #[test]
+    fn explicit_single_category_opt_in_deletes_only_that_category() {
+        // The mechanism still works when the user genuinely opts in: enable ONLY memory_candidate
+        // at after_days(30); leave every other category permanent. Aged rows exist in MANY
+        // categories, but ONLY the aged rejected memory candidate is deleted.
+        let db = Db::open_hub(&tmp("opt-in-one")).unwrap();
+        let now = 1_000_000 * 24 * 60 * 60 * 1000_i64;
+        seed_all_aged_canonical(&db, now);
+
+        let w = RetentionWindows {
+            memory_candidate: CategoryRetention::AfterDays(30),
+            ..RetentionWindows::default()
+        };
+        let out = sweep_retention(db.conn(), now, w);
+        assert_eq!(out.table_errors, 0);
+
+        // Exactly the aged rejected candidate went; the confirmed memory (durable) stayed.
+        assert_eq!(out.memory_item_deleted, 1);
+        assert!(!exists(&db, "memory_item", "memory_id", "mem_rejected_old"));
+        assert!(
+            exists(&db, "memory_item", "memory_id", "mem_confirmed_old"),
+            "confirmed memory is never deleted, even when the category is enabled"
+        );
+        // Nothing else was touched (all other categories still permanent).
+        assert_eq!(out.token_ledger_deleted, 0);
+        assert_eq!(out.run_result_deleted, 0);
+        assert_eq!(out.surface_event_deleted, 0);
+        assert_eq!(out.provider_session_event_deleted, 0);
+        assert_eq!(out.mission_deleted, 0);
+        assert_eq!(out.work_item_deleted, 0);
+        assert_eq!(out.agent_run_deleted, 0);
+        assert!(exists(&db, "token_ledger", "ledger_id", "tl_old"));
+        assert!(exists(&db, "run_result", "run_id", "rr_old"));
+        assert!(exists(&db, "mission", "mission_id", "miss_term_old"));
+        assert!(exists(&db, "work_item", "work_item_id", "wi_term_old"));
+    }
+
+    // --- audit_ledger is NEVER swept, under any policy ---
+
+    #[test]
+    fn audit_ledger_is_never_swept_under_any_policy() {
+        let db = Db::open_hub(&tmp("audit-permanent")).unwrap();
+        let now = 1_000_000 * 24 * 60 * 60 * 1000_i64;
+        seed_audit(&db, "audit_1");
+        seed_audit(&db, "audit_2");
+        let before = count(&db, "audit_ledger");
+        // Even with EVERY category maximally enabled (operator_windows) + extreme time-travel,
+        // the audit hash-chain is untouched (the sweep never references audit_ledger).
+        let _ = sweep_retention(db.conn(), now, RetentionWindows::operator_windows());
+        assert_eq!(
+            count(&db, "audit_ledger"),
+            before,
+            "audit_ledger row count unchanged"
+        );
+        assert_eq!(crate::audit::verify_audit_chain(db.conn()).unwrap(), 2);
     }
 }

--- a/rust-core/crates/friday-storage/src/session_lifecycle.rs
+++ b/rust-core/crates/friday-storage/src/session_lifecycle.rs
@@ -163,15 +163,21 @@ pub fn sweep_lifecycle_with_policy(
 
     // 1. active → idle: no activity for > IDLE_TIMEOUT. Drive off
     //    COALESCE(last_activity_at, updated_at) — last_activity_at has no writer yet, so
-    //    updated_at (genuinely maintained) is the live signal. STRICT `<` boundary.
-    let idle_before = now_ms - IDLE_TIMEOUT_MS;
-    let idled = tx.execute(
-        "UPDATE agent_session
+    //    updated_at (genuinely maintained) is the live signal. STRICT `<` boundary. The boundary is
+    //    computed with `checked_sub`: an i64 UNDERFLOW (a pathological near-`i64::MIN` now_ms) FAILS
+    //    CLOSED — the phase is SKIPPED (idled = 0), never a wrapped/bogus cutoff that could
+    //    mis-transition a fresh row (#60's "overflow fail-closed" rule, matching `resolve_cutoff`).
+    //    Any sane wall clock (~1.7e12) never underflows, so behaviour is unchanged for real times.
+    let idled = match now_ms.checked_sub(IDLE_TIMEOUT_MS) {
+        Some(idle_before) => tx.execute(
+            "UPDATE agent_session
             SET status = 'idle', idle_at = ?1, status_changed_at = ?1, updated_at = ?1
           WHERE status = 'active'
             AND COALESCE(last_activity_at, updated_at) < ?2",
-        params![now_ms, idle_before],
-    )?;
+            params![now_ms, idle_before],
+        )?,
+        None => 0,
+    };
 
     // DATA-RETENTION-001 SOFT-HIDING GATE (the single fail-closed switch for the non-idle legs).
     // `archived` and `pruned` are BOTH EXCLUDED from the ONLY owner-discovery path —
@@ -189,37 +195,36 @@ pub fn sweep_lifecycle_with_policy(
     // resumable conversation), so idling never hides a session.
     let content_cutoff = resolve_cutoff(now_ms, session_content);
 
-    // 2. idle → archived: GATED. Runs ONLY under an explicit session-content policy; under the
-    //    permanent default it is SKIPPED (archiving would soft-hide the session). idle for
-    //    > ARCHIVE_TIMEOUT (drives off idle_at). STRICT `<`.
-    let archived = if content_cutoff.is_some() {
-        let archive_before = now_ms - ARCHIVE_TIMEOUT_MS;
-        tx.execute(
+    // 2. idle → archived: GATED + overflow-safe. Runs ONLY under an explicit session-content policy
+    //    (content_cutoff is Some); under the permanent default it is SKIPPED (archiving would
+    //    soft-hide the session). idle for > ARCHIVE_TIMEOUT (drives off idle_at). STRICT `<`. The
+    //    boundary is computed with `checked_sub`, so an i64 UNDERFLOW ALSO fails closed (skip = 0);
+    //    `and_then` folds the policy gate AND the overflow check into one Option (#60 overflow rule).
+    let archived = match content_cutoff.and_then(|_| now_ms.checked_sub(ARCHIVE_TIMEOUT_MS)) {
+        Some(archive_before) => tx.execute(
             "UPDATE agent_session
                 SET status = 'archived', archived_at = ?1, status_changed_at = ?1, updated_at = ?1
               WHERE status = 'idle'
                 AND idle_at IS NOT NULL
                 AND idle_at < ?2",
             params![now_ms, archive_before],
-        )?
-    } else {
-        0
+        )?,
+        None => 0,
     };
 
-    // 3. archived → pruned: GATED by the SAME gate as archive. archived for > PRUNE_TIMEOUT
-    //    (drives off archived_at). STRICT `<`.
-    let pruned = if content_cutoff.is_some() {
-        let prune_before = now_ms - PRUNE_TIMEOUT_MS;
-        tx.execute(
+    // 3. archived → pruned: GATED by the SAME gate as archive, and overflow-safe via `checked_sub`
+    //    (an i64 UNDERFLOW fails closed = skip = 0). archived for > PRUNE_TIMEOUT (drives off
+    //    archived_at). STRICT `<`.
+    let pruned = match content_cutoff.and_then(|_| now_ms.checked_sub(PRUNE_TIMEOUT_MS)) {
+        Some(prune_before) => tx.execute(
             "UPDATE agent_session
                 SET status = 'pruned', pruned_at = ?1, status_changed_at = ?1, updated_at = ?1
               WHERE status = 'archived'
                 AND archived_at IS NOT NULL
                 AND archived_at < ?2",
             params![now_ms, prune_before],
-        )?
-    } else {
-        0
+        )?,
+        None => 0,
     };
 
     // 4. pruned → hard-delete: the IRREVERSIBLE deletion of chat/session USER-DATA, gated by the
@@ -1327,6 +1332,45 @@ mod tests {
         assert!(
             exists(&default_db, "old_pruned"),
             "pruned row retained under the default"
+        );
+    }
+
+    // --- #60 overflow rule: each per-phase cutoff fails CLOSED on an i64 underflow -------------
+    //
+    // The three per-phase boundaries (`now_ms - IDLE_TIMEOUT_MS` / `- ARCHIVE_TIMEOUT_MS` /
+    // `- PRUNE_TIMEOUT_MS`) are computed with `checked_sub`, so a pathological near-`i64::MIN`
+    // now_ms UNDERFLOWS → that phase is SKIPPED (does 0), never a wrapped/bogus cutoff that could
+    // mis-transition a fresh row — matching `resolve_cutoff`'s fail-closed math. A real wall clock
+    // (~1.7e12) never reaches here; this only guards a future refactor from silently reintroducing
+    // unchecked subtraction (which would also PANIC in a debug build at this input).
+    #[test]
+    fn per_phase_boundary_underflow_fails_closed_and_never_mistransitions() {
+        let db = Db::open_hub(&tmp("overflow-failclosed")).unwrap();
+        // A brand-new ACTIVE session with a normal updated_at.
+        ensure_session(db.conn(), "s", 1_000).unwrap();
+
+        // DEFAULT policy at i64::MIN: `i64::MIN - IDLE_TIMEOUT_MS` underflows → idle phase skipped.
+        let out = sweep_lifecycle(db.conn(), i64::MIN).unwrap();
+        assert_eq!(
+            out.idled, 0,
+            "idle phase fails closed on underflow (no wrapped cutoff)"
+        );
+        assert_eq!(
+            status_of(&db, "s"),
+            "active",
+            "the session is NOT mis-transitioned by an overflowing clock"
+        );
+
+        // EXPLICIT policy at i64::MIN: the archive/prune boundaries also fail closed (no panic, 0),
+        // and no row is destroyed.
+        let out2 = sweep_enabled(db.conn(), i64::MIN).unwrap();
+        assert_eq!(out2.idled, 0);
+        assert_eq!(out2.archived, 0);
+        assert_eq!(out2.pruned, 0);
+        assert_eq!(out2.hard_deleted, 0);
+        assert!(
+            exists(&db, "s"),
+            "no row destroyed under an overflowing clock"
         );
     }
 }

--- a/rust-core/crates/friday-storage/src/session_lifecycle.rs
+++ b/rust-core/crates/friday-storage/src/session_lifecycle.rs
@@ -13,6 +13,19 @@
 //!   3. `archived` → `pruned`   when archived for > [`PRUNE_TIMEOUT_MS`]    (30d)
 //!   4. `pruned`   → hard-delete when pruned for  > [`HARD_DELETE_TIMEOUT_MS`] (7d after pruned)
 //!
+//! ## DATA-RETENTION-001 gating (transitions 2–4 are DEFAULT-OFF)
+//! Only transition 1 (active→idle) runs under the DEFAULT (permanent) policy. Transitions 2–4 —
+//! idle→archived, archived→pruned, and the irreversible pruned→hard-delete — are ALL gated behind an
+//! explicit `session_content` retention policy (the fail-closed [`resolve_cutoff`]). The reason:
+//! `archived` and `pruned` are EXCLUDED from the owner-discoverable list
+//! ([`crate::agent_session::list_sessions_for_owner`]) and there is NO other list/search/export/
+//! restore surface for them, so auto-advancing a session into either status by mere time passing
+//! SOFT-HIDES it from its owner (a soft-deletion) — barred by DATA-RETENTION-001. `idle` REMAINS in
+//! the owner list (a live, resumable conversation), so idling is safe and stays outside the gate. A
+//! session therefore stays active/idle — listed + accessible — forever until the user explicitly
+//! archives it ([`crate::agent_session::archive_session_for_owner`]) or explicitly enables a
+//! session-content retention policy. See [`sweep_lifecycle_with_policy`].
+//!
 //! Each transition uses a STRICT `<` boundary (faithful to the TS repo's
 //! `... < beforeIso` predicates), advances `status`, writes the relevant per-phase
 //! timestamp + `status_changed_at` + `updated_at`, and runs INSIDE one transaction
@@ -106,27 +119,36 @@ impl SweepOutcome {
     }
 }
 
-/// Run the four lifecycle transitions with the DEFAULT session-content policy — `Permanent`
-/// (DATA-RETENTION-001). This is the entry the runtime reaper calls. The reversible status
-/// transitions (active→idle→archived→pruned) still fire; the IRREVERSIBLE pruned→hard-delete leg,
-/// which destroys chat/session USER-DATA, is SKIPPED (deletes nothing) under the permanent default,
-/// so local chat is retained forever until the user explicitly deletes it. Enabling a real
-/// time-based hard-delete is an explicit, per-category opt-in via [`sweep_lifecycle_with_policy`].
+/// Run the lifecycle transitions with the DEFAULT session-content policy — `Permanent`
+/// (DATA-RETENTION-001). This is the entry the runtime reaper calls. Under the permanent default
+/// ONLY the active→idle leg runs (idle stays in the owner-discoverable list — a live, resumable
+/// conversation). The idle→archived and archived→pruned legs are DEFAULT-OFF because `archived`/
+/// `pruned` are excluded from that list (`list_sessions_for_owner`) with no other discovery/restore
+/// path, so auto-advancing into them by mere time passing would SOFT-HIDE the session from its
+/// owner — a soft-deletion barred by DATA-RETENTION-001. The IRREVERSIBLE pruned→hard-delete leg is
+/// likewise SKIPPED. So a session stays active/idle — LISTED + accessible — forever until the user
+/// explicitly archives it ([`crate::agent_session::archive_session_for_owner`]) or explicitly
+/// enables a session-content retention policy via [`sweep_lifecycle_with_policy`].
 pub fn sweep_lifecycle(conn: &Connection, now_ms: i64) -> Result<SweepOutcome> {
     sweep_lifecycle_with_policy(conn, now_ms, CategoryRetention::Permanent)
 }
 
-/// Run the four lifecycle transitions over `agent_session` in ONE transaction at logical
-/// time `now_ms` (epoch ms), with an explicit `session_content` retention policy for the
-/// IRREVERSIBLE pruned→hard-delete leg. Returns the per-transition [`SweepOutcome`] counts.
+/// Run the lifecycle transitions over `agent_session` in ONE transaction at logical time `now_ms`
+/// (epoch ms), with an explicit `session_content` retention policy. Returns the per-transition
+/// [`SweepOutcome`] counts.
 ///
-/// The active→idle→archived→pruned STATUS transitions are reversible lifecycle bookkeeping (they
-/// destroy no content) and ALWAYS run — they are session lifecycle, not user-data retention, and
-/// are left non-degraded. The pruned→hard-delete leg deletes chat/session USER-DATA and is gated by
-/// `session_content` through the fail-closed [`resolve_cutoff`]: `Permanent` (the default) or ANY
-/// invalid config ⇒ NO hard-delete (delete 0); an explicit, well-formed
-/// `AfterDays(HARD_DELETE_TIMEOUT_DAYS)` reproduces the original 7-day cutoff. This mirrors PR
-/// #1608's default-permanent + fail-closed policy for the user-data portion of the sweep.
+/// active→idle ALWAYS runs (idle is a live, resumable conversation that REMAINS in the
+/// owner-discoverable [`crate::agent_session::list_sessions_for_owner`], so idling never hides a
+/// session). The idle→archived, archived→pruned, AND pruned→hard-delete legs are ALL gated by
+/// `session_content` through the fail-closed [`resolve_cutoff`] — because `archived`/`pruned` are
+/// EXCLUDED from the owner list (with no other discovery/restore surface), so auto-advancing into
+/// them by mere time passing SOFT-HIDES the session (a soft-deletion), which DATA-RETENTION-001
+/// bars. `Permanent` (the default) or ANY invalid config ⇒ [`resolve_cutoff`] returns None ⇒ NONE
+/// of those three legs run (only idle); an explicit, well-formed `AfterDays(n)` ⇒ Some ⇒ all three
+/// run on their ported per-phase boundaries, with the hard-delete keyed on the resolved cutoff
+/// (`AfterDays(HARD_DELETE_TIMEOUT_DAYS)` reproduces the original 7-day pruned→hard-delete cutoff).
+/// This extends PR #1608/#1609's default-permanent + fail-closed policy to the full session
+/// lifecycle, not just the irreversible hard-delete.
 ///
 /// The steps run in order; each reads the timestamp the PRIOR step wrote, but a strict `<` boundary
 /// plus the per-phase timeouts mean a row advances at most one phase per call (a just-idled row's
@@ -151,35 +173,61 @@ pub fn sweep_lifecycle_with_policy(
         params![now_ms, idle_before],
     )?;
 
-    // 2. idle → archived: idle for > ARCHIVE_TIMEOUT (drives off idle_at). STRICT `<`.
-    let archive_before = now_ms - ARCHIVE_TIMEOUT_MS;
-    let archived = tx.execute(
-        "UPDATE agent_session
-            SET status = 'archived', archived_at = ?1, status_changed_at = ?1, updated_at = ?1
-          WHERE status = 'idle'
-            AND idle_at IS NOT NULL
-            AND idle_at < ?2",
-        params![now_ms, archive_before],
-    )?;
+    // DATA-RETENTION-001 SOFT-HIDING GATE (the single fail-closed switch for the non-idle legs).
+    // `archived` and `pruned` are BOTH EXCLUDED from the ONLY owner-discovery path —
+    // `list_sessions_for_owner` (agent_session.rs: `status NOT IN ('archived','pruned')`) — and
+    // there is NO archived/pruned list/search/export/restore surface. So auto-advancing a session
+    // into `archived`/`pruned` by mere time passing SOFT-HIDES it from its owner (a soft-deletion),
+    // even though the row is not hard-deleted. Therefore the reversible archive/prune legs AND the
+    // irreversible hard-delete all bind to the SAME fail-closed `resolve_cutoff` gate the artifact
+    // sweep (#1608) and the #1609 hard-delete use: `Permanent` (the default) or ANY invalid config ⇒
+    // None ⇒ ONLY the active→idle leg runs, so a session stays active/idle — LISTED + accessible —
+    // FOREVER until the user explicitly archives it (`archive_session_for_owner`) or explicitly
+    // enables a session-content retention policy. An explicit, well-formed `AfterDays(n)` ⇒ Some ⇒
+    // the full lifecycle runs on its ported per-phase boundaries (hard-delete at the resolved cutoff).
+    // active→idle is DELIBERATELY outside this gate: idle REMAINS in the owner list (a live,
+    // resumable conversation), so idling never hides a session.
+    let content_cutoff = resolve_cutoff(now_ms, session_content);
 
-    // 3. archived → pruned: archived for > PRUNE_TIMEOUT (drives off archived_at). STRICT `<`.
-    let prune_before = now_ms - PRUNE_TIMEOUT_MS;
-    let pruned = tx.execute(
-        "UPDATE agent_session
-            SET status = 'pruned', pruned_at = ?1, status_changed_at = ?1, updated_at = ?1
-          WHERE status = 'archived'
-            AND archived_at IS NOT NULL
-            AND archived_at < ?2",
-        params![now_ms, prune_before],
-    )?;
+    // 2. idle → archived: GATED. Runs ONLY under an explicit session-content policy; under the
+    //    permanent default it is SKIPPED (archiving would soft-hide the session). idle for
+    //    > ARCHIVE_TIMEOUT (drives off idle_at). STRICT `<`.
+    let archived = if content_cutoff.is_some() {
+        let archive_before = now_ms - ARCHIVE_TIMEOUT_MS;
+        tx.execute(
+            "UPDATE agent_session
+                SET status = 'archived', archived_at = ?1, status_changed_at = ?1, updated_at = ?1
+              WHERE status = 'idle'
+                AND idle_at IS NOT NULL
+                AND idle_at < ?2",
+            params![now_ms, archive_before],
+        )?
+    } else {
+        0
+    };
 
-    // 4. pruned → hard-delete: the IRREVERSIBLE deletion of chat/session USER-DATA. DATA-RETENTION-
-    //    001: default-permanent + fail-closed. `resolve_cutoff` returns the cutoff ONLY for an
-    //    explicitly-enabled, well-formed AfterDays policy; `Permanent` (default) or any invalid
-    //    config ⇒ None ⇒ NO hard-delete (chat retained forever). When enabled, STRICT `<` on
-    //    pruned_at; child messages deleted FIRST (FK has no ON DELETE CASCADE and foreign_keys is
-    //    ON), then the parent rows — same txn, no orphans.
-    let (messages_deleted, hard_deleted) = match resolve_cutoff(now_ms, session_content) {
+    // 3. archived → pruned: GATED by the SAME gate as archive. archived for > PRUNE_TIMEOUT
+    //    (drives off archived_at). STRICT `<`.
+    let pruned = if content_cutoff.is_some() {
+        let prune_before = now_ms - PRUNE_TIMEOUT_MS;
+        tx.execute(
+            "UPDATE agent_session
+                SET status = 'pruned', pruned_at = ?1, status_changed_at = ?1, updated_at = ?1
+              WHERE status = 'archived'
+                AND archived_at IS NOT NULL
+                AND archived_at < ?2",
+            params![now_ms, prune_before],
+        )?
+    } else {
+        0
+    };
+
+    // 4. pruned → hard-delete: the IRREVERSIBLE deletion of chat/session USER-DATA, gated by the
+    //    SAME `content_cutoff`. `Permanent` (default) or any invalid config ⇒ None ⇒ NO hard-delete
+    //    (chat retained forever). When enabled, STRICT `<` on pruned_at; child messages deleted
+    //    FIRST (FK has no ON DELETE CASCADE and foreign_keys is ON), then the parent rows — same
+    //    txn, no orphans.
+    let (messages_deleted, hard_deleted) = match content_cutoff {
         Some(hard_delete_before) => {
             let m = tx.execute(
                 "DELETE FROM agent_session_message
@@ -242,7 +290,11 @@ pub fn sweep_lifecycle_with_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent_session::{append_session_message, ensure_session, SessionMessage};
+    use crate::agent_session::{
+        append_session_message, ensure_session, ensure_session_with_owner, fork_session_for_owner,
+        list_sessions_for_owner, open_session_for_owner, session_message_count_for_owner,
+        SessionMessage, SessionOwner,
+    };
     use crate::Db;
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -457,6 +509,10 @@ mod tests {
 
     #[test]
     fn idle_to_archived_boundary() {
+        // The idle→archived transition is now DEFAULT-OFF (DATA-RETENTION-001: archiving soft-hides
+        // the session). This boundary test exercises the MECHANISM, so it runs the EXPLICIT-policy
+        // entry (`sweep_enabled`); the default-policy behaviour (archive does NOT fire) is asserted
+        // separately by the soft-hiding tests.
         let db = Db::open_hub(&tmp("archive")).unwrap();
         let now = 100_000_000_000_i64;
         // idle_at just UNDER the archive timeout (not strictly past) → not archived.
@@ -479,7 +535,7 @@ mod tests {
             None,
             1,
         );
-        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        let out = sweep_enabled(db.conn(), now).unwrap();
         assert_eq!(out.archived, 1);
         assert_eq!(status_of(&db, "under"), "idle");
         assert_eq!(status_of(&db, "over"), "archived");
@@ -496,6 +552,8 @@ mod tests {
 
     #[test]
     fn archived_to_pruned_boundary() {
+        // The archived→pruned transition is now DEFAULT-OFF (gated with archive). This boundary test
+        // exercises the MECHANISM, so it runs the EXPLICIT-policy entry (`sweep_enabled`).
         let db = Db::open_hub(&tmp("prune")).unwrap();
         let now = 100_000_000_000_i64;
         seed(
@@ -516,7 +574,7 @@ mod tests {
             None,
             1,
         );
-        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        let out = sweep_enabled(db.conn(), now).unwrap();
         assert_eq!(out.pruned, 1);
         assert_eq!(status_of(&db, "under"), "archived");
         assert_eq!(status_of(&db, "over"), "pruned");
@@ -971,16 +1029,17 @@ mod tests {
     }
 
     #[test]
-    fn default_policy_still_advances_status_lifecycle_but_never_hard_deletes() {
-        // NON-DEGRADE (lifecycle): the reversible active→idle→archived→pruned STATUS transitions
-        // are session lifecycle (they destroy no content) and MUST keep firing under the default
-        // (permanent) policy — only the IRREVERSIBLE hard-delete of chat user-data is gated OFF.
-        // A session walks the full status lifecycle across ticks, then — even far past the old
-        // hard-delete window — is NOT deleted.
-        let db = Db::open_hub(&tmp("default-lifecycle-intact")).unwrap();
+    fn default_policy_idles_but_never_archives_prunes_or_hard_deletes() {
+        // DATA-RETENTION-001 (corrected): under the DEFAULT (permanent) policy the reaper advances a
+        // session active→idle ONLY. It must NOT auto-archive or auto-prune — `archived`/`pruned` are
+        // excluded from the owner-discoverable list, so advancing into them would SOFT-HIDE the
+        // session (a soft-deletion). And it never hard-deletes. So a session idles once and then
+        // stays `idle` — LISTED + accessible — forever, no matter how far time advances.
+        let db = Db::open_hub(&tmp("default-idle-only")).unwrap();
         let t0 = 1_000_000_000_i64;
         ensure_session(db.conn(), "s", t0).unwrap();
 
+        // active→idle DOES fire (idle is safe: it stays in the owner list).
         let t1 = t0 + IDLE_TIMEOUT_MS + 1;
         assert_eq!(
             sweep_lifecycle(db.conn(), t1).unwrap().idled,
@@ -989,31 +1048,285 @@ mod tests {
         );
         assert_eq!(status_of(&db, "s"), "idle");
 
+        // Far past the old 7d archive boundary: idle→archived is DEFAULT-OFF, so it does NOT fire.
         let t2 = t1 + ARCHIVE_TIMEOUT_MS + 1;
+        let out2 = sweep_lifecycle(db.conn(), t2).unwrap();
         assert_eq!(
-            sweep_lifecycle(db.conn(), t2).unwrap().archived,
-            1,
-            "idle→archived still fires"
+            out2.archived, 0,
+            "idle→archived is default-OFF (archiving would soft-hide the session)"
         );
-        assert_eq!(status_of(&db, "s"), "archived");
-
-        let t3 = t2 + PRUNE_TIMEOUT_MS + 1;
+        assert_eq!(out2.pruned, 0);
         assert_eq!(
-            sweep_lifecycle(db.conn(), t3).unwrap().pruned,
-            1,
-            "archived→pruned still fires"
+            status_of(&db, "s"),
+            "idle",
+            "the session stays idle (listed)"
         );
-        assert_eq!(status_of(&db, "s"), "pruned");
 
-        // Far past the old 7-day hard-delete window: under the DEFAULT policy the pruned session
-        // is NEVER hard-deleted (chat user-data is permanent).
-        let t4 = t3 + HARD_DELETE_TIMEOUT_MS * 1000 + 1;
-        let out = sweep_lifecycle(db.conn(), t4).unwrap();
-        assert_eq!(out.hard_deleted, 0, "default policy never hard-deletes");
+        // Far past the old prune + hard-delete windows combined: still idle, still present.
+        let t3 = t2 + PRUNE_TIMEOUT_MS + HARD_DELETE_TIMEOUT_MS * 1000 + 1;
+        let out3 = sweep_lifecycle(db.conn(), t3).unwrap();
+        assert!(
+            out3.archived == 0 && out3.pruned == 0 && out3.hard_deleted == 0,
+            "default policy never archives/prunes/hard-deletes, no matter how far time advances"
+        );
         assert!(
             exists(&db, "s"),
-            "the pruned session survives forever under the permanent default"
+            "the session survives forever under the permanent default"
         );
-        assert_eq!(status_of(&db, "s"), "pruned");
+        assert_eq!(
+            status_of(&db, "s"),
+            "idle",
+            "it stays idle — the owner keeps normal discovery + access forever"
+        );
+    }
+
+    // --- DATA-RETENTION-001: the DEFAULT policy must NOT SOFT-HIDE a session from its owner ---
+    //
+    // The Advisor defect this PR fixes: under the permanent default the reaper still auto-advanced a
+    // session active→idle→ARCHIVED→PRUNED by mere time passing. `archived`/`pruned` are EXCLUDED from
+    // the ONLY owner-discovery path — `list_sessions_for_owner` (agent_session.rs:
+    // `WHERE user_id = ?1 AND status NOT IN ('archived','pruned')`) — and there is NO archived/pruned
+    // list/search/export/restore surface. So even though the DB row is NOT hard-deleted, the owner
+    // AUTOMATICALLY loses the normal discovery + access path to their own session once time passes.
+    // That is SOFT-HIDING = soft-deletion, which VIOLATES DATA-RETENTION-001 (local data stays
+    // PERMANENT + ACCESSIBLE until the user explicitly deletes; auto time-based lifecycle is
+    // default-OFF / user-controlled).
+    //
+    // ORACLE = the REAL owner-facing functions, NOT "DB row exists". This drives TWO real DEFAULT
+    // `sweep_lifecycle` ticks across time (the exact call the production reaper makes,
+    // hub_agent_run_server.rs) and asserts the session stays discoverable + readable + resumable
+    // through `list_sessions_for_owner` / `open_session_for_owner` / `fork_session_for_owner`.
+    //
+    // RED-FIRST: against the pre-fix code the second tick ARCHIVES the session, so
+    // `list_sessions_for_owner` returns [] and the discovery assertion FAILS. After the fix (archive
+    // is default-OFF, only idle auto-runs) the session stays `idle` — which IS in the owner list —
+    // and every owner-path assertion PASSES.
+    #[test]
+    fn default_permanent_keeps_session_discoverable_via_owner_list_forever() {
+        let db = Db::open_hub(&tmp("softhide-default-discoverable")).unwrap();
+        let owner = SessionOwner {
+            user_id: Some("owner-u1".into()),
+            ..Default::default()
+        };
+        let t0 = 1_000_000_000_i64;
+        ensure_session_with_owner(db.conn(), "s1", &owner, t0).unwrap();
+        append_session_message(
+            db.conn(),
+            "s1",
+            &SessionMessage::new("user", "CANONICAL-OWNER-CHAT", None),
+            t0,
+        )
+        .unwrap();
+
+        // Precondition: a fresh owned session is discoverable via the owner list.
+        assert!(
+            list_sessions_for_owner(db.conn(), "owner-u1")
+                .unwrap()
+                .iter()
+                .any(|s| s.agent_session_id == "s1"),
+            "precondition: a fresh owned session is discoverable"
+        );
+
+        // Tick 1 (DEFAULT policy): active→idle. An idle session REMAINS in the owner list (a live,
+        // resumable conversation), so discovery is unaffected.
+        let t1 = t0 + IDLE_TIMEOUT_MS + 1;
+        sweep_lifecycle(db.conn(), t1).unwrap();
+        assert_eq!(status_of(&db, "s1"), "idle");
+        assert!(
+            list_sessions_for_owner(db.conn(), "owner-u1")
+                .unwrap()
+                .iter()
+                .any(|s| s.agent_session_id == "s1"),
+            "an idle session is still discoverable in the owner list"
+        );
+
+        // Tick 2 (DEFAULT policy), far past the 7d archive boundary. Pre-fix: this ARCHIVES the
+        // session (idle_at is > 7d old) and it VANISHES from the owner list. Post-fix: archive is
+        // default-OFF, so it stays idle and STAYS discoverable.
+        let t2 = t1 + ARCHIVE_TIMEOUT_MS + PRUNE_TIMEOUT_MS + 1;
+        let out = sweep_lifecycle(db.conn(), t2).unwrap();
+        assert_eq!(
+            out.archived, 0,
+            "DEFAULT (permanent) policy must NOT auto-archive: archiving soft-hides the session"
+        );
+        assert_eq!(out.pruned, 0, "DEFAULT policy must NOT auto-prune");
+        assert_eq!(out.hard_deleted, 0, "DEFAULT policy never hard-deletes");
+        assert_eq!(
+            status_of(&db, "s1"),
+            "idle",
+            "the session stays in an owner-LISTED status forever under the permanent default"
+        );
+
+        // (1) DISCOVERABLE — the load-bearing RED assertion: still returned by the owner LIST query.
+        let listed = list_sessions_for_owner(db.conn(), "owner-u1").unwrap();
+        assert!(
+            listed.iter().any(|s| s.agent_session_id == "s1"),
+            "SOFT-HIDING defect: the owner must STILL discover their own session via the normal list"
+        );
+
+        // (2) READABLE / EXPORTABLE — get-by-id via the normal owner path returns the chat body.
+        let opened = open_session_for_owner(db.conn(), "owner-u1", "s1")
+            .unwrap()
+            .expect("owner can open their own session");
+        assert_eq!(opened.len(), 1);
+        assert_eq!(opened[0].content, "CANONICAL-OWNER-CHAT");
+        assert_eq!(
+            session_message_count_for_owner(db.conn(), "owner-u1", "s1").unwrap(),
+            Some(1),
+            "the owner can export/count the session content via the normal path"
+        );
+
+        // (3) RESTORABLE / ACCESSIBLE — the owner can resume the conversation (fork it into a fresh
+        // ACTIVE branch), and that branch is itself discoverable in the owner list.
+        let fork = fork_session_for_owner(db.conn(), "owner-u1", "s1", t2 + 1).unwrap();
+        assert!(
+            fork.accepted,
+            "the owner can restore/resume their session by forking it"
+        );
+        let child = fork.child_session_id.expect("fork mints a child session");
+        let listed_after = list_sessions_for_owner(db.conn(), "owner-u1").unwrap();
+        assert!(
+            listed_after.iter().any(|s| s.agent_session_id == child),
+            "the restored (forked) branch is discoverable in the owner list"
+        );
+    }
+
+    // --- DATA-RETENTION-001 positive control: an EXPLICIT session-content policy opts IN ---
+    //
+    // The mirror of the RED test: when the user EXPLICITLY enables a session-content retention policy
+    // (`AfterDays(n)`), the archived/pruned/hard-delete legs run PER that policy — gated by the SAME
+    // `resolve_cutoff` the artifact sweep and the #1609 hard-delete already use. This asserts the
+    // transition only affects the opted-IN category (archive/prune fire ONLY under the explicit
+    // policy, NEVER under the Permanent default) and only PAST the cutoff (a not-yet-eligible session
+    // is untouched even with the policy on).
+    #[test]
+    fn explicit_session_policy_archives_prunes_and_hard_deletes_only_past_cutoff() {
+        let now = 100_000_000_000_i64;
+        let policy = CategoryRetention::AfterDays(HARD_DELETE_TIMEOUT_DAYS);
+
+        // --- opted-IN db: the explicit AfterDays policy runs the FULL lifecycle on the ported
+        //     per-phase boundaries, but ONLY past each cutoff. ---
+        let db = Db::open_hub(&tmp("optin-enabled")).unwrap();
+        // NOT past the archive cutoff (idle_at exactly at the boundary, strict `<`) → stays idle.
+        seed(
+            &db,
+            "young_idle",
+            "idle",
+            Some(now - ARCHIVE_TIMEOUT_MS),
+            None,
+            None,
+            1,
+        );
+        // Each past its respective cutoff → advances exactly one phase this tick.
+        seed(
+            &db,
+            "old_idle",
+            "idle",
+            Some(now - ARCHIVE_TIMEOUT_MS - 1),
+            None,
+            None,
+            1,
+        );
+        seed(
+            &db,
+            "old_archived",
+            "archived",
+            None,
+            Some(now - PRUNE_TIMEOUT_MS - 1),
+            None,
+            1,
+        );
+        seed(
+            &db,
+            "old_pruned",
+            "pruned",
+            None,
+            None,
+            Some(now - HARD_DELETE_TIMEOUT_MS - 1),
+            1,
+        );
+
+        let out = sweep_lifecycle_with_policy(db.conn(), now, policy).unwrap();
+        assert_eq!(
+            out.archived, 1,
+            "explicit policy archives the eligible idle session"
+        );
+        assert_eq!(
+            out.pruned, 1,
+            "explicit policy prunes the eligible archived session"
+        );
+        assert_eq!(
+            out.hard_deleted, 1,
+            "explicit policy hard-deletes the eligible pruned session"
+        );
+        assert_eq!(
+            status_of(&db, "young_idle"),
+            "idle",
+            "not past the archive cutoff → untouched even with the policy on"
+        );
+        assert_eq!(status_of(&db, "old_idle"), "archived");
+        assert_eq!(status_of(&db, "old_archived"), "pruned");
+        assert!(
+            !exists(&db, "old_pruned"),
+            "past the hard-delete cutoff → removed under the explicit policy"
+        );
+
+        // --- category gate: the SAME fixtures under the DEFAULT (Permanent) policy fire NOTHING —
+        //     archive/prune/hard-delete are opt-in per the session-content category. ---
+        let default_db = Db::open_hub(&tmp("optin-default-contrast")).unwrap();
+        seed(
+            &default_db,
+            "old_idle",
+            "idle",
+            Some(now - ARCHIVE_TIMEOUT_MS - 1),
+            None,
+            None,
+            1,
+        );
+        seed(
+            &default_db,
+            "old_archived",
+            "archived",
+            None,
+            Some(now - PRUNE_TIMEOUT_MS - 1),
+            None,
+            1,
+        );
+        seed(
+            &default_db,
+            "old_pruned",
+            "pruned",
+            None,
+            None,
+            Some(now - HARD_DELETE_TIMEOUT_MS - 1),
+            1,
+        );
+        let default_out = sweep_lifecycle(default_db.conn(), now).unwrap();
+        assert_eq!(
+            default_out.archived, 0,
+            "default policy does NOT archive (opt-in only) — no soft-hiding"
+        );
+        assert_eq!(
+            default_out.pruned, 0,
+            "default policy does NOT prune (opt-in only)"
+        );
+        assert_eq!(
+            default_out.hard_deleted, 0,
+            "default policy never hard-deletes"
+        );
+        assert_eq!(
+            status_of(&default_db, "old_idle"),
+            "idle",
+            "stays discoverable (idle) under the default"
+        );
+        assert_eq!(
+            status_of(&default_db, "old_archived"),
+            "archived",
+            "no further advance under the default"
+        );
+        assert!(
+            exists(&default_db, "old_pruned"),
+            "pruned row retained under the default"
+        );
     }
 }

--- a/rust-core/crates/friday-storage/src/session_lifecycle.rs
+++ b/rust-core/crates/friday-storage/src/session_lifecycle.rs
@@ -57,6 +57,7 @@
 //! NOT a v1 GO.
 
 use crate::error::Result;
+use crate::retention::{resolve_cutoff, CategoryRetention};
 use rusqlite::params;
 use rusqlite::Connection;
 
@@ -68,8 +69,13 @@ pub const IDLE_TIMEOUT_MS: i64 = 30 * 60 * 1000;
 pub const ARCHIVE_TIMEOUT_MS: i64 = 7 * 24 * 60 * 60 * 1000;
 /// archived → pruned: archived for longer than 30 days.
 pub const PRUNE_TIMEOUT_MS: i64 = 30 * 24 * 60 * 60 * 1000;
-/// pruned → hard-delete: pruned for longer than 7 days.
-pub const HARD_DELETE_TIMEOUT_MS: i64 = 7 * 24 * 60 * 60 * 1000;
+/// pruned → hard-delete: the ORIGINAL 7-day window. Under DATA-RETENTION-001 the hard-delete is now
+/// default-OFF (see [`sweep_lifecycle`]); this window applies ONLY when an operator explicitly opts
+/// the session-content category in as `CategoryRetention::AfterDays(HARD_DELETE_TIMEOUT_DAYS)`,
+/// which reproduces exactly the old `now - HARD_DELETE_TIMEOUT_MS` cutoff.
+pub const HARD_DELETE_TIMEOUT_DAYS: i64 = 7;
+/// pruned → hard-delete window in ms (derived from [`HARD_DELETE_TIMEOUT_DAYS`]).
+pub const HARD_DELETE_TIMEOUT_MS: i64 = HARD_DELETE_TIMEOUT_DAYS * 24 * 60 * 60 * 1000;
 
 /// Per-transition counts from one [`sweep_lifecycle`] call, for observability. The
 /// `hard_deleted` count is the number of `agent_session` ROWS removed (each may have
@@ -100,15 +106,37 @@ impl SweepOutcome {
     }
 }
 
-/// Run the four lifecycle transitions over `agent_session` in ONE transaction at logical
-/// time `now_ms` (epoch ms). Returns the per-transition [`SweepOutcome`] counts.
-///
-/// The four steps run in order (active→idle→archived→pruned→hard-delete); each reads the
-/// timestamp the PRIOR step wrote, but a strict `<` boundary plus the per-phase timeouts
-/// mean a row advances at most one phase per call (a just-idled row's `idle_at = now` is
-/// not `< now - ARCHIVE_TIMEOUT`). The whole sweep is all-or-nothing: any error rolls back
-/// every transition (no partial sweep).
+/// Run the four lifecycle transitions with the DEFAULT session-content policy — `Permanent`
+/// (DATA-RETENTION-001). This is the entry the runtime reaper calls. The reversible status
+/// transitions (active→idle→archived→pruned) still fire; the IRREVERSIBLE pruned→hard-delete leg,
+/// which destroys chat/session USER-DATA, is SKIPPED (deletes nothing) under the permanent default,
+/// so local chat is retained forever until the user explicitly deletes it. Enabling a real
+/// time-based hard-delete is an explicit, per-category opt-in via [`sweep_lifecycle_with_policy`].
 pub fn sweep_lifecycle(conn: &Connection, now_ms: i64) -> Result<SweepOutcome> {
+    sweep_lifecycle_with_policy(conn, now_ms, CategoryRetention::Permanent)
+}
+
+/// Run the four lifecycle transitions over `agent_session` in ONE transaction at logical
+/// time `now_ms` (epoch ms), with an explicit `session_content` retention policy for the
+/// IRREVERSIBLE pruned→hard-delete leg. Returns the per-transition [`SweepOutcome`] counts.
+///
+/// The active→idle→archived→pruned STATUS transitions are reversible lifecycle bookkeeping (they
+/// destroy no content) and ALWAYS run — they are session lifecycle, not user-data retention, and
+/// are left non-degraded. The pruned→hard-delete leg deletes chat/session USER-DATA and is gated by
+/// `session_content` through the fail-closed [`resolve_cutoff`]: `Permanent` (the default) or ANY
+/// invalid config ⇒ NO hard-delete (delete 0); an explicit, well-formed
+/// `AfterDays(HARD_DELETE_TIMEOUT_DAYS)` reproduces the original 7-day cutoff. This mirrors PR
+/// #1608's default-permanent + fail-closed policy for the user-data portion of the sweep.
+///
+/// The steps run in order; each reads the timestamp the PRIOR step wrote, but a strict `<` boundary
+/// plus the per-phase timeouts mean a row advances at most one phase per call (a just-idled row's
+/// `idle_at = now` is not `< now - ARCHIVE_TIMEOUT`). The whole sweep is all-or-nothing: any error
+/// rolls back every transition (no partial sweep).
+pub fn sweep_lifecycle_with_policy(
+    conn: &Connection,
+    now_ms: i64,
+    session_content: CategoryRetention,
+) -> Result<SweepOutcome> {
     let tx = conn.unchecked_transaction()?;
 
     // 1. active → idle: no activity for > IDLE_TIMEOUT. Drive off
@@ -145,27 +173,36 @@ pub fn sweep_lifecycle(conn: &Connection, now_ms: i64) -> Result<SweepOutcome> {
         params![now_ms, prune_before],
     )?;
 
-    // 4. pruned → hard-delete: pruned for > HARD_DELETE_TIMEOUT (drives off pruned_at).
-    //    STRICT `<`. Delete child messages FIRST (FK has no ON DELETE CASCADE and
-    //    foreign_keys is ON), then the parent rows — same txn, no orphans.
-    let hard_delete_before = now_ms - HARD_DELETE_TIMEOUT_MS;
-    let messages_deleted = tx.execute(
-        "DELETE FROM agent_session_message
+    // 4. pruned → hard-delete: the IRREVERSIBLE deletion of chat/session USER-DATA. DATA-RETENTION-
+    //    001: default-permanent + fail-closed. `resolve_cutoff` returns the cutoff ONLY for an
+    //    explicitly-enabled, well-formed AfterDays policy; `Permanent` (default) or any invalid
+    //    config ⇒ None ⇒ NO hard-delete (chat retained forever). When enabled, STRICT `<` on
+    //    pruned_at; child messages deleted FIRST (FK has no ON DELETE CASCADE and foreign_keys is
+    //    ON), then the parent rows — same txn, no orphans.
+    let (messages_deleted, hard_deleted) = match resolve_cutoff(now_ms, session_content) {
+        Some(hard_delete_before) => {
+            let m = tx.execute(
+                "DELETE FROM agent_session_message
           WHERE agent_session_id IN (
               SELECT agent_session_id FROM agent_session
                WHERE status = 'pruned'
                  AND pruned_at IS NOT NULL
                  AND pruned_at < ?1
           )",
-        params![hard_delete_before],
-    )?;
-    let hard_deleted = tx.execute(
-        "DELETE FROM agent_session
+                params![hard_delete_before],
+            )?;
+            let h = tx.execute(
+                "DELETE FROM agent_session
           WHERE status = 'pruned'
             AND pruned_at IS NOT NULL
             AND pruned_at < ?1",
-        params![hard_delete_before],
-    )?;
+                params![hard_delete_before],
+            )?;
+            (m, h)
+        }
+        // PERMANENT / fail-closed: chat/session user-data is never destroyed.
+        None => (0usize, 0usize),
+    };
 
     // M4 receipt — FOLDED INTO THE SWEEP TXN, before commit, so it is ATOMIC with the irreversible
     // hard-delete. Reversibility rationale: M4's prune leg is IRREVERSIBLE (the rows are gone), so
@@ -244,6 +281,18 @@ mod tests {
                 |r| r.get::<_, bool>(0),
             )
             .unwrap()
+    }
+
+    /// Run the sweep with the hard-delete leg EXPLICITLY opted in (the operator-enabled policy that
+    /// reproduces the original 7-day pruned→hard-delete cutoff). Tests that exercise the hard-delete
+    /// mechanism call this; the DEFAULT-policy [`sweep_lifecycle`] is covered separately (it must
+    /// hard-delete NOTHING — DATA-RETENTION-001).
+    fn sweep_enabled(conn: &Connection, now_ms: i64) -> Result<SweepOutcome> {
+        sweep_lifecycle_with_policy(
+            conn,
+            now_ms,
+            CategoryRetention::AfterDays(HARD_DELETE_TIMEOUT_DAYS),
+        )
     }
 
     /// Hand-place a session in a given phase with explicit timestamps so a boundary test can
@@ -506,7 +555,7 @@ mod tests {
             Some(now - HARD_DELETE_TIMEOUT_MS - 1),
             1,
         );
-        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        let out = sweep_enabled(db.conn(), now).unwrap();
         assert_eq!(out.hard_deleted, 1);
         assert!(
             exists(&db, "keep"),
@@ -541,7 +590,7 @@ mod tests {
             Some(now - HARD_DELETE_TIMEOUT_MS - 1),
             1,
         );
-        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        let out = sweep_enabled(db.conn(), now).unwrap();
         assert_eq!(
             out.hard_deleted, 1,
             "only the expired pruned row is deleted"
@@ -597,7 +646,7 @@ mod tests {
         // (it keys on pruned_at), and the pre-set pruned_at survives the append's
         // updated_at bump.
 
-        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        let out = sweep_enabled(db.conn(), now).unwrap();
         assert_eq!(out.hard_deleted, 1);
         assert_eq!(
             out.messages_deleted, 2,
@@ -666,7 +715,7 @@ mod tests {
         )
         .unwrap();
 
-        let out = sweep_lifecycle(db.conn(), now).unwrap();
+        let out = sweep_enabled(db.conn(), now).unwrap();
         assert_eq!(out.hard_deleted, 1);
         assert_eq!(out.messages_deleted, 2);
 
@@ -717,7 +766,7 @@ mod tests {
         // Remove the receipt table so the folded INSERT cannot succeed.
         db.conn().execute_batch("DROP TABLE retention_log").unwrap();
 
-        let res = sweep_lifecycle(db.conn(), now);
+        let res = sweep_enabled(db.conn(), now);
         assert!(
             res.is_err(),
             "a receipt-write failure must surface as an Err, not a silently-committed prune"
@@ -795,7 +844,7 @@ mod tests {
             1,
         );
 
-        let first = sweep_lifecycle(db.conn(), now).unwrap();
+        let first = sweep_enabled(db.conn(), now).unwrap();
         assert_eq!(first.idled, 1);
         assert_eq!(first.archived, 1);
         assert_eq!(first.pruned, 1);
@@ -804,7 +853,7 @@ mod tests {
         assert_eq!(status_of(&db, "a"), "idle");
 
         // Second sweep at the SAME now: nothing is newly eligible → no-op.
-        let second = sweep_lifecycle(db.conn(), now).unwrap();
+        let second = sweep_enabled(db.conn(), now).unwrap();
         assert!(
             second.is_empty(),
             "second back-to-back sweep changes nothing"
@@ -849,22 +898,122 @@ mod tests {
 
         // Tick 1: past idle → idle.
         let t1 = t0 + IDLE_TIMEOUT_MS + 1;
-        assert_eq!(sweep_lifecycle(db.conn(), t1).unwrap().idled, 1);
+        assert_eq!(sweep_enabled(db.conn(), t1).unwrap().idled, 1);
         assert_eq!(status_of(&db, "s"), "idle");
 
         // Tick 2: past archive (idle_at was t1) → archived.
         let t2 = t1 + ARCHIVE_TIMEOUT_MS + 1;
-        assert_eq!(sweep_lifecycle(db.conn(), t2).unwrap().archived, 1);
+        assert_eq!(sweep_enabled(db.conn(), t2).unwrap().archived, 1);
         assert_eq!(status_of(&db, "s"), "archived");
 
         // Tick 3: past prune (archived_at was t2) → pruned.
         let t3 = t2 + PRUNE_TIMEOUT_MS + 1;
-        assert_eq!(sweep_lifecycle(db.conn(), t3).unwrap().pruned, 1);
+        assert_eq!(sweep_enabled(db.conn(), t3).unwrap().pruned, 1);
         assert_eq!(status_of(&db, "s"), "pruned");
 
         // Tick 4: past hard-delete (pruned_at was t3) → gone.
         let t4 = t3 + HARD_DELETE_TIMEOUT_MS + 1;
-        assert_eq!(sweep_lifecycle(db.conn(), t4).unwrap().hard_deleted, 1);
+        assert_eq!(sweep_enabled(db.conn(), t4).unwrap().hard_deleted, 1);
         assert!(!exists(&db, "s"));
+    }
+
+    // --- DATA-RETENTION-001: the DEFAULT session-content policy never hard-deletes chat ---
+
+    #[test]
+    fn default_policy_never_hard_deletes_chat_even_under_far_future_time_travel() {
+        // The pruned→hard-delete leg destroys chat/session USER-DATA. DATA-RETENTION-001: that
+        // deletion is PERMANENT-by-default (default-OFF), so `sweep_lifecycle` (the default-policy
+        // entry the runtime reaper calls) must hard-delete NOTHING even far in the future.
+        //
+        // RED-FIRST: against the pre-fix code (hard-delete keyed only on pruned_at age) this
+        // deletes the expired pruned session, so `hard_deleted == 1` and this test FAILS. After
+        // the fix (default session-content policy = permanent, fail-closed) it hard-deletes
+        // nothing and PASSES. The status transitions (idle/archive/prune) are NON-destructive
+        // lifecycle and are unaffected.
+        let db = Db::open_hub(&tmp("session-default-permanent")).unwrap();
+        let now = 1_000_000 * 24 * 60 * 60 * 1000_i64; // ~1e6 days into the future
+                                                       // A long-pruned session WITH chat messages — maximally eligible under an age-only rule.
+        seed(&db, "old_pruned", "pruned", None, None, Some(1), 1);
+        append_session_message(
+            db.conn(),
+            "old_pruned",
+            &SessionMessage::new("user", "CANONICAL-CHAT-CONTENT", None),
+            10,
+        )
+        .unwrap();
+
+        let out = sweep_lifecycle(db.conn(), now).unwrap();
+
+        assert_eq!(
+            out.hard_deleted, 0,
+            "DEFAULT policy is PERMANENT: chat/session user-data is never hard-deleted"
+        );
+        assert_eq!(
+            out.messages_deleted, 0,
+            "chat messages are never destroyed by default"
+        );
+        assert!(
+            exists(&db, "old_pruned"),
+            "the pruned session + its chat survive the default (permanent) reaper forever"
+        );
+        let msgs: i64 = db
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM agent_session_message WHERE agent_session_id = 'old_pruned'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            msgs, 1,
+            "chat content is retained until the user explicitly deletes"
+        );
+    }
+
+    #[test]
+    fn default_policy_still_advances_status_lifecycle_but_never_hard_deletes() {
+        // NON-DEGRADE (lifecycle): the reversible active→idle→archived→pruned STATUS transitions
+        // are session lifecycle (they destroy no content) and MUST keep firing under the default
+        // (permanent) policy — only the IRREVERSIBLE hard-delete of chat user-data is gated OFF.
+        // A session walks the full status lifecycle across ticks, then — even far past the old
+        // hard-delete window — is NOT deleted.
+        let db = Db::open_hub(&tmp("default-lifecycle-intact")).unwrap();
+        let t0 = 1_000_000_000_i64;
+        ensure_session(db.conn(), "s", t0).unwrap();
+
+        let t1 = t0 + IDLE_TIMEOUT_MS + 1;
+        assert_eq!(
+            sweep_lifecycle(db.conn(), t1).unwrap().idled,
+            1,
+            "active→idle still fires under the default policy"
+        );
+        assert_eq!(status_of(&db, "s"), "idle");
+
+        let t2 = t1 + ARCHIVE_TIMEOUT_MS + 1;
+        assert_eq!(
+            sweep_lifecycle(db.conn(), t2).unwrap().archived,
+            1,
+            "idle→archived still fires"
+        );
+        assert_eq!(status_of(&db, "s"), "archived");
+
+        let t3 = t2 + PRUNE_TIMEOUT_MS + 1;
+        assert_eq!(
+            sweep_lifecycle(db.conn(), t3).unwrap().pruned,
+            1,
+            "archived→pruned still fires"
+        );
+        assert_eq!(status_of(&db, "s"), "pruned");
+
+        // Far past the old 7-day hard-delete window: under the DEFAULT policy the pruned session
+        // is NEVER hard-deleted (chat user-data is permanent).
+        let t4 = t3 + HARD_DELETE_TIMEOUT_MS * 1000 + 1;
+        let out = sweep_lifecycle(db.conn(), t4).unwrap();
+        assert_eq!(out.hard_deleted, 0, "default policy never hard-deletes");
+        assert!(
+            exists(&db, "s"),
+            "the pruned session survives forever under the permanent default"
+        );
+        assert_eq!(status_of(&db, "s"), "pruned");
     }
 }

--- a/rust-core/crates/friday-storage/tests/atomic.rs
+++ b/rust-core/crates/friday-storage/tests/atomic.rs
@@ -555,11 +555,12 @@ fn concurrent_billing_survives_a_reaper_sweeping_on_a_short_cadence() {
         seed_aged_ledger(hub.conn(), &format!("aged_{i}"), now_ms - one_year_ms - 1);
     }
 
-    // Small batch + the same `now_ms` so only the seeded-aged rows match the cutoffs. Large
-    // windows everywhere so the freshly-billed recent rows (created_at == now_ms) never age.
+    // Small batch + the same `now_ms` so only the seeded-aged rows match the cutoffs. The DEFAULT
+    // policy is now permanent (deletes nothing), so this concurrency stress explicitly opts EVERY
+    // category in via `operator_windows()` to exercise the deletion mechanism under contention.
     let windows = RetentionWindows {
         batch_limit: 4,
-        ..RetentionWindows::default()
+        ..RetentionWindows::operator_windows()
     };
 
     let stop = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
## Requirement
RETENTION-R-RUST (#60) + DATA-RETENTION-001. Mirrors merged PR #1608's default-permanent + fail-closed CONTENT retention policy INTO the two DARK (default-OFF) Rust sweep paths, **and** closes a session soft-hiding sub-defect in the Rust lifecycle sweep.

- **This PR head SHA:** `2ef628c51445fb2e2bd0c80e42a19633192caf6d`
- **Parent / base:** `6cae87c7825a833336871e9c345e4c751ff5258b` (current `main`; this PR is born-current onto it)

## Files changed (all Rust; disjoint from other open PRs)
`rust-core/crates/friday-storage/src/{retention.rs, session_lifecycle.rs, lib.rs}`, `rust-core/crates/friday-storage/tests/atomic.rs`, `rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs`.

## What changed (source hardening of DARK paths)

**`retention.rs` — `sweep_retention`** (flag `FRIDAY_RETENTION_SWEEP`, still default-off)
- New discriminated policy `CategoryRetention = Permanent | AfterDays(n)` (Rust mirror of TS `{mode:'permanent'} | {mode:'after_days',days:n}`).
- Fail-closed `CategoryRetention::from_config(mode, days)` (unknown/empty mode, missing/zero/negative days ⇒ `Permanent`) + fail-closed `resolve_cutoff(now_ms, policy) -> Option<i64>` (`Permanent` / `n<=0` / overflow ⇒ `None` ⇒ skip DELETE; never panics). Mirror of TS `resolveCutoff`.
- `RetentionWindows` per-category fields are `CategoryRetention`; `Default` = **Permanent for every user-data content category**. `operator_windows()` carries the explicit opt-in after-days windows (NOT a default) used only to exercise the deletion mechanism.
- Every per-table DELETE (the **18 content/derived** tables: agent_run, agent_run_event, memory_item, mission(+body_snapshot,+link), process_lease, process_observation, provider_session_event, provider_session_link, route_decision(+control), run_result, surface_event, surface_thread, token_ledger, work_item, workspace_claim) is gated behind `resolve_cutoff`; under the default policy all are skipped ⇒ **0 rows deleted at any `now_ms`**. No magic sentinel — "off" is the distinct `Permanent` variant.
- **`audit_ledger` (the hash-chained audit chain) is NEVER swept/deleted under any policy** — it is never a DELETE target, is doc-commented as intentionally excluded (hash-chain immutability), and `audit_ledger_is_never_swept_under_any_policy` asserts its row count is unchanged.

**`session_lifecycle.rs` — `sweep_lifecycle`** (flag `FRIDAY_RUST_SESSION_REAPER_ENABLED`, still default-off)
- Split into `sweep_lifecycle` (DEFAULT = `Permanent`) + `sweep_lifecycle_with_policy`.
- **Default-permanent runs ONLY `active→idle`** (non-destructive; `idle` stays in the owner list). The `idle→archived`, `archived→pruned`, and `pruned→hard-delete` legs are ALL gated fail-closed behind `resolve_cutoff(session_content)` — under the default they never fire.
- **Soft-hiding closure:** `archived`/`pruned` are excluded from the only owner-discovery path — `list_sessions_for_owner` (`status NOT IN ('archived','pruned')`) — and there is no other list/search/export/restore surface, so auto-advancing a session into them by mere time passing would SOFT-HIDE (soft-delete) it. Gating those legs OFF by default means a session stays listed + readable + exportable + restorable via the normal owner functions FOREVER until the user explicitly archives it (`archive_session_for_owner`) or opts into a session-content policy.
- **Overflow fail-closed:** the three per-phase cutoffs (`now_ms - IDLE/ARCHIVE/PRUNE_TIMEOUT_MS`) use `checked_sub`; an i64 underflow skips the phase (fail-closed = 0) instead of wrapping to a bogus cutoff. Behaviour unchanged for real timestamps.
- `AfterDays(HARD_DELETE_TIMEOUT_DAYS)` reproduces the original explicit cutoff.

**Classification** (per constraint #4 — corrected for accuracy): the Rust storage crate **DOES contain** security-lifecycle / approval tables — e.g. `device_identity`, `trusted_device`, `offline_queue`, `system_intent_request`/`_result`/`_approval_record`, `consumed_approval`, `pending_approval_request`, and pairing tables — owned by separate modules (`pairing.rs`, `authorize.rs`/`authorize_ed25519.rs`, `offline.rs`, `system_intent.rs`, `pending_request.rs`). **These are OUTSIDE and UNTOUCHED by the two sweep paths in this PR** (verified: `sweep_retention` deletes only the 18 content/derived tables listed above and references none of these security tables; `sweep_lifecycle` touches only `agent_session` + `agent_session_message`). Their security-expiry / TTL cleanup runs on their own owner/security paths and is **not** disabled by this default-permanent change. Genuinely TS-side privacy-transient cleanup (raw-audio / share-temp) lives in the TS retention job, also untouched. Within `sweep_lifecycle`, `active→idle` is non-destructive lifecycle (kept); `archived`/`pruned`/hard-delete are treated as user-data (default-permanent).

**`friday-hub` reaper-tick test** asserts the live tick is default-permanent even when the retention flag is ON.

## Red-first evidence (oracle = real owner-facing functions, not DB-row-exists)
Core tests were written FIRST against pre-fix code and FAILED behaviorally, then pass post-fix:
- `retention::…default_policy_deletes_nothing_even_under_far_future_time_travel` — pre-fix deleted token_ledger/run_result/agent_run(+event)/surface_event/provider_session_event/provider_session_link/surface_thread/mission×2/work_item/memory_item; now GREEN (0 deleted).
- `session_lifecycle::default_permanent_keeps_session_discoverable_via_owner_list_forever` — pre-fix the session was auto-archived and dropped from `list_sessions_for_owner`; now GREEN: after a far-future DEFAULT sweep the session is still listed, readable via `open_session_for_owner` + `session_message_count_for_owner`, and restorable via `fork_session_for_owner`.
- `session_lifecycle::per_phase_boundary_underflow_fails_closed_and_never_mistransitions` — at `i64::MIN` no phase mis-transitions and no row is destroyed.
- Fail-closed matrix (permanent/zero/negative/overflow/unknown-mode/missing ⇒ delete 0), explicit-policy positive control (single-category `AfterDays` deletes only that category strictly past its cutoff; memory never deleted; `operator_windows()` still deletes as before), audit_ledger-never-swept.

## Checks
- All required CI on head `2ef628c5`: **17/17 green** (rust-core, build, test, migrations, contracts, security, secrets, etc.).
- `cargo test -p friday-storage` (lib + atomic concurrency integration) + `-p friday-hub` session/reaper tick + `cargo clippy --workspace --all-targets -- -D warnings` + `cargo fmt --all --check`: all green.

## Independent review (exact-SHA, bound to head `2ef628c5`)
Independent adversarial review: **PASS — 0 Blocker, 0 High.** Verified the soft-hiding closure (default-permanent keeps the session discoverable/readable/exportable/restorable via the real owner functions), the fail-closed gating (default/invalid/zero/negative/overflow ⇒ delete 0), strict `<` phase boundaries (no off-by-one), and explicit `checked_sub` overflow-safety. The review was performed on the pre-born-current content and carries to head `2ef628c5`: the born-current rebase onto `6cae87c7` is no-drift (the PR's own file-delta is byte-identical pre/post — verified by `git patch-id --stable`, raw-diff sha256, and blob-sha-level file comparison).

## Known sharp edge (explicit opt-in path — R3/#57 to own)
Under an explicit `AfterDays(n)` session-content policy, `n` currently governs ONLY the pruned→hard-delete window and the on/off gate for the whole non-idle lifecycle; the `idle→archived` (7d) and `archived→pruned` (30d) boundaries still use fixed ported constants regardless of `n`. This is correct for #60 (default-permanent + fail-closed) and does **NOT** affect the default-permanent guarantee (default = `Permanent` = `resolve_cutoff` None = nothing archived/pruned/deleted, ever). Making those boundaries track a user-facing per-category `n` is deferred to the persisted per-category policy work (R3/#57).

## does_not_prove / scope
- Source hardening of the DARK (default-OFF) Rust sweep paths + the soft-hiding closure ONLY. **Flags remain off** (unchanged); this does NOT enable any sweep and makes no runtime/prod claim — the Rust reaper stays dark.
- Does **NOT** close DATA-RETENTION-001; not a v1/Endbar GO.
- Persisted per-category user-control / API / Settings UI (R3) is out of scope; a future operator-supplied policy would flow through the same `CategoryRetention` / `resolve_cutoff` seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48
