### PR TITLE
fix(memory): redact learned-fact PII on sibling egress routes (uix/asset-inventory/agent-tool)

### DIFF
--- a/src/agent/tools/friday-agent-memory-tools.ts
+++ b/src/agent/tools/friday-agent-memory-tools.ts
@@ -5,6 +5,7 @@ import type {
   FridayMemoryService,
 } from "#memory";
 import type { FridayMemoryItem, FridayMemorySearchResult } from "#memory";
+import { createFridayMemoryOutputFilter } from "#memory";
 import type { FridayLearningEventAppendInput } from "#ledger";
 import {
   errorResult,
@@ -52,6 +53,14 @@ export interface CreateFridayAgentMemoryToolsDeps {
 }
 
 // ─── Namespace scoping ───
+
+// Learned facts are appended to memory_search results AFTER being written verbatim (they
+// bypass the write-time PII guard). memory_search egresses across a TRUST BOUNDARY to the
+// agent, so the learned-fact result is routed through the SAME production PII output filter
+// (#1607) before it reaches the tool caller — redacting content/metadata/tags/snippet. This
+// applies ONLY to learned facts; stored results come from `memoryService` unchanged (out of
+// scope for this fix).
+const memoryLearnedFactOutputFilter = createFridayMemoryOutputFilter();
 
 const AGENT_MEMORY_BASE_NAMESPACE = "agent";
 const USER_FACING_MEMORY_NAMESPACES = new Set(["default", "user", "preference"]);
@@ -759,7 +768,8 @@ function createMemorySearchTool(
         const learnedResults = principalId && deps.listLearnedFacts && shouldIncludeLearnedFacts(explicitNamespace)
           ? deps.listLearnedFacts({ userId: principalId, limit })
             .filter((fact) => matchesLearnedFactQuery(fact, query))
-            .map((fact) => toLearnedFactSearchResult(fact, query))
+            // Egress PII filter across the agent trust boundary (learned facts only).
+            .map((fact) => memoryLearnedFactOutputFilter.filterSearchResult(toLearnedFactSearchResult(fact, query)))
           : [];
         const combined = [...dedupedResults, ...learnedResults]
           .sort((a, b) => b.score - a.score)

--- a/src/api/http/routes/friday-asset-inventory-routes.ts
+++ b/src/api/http/routes/friday-asset-inventory-routes.ts
@@ -1,6 +1,7 @@
 import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import type { FridayAutonomySubjectRecord } from "../../../autonomy/model/friday-autonomy-subject.types.js";
 import type { FridayAgentAutomationRecord } from "../../../agent/services/friday-agent-automation-service.types.js";
+import { createFridayMemoryOutputFilter } from "#memory";
 
 export interface FridayAssetInventoryRoutesDeps {
   subjectInventory: { list(): FridayAutonomySubjectRecord[] };
@@ -74,6 +75,10 @@ function confidenceToStatus(confidence: number): string {
 export function createFridayAssetInventoryRoutes(
   deps: FridayAssetInventoryRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
+  // Learned facts bypass the write-time PII guard (written verbatim), so their free-form
+  // `value` is routed through the SAME production PII output filter (#1607) as a final egress
+  // transform here — no raw PII (full-width / CJK / ASCII) leaks into the asset inventory.
+  const outputFilter = createFridayMemoryOutputFilter();
   return [
     {
       operationId: "assets.inventory.list",
@@ -109,7 +114,7 @@ export function createFridayAssetInventoryRoutes(
               displayName: fact.key,
               status: confidenceToStatus(fact.confidence),
               details: {
-                value: fact.value,
+                value: outputFilter.redactLearnedFactValue(fact.value),
                 confidence: fact.confidence,
                 evidenceCount: fact.evidenceCount,
                 lastConfirmedAt: fact.lastConfirmedAt,

--- a/src/api/http/routes/friday-uix-routes.ts
+++ b/src/api/http/routes/friday-uix-routes.ts
@@ -1,4 +1,5 @@
 import { FridayDomainError } from "#errors";
+import { createFridayMemoryOutputFilter } from "#memory";
 import type { FridayProviderTenantContext } from "#providers";
 import {
   FRIDAY_COMMUNICATION_PREFERENCE_KEYS,
@@ -186,6 +187,13 @@ function enrichLearnedFactBoundary<T extends {
 export function createFridayUixRoutes(
   deps: FridayUixRoutesDeps,
 ): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
+  // Learned facts are written verbatim (bypassing the write-time PII guard) and are exposed
+  // here for user transparency. Route the free-form `value` through the SAME production PII
+  // output filter (#1607) as a final egress transform so no raw PII (full-width / CJK / ASCII)
+  // leaks. `enrichLearnedFactBoundary` already strips `metadata`, so `value` is the carrier.
+  const outputFilter = createFridayMemoryOutputFilter();
+  const redactLearnedFact = <T extends { value: unknown }>(fact: T): T =>
+    ({ ...fact, value: outputFilter.redactLearnedFactValue(fact.value) });
   return [
     {
       operationId: "uix.intents.resolve",
@@ -533,7 +541,9 @@ export function createFridayUixRoutes(
         if (!deps.listLearnedFacts) {
           return { items: [] };
         }
-        const items = deps.listLearnedFacts({ userId }).map(enrichLearnedFactBoundary);
+        const items = deps.listLearnedFacts({ userId })
+          .map(redactLearnedFact)
+          .map(enrichLearnedFactBoundary);
         return { items };
       },
     },
@@ -578,7 +588,7 @@ export function createFridayUixRoutes(
         if (!updated) {
           throw new FridayDomainError("UIX_PREFERENCE_NOT_FOUND", `Learned fact '${key}' was not found`, { httpStatus: 404 });
         }
-        return enrichLearnedFactBoundary(updated);
+        return enrichLearnedFactBoundary(redactLearnedFact(updated));
       },
     },
     {

--- a/src/memory/guard/model/friday-memory-guard.types.ts
+++ b/src/memory/guard/model/friday-memory-guard.types.ts
@@ -143,6 +143,14 @@ export interface FridayMemoryGuardOutputFilter {
    * result passes the same PII filter regardless of the total count.
    */
   filterSearchResult(result: FridayMemorySearchResult): FridayMemorySearchResult;
+  /**
+   * Redact PII from a learned-fact `value` (which is free-form `unknown` — a string or a
+   * nested object/array), returning the value with the SAME structure/type, PII redacted in
+   * place via the production deep redactor. Unlike `filterItem`, it does NOT stringify or
+   * truncate — sibling egress paths (uix / asset-inventory) return the raw `value` field, so
+   * only redaction is applied. Idempotent on an already-redacted value.
+   */
+  redactLearnedFactValue(value: unknown): unknown;
 }
 
 // ─── Guard service ───

--- a/src/memory/guard/services/friday-memory-output-filter.ts
+++ b/src/memory/guard/services/friday-memory-output-filter.ts
@@ -47,10 +47,21 @@ function filterSearchResultImpl(result: FridayMemorySearchResult): FridayMemoryS
   };
 }
 
+// Redact PII from a learned-fact `value` (free-form `unknown`). Learned facts are appended to
+// egress responses (uix / asset-inventory) AFTER the write-time guard, verbatim, so their
+// value skips PII redaction entirely. These sibling routes return the RAW `value` field (a
+// string or a nested object/array), not a stringified/truncated memory item, so we redact deep
+// in place — preserving structure and type — via the SAME production redactor used by
+// `redactMetadata`. Idempotent on already-redacted values.
+function redactLearnedFactValueImpl(value: unknown): unknown {
+  return piiRedactor.redactDeep(value).value;
+}
+
 export function createFridayMemoryOutputFilter(): FridayMemoryGuardOutputFilter {
   return {
     filterItem: filterItemImpl,
     filterSearchResult: filterSearchResultImpl,
+    redactLearnedFactValue: redactLearnedFactValueImpl,
     filterSearchResults(results: FridayMemorySearchResult[]): FridayMemorySearchResult[] {
       return results
         .slice(0, FRIDAY_MEMORY_GUARD_MAX_SEARCH_RESULTS)

--- a/test/unit/agent/tools/friday-agent-memory-tools-learned-fact-pii.test.ts
+++ b/test/unit/agent/tools/friday-agent-memory-tools-learned-fact-pii.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import { createFridayAgentMemoryTools } from "#agent";
+import type { FridayMemoryService } from "#memory";
+import type { FridayMemoryItem, FridayMemorySearchResult } from "#memory";
+import { attachFridayAgentToolExecutionContext } from "../../../../src/agent/runtime/friday-agent-tool-execution-context.js";
+
+// ─── Sibling learned-fact egress leak (agent memory_search TOOL — a trust boundary): learned
+//     facts are appended to memory_search results AFTER being written verbatim (they bypass
+//     the write-time PII guard). Their content crossed the agent trust boundary unredacted, so
+//     a full-width / CJK / ASCII card/email leaked to the tool caller. Default here is to
+//     REDACT: no functional reason for the agent to receive raw PII from a learned preference
+//     fact. These tests invoke the REAL tool `execute` and assert on the serialized result. ───
+
+const NOW = "2026-02-19T00:00:00.000Z";
+// toFullwidth("4111111111111111") — Luhn-valid Visa test number in full-width digits.
+const FULLWIDTH_CARD = "４１１１１１１１１１１１１１１１";
+
+function signalWithPrincipal(principalId: string): AbortSignal {
+  return attachFridayAgentToolExecutionContext(new AbortController().signal, {
+    runId: "run-1",
+    sessionKey: "agent:run:run-1",
+    readOnly: false,
+    principalId,
+  });
+}
+
+function makeSearchResult(overrides?: Partial<FridayMemorySearchResult>): FridayMemorySearchResult {
+  const item: FridayMemoryItem = {
+    id: "item-1",
+    namespace: "agent",
+    key: "key-1",
+    content: "The weather in Seattle is rainy",
+    source: "agent",
+    tags: ["weather"],
+    metadata: {},
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+  return {
+    item,
+    score: 0.5,
+    ftsScore: 0.5,
+    semanticScore: 0.5,
+    matchedBy: ["fts"],
+    snippet: "The weather in Seattle...",
+    ...overrides,
+  };
+}
+
+function mockMemoryService(searchResults: FridayMemorySearchResult[]): FridayMemoryService {
+  return {
+    search: vi.fn().mockResolvedValue(searchResults),
+    store: vi.fn(),
+    get: vi.fn().mockResolvedValue(null),
+    list: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockResolvedValue(false),
+    prune: vi.fn().mockResolvedValue({ deletedCount: 0, deletedIds: [], dryRun: false }),
+  } as unknown as FridayMemoryService;
+}
+
+describe("FridayAgentMemoryTools memory_search — learned-fact PII egress", () => {
+  it("redacts a full-width card in the appended learned-fact content", async () => {
+    const [searchTool] = createFridayAgentMemoryTools({
+      memoryService: mockMemoryService([]),
+      listLearnedFacts: () => [{
+        key: "card",
+        value: `カード番号は${FULLWIDTH_CARD}です`,
+        confidence: 0.9,
+        evidenceCount: 3,
+        lastConfirmedAt: NOW,
+      }],
+    });
+
+    const result = await searchTool!.execute({ query: "card" }, signalWithPrincipal("user-1"));
+    expect(result.isError).toBeUndefined();
+
+    const parsed = JSON.parse(result.content) as Array<{ content: string; metadata: { source: string } }>;
+    const learned = parsed.find((r) => r.metadata.source === "learned_fact")!;
+    expect(learned.content).toContain("[CREDIT_CARD]");
+    expect(learned.content).not.toContain(FULLWIDTH_CARD);
+    // No raw full-width digits anywhere in the serialized tool result.
+    expect(result.content).not.toContain(FULLWIDTH_CARD);
+  });
+
+  it("redacts a learned fact but leaves an unrelated stored result unchanged (surgical scope)", async () => {
+    const [searchTool] = createFridayAgentMemoryTools({
+      memoryService: mockMemoryService([makeSearchResult()]),
+      listLearnedFacts: () => [{
+        key: "card",
+        value: `カード番号は${FULLWIDTH_CARD}です`,
+        confidence: 0.9,
+        evidenceCount: 3,
+        lastConfirmedAt: NOW,
+      }],
+    });
+
+    const result = await searchTool!.execute({ query: "card" }, signalWithPrincipal("user-1"));
+    const parsed = JSON.parse(result.content) as Array<{ content: string; metadata: { source: string } }>;
+
+    const stored = parsed.find((r) => r.metadata.source === "agent")!;
+    expect(stored.content).toBe("The weather in Seattle is rainy");
+    const learned = parsed.find((r) => r.metadata.source === "learned_fact")!;
+    expect(learned.content).not.toContain(FULLWIDTH_CARD);
+    expect(learned.content).toContain("[CREDIT_CARD]");
+  });
+
+  it("leaves a learned fact with no PII unchanged (negative control)", async () => {
+    const [searchTool] = createFridayAgentMemoryTools({
+      memoryService: mockMemoryService([]),
+      listLearnedFacts: () => [{
+        key: "pref:display_name",
+        value: "Captain Friday",
+        confidence: 0.8,
+        evidenceCount: 1,
+        lastConfirmedAt: NOW,
+      }],
+    });
+
+    const result = await searchTool!.execute(
+      { query: "what should you call me" },
+      signalWithPrincipal("user-1"),
+    );
+    const parsed = JSON.parse(result.content) as Array<{ content: string; metadata: { source: string } }>;
+    const learned = parsed.find((r) => r.metadata.source === "learned_fact")!;
+    expect(learned.content).toBe("Captain Friday");
+  });
+});

--- a/test/unit/api/http/routes/friday-asset-inventory-routes-learned-fact-pii.test.ts
+++ b/test/unit/api/http/routes/friday-asset-inventory-routes-learned-fact-pii.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import { createFridayAssetInventoryRoutes } from "#api";
+import type { FridayHttpContext } from "#api";
+
+// ─── Sibling learned-fact egress leak (asset-inventory): learned facts appear as "knowledge"
+//     assets via GET /v1/assets/inventory with the verbatim value in `details.value`. That
+//     value bypasses the write-time PII guard, so a full-width / CJK / ASCII card/email leaked
+//     unredacted. These tests exercise the REAL route handler and assert the returned JSON. ───
+
+const NOW = "2026-03-07T10:00:00.000Z";
+// toFullwidth("4111111111111111") — Luhn-valid Visa test number in full-width digits.
+const FULLWIDTH_CARD = "４１１１１１１１１１１１１１１１";
+
+function makeCtx(
+  overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {},
+): FridayHttpContext<unknown, unknown, unknown> {
+  return {
+    requestId: "req-1",
+    receivedAt: NOW,
+    params: {},
+    query: {},
+    body: {},
+    headers: {},
+    principal: { userId: "user-1" } as never,
+    ...overrides,
+  };
+}
+
+const emptyInventory = { list: () => [] };
+
+function findRoute(deps: Parameters<typeof createFridayAssetInventoryRoutes>[0]) {
+  return createFridayAssetInventoryRoutes(deps)
+    .find((r) => r.operationId === "assets.inventory.list")!;
+}
+
+describe("FridayAssetInventoryRoutes — learned-fact PII egress", () => {
+  it("redacts a full-width card in the learned-fact details.value", async () => {
+    const route = findRoute({
+      subjectInventory: emptyInventory,
+      listLearnedFacts: vi.fn(() => [{
+        key: "pref:card",
+        value: `カード番号は${FULLWIDTH_CARD}です`,
+        confidence: 0.9,
+        evidenceCount: 3,
+        lastConfirmedAt: NOW,
+      }]),
+    });
+    const res = (await route.handler(makeCtx())) as {
+      items: Array<{ kind: string; details: { value: unknown } }>;
+    };
+
+    const learned = res.items.find((i) => i.kind === "learned_fact")!;
+    expect(learned.details.value).toBe("カード番号は[CREDIT_CARD]です");
+    expect(JSON.stringify(res)).not.toContain(FULLWIDTH_CARD);
+  });
+
+  it("redacts PII nested inside a structured learned-fact value", async () => {
+    const route = findRoute({
+      subjectInventory: emptyInventory,
+      listLearnedFacts: vi.fn(() => [{
+        key: "pref:contact",
+        value: { channels: [{ kind: "email", raw: "alice@example.com" }], note: "ok" },
+        confidence: 0.8,
+        evidenceCount: 1,
+        lastConfirmedAt: NOW,
+      }]),
+    });
+    const res = (await route.handler(makeCtx())) as {
+      items: Array<{ kind: string; details: { value: { channels: Array<{ raw: string }>; note: string } } }>;
+    };
+
+    const learned = res.items.find((i) => i.kind === "learned_fact")!;
+    expect(learned.details.value.channels[0]!.raw).toBe("[EMAIL]");
+    expect(learned.details.value.note).toBe("ok");
+    expect(JSON.stringify(res)).not.toContain("alice@example.com");
+  });
+
+  it("leaves a value with no PII unchanged (negative control)", async () => {
+    const route = findRoute({
+      subjectInventory: emptyInventory,
+      listLearnedFacts: vi.fn(() => [{
+        key: "pref:favorite_color",
+        value: "blue",
+        confidence: 0.7,
+        evidenceCount: 1,
+        lastConfirmedAt: NOW,
+      }]),
+    });
+    const res = (await route.handler(makeCtx())) as {
+      items: Array<{ kind: string; details: { value: unknown } }>;
+    };
+    const learned = res.items.find((i) => i.kind === "learned_fact")!;
+    expect(learned.details.value).toBe("blue");
+  });
+});

--- a/test/unit/api/http/routes/friday-uix-routes-learned-fact-pii.test.ts
+++ b/test/unit/api/http/routes/friday-uix-routes-learned-fact-pii.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import { createFridayUixRoutes } from "#api";
+import type { FridayHttpContext } from "#api";
+import type { FridayUixSurfaceService } from "../../../../src/uix/services/friday-uix-surface-service.js";
+
+// ─── Sibling learned-fact egress leak (uix): learned facts are written verbatim (they bypass
+//     the write-time PII guard) and are exposed to users for transparency via GET/PATCH
+//     /v1/uix/learned-facts. The free-form `value` field skipped PII redaction entirely, so a
+//     full-width / CJK / ASCII card/email leaked verbatim. These tests exercise the REAL uix
+//     route handlers and assert the returned JSON is redacted. ───
+
+const NOW = "2026-03-07T10:00:00.000Z";
+// toFullwidth("4111111111111111") — Luhn-valid Visa test number in full-width digits.
+const FULLWIDTH_CARD = "４１１１１１１１１１１１１１１１";
+
+function makeCtx(
+  overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {},
+): FridayHttpContext<unknown, unknown, unknown> {
+  return {
+    requestId: "req-1",
+    receivedAt: NOW,
+    params: {},
+    query: {},
+    body: {},
+    headers: {},
+    principal: { userId: "user-1" } as never,
+    ...overrides,
+  };
+}
+
+const service = {} as unknown as FridayUixSurfaceService;
+
+describe("FridayUixRoutes — learned-fact PII egress", () => {
+  it("uix.learnedfacts.list redacts a full-width card in the learned-fact value", async () => {
+    const routes = createFridayUixRoutes({
+      service,
+      listLearnedFacts: vi.fn(() => [{
+        key: "pref:card",
+        value: `カード番号は${FULLWIDTH_CARD}です`,
+        confidence: 0.9,
+        evidenceCount: 3,
+        lastConfirmedAt: NOW,
+      }]),
+    });
+    const route = routes.find((r) => r.operationId === "uix.learnedfacts.list")!;
+    const res = (await route.handler(makeCtx())) as { items: Array<{ value: unknown }> };
+
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0]!.value).toBe("カード番号は[CREDIT_CARD]です");
+    expect(JSON.stringify(res)).not.toContain(FULLWIDTH_CARD);
+  });
+
+  it("uix.learnedfacts.list redacts PII nested inside a structured value", async () => {
+    const routes = createFridayUixRoutes({
+      service,
+      listLearnedFacts: vi.fn(() => [{
+        key: "pref:contact",
+        value: { channels: [{ kind: "email", raw: "alice@example.com" }], note: "ok" },
+        confidence: 0.8,
+        evidenceCount: 1,
+        lastConfirmedAt: NOW,
+      }]),
+    });
+    const route = routes.find((r) => r.operationId === "uix.learnedfacts.list")!;
+    const res = (await route.handler(makeCtx())) as {
+      items: Array<{ value: { channels: Array<{ kind: string; raw: string }>; note: string } }>;
+    };
+
+    expect(res.items[0]!.value.channels[0]!.kind).toBe("email");
+    expect(res.items[0]!.value.channels[0]!.raw).toBe("[EMAIL]");
+    expect(res.items[0]!.value.note).toBe("ok");
+    expect(JSON.stringify(res)).not.toContain("alice@example.com");
+  });
+
+  it("uix.learnedfacts.update redacts a full-width card in the updated value", async () => {
+    const routes = createFridayUixRoutes({
+      service,
+      updateLearnedFact: vi.fn(() => ({
+        key: "pref:card",
+        value: `カード番号は${FULLWIDTH_CARD}です`,
+        confidence: 0.9,
+        evidenceCount: 3,
+        lastConfirmedAt: NOW,
+      })),
+    });
+    const route = routes.find((r) => r.operationId === "uix.learnedfacts.update")!;
+    const res = (await route.handler(makeCtx({
+      params: { factKey: encodeURIComponent("pref:card") },
+      body: { value: "redact me" },
+    }))) as { value: unknown };
+
+    expect(res.value).toBe("カード番号は[CREDIT_CARD]です");
+    expect(JSON.stringify(res)).not.toContain(FULLWIDTH_CARD);
+  });
+
+  it("uix.learnedfacts.list leaves a value with no PII unchanged (negative control)", async () => {
+    const routes = createFridayUixRoutes({
+      service,
+      listLearnedFacts: vi.fn(() => [{
+        key: "pref:favorite_color",
+        value: "blue",
+        confidence: 0.7,
+        evidenceCount: 1,
+        lastConfirmedAt: NOW,
+      }]),
+    });
+    const route = routes.find((r) => r.operationId === "uix.learnedfacts.list")!;
+    const res = (await route.handler(makeCtx())) as { items: Array<{ value: unknown }> };
+    expect(res.items[0]!.value).toBe("blue");
+  });
+});

--- a/test/unit/memory/guard/services/friday-memory-output-filter-learned-fact.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-output-filter-learned-fact.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { createFridayMemoryOutputFilter } from "#memory";
+
+// ─── Unit coverage for the learned-fact egress redactor added for the sibling-route leak
+//     closure (uix / asset-inventory / agent-tool). `redactLearnedFactValue` runs the SAME
+//     production deep PII redactor (#1607) over a free-form `value: unknown`, preserving the
+//     value's structure/type while redacting PII in place (string, nested object, array). ───
+
+// toFullwidth("4111111111111111") — Luhn-valid Visa test number in full-width digits.
+const FULLWIDTH_CARD = "４１１１１１１１１１１１１１１１";
+const ASCII_CARD = "4111 1111 1111 1111";
+
+describe("FridayMemoryOutputFilter.redactLearnedFactValue", () => {
+  const filter = createFridayMemoryOutputFilter();
+
+  it("redacts a full-width card in a plain string value (width fold)", () => {
+    const out = filter.redactLearnedFactValue(`カード番号は${FULLWIDTH_CARD}です`);
+    expect(out).toBe("カード番号は[CREDIT_CARD]です");
+    expect(JSON.stringify(out)).not.toContain(FULLWIDTH_CARD);
+  });
+
+  it("redacts PII inside a nested object/array value, preserving structure", () => {
+    const value = {
+      label: "contact",
+      channels: [
+        { kind: "email", raw: "alice@example.com" },
+        { kind: "card", raw: FULLWIDTH_CARD },
+      ],
+      note: "no pii here",
+    };
+    const out = filter.redactLearnedFactValue(value) as {
+      label: string;
+      channels: Array<{ kind: string; raw: string }>;
+      note: string;
+    };
+    // Structure/type preserved.
+    expect(out.label).toBe("contact");
+    expect(out.note).toBe("no pii here");
+    expect(Array.isArray(out.channels)).toBe(true);
+    expect(out.channels).toHaveLength(2);
+    expect(out.channels[0]!.kind).toBe("email");
+    // PII redacted in place.
+    expect(out.channels[0]!.raw).toBe("[EMAIL]");
+    expect(out.channels[1]!.raw).toBe("[CREDIT_CARD]");
+    expect(JSON.stringify(out)).not.toContain("alice@example.com");
+    expect(JSON.stringify(out)).not.toContain(FULLWIDTH_CARD);
+  });
+
+  it("is idempotent — a second pass over an already-redacted value is a no-op", () => {
+    const once = filter.redactLearnedFactValue({ raw: ASCII_CARD, nested: { raw: FULLWIDTH_CARD } });
+    const twice = filter.redactLearnedFactValue(once);
+    expect(twice).toEqual(once);
+    expect(JSON.stringify(twice)).not.toContain(ASCII_CARD);
+    expect(JSON.stringify(twice)).not.toContain(FULLWIDTH_CARD);
+  });
+
+  it("leaves a value with no PII unchanged (negative control)", () => {
+    expect(filter.redactLearnedFactValue("blue")).toBe("blue");
+    const obj = { color: "blue", count: 3, ok: true, nothing: null };
+    expect(filter.redactLearnedFactValue(obj)).toEqual(obj);
+  });
+
+  it("passes non-string scalars through unchanged", () => {
+    expect(filter.redactLearnedFactValue(42)).toBe(42);
+    expect(filter.redactLearnedFactValue(true)).toBe(true);
+    expect(filter.redactLearnedFactValue(null)).toBe(null);
+    expect(filter.redactLearnedFactValue(undefined)).toBe(undefined);
+  });
+
+  it("perf sanity: redacts a large mixed string well within a generous bound (no O(n^2))", () => {
+    const big = `${"lorem ipsum dolor sit amet ".repeat(4000)} card ${FULLWIDTH_CARD}`;
+    const start = Date.now();
+    const out = filter.redactLearnedFactValue(big) as string;
+    const elapsed = Date.now() - start;
+    expect(out).toContain("[CREDIT_CARD]");
+    expect(out).not.toContain(FULLWIDTH_CARD);
+    expect(elapsed).toBeLessThan(2000);
+  });
+});


### PR DESCRIPTION
## req #61 LEARNED-FACT-EGRESS-FILTER (+ PII)

**Head SHA:** e67a91a5936ea0d043098f27dbc39a59c3606086
**Base:** main @ ddc379d6 (#1607, merged)
**Reviewer:** Advisor PASS @ `e67a91a5936ea0d043098f27dbc39a59c3606086` — code audit PASS, required CI green, independent focused tests 16/16 PASS; scope confirmed (3 sibling value leaks only).

### What & why
PR #1607 added a route-level PII output filter to the memory read routes (`GET /v1/memory/items`, `POST /v1/memory/search`) so appended **learned facts** — written verbatim, bypassing the write-time guard — are redacted at egress. The **same raw learned-fact value** still egressed **UNREDACTED** through three sibling paths that read `deps.listLearnedFacts` directly:

1. `GET`/`PATCH` `/v1/uix/learned-facts` — `src/api/http/routes/friday-uix-routes.ts` (~536, ~581)
2. `GET /v1/assets/inventory` — `src/api/http/routes/friday-asset-inventory-routes.ts` (~112, `details.value`)
3. `memory_search` **agent TOOL** — `src/agent/tools/friday-agent-memory-tools.ts` (~759-769) — a **trust boundary** to the agent

### Fix — reuse the #1607 production filter (no reimplementation)
- **New** `FridayMemoryGuardOutputFilter.redactLearnedFactValue(value)` in `friday-memory-output-filter.ts`, delegating to the SAME production deep redactor (`redactDeep`) that #1607's `redactMetadata` uses. It preserves the free-form `value`'s structure/type (string, nested object/array) and redacts PII in place. **No stringify/truncate** — these sibling routes return the RAW `value` field (avoids degrade). Idempotent.
- **uix** (list + update): redact learned-fact `value` before `enrichLearnedFactBoundary` (which already strips metadata → `value` is the only carrier).
- **asset-inventory**: redact `details.value` on the `learned_fact` item.
- **agent tool**: route the learned-fact search result through the SAME `filterSearchResult` (#1607) as the final egress transform.

### Agent-tool trust-boundary decision → **DEFAULT = FILTER (redact)**
No hard functional reason for the agent to receive raw PII (email/phone/ssn/card) from a learned *preference* fact — that raw value is exactly what must not cross the boundary. Applied to **learned facts only**; stored results come from `memoryService` and are **unchanged** (out of scope; changing stored egress would broaden scope and risk degrading legitimate agent memory access). **No remaining leaf registered** — the learned-fact value is filtered.

### red-first evidence (production route handler + agent tool oracle, not mocks)
With the egress wiring reverted (new filter method present but unused), the 3 path specs fail with the **raw** value egressing verbatim; re-applying the wiring makes them pass:
- uix list/update — before: `カード番号は４１１１１１１１１１１１１１１１です` (raw full-width card) / `alice@example.com`; after: `カード番号は[CREDIT_CARD]です` / `[EMAIL]`
- asset `details.value` — before: raw full-width card / raw email; after: `[CREDIT_CARD]` / `[EMAIL]`
- agent `memory_search` content — before: raw full-width card; after: `[CREDIT_CARD]`

Also covered: nested metadata/arrays (deep), idempotency (filter-once stable), Unicode full-width width-fold, a perf-sanity bound (no O(n^2)), and negative controls (no-PII values pass unchanged; unrelated stored agent result unchanged).

### Tests / checks
- 4 new specs, 16 tests — green. Existing regression suites for touched files (uix, agent tools, asset-inventory, memory output-filter, memory-pii-guard, #1607 route test) — 141 tests green.
- `tsc --noEmit` (src) — 0 errors. `eslint` — 0 errors on touched files (pre-existing warnings only).
- `src/hub/friday-hub-bootstrap.ts` **NOT** modified (PR #1606 owns it).

### does_not_prove
This closes the **3 sibling learned-fact egress leaves only**. Overall PII requirement is **NOT** closed: the realtime payload redactor, other Unicode scripts, write-scan-dark, key/id fields, and deep-object leaves remain **OPEN** (numeric-typed value + object-key coverage tracked as follow-up). No expansion of closure claim.
