### PR TITLE
fix(pii): redactDeep context-aware typed PII + object-key coverage + Date fix

### DIFF
--- a/src/memory/guard/model/friday-memory-guard.types.ts
+++ b/src/memory/guard/model/friday-memory-guard.types.ts
@@ -125,10 +125,21 @@ export interface FridayMemoryGuardQuotaRepository {
 export interface FridayMemoryGuardPiiGuard {
   scanAndTransform(content: string): FridayMemoryGuardPiiScanResult;
   /**
-   * Recursively redact PII in the string leaves of an arbitrary structured value
-   * (memory metadata objects, tag arrays). Returns the redacted value (or the original
-   * when not in redact mode) plus the PII-type tags discovered, so callers can scan
-   * metadata/tags the same way `scanAndTransform` scans content.
+   * Recursively redact PII in an arbitrary structured value (memory metadata objects, tag
+   * arrays, learned-fact values). Coverage:
+   *  - STRING leaves and STRING key content: existing shape-based patterns (email / phone /
+   *    SSN / Luhn-gated card), unchanged by this contract.
+   *  - Typed `number` / `bigint` values: redacted CONTEXT-AWARELY under TWO gates — the value's
+   *    object KEY names a known sensitive field (ssn / phone / card and variants) AND the value's
+   *    string form actually matches that type's detector (SSN / phone / Luhn card). A bare number
+   *    is never redacted by digit shape or Luhn ALONE, so business ids, order numbers, epoch
+   *    timestamps, benign numerics under sensitive-sounding keys (`gift_card: 3`), and
+   *    pure-numeric object keys are preserved. Array elements inherit a sensitive parent key;
+   *    nested objects do not.
+   *  - `Date` values: their original type is preserved (never corrupted into `{}`).
+   * Returns the (possibly) redacted value plus the PII-type tags discovered. This closes the
+   * typed-value, Date-corruption, and object-KEY coverage gaps; it is NOT a guarantee that every
+   * possible PII representation is caught.
    */
   redactDeep(value: unknown): { value: unknown; tagsToAdd: string[] };
 }

--- a/src/memory/guard/services/friday-memory-pii-guard.ts
+++ b/src/memory/guard/services/friday-memory-pii-guard.ts
@@ -187,6 +187,80 @@ function redactContent(content: string, matches: FridayMemoryGuardPiiMatch[]): s
   return result;
 }
 
+/**
+ * Sensitive-field registry for CONTEXT-AWARE typed redaction.
+ *
+ * A bare `number`/`bigint` carries no reliable signal of being PII: a 9/10/13–19-digit run or a
+ * Luhn-valid value is just as likely an order number, invoice id, account id, or epoch
+ * timestamp. `redactDeep` therefore redacts a numeric/bigint value only under TWO gates:
+ *  (1) its OBJECT KEY names a known sensitive field (this registry), AND
+ *  (2) the value's string form ACTUALLY matches that type's canonical detector (SSN / phone /
+ *      Luhn-gated card) — see the value gate in `redactDeep`.
+ * Never by digit shape or Luhn validity ALONE. Ambiguous numerics under other keys, benign
+ * numerics under sensitive-sounding keys (`gift_card: 3`, `head_phone: 42`), and pure-numeric
+ * object keys are preserved unchanged (no irreversible masking of legitimate ids). The string
+ * at-rest policy is untouched: string values/keys still use the existing shape-based patterns.
+ *
+ * Key matching is by normalized token SUFFIX so prefixed variants match (`home_phone`,
+ * `user_ssn`, `billing_card_number`) while unrelated names do not (`phone_count`, `telemetry`,
+ * `discard`, `cardinality`, `order_id`). The final-token footgun (`gift_card`, `dust_pan`, …) is
+ * covered by the value gate rather than a brittle denylist. Keys are normalized: camelCase is
+ * split, digits and separators are dropped, and a trailing plural `s` on the final token folded.
+ */
+type FridayKeyDrivenPiiType = Extract<FridayMemoryGuardPiiType, "ssn_us" | "phone_us" | "credit_card">;
+
+const SENSITIVE_KEY_PHRASE_TO_TYPE = new Map<string, FridayKeyDrivenPiiType>([
+  ["ssn", "ssn_us"],
+  ["ssn number", "ssn_us"],
+  ["social security", "ssn_us"],
+  ["social security number", "ssn_us"],
+  ["phone", "phone_us"],
+  ["phone number", "phone_us"],
+  ["telephone", "phone_us"],
+  ["tel", "phone_us"],
+  ["mobile", "phone_us"],
+  ["mobile number", "phone_us"],
+  ["mobile phone", "phone_us"],
+  ["card", "credit_card"],
+  ["card number", "credit_card"],
+  ["credit card", "credit_card"],
+  ["credit card number", "credit_card"],
+  ["pan", "credit_card"],
+]);
+const SENSITIVE_KEY_MAX_PHRASE_TOKENS = 3;
+
+function normalizeKeyTokens(key: string): string[] {
+  const tokens = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z]+/)
+    .filter((t) => t.length > 0);
+  const last = tokens.pop();
+  if (last === undefined) return tokens;
+  const singular =
+    last.length > 3 && last.endsWith("s") && !last.endsWith("ss") ? last.slice(0, -1) : last;
+  tokens.push(singular);
+  return tokens;
+}
+
+/**
+ * Resolve the PII type a value inherits from its object KEY, or `undefined` for a non-sensitive
+ * key. The longest matching suffix wins (most specific). Purely key-driven — the value itself is
+ * never inspected, so no benign number can be redacted by this path.
+ */
+function sensitiveTypeForKey(key: string): FridayKeyDrivenPiiType | undefined {
+  const tokens = normalizeKeyTokens(key);
+  if (tokens.length === 0) return undefined;
+  const maxLen = Math.min(SENSITIVE_KEY_MAX_PHRASE_TOKENS, tokens.length);
+  for (let len = maxLen; len >= 1; len -= 1) {
+    const suffix = tokens.slice(tokens.length - len).join(" ");
+    const type = SENSITIVE_KEY_PHRASE_TO_TYPE.get(suffix);
+    if (type) return type;
+  }
+  return undefined;
+}
+
 export function createFridayMemoryPiiGuard(
   mode?: FridayMemoryGuardPiiMode,
 ): FridayMemoryGuardPiiGuard {
@@ -217,23 +291,84 @@ export function createFridayMemoryPiiGuard(
       const tagSet = new Set<string>();
       const MAX_DEPTH = 6;
 
-      const walk = (v: unknown, depth: number): unknown => {
+      // String leaves keep the EXISTING shape-based at-rest policy (unchanged by this lane):
+      // scan with the PII patterns and redact in place in redact mode, tag-only otherwise.
+      const redactStringLeaf = (s: string): string => {
+        const matches = findMatches(s);
+        if (matches.length === 0) return s;
+        for (const m of matches) {
+          tagSet.add(`${FRIDAY_MEMORY_GUARD_PII_TAG_PREFIX}.${m.type}`);
+        }
+        return effectiveMode === "redact" ? redactContent(s, matches) : s;
+      };
+
+      // Redact PII carried in an object KEY. String key CONTENT that is itself recognizable PII
+      // (email, or a formatted phone/SSN/card) is redacted in place, so `user@example.com` →
+      // `[EMAIL]` and a compound `ssn:123-45-6789` → `ssn:[SSN_US]`. A PURE-NUMERIC key
+      // (`/^\d+$/`) is NEVER shape-redacted — it is an ambiguous id and is preserved verbatim.
+      const redactKey = (key: string): string => {
+        if (/^\d+$/.test(key)) return key;
+        const matches = findMatches(key);
+        if (matches.length === 0) return key;
+        for (const m of matches) {
+          tagSet.add(`${FRIDAY_MEMORY_GUARD_PII_TAG_PREFIX}.${m.type}`);
+        }
+        return effectiveMode === "redact" ? redactContent(key, matches) : key;
+      };
+
+      // Assign `value` under `key`, never dropping data. Redacting keys can collapse two
+      // distinct PII keys onto the same token (e.g. `a@x.com` and `b@y.com` → `[EMAIL]`); on
+      // collision the later entry is disambiguated deterministically so both VALUES survive.
+      // The suffix contains no PII pattern, so a second redactDeep pass is a no-op (idempotent).
+      const assignKey = (out: Record<string, unknown>, key: string, val: unknown): void => {
+        let finalKey = key;
+        if (Object.prototype.hasOwnProperty.call(out, key)) {
+          let suffix = 2;
+          while (Object.prototype.hasOwnProperty.call(out, `${key}#${suffix}`)) {
+            suffix += 1;
+          }
+          finalKey = `${key}#${suffix}`;
+        }
+        out[finalKey] = val;
+      };
+
+      // `keyedType` is the PII type a numeric/bigint value INHERITS FROM ITS OBJECT KEY (see
+      // sensitiveTypeForKey). It is threaded down through arrays (a list under a sensitive key)
+      // but NOT into nested objects, which re-establish their own key context.
+      const walk = (v: unknown, depth: number, keyedType?: FridayKeyDrivenPiiType): unknown => {
         if (depth > MAX_DEPTH) return v;
         if (typeof v === "string") {
-          const matches = findMatches(v);
-          if (matches.length === 0) return v;
-          for (const m of matches) {
-            tagSet.add(`${FRIDAY_MEMORY_GUARD_PII_TAG_PREFIX}.${m.type}`);
-          }
-          return effectiveMode === "redact" ? redactContent(v, matches) : v;
+          return redactStringLeaf(v);
+        }
+        // CONTEXT-AWARE typed redaction, gated on BOTH the key AND the value:
+        //  (1) key gate  — the object key must name a known PII type (keyedType); unknown keys
+        //      and context-less/array numbers are never candidates.
+        //  (2) value gate — the value's string form must ACTUALLY match that type's canonical
+        //      detector (SSN / phone / Luhn-gated card). This is strictly more conservative than
+        //      key-alone: a benign numeric under a sensitive-sounding field (gift_card: 3,
+        //      head_phone: 42, sim_card: 2) is preserved because "3"/"42"/"2" is not card/phone
+        //      shaped. It does NOT reintroduce shape-alone inference — the value gate only runs
+        //      AFTER the sensitive-key gate, so a Luhn-valid `order_id` under a NON-sensitive key
+        //      is still preserved.
+        if (typeof v === "number" || typeof v === "bigint") {
+          if (!keyedType) return v;
+          const valueIsTypeShaped = findMatches(String(v)).some((m) => m.type === keyedType);
+          if (!valueIsTypeShaped) return v;
+          tagSet.add(`${FRIDAY_MEMORY_GUARD_PII_TAG_PREFIX}.${keyedType}`);
+          return effectiveMode === "redact" ? `[${keyedType.toUpperCase()}]` : v;
+        }
+        // Preserve a Date's original TYPE (the object branch below would otherwise walk its zero
+        // own-enumerable props and corrupt it into `{}`). A Date is not a numeric PII carrier.
+        if (v instanceof Date) {
+          return v;
         }
         if (Array.isArray(v)) {
-          return v.map((entry) => walk(entry, depth + 1));
+          return v.map((entry) => walk(entry, depth + 1, keyedType));
         }
         if (v && typeof v === "object") {
           const out: Record<string, unknown> = {};
           for (const [k, entry] of Object.entries(v as Record<string, unknown>)) {
-            out[k] = walk(entry, depth + 1);
+            assignKey(out, redactKey(k), walk(entry, depth + 1, sensitiveTypeForKey(k)));
           }
           return out;
         }

--- a/src/memory/guard/services/friday-memory-pii-guard.ts
+++ b/src/memory/guard/services/friday-memory-pii-guard.ts
@@ -261,6 +261,26 @@ function sensitiveTypeForKey(key: string): FridayKeyDrivenPiiType | undefined {
   return undefined;
 }
 
+/**
+ * VALUE gate for a numeric/bigint value whose OBJECT KEY already resolved to `type`
+ * (sensitiveTypeForKey). Returns true only when the value's string form actually matches that
+ * type's canonical detector. This runs strictly AFTER the sensitive-key gate, so it can never
+ * reintroduce shape-only inference — a value under a non-sensitive key never reaches here.
+ *
+ * Phone normalization (F1): a US number persisted as a numeric loses its leading '+', producing
+ * the 11-digit country-code form 1XXXXXXXXXX. The reused phone detector only accepts +1XXXXXXXXXX
+ * or the bare 10-digit form, so that numeric form leaked. Because the key is ALREADY a registered
+ * phone key, we may safely normalize by stripping the leading country-code '1' to the 10-digit
+ * form the SAME detector recognizes — no new shape-only redaction is introduced.
+ */
+function numericValueMatchesKeyedType(str: string, type: FridayKeyDrivenPiiType): boolean {
+  if (findMatches(str).some((m) => m.type === type)) return true;
+  if (type === "phone_us" && /^1\d{10}$/.test(str)) {
+    return findMatches(str.slice(1)).some((m) => m.type === "phone_us");
+  }
+  return false;
+}
+
 export function createFridayMemoryPiiGuard(
   mode?: FridayMemoryGuardPiiMode,
 ): FridayMemoryGuardPiiGuard {
@@ -289,7 +309,15 @@ export function createFridayMemoryPiiGuard(
 
     redactDeep(value: unknown): { value: unknown; tagsToAdd: string[] } {
       const tagSet = new Set<string>();
-      const MAX_DEPTH = 6;
+      // Structural recursion cap — a STACK-OVERFLOW / DoS guard, NOT a scan-coverage limit. It
+      // sits far above any realistic metadata nesting (real metadata is a handful of levels
+      // deep) so legitimate byte-bounded input is ALWAYS fully scanned, and comfortably below
+      // the JS call-stack limit for this walker so it never throws. If a pathological,
+      // adversarially deep structure exceeds it, the walker fails CLOSED: the over-deep subtree
+      // is replaced by a redaction SENTINEL and NEVER emitted in cleartext. (The previous code
+      // returned the unscanned subtree verbatim past depth 6 — a fail-OPEN egress leak.)
+      const MAX_DEPTH = 500;
+      const DEPTH_REDACTION_SENTINEL = "[REDACTED_DEPTH]";
 
       // String leaves keep the EXISTING shape-based at-rest policy (unchanged by this lane):
       // scan with the PII patterns and redact in place in redact mode, tag-only otherwise.
@@ -320,6 +348,12 @@ export function createFridayMemoryPiiGuard(
       // distinct PII keys onto the same token (e.g. `a@x.com` and `b@y.com` → `[EMAIL]`); on
       // collision the later entry is disambiguated deterministically so both VALUES survive.
       // The suffix contains no PII pattern, so a second redactDeep pass is a no-op (idempotent).
+      //
+      // Define an OWN DATA property rather than `out[finalKey] = val`: a JSON-originated own key
+      // named `__proto__` would otherwise invoke the legacy prototype setter, mutating the
+      // output object's prototype (prototype confusion) AND dropping the field from
+      // serialization. `Object.defineProperty` round-trips such keys as ordinary own enumerable
+      // data properties with the prototype untouched.
       const assignKey = (out: Record<string, unknown>, key: string, val: unknown): void => {
         let finalKey = key;
         if (Object.prototype.hasOwnProperty.call(out, key)) {
@@ -329,14 +363,21 @@ export function createFridayMemoryPiiGuard(
           }
           finalKey = `${key}#${suffix}`;
         }
-        out[finalKey] = val;
+        Object.defineProperty(out, finalKey, {
+          value: val,
+          enumerable: true,
+          writable: true,
+          configurable: true,
+        });
       };
 
       // `keyedType` is the PII type a numeric/bigint value INHERITS FROM ITS OBJECT KEY (see
       // sensitiveTypeForKey). It is threaded down through arrays (a list under a sensitive key)
       // but NOT into nested objects, which re-establish their own key context.
       const walk = (v: unknown, depth: number, keyedType?: FridayKeyDrivenPiiType): unknown => {
-        if (depth > MAX_DEPTH) return v;
+        // Fail CLOSED past the structural safety cap: never return an unscanned subtree in
+        // cleartext. The sentinel carries no PII and is inert on a re-scan (idempotent).
+        if (depth > MAX_DEPTH) return DEPTH_REDACTION_SENTINEL;
         if (typeof v === "string") {
           return redactStringLeaf(v);
         }
@@ -352,8 +393,7 @@ export function createFridayMemoryPiiGuard(
         //      is still preserved.
         if (typeof v === "number" || typeof v === "bigint") {
           if (!keyedType) return v;
-          const valueIsTypeShaped = findMatches(String(v)).some((m) => m.type === keyedType);
-          if (!valueIsTypeShaped) return v;
+          if (!numericValueMatchesKeyedType(String(v), keyedType)) return v;
           tagSet.add(`${FRIDAY_MEMORY_GUARD_PII_TAG_PREFIX}.${keyedType}`);
           return effectiveMode === "redact" ? `[${keyedType.toUpperCase()}]` : v;
         }

--- a/src/memory/guard/services/friday-memory-pii-guard.ts
+++ b/src/memory/guard/services/friday-memory-pii-guard.ts
@@ -333,10 +333,23 @@ export function createFridayMemoryPiiGuard(
 
       // Redact PII carried in an object KEY. String key CONTENT that is itself recognizable PII
       // (email, or a formatted phone/SSN/card) is redacted in place, so `user@example.com` →
-      // `[EMAIL]` and a compound `ssn:123-45-6789` → `ssn:[SSN_US]`. A PURE-NUMERIC key
-      // (`/^\d+$/`) is NEVER shape-redacted — it is an ambiguous id and is preserved verbatim.
+      // `[EMAIL]` and a compound `ssn:123-45-6789` → `ssn:[SSN_US]`. A PURE-DIGIT key is NEVER
+      // shape-redacted — it is an ambiguous business id and is preserved verbatim.
+      //
+      // The pure-digit exemption is Unicode-decimal-aware (`/^\p{Nd}+$/u`), NOT ASCII-only
+      // (`/^\d+$/`). The PII matcher folds full-width digits before matching, so an ASCII-only
+      // exemption let the ASCII key "4111111111111111" through (correct) but folded its
+      // semantically-identical FULL-WIDTH form "４１１１…" into a card and irreversibly renamed it
+      // to "[CREDIT_CARD]" — corrupting a benign business id (DATA-RETENTION-001 no-corruption;
+      // PRIV-UNICODE-REDACTION-001 benign-multilingual no-degrade). Testing `\p{Nd}` makes ASCII,
+      // full-width, Arabic-Indic, and MIXED-width digit-only keys reach the SAME exempt outcome —
+      // width/script-consistent with the matcher's fold. Only keys composed ENTIRELY of decimal
+      // digits (any script, NON-empty, NO separators/other chars) are exempt: a FORMATTED PII key
+      // (dashes/spaces/letters, e.g. "４１１１-…" or "ssn:123-45-6789") contains a non-`Nd` char, so
+      // it fails the exemption and STILL redacts. This is purely the key-preservation exemption —
+      // it does NOT weaken the value path (a full-width card VALUE is redacted as before).
       const redactKey = (key: string): string => {
-        if (/^\d+$/.test(key)) return key;
+        if (/^\p{Nd}+$/u.test(key)) return key;
         const matches = findMatches(key);
         if (matches.length === 0) return key;
         for (const m of matches) {

--- a/src/memory/guard/services/friday-memory-pii-guard.ts
+++ b/src/memory/guard/services/friday-memory-pii-guard.ts
@@ -309,15 +309,16 @@ export function createFridayMemoryPiiGuard(
 
     redactDeep(value: unknown): { value: unknown; tagsToAdd: string[] } {
       const tagSet = new Set<string>();
-      // Structural recursion cap — a STACK-OVERFLOW / DoS guard, NOT a scan-coverage limit. It
-      // sits far above any realistic metadata nesting (real metadata is a handful of levels
-      // deep) so legitimate byte-bounded input is ALWAYS fully scanned, and comfortably below
-      // the JS call-stack limit for this walker so it never throws. If a pathological,
-      // adversarially deep structure exceeds it, the walker fails CLOSED: the over-deep subtree
-      // is replaced by a redaction SENTINEL and NEVER emitted in cleartext. (The previous code
-      // returned the unscanned subtree verbatim past depth 6 — a fail-OPEN egress leak.)
-      const MAX_DEPTH = 500;
-      const DEPTH_REDACTION_SENTINEL = "[REDACTED_DEPTH]";
+      // Traversal is ITERATIVE (an explicit heap-allocated work stack), CYCLE-AWARE, and
+      // FULL-SCAN — there is NO depth cap and NO truncation sentinel. The real resource bound
+      // is the UPSTREAM 16 KiB metadata byte-limit (validateMetadata runs before this on the
+      // store path); every structure admitted by that bound is scanned to its leaves. Because
+      // the work stack lives on the heap (not the ~2000–5000-frame JS call stack), arbitrarily
+      // deep byte-bounded input is scanned without stack overflow. This replaces the previous
+      // fixed recursion that returned a "[REDACTED_DEPTH]" sentinel past a depth cap in ALL
+      // modes — silently corrupting valid deep metadata (canonical-data loss, DATA-RETENTION-001)
+      // and violating the tag/block mode contracts. Deep PII is still ALWAYS found (the F2 leak
+      // stays closed) and benign deep data now round-trips UNCHANGED.
 
       // String leaves keep the EXISTING shape-based at-rest policy (unchanged by this lane):
       // scan with the PII patterns and redact in place in redact mode, tag-only otherwise.
@@ -344,26 +345,13 @@ export function createFridayMemoryPiiGuard(
         return effectiveMode === "redact" ? redactContent(key, matches) : key;
       };
 
-      // Assign `value` under `key`, never dropping data. Redacting keys can collapse two
-      // distinct PII keys onto the same token (e.g. `a@x.com` and `b@y.com` → `[EMAIL]`); on
-      // collision the later entry is disambiguated deterministically so both VALUES survive.
-      // The suffix contains no PII pattern, so a second redactDeep pass is a no-op (idempotent).
-      //
-      // Define an OWN DATA property rather than `out[finalKey] = val`: a JSON-originated own key
-      // named `__proto__` would otherwise invoke the legacy prototype setter, mutating the
-      // output object's prototype (prototype confusion) AND dropping the field from
-      // serialization. `Object.defineProperty` round-trips such keys as ordinary own enumerable
-      // data properties with the prototype untouched.
-      const assignKey = (out: Record<string, unknown>, key: string, val: unknown): void => {
-        let finalKey = key;
-        if (Object.prototype.hasOwnProperty.call(out, key)) {
-          let suffix = 2;
-          while (Object.prototype.hasOwnProperty.call(out, `${key}#${suffix}`)) {
-            suffix += 1;
-          }
-          finalKey = `${key}#${suffix}`;
-        }
-        Object.defineProperty(out, finalKey, {
+      // Write `val` under `key` as an OWN DATA property rather than `out[key] = val`: a
+      // JSON-originated own key named `__proto__` would otherwise invoke the legacy prototype
+      // setter, mutating the output object's prototype (prototype confusion) AND dropping the
+      // field from serialization. `Object.defineProperty` round-trips such keys as ordinary own
+      // enumerable data properties with the prototype untouched. (F3 — preserved.)
+      const defineOwn = (out: Record<string, unknown>, key: string, val: unknown): void => {
+        Object.defineProperty(out, key, {
           value: val,
           enumerable: true,
           writable: true,
@@ -371,13 +359,28 @@ export function createFridayMemoryPiiGuard(
         });
       };
 
-      // `keyedType` is the PII type a numeric/bigint value INHERITS FROM ITS OBJECT KEY (see
-      // sensitiveTypeForKey). It is threaded down through arrays (a list under a sensitive key)
-      // but NOT into nested objects, which re-establish their own key context.
-      const walk = (v: unknown, depth: number, keyedType?: FridayKeyDrivenPiiType): unknown => {
-        // Fail CLOSED past the structural safety cap: never return an unscanned subtree in
-        // cleartext. The sentinel carries no PII and is inert on a re-scan (idempotent).
-        if (depth > MAX_DEPTH) return DEPTH_REDACTION_SENTINEL;
+      // Resolve the collision-disambiguated final key for `key` in `out`, WITHOUT writing the
+      // value. Redacting keys can collapse two distinct PII keys onto the same token (e.g.
+      // `a@x.com` and `b@y.com` → `[EMAIL]`); on collision the later entry is disambiguated
+      // deterministically so both VALUES survive. The `#N` suffix contains no PII pattern, so a
+      // second redactDeep pass is a no-op (idempotent). The slot is RESERVED in forward key
+      // order (see the object branch) so the resulting key set and enumeration order are
+      // byte-identical to the previous recursive walker; the deep value fills the slot later.
+      const resolveFinalKey = (out: Record<string, unknown>, key: string): string => {
+        if (!Object.prototype.hasOwnProperty.call(out, key)) return key;
+        let suffix = 2;
+        while (Object.prototype.hasOwnProperty.call(out, `${key}#${suffix}`)) {
+          suffix += 1;
+        }
+        return `${key}#${suffix}`;
+      };
+
+      // Transform a scalar leaf. `keyedType` is the PII type a numeric/bigint value INHERITS
+      // FROM ITS OBJECT KEY (see sensitiveTypeForKey); it is threaded through arrays (a list
+      // under a sensitive key) but NOT into nested objects, which re-establish their own key
+      // context. Containers (array/object) are NOT handled here — the iterative loop below
+      // reconstructs them so the traversal never touches the call stack.
+      const transformScalar = (v: unknown, keyedType?: FridayKeyDrivenPiiType): unknown => {
         if (typeof v === "string") {
           return redactStringLeaf(v);
         }
@@ -390,32 +393,100 @@ export function createFridayMemoryPiiGuard(
         //      head_phone: 42, sim_card: 2) is preserved because "3"/"42"/"2" is not card/phone
         //      shaped. It does NOT reintroduce shape-alone inference — the value gate only runs
         //      AFTER the sensitive-key gate, so a Luhn-valid `order_id` under a NON-sensitive key
-        //      is still preserved.
+        //      is still preserved. In tag/block mode the value is returned UNCHANGED (contract:
+        //      those modes never transform data) while the pii.* tag is still collected.
         if (typeof v === "number" || typeof v === "bigint") {
           if (!keyedType) return v;
           if (!numericValueMatchesKeyedType(String(v), keyedType)) return v;
           tagSet.add(`${FRIDAY_MEMORY_GUARD_PII_TAG_PREFIX}.${keyedType}`);
           return effectiveMode === "redact" ? `[${keyedType.toUpperCase()}]` : v;
         }
-        // Preserve a Date's original TYPE (the object branch below would otherwise walk its zero
+        // Preserve a Date's original TYPE (the object branch would otherwise walk its zero
         // own-enumerable props and corrupt it into `{}`). A Date is not a numeric PII carrier.
-        if (v instanceof Date) {
-          return v;
-        }
-        if (Array.isArray(v)) {
-          return v.map((entry) => walk(entry, depth + 1, keyedType));
-        }
-        if (v && typeof v === "object") {
-          const out: Record<string, unknown> = {};
-          for (const [k, entry] of Object.entries(v as Record<string, unknown>)) {
-            assignKey(out, redactKey(k), walk(entry, depth + 1, sensitiveTypeForKey(k)));
-          }
-          return out;
-        }
         return v;
       };
 
-      return { value: walk(value, 0), tagsToAdd: [...tagSet] };
+      // Explicit work stack. Each `value` frame writes its transformed result into a parent slot
+      // via `assign`; each `exit` frame pops a container off the ancestor path once its whole
+      // subtree is processed. `onPath` maps a container currently on the DFS ancestor path to
+      // its output container; a back-edge to a node still on the path is a CYCLE — we assign the
+      // (in-progress) output reference and do NOT recurse, so a cyclic input never infinite-loops
+      // or stack-overflows and no data is lost. `onPath` is cleared on exit, so a re-referenced
+      // node reached via a sibling path (a DAG, not a cycle) is fully re-walked — byte-identical
+      // to the old recursive walker for every acyclic input.
+      type ValueFrame = { value: unknown; keyedType?: FridayKeyDrivenPiiType; assign: (r: unknown) => void };
+      type ExitFrame = { exit: object };
+      const root: { out: unknown } = { out: undefined };
+      const onPath = new WeakMap<object, unknown>();
+      const stack: Array<ValueFrame | ExitFrame> = [
+        { value, assign: (r) => { root.out = r; } },
+      ];
+
+      while (stack.length > 0) {
+        const frame = stack.pop() as ValueFrame | ExitFrame;
+        if ("exit" in frame) {
+          onPath.delete(frame.exit);
+          continue;
+        }
+        const { value: v, keyedType, assign } = frame;
+
+        if (Array.isArray(v)) {
+          if (onPath.has(v)) {
+            assign(onPath.get(v)); // cycle back-edge → structural share (no data loss)
+            continue;
+          }
+          const out: unknown[] = new Array(v.length);
+          onPath.set(v, out);
+          assign(out);
+          stack.push({ exit: v });
+          // Push in reverse so element frames are processed in forward index order (arrays
+          // thread the parent keyedType into their elements).
+          for (let i = v.length - 1; i >= 0; i -= 1) {
+            const idx = i;
+            stack.push({ value: v[idx], keyedType, assign: (r) => { out[idx] = r; } });
+          }
+          continue;
+        }
+
+        if (v instanceof Date) {
+          assign(v);
+          continue;
+        }
+
+        if (v && typeof v === "object") {
+          if (onPath.has(v)) {
+            assign(onPath.get(v)); // cycle back-edge → structural share (no data loss)
+            continue;
+          }
+          const out: Record<string, unknown> = {};
+          onPath.set(v, out);
+          assign(out);
+          stack.push({ exit: v });
+          // Reserve every key slot in FORWARD Object.entries order (collision-disambiguated,
+          // own data property) so the key set / enumeration order match the old recursive
+          // walker exactly; deep values fill the reserved slots as their frames complete.
+          const childFrames: ValueFrame[] = [];
+          for (const [k, entry] of Object.entries(v as Record<string, unknown>)) {
+            const finalKey = resolveFinalKey(out, redactKey(k));
+            defineOwn(out, finalKey, undefined);
+            const childKeyedType = sensitiveTypeForKey(k);
+            childFrames.push({
+              value: entry,
+              keyedType: childKeyedType,
+              assign: (r) => { defineOwn(out, finalKey, r); },
+            });
+          }
+          for (let i = childFrames.length - 1; i >= 0; i -= 1) {
+            stack.push(childFrames[i]);
+          }
+          continue;
+        }
+
+        // Scalar leaf (string / number / bigint / Date / null / boolean / undefined / other).
+        assign(transformScalar(v, keyedType));
+      }
+
+      return { value: root.out, tagsToAdd: [...tagSet] };
     },
   };
 }

--- a/test/integration/memory/guard/friday-memory-guard-pii-namespace.test.ts
+++ b/test/integration/memory/guard/friday-memory-guard-pii-namespace.test.ts
@@ -207,4 +207,64 @@ describe("FridayMemoryGuard — PII + Namespace + Rate Limit (Integration)", () 
       }
     });
   });
+
+  // ─── Typed-value PII: preserved at rest + redacted on authoritative read-back (R62) ───
+  //
+  // Exercises the REAL guard write path (guard.store → write-time redactDeep → core.store) with
+  // an authoritative echoing core (store persists exactly what it is handed; get returns it).
+  // Proves (a) ambiguous numeric ids are preserved AT REST (no irreversible masking) and
+  // (b) registry-keyed numeric PII is redacted before persistence and never returned in
+  // cleartext on read-back. Metadata is JSON (numbers, not bigint) — the store path is JSON-
+  // validated. Key-driven redaction is context-aware: shape/Luhn is never consulted.
+  describe("typed-value PII at rest + authoritative read-back (R62)", () => {
+    it("preserves ambiguous numeric ids at rest and redacts registry-keyed numeric PII", async () => {
+      const { guard, core, piiGuard } = createGuardTestSetup();
+      const realGuard = createFridayMemoryPiiGuard("redact");
+      vi.mocked(piiGuard.scanAndTransform).mockImplementation((c) => realGuard.scanAndTransform(c));
+      vi.mocked(piiGuard.redactDeep).mockImplementation((v) => realGuard.redactDeep(v));
+
+      // Authoritative store: persist exactly what the guard hands to core, echo it back on get.
+      let persisted: ReturnType<typeof createMockMemoryItem> | undefined;
+      vi.mocked(core.store).mockImplementation(async (namespace, content, meta) => {
+        persisted = createMockMemoryItem({
+          namespace,
+          content,
+          metadata: (meta?.metadata ?? {}) as Record<string, unknown>,
+          tags: meta?.tags ?? [],
+        });
+        return persisted;
+      });
+      vi.mocked(core.get).mockImplementation(async () => persisted!);
+
+      const stored = await guard.store("test-ns", "profile", {
+        metadata: {
+          order_id: 123456789, // ambiguous business id → preserved
+          epoch_ms: 1_700_000_000_000, // epoch timestamp → preserved
+          txn: 4111111111111111, // Luhn-valid under a NON-sensitive key → preserved
+          sim_card: 2, // sensitive-SOUNDING key but value not card-shaped → preserved (value gate)
+          ssn: 123456789, // registry key + SSN-shaped value → redacted
+          phone: 5552345678, // registry key + phone-shaped value → redacted
+          card: 4111111111111111, // registry key + Luhn card value → redacted
+        },
+      });
+
+      // (a) authoritative AT-REST state = exactly what was handed to core.store for persistence.
+      const atRest = vi.mocked(core.store).mock.calls.at(-1)![2]!.metadata as Record<string, unknown>;
+      expect(atRest.order_id).toBe(123456789);
+      expect(atRest.epoch_ms).toBe(1_700_000_000_000);
+      expect(atRest.txn).toBe(4111111111111111);
+      expect(atRest.sim_card).toBe(2); // benign business field survives at rest
+      expect(atRest.ssn).toBe("[SSN_US]");
+      expect(atRest.phone).toBe("[PHONE_US]");
+      expect(atRest.card).toBe("[CREDIT_CARD]");
+
+      // (b) authoritative READ-BACK returns the same preserved ids and no cleartext PII.
+      const readBack = await guard.get(stored.id);
+      const meta = readBack.metadata as Record<string, unknown>;
+      expect(meta.order_id).toBe(123456789);
+      expect(meta.ssn).toBe("[SSN_US]");
+      expect(meta.phone).toBe("[PHONE_US]");
+      expect(JSON.stringify(meta)).not.toContain("5552345678"); // phone value not leaked
+    });
+  });
 });

--- a/test/unit/api/http/routes/friday-uix-routes-learned-fact-pii.test.ts
+++ b/test/unit/api/http/routes/friday-uix-routes-learned-fact-pii.test.ts
@@ -93,6 +93,33 @@ describe("FridayUixRoutes — learned-fact PII egress", () => {
     expect(JSON.stringify(res)).not.toContain(FULLWIDTH_CARD);
   });
 
+  it("uix.learnedfacts.list redacts registry-keyed numeric PII but preserves ambiguous business ids (egress)", async () => {
+    // Real HTTP egress path: a structured learned-fact value with typed numeric fields. The
+    // key-driven redactor redacts ssn/card (registry keys) while preserving order_id (an
+    // ambiguous business id) — no digit-shape inference. `123456789` still appears in the JSON
+    // via order_id; the assertion targets the card value, which must not leak in cleartext.
+    const routes = createFridayUixRoutes({
+      service,
+      listLearnedFacts: vi.fn(() => [{
+        key: "pref:profile",
+        value: { order_id: 123456789, sim_card: 2, ssn: 123456789, card: 4111111111111111 },
+        confidence: 0.8,
+        evidenceCount: 1,
+        lastConfirmedAt: NOW,
+      }]),
+    });
+    const route = routes.find((r) => r.operationId === "uix.learnedfacts.list")!;
+    const res = (await route.handler(makeCtx())) as {
+      items: Array<{ value: { order_id: unknown; sim_card: unknown; ssn: unknown; card: unknown } }>;
+    };
+    const v = res.items[0]!.value;
+    expect(v.order_id).toBe(123456789); // ambiguous business id preserved on egress
+    expect(v.sim_card).toBe(2); // sensitive-sounding key, non-card value → preserved (value gate)
+    expect(v.ssn).toBe("[SSN_US]"); // registry key + SSN-shaped value redacted
+    expect(v.card).toBe("[CREDIT_CARD]");
+    expect(JSON.stringify(res)).not.toContain("4111111111111111"); // card not leaked in cleartext
+  });
+
   it("uix.learnedfacts.list leaves a value with no PII unchanged (negative control)", async () => {
     const routes = createFridayUixRoutes({
       service,

--- a/test/unit/api/http/routes/friday-uix-routes-learned-fact-pii.test.ts
+++ b/test/unit/api/http/routes/friday-uix-routes-learned-fact-pii.test.ts
@@ -120,6 +120,26 @@ describe("FridayUixRoutes — learned-fact PII egress", () => {
     expect(JSON.stringify(res)).not.toContain("4111111111111111"); // card not leaked in cleartext
   });
 
+  it("uix.learnedfacts.list redacts a numeric country-code phone (1XXXXXXXXXX) under a phone key [F1 red-first]", async () => {
+    // Real HTTP egress: a US phone persisted as a country-code INTEGER (11-digit 1XXXXXXXXXX,
+    // no '+') under a registry phone key. The reused phone detector rejects that numeric form,
+    // so before the fix it egressed in cleartext. The key+value gates must now redact it.
+    const routes = createFridayUixRoutes({
+      service,
+      listLearnedFacts: vi.fn(() => [{
+        key: "pref:contact",
+        value: { phone: 15552345678 },
+        confidence: 0.8,
+        evidenceCount: 1,
+        lastConfirmedAt: NOW,
+      }]),
+    });
+    const route = routes.find((r) => r.operationId === "uix.learnedfacts.list")!;
+    const res = (await route.handler(makeCtx())) as { items: Array<{ value: { phone: unknown } }> };
+    expect(res.items[0]!.value.phone).toBe("[PHONE_US]");
+    expect(JSON.stringify(res)).not.toContain("15552345678");
+  });
+
   it("uix.learnedfacts.list leaves a value with no PII unchanged (negative control)", async () => {
     const routes = createFridayUixRoutes({
       service,

--- a/test/unit/memory/guard/services/friday-memory-guard-service-deep-pii-seam.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-deep-pii-seam.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest";
+import type { FridayMemoryGuardContext } from "#memory";
+import { createFridayMemoryGuardService, createFridayMemoryPiiGuard } from "#memory";
+import {
+  createMockCoreService,
+  createMockRateLimiter,
+  createMockQuotaRepo,
+  createMockOutputFilter,
+  createMockDb,
+} from "./_helpers/create-guard-service.helper.js";
+
+// ─── Advisor round 2 — production guard/store seam probe ─────────────────────────
+//
+// This reproduces the exact `guard.store` probe the Advisor ran. It wires the REAL PII guard
+// (redact mode, the production default) into the REAL guard service and asserts what
+// `core.store` actually receives. The finding: a deep-but-benign metadata object that
+// serializes UNDER the 16 KiB metadata limit passed validation, but `redactDeep`'s fixed depth
+// cap replaced the over-deep subtree with a "[REDACTED_DEPTH]" sentinel — so core.store
+// persisted the sentinel instead of the user's canonical metadata (silent data loss,
+// DATA-RETENTION-001). After the iterative full-scan rewrite, core.store must receive the
+// ORIGINAL metadata, byte-identical.
+
+const NOW = "2026-02-18T10:00:00.000Z";
+const NOW_MS = new Date(NOW).getTime();
+
+function makeRealPiiGuardService(mode: "redact" | "tag" | "block" = "redact") {
+  const core = createMockCoreService();
+  const context: FridayMemoryGuardContext = {
+    subject: { hubId: "default", userId: "user1", accessLevel: "tenant" },
+    principalId: "principal-1",
+  };
+  const guard = createFridayMemoryGuardService({
+    core,
+    db: createMockDb(),
+    nowIso: () => NOW,
+    nowMs: () => NOW_MS,
+    context,
+    rateLimiter: createMockRateLimiter(),
+    quotaRepo: createMockQuotaRepo(),
+    piiGuard: createFridayMemoryPiiGuard(mode), // REAL guard, not a mock
+    outputFilter: createMockOutputFilter(),
+  });
+  return { guard, core };
+}
+
+// `depth` levels of {child: …} around a benign leaf. At depth 501 the serialized JSON is a few
+// KB — comfortably under the 16 KiB metadata limit (validateMetadata passes) — yet the leaf
+// sits past the old depth-500 cap, so the pre-fix walker corrupted it.
+function deepBenignMetadata(depth: number): Record<string, unknown> {
+  let node: Record<string, unknown> = {
+    deep_value: "keepme-benign-canonical-marker",
+    count: 42,
+    ratio: 3.14,
+    ok: true,
+  };
+  for (let i = 0; i < depth; i += 1) node = { child: node, level: i };
+  return node;
+}
+
+describe("FridayMemoryGuardService — deep metadata store seam (Advisor round 2) [red-first]", () => {
+  it("core.store receives the ORIGINAL benign deep metadata, not a [REDACTED_DEPTH] sentinel", async () => {
+    const { guard, core } = makeRealPiiGuardService("redact");
+    const metadata = deepBenignMetadata(501);
+
+    // Sanity: this input is under the 16 KiB metadata byte-bound (so it passes validation and
+    // the write actually reaches core.store — the seam where the loss occurred).
+    expect(new TextEncoder().encode(JSON.stringify(metadata)).length).toBeLessThan(16 * 1024);
+
+    await guard.store("test-ns", "benign content", { metadata });
+
+    const callArgs = vi.mocked(core.store).mock.calls[0];
+    const storedMeta = callArgs[2]?.metadata as Record<string, unknown> | undefined;
+
+    // The probe: what core.store actually got.
+    const storedJson = JSON.stringify(storedMeta);
+    expect(storedJson).not.toContain("[REDACTED_DEPTH]"); // no sentinel corruption
+    expect(storedJson).toContain("keepme-benign-canonical-marker"); // deep canonical value survived
+    expect(storedJson).toBe(JSON.stringify(metadata)); // byte-identical: zero data loss
+  });
+
+  it("still redacts DEEP PII in metadata on the store path (leak stays closed)", async () => {
+    const { guard, core } = makeRealPiiGuardService("redact");
+    // Benign wrapper, deep PII leaf under sensitive keys + an email string.
+    let node: Record<string, unknown> = { contact: "owner@example.com", phone: 5552345678, ssn: 123456789 };
+    for (let i = 0; i < 600; i += 1) node = { child: node };
+    const metadata = node;
+    expect(new TextEncoder().encode(JSON.stringify(metadata)).length).toBeLessThan(16 * 1024);
+
+    await guard.store("test-ns", "benign content", { metadata });
+
+    const callArgs = vi.mocked(core.store).mock.calls[0];
+    const storedJson = JSON.stringify(callArgs[2]?.metadata);
+    expect(storedJson).not.toContain("owner@example.com"); // deep PII never persisted clear
+    expect(storedJson).not.toContain("5552345678");
+    expect(storedJson).not.toContain("123456789");
+    expect(storedJson).not.toContain("[REDACTED_DEPTH]");
+    expect(storedJson).toContain("[EMAIL]");
+    expect(storedJson).toContain("[PHONE_US]");
+    expect(storedJson).toContain("[SSN_US]");
+    // PII surfaced as tags on the stored item.
+    const storedTags = callArgs[2]?.tags as string[] | undefined;
+    expect(storedTags).toEqual(expect.arrayContaining(["pii.email", "pii.phone_us", "pii.ssn_us"]));
+  });
+});

--- a/test/unit/memory/guard/services/friday-memory-guard-service-deep-pii-seam.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-deep-pii-seam.test.ts
@@ -102,3 +102,38 @@ describe("FridayMemoryGuardService — deep metadata store seam (Advisor round 2
     expect(storedTags).toEqual(expect.arrayContaining(["pii.email", "pii.phone_us", "pii.ssn_us"]));
   });
 });
+
+// ─── Advisor round 3 — production guard/store seam probe: full-width pure-numeric KEY ─────
+//
+// The pure-numeric object-KEY exemption preserved the ASCII business key "4111111111111111" but
+// its semantically-identical FULL-WIDTH form was folded by the PII matcher, matched as a card, and
+// irreversibly renamed to "[CREDIT_CARD]" — so on the REAL store path core.store received a
+// corrupted key (canonical-lookup identity broken). After making the exemption Unicode-decimal-
+// aware, core.store must receive the ORIGINAL full-width key, byte-identical.
+describe("FridayMemoryGuardService — full-width pure-numeric metadata KEY store seam (Advisor round 3) [red-first]", () => {
+  const fullwidth = (s: string): string =>
+    [...s]
+      .map((ch) => {
+        const c = ch.charCodeAt(0);
+        return c >= 0x21 && c <= 0x7e ? String.fromCharCode(c + 0xfee0) : ch;
+      })
+      .join("");
+
+  it("core.store receives the ORIGINAL full-width pure-numeric KEY (not renamed to [CREDIT_CARD])", async () => {
+    const { guard, core } = makeRealPiiGuardService("redact");
+    const fwKey = fullwidth("4111111111111111"); // full-width Luhn-valid Visa test number as a KEY
+    const metadata: Record<string, unknown> = { [fwKey]: "canonical-marker" };
+
+    await guard.store("test-ns", "benign content", { metadata });
+
+    const callArgs = vi.mocked(core.store).mock.calls[0];
+    const storedMeta = callArgs[2]?.metadata as Record<string, unknown> | undefined;
+    expect(storedMeta).toBeDefined();
+    expect(Object.keys(storedMeta as Record<string, unknown>)).toContain(fwKey); // key preserved
+    expect(Object.keys(storedMeta as Record<string, unknown>)).not.toContain("[CREDIT_CARD]");
+    expect((storedMeta as Record<string, unknown>)[fwKey]).toBe("canonical-marker");
+    // No PII tag was fabricated from a benign business id.
+    const storedTags = (callArgs[2]?.tags as string[] | undefined) ?? [];
+    expect(storedTags).not.toContain("pii.credit_card");
+  });
+});

--- a/test/unit/memory/guard/services/friday-memory-guard-service-output-filter.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-guard-service-output-filter.test.ts
@@ -85,6 +85,18 @@ describe("FridayMemoryOutputFilter", () => {
     expect(filtered.tags).not.toContain("123-45-6789"); // PII-bearing tag dropped
   });
 
+  // Advisor round 3 — output-filter read-back seam: a FULL-WIDTH pure-numeric metadata KEY is a
+  // benign business id and must be preserved byte-identical, not folded + renamed to [CREDIT_CARD].
+  it("preserves a FULL-WIDTH pure-numeric metadata KEY on read-back (not renamed to [CREDIT_CARD]) [red-first]", () => {
+    const fullwidthKey = "４１１１１１１１１１１１１１１１"; // toFullwidth("4111111111111111") used as a KEY
+    const item = makeItem({ metadata: { [fullwidthKey]: "canonical-marker" } });
+    const filtered = filter.filterItem(item);
+    const meta = filtered.metadata as Record<string, unknown>;
+    expect(Object.keys(meta)).toContain(fullwidthKey); // preserved
+    expect(Object.keys(meta)).not.toContain("[CREDIT_CARD]");
+    expect(meta[fullwidthKey]).toBe("canonical-marker");
+  });
+
   // ─── filterSearchResults ───
 
   it("returns results as-is when within limits", () => {

--- a/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
@@ -707,14 +707,16 @@ describe("FridayMemoryPiiGuard", () => {
     });
   });
 
-  // ─── F2: deep nesting must fail CLOSED, never emit an unscanned subtree ───
+  // ─── F2 (Advisor round 2): deep nesting is FULLY SCANNED — no cap, no sentinel ───
   //
-  // The walker returned the remaining subtree UNCHANGED past the recursion cap (fail-OPEN):
-  // a 7-level object carrying `owner@example.com` egressed in cleartext. The fix scans every
-  // depth realistic (byte-bounded) input can reach and, at a high structural safety cap
-  // (stack-overflow guard), fails CLOSED by replacing the over-deep subtree with a redaction
-  // sentinel — never cleartext.
-  describe("redactDeep F2 — deep nesting fails CLOSED (no unscanned egress) [red-first]", () => {
+  // The prior round replaced every subtree past a fixed recursion cap (depth 500) with a
+  // "[REDACTED_DEPTH]" sentinel in ALL modes. That silently CORRUPTED valid deep user metadata
+  // (canonical-data loss — DATA-RETENTION-001) and violated the tag/block non-transform
+  // contract. The rewrite makes the walker ITERATIVE (heap work stack) + CYCLE-AWARE + FULL-
+  // SCAN: bounded only by the upstream 16 KiB metadata byte-limit, every admitted structure is
+  // scanned to its leaves. Deep PII is ALWAYS found (the F2 leak stays closed) AND benign deep
+  // data round-trips UNCHANGED (the new data-loss defect is fixed). No sentinel exists anymore.
+  describe("redactDeep F2 — deep nesting fully scanned, no cap/sentinel [red-first]", () => {
     const guard = createFridayMemoryPiiGuard("redact");
 
     // `depth` levels of {child: …} wrapping a leaf object with an email + keyed phone/ssn.
@@ -728,7 +730,14 @@ describe("FridayMemoryPiiGuard", () => {
       return node;
     }
 
-    it("redacts PII at depth 7 (previously beyond the depth-6 fail-open boundary)", () => {
+    // `depth` levels of {child: …} wrapping a purely BENIGN leaf that must round-trip unchanged.
+    function deepBenign(depth: number): unknown {
+      let node: Record<string, unknown> = { keepme: "benign-canonical-marker", count: 42 };
+      for (let i = 0; i < depth; i += 1) node = { child: node, idx: i };
+      return node;
+    }
+
+    it("redacts PII at depth 7 (regression — was the depth-6 fail-open boundary)", () => {
       const { value, tagsToAdd } = guard.redactDeep(deepPii(7));
       const json = JSON.stringify(value);
       expect(json).not.toContain("owner@example.com");
@@ -742,7 +751,7 @@ describe("FridayMemoryPiiGuard", () => {
       );
     });
 
-    it("redacts PII much deeper (depth 300) — still fully scanned below the safety cap", () => {
+    it("redacts PII much deeper (depth 300) — regression, was below the old cap", () => {
       const { value } = guard.redactDeep(deepPii(300));
       const json = JSON.stringify(value);
       expect(json).not.toContain("owner@example.com");
@@ -750,12 +759,109 @@ describe("FridayMemoryPiiGuard", () => {
       expect(json).toContain("[EMAIL]");
     });
 
-    it("fails CLOSED beyond the structural safety cap: the over-deep subtree is replaced by a redaction sentinel, never emitted clear", () => {
-      const { value } = guard.redactDeep(deepPii(1200));
+    // Red-first: on the pre-fix code the leaf sits past the depth-500 cap, so it was replaced by
+    // the sentinel (no [EMAIL], a "[REDACTED_DEPTH]" instead). Now it is fully scanned.
+    it.each([501, 1200, 2000])(
+      "redacts deep PII at depth %i — no sentinel, no leak (red-first)",
+      (depth) => {
+        const { value, tagsToAdd } = guard.redactDeep(deepPii(depth));
+        const json = JSON.stringify(value);
+        expect(json).not.toContain("owner@example.com"); // no cleartext leak
+        expect(json).not.toContain("5552345678");
+        expect(json).not.toContain("123456789");
+        expect(json).not.toContain("[REDACTED_DEPTH]"); // sentinel is gone entirely
+        expect(json).toContain("[EMAIL]"); // deep PII actually redacted
+        expect(json).toContain("[PHONE_US]");
+        expect(json).toContain("[SSN_US]");
+        expect(tagsToAdd).toEqual(
+          expect.arrayContaining(["pii.email", "pii.phone_us", "pii.ssn_us"]),
+        );
+      },
+    );
+
+    // Red-first: on the pre-fix code the benign leaf past depth 500 was CORRUPTED to the
+    // sentinel (silent canonical-data loss). Now deep benign metadata round-trips byte-identical.
+    it.each([501, 1200, 2000])(
+      "round-trips BENIGN deep data UNCHANGED at depth %i (no silent loss — red-first)",
+      (depth) => {
+        const input = deepBenign(depth);
+        const { value, tagsToAdd } = guard.redactDeep(input);
+        const json = JSON.stringify(value);
+        expect(json).not.toContain("[REDACTED_DEPTH]"); // never corrupted
+        expect(json).toContain("benign-canonical-marker"); // deep canonical value survives
+        expect(json).toBe(JSON.stringify(input)); // byte-identical round-trip
+        expect(tagsToAdd).toHaveLength(0); // no PII → no tags
+      },
+    );
+  });
+
+  // ─── F2b (Advisor round 2): the tag/block MODE CONTRACTS hold at ANY depth ───
+  //
+  // The old sentinel replaced deep subtrees regardless of mode. tag mode MUST NOT transform any
+  // value; block mode MUST surface a pii.* tag for PII at any depth so the guard service can
+  // reject the whole write (never persist an untagged "scanned-clean" sentinel).
+  describe("redactDeep F2b — deep mode contracts (tag non-transform / block tags) [red-first]", () => {
+    function deepNode(depth: number, leaf: Record<string, unknown>): unknown {
+      let node: Record<string, unknown> = leaf;
+      for (let i = 0; i < depth; i += 1) node = { child: node };
+      return node;
+    }
+
+    it("tag mode: deep subtree is returned UNCHANGED (no sentinel, no value transform)", () => {
+      const tagGuard = createFridayMemoryPiiGuard("tag");
+      const input = deepNode(1200, { contact: "owner@example.com", phone: 5552345678, note: "keep-me" });
+      const { value, tagsToAdd } = tagGuard.redactDeep(input);
       const json = JSON.stringify(value);
-      expect(json).not.toContain("owner@example.com"); // deep email never leaked
-      expect(json).not.toContain("5552345678");
-      expect(json).toContain("[REDACTED_DEPTH]"); // fail-closed sentinel present
+      expect(json).not.toContain("[REDACTED_DEPTH]");
+      expect(json).toBe(JSON.stringify(input)); // tag mode transforms NOTHING, even deep
+      expect(json).toContain("owner@example.com"); // value untouched
+      expect(json).toContain("5552345678");
+      // …but the deep PII is still DETECTED and reported as tags.
+      expect(tagsToAdd).toEqual(expect.arrayContaining(["pii.email", "pii.phone_us"]));
+    });
+
+    it("block mode: deep PII yields pii.* tags (so the blocker can reject) — no untagged sentinel", () => {
+      const blockGuard = createFridayMemoryPiiGuard("block");
+      const input = deepNode(1200, { contact: "owner@example.com", ssn: 123456789 });
+      const { value, tagsToAdd } = blockGuard.redactDeep(input);
+      const json = JSON.stringify(value);
+      // block mode does not transform values here (the guard service throws on tagsToAdd);
+      // crucially the deep PII must be TAGGED, never silently replaced by an untagged sentinel.
+      expect(json).not.toContain("[REDACTED_DEPTH]");
+      expect(tagsToAdd).toEqual(expect.arrayContaining(["pii.email", "pii.ssn_us"]));
+    });
+  });
+
+  // ─── F2c (Advisor round 2): cycle safety — no hang, no stack overflow ───
+  //
+  // A cyclic object must terminate: the ancestor-path guard breaks the back-edge (structural
+  // share, no data loss) instead of infinite-looping. The old recursive walker would stack-
+  // overflow (or, past the cap, sentinel-truncate) a deep/cyclic structure.
+  describe("redactDeep F2c — cycle safety (terminates, each node once) [red-first]", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    it("terminates on a direct self-cycle and still redacts the PII leaf", () => {
+      const node: Record<string, unknown> = { contact: "owner@example.com", phone: 5552345678 };
+      node.self = node; // cycle
+      const { value, tagsToAdd } = guard.redactDeep(node);
+      const out = value as Record<string, unknown>;
+      expect(out.contact).toBe("[EMAIL]"); // PII in the cyclic node is redacted
+      expect(out.phone).toBe("[PHONE_US]");
+      expect(out.self).toBe(out); // back-edge preserved as a structural self-reference
+      expect(tagsToAdd).toEqual(expect.arrayContaining(["pii.email", "pii.phone_us"]));
+    });
+
+    it("terminates on a mutual (A→B→A) cycle nested under a benign parent", () => {
+      const a: Record<string, unknown> = { email: "a-owner@example.com" };
+      const b: Record<string, unknown> = { ssn: 123456789, back: a };
+      a.next = b; // A → B → A
+      const { value } = guard.redactDeep({ root: a, note: "keep" });
+      const out = value as { root: Record<string, unknown>; note: string };
+      expect(out.note).toBe("keep");
+      expect(out.root.email).toBe("[EMAIL]");
+      const bOut = out.root.next as Record<string, unknown>;
+      expect(bOut.ssn).toBe("[SSN_US]");
+      expect(bOut.back).toBe(out.root); // cycle closed back onto the same output node
     });
   });
 

--- a/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
@@ -656,4 +656,146 @@ describe("FridayMemoryPiiGuard", () => {
       expect(tagsToAdd).toContain("pii.credit_card");
     });
   });
+
+  // ─── Advisor round 2 ─────────────────────────────────────────────────────────
+  //
+  // Three real defects the independent Advisor found in the two-gate typed-PII redactor.
+  // Each block is red-first: it reproduces the leak/bug against the pre-fix code, then the
+  // fix makes it pass. Benign controls assert no over-redaction is introduced.
+
+  // ─── F1: keyed numeric US phone stored as a country-code integer (1XXXXXXXXXX) ───
+  //
+  // A US number persisted numerically loses its leading '+', becoming the 11-digit form
+  // 1XXXXXXXXXX. The reused phone detector only accepts +1XXXXXXXXXX (which it cannot even
+  // anchor at string start) or the bare 10-digit form, so `redactDeep({phone: 15552345678})`
+  // returned the CLEAR value. The fix normalizes the numeric string ONLY under an already-
+  // phone-typed key (no shape-only redaction) against the SAME detector.
+  describe("redactDeep F1 — keyed numeric country-code US phone (1XXXXXXXXXX) [red-first]", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    it("redacts a numeric country-code phone (1XXXXXXXXXX) under a `phone` key", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ phone: 15552345678 });
+      expect((value as { phone: unknown }).phone).toBe("[PHONE_US]");
+      expect(tagsToAdd).toContain("pii.phone_us");
+    });
+
+    it("redacts a bigint country-code phone under a `phone` key", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ phone: 15552345678n });
+      expect((value as { phone: unknown }).phone).toBe("[PHONE_US]");
+      expect(tagsToAdd).toContain("pii.phone_us");
+    });
+
+    // Benign controls that MUST still preserve (no new over-redaction, no shape-only path).
+    it("preserves a tiny number under a `phone` key (value gate still applies)", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ phone: 42 });
+      expect((value as { phone: unknown }).phone).toBe(42);
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("preserves an 11-digit phone-ish value under a NON-phone key (gift_card → credit_card type)", () => {
+      // The KEY governs the type; gift_card is a card key, and 11 digits is not card-shaped,
+      // so the value gate preserves it. The phone normalization must NOT leak across key types.
+      const { value, tagsToAdd } = guard.redactDeep({ gift_card: 15552345678 });
+      expect((value as { gift_card: unknown }).gift_card).toBe(15552345678);
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("preserves an 11-digit value under a non-sensitive key (order_id)", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ order_id: 15552345678 });
+      expect((value as { order_id: unknown }).order_id).toBe(15552345678);
+      expect(tagsToAdd).toHaveLength(0);
+    });
+  });
+
+  // ─── F2: deep nesting must fail CLOSED, never emit an unscanned subtree ───
+  //
+  // The walker returned the remaining subtree UNCHANGED past the recursion cap (fail-OPEN):
+  // a 7-level object carrying `owner@example.com` egressed in cleartext. The fix scans every
+  // depth realistic (byte-bounded) input can reach and, at a high structural safety cap
+  // (stack-overflow guard), fails CLOSED by replacing the over-deep subtree with a redaction
+  // sentinel — never cleartext.
+  describe("redactDeep F2 — deep nesting fails CLOSED (no unscanned egress) [red-first]", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    // `depth` levels of {child: …} wrapping a leaf object with an email + keyed phone/ssn.
+    function deepPii(depth: number): unknown {
+      let node: Record<string, unknown> = {
+        contact: "owner@example.com",
+        phone: 5552345678,
+        ssn: 123456789,
+      };
+      for (let i = 0; i < depth; i += 1) node = { child: node };
+      return node;
+    }
+
+    it("redacts PII at depth 7 (previously beyond the depth-6 fail-open boundary)", () => {
+      const { value, tagsToAdd } = guard.redactDeep(deepPii(7));
+      const json = JSON.stringify(value);
+      expect(json).not.toContain("owner@example.com");
+      expect(json).not.toContain("5552345678");
+      expect(json).not.toContain("123456789");
+      expect(json).toContain("[EMAIL]");
+      expect(json).toContain("[PHONE_US]");
+      expect(json).toContain("[SSN_US]");
+      expect(tagsToAdd).toEqual(
+        expect.arrayContaining(["pii.email", "pii.phone_us", "pii.ssn_us"]),
+      );
+    });
+
+    it("redacts PII much deeper (depth 300) — still fully scanned below the safety cap", () => {
+      const { value } = guard.redactDeep(deepPii(300));
+      const json = JSON.stringify(value);
+      expect(json).not.toContain("owner@example.com");
+      expect(json).not.toContain("5552345678");
+      expect(json).toContain("[EMAIL]");
+    });
+
+    it("fails CLOSED beyond the structural safety cap: the over-deep subtree is replaced by a redaction sentinel, never emitted clear", () => {
+      const { value } = guard.redactDeep(deepPii(1200));
+      const json = JSON.stringify(value);
+      expect(json).not.toContain("owner@example.com"); // deep email never leaked
+      expect(json).not.toContain("5552345678");
+      expect(json).toContain("[REDACTED_DEPTH]"); // fail-closed sentinel present
+    });
+  });
+
+  // ─── F3: JSON-originated dangerous keys must be OWN data properties (no proto pollution) ───
+  //
+  // `out[key] = val` invokes the legacy `__proto__` setter for a JSON-originated own key
+  // `__proto__`, mutating the output object's prototype AND dropping the field. The fix
+  // defines an OWN data property so `__proto__` round-trips and the prototype is unchanged.
+  describe("redactDeep F3 — JSON-originated dangerous keys are own data properties [red-first]", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    it("round-trips a JSON `__proto__` own key without mutating the output prototype or dropping data", () => {
+      const input = JSON.parse(String.raw`{"__proto__": {"polluted": true}, "safe": 1}`);
+      const { value } = guard.redactDeep(input);
+      const out = value as Record<string, unknown>;
+      expect(Object.getPrototypeOf(out)).toBe(Object.prototype); // prototype untouched
+      expect(Object.prototype.hasOwnProperty.call(out, "__proto__")).toBe(true); // no data drop
+      expect(Object.keys(out)).toContain("__proto__");
+      expect(out.safe).toBe(1);
+      expect(JSON.parse(JSON.stringify(out)).safe).toBe(1); // still JSON-round-trips
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined(); // no global pollution
+    });
+
+    it("preserves JSON `constructor` and `prototype` own keys as own data properties", () => {
+      const input = JSON.parse(String.raw`{"constructor": 1, "prototype": 2, "clean": 3}`);
+      const { value } = guard.redactDeep(input);
+      const out = value as Record<string, unknown>;
+      expect(Object.prototype.hasOwnProperty.call(out, "constructor")).toBe(true);
+      expect(out.constructor).toBe(1);
+      expect(out.prototype).toBe(2);
+      expect(out.clean).toBe(3);
+      expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+    });
+
+    it("keeps idempotence and collision-safety with a dangerous key", () => {
+      const input = JSON.parse(String.raw`{"__proto__": 1}`);
+      const once = guard.redactDeep(input).value;
+      const twice = guard.redactDeep(once).value;
+      expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+      expect(Object.prototype.hasOwnProperty.call(twice as object, "__proto__")).toBe(true);
+    });
+  });
 });

--- a/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
@@ -411,4 +411,249 @@ describe("FridayMemoryPiiGuard", () => {
       expect(tagsToAdd).toContain("pii.email");
     });
   });
+
+  // ─── redactDeep — CONTEXT-AWARE typed PII + object-KEY coverage (lane R62) ───
+  //
+  // Honest boundary: redactDeep closes three gaps in the deep walker — (1) typed number/bigint
+  // values, (2) Date corruption to `{}`, (3) object-KEY PII — WITHOUT inferring PII from digit
+  // shape alone. A bare number/bigint is redacted only under TWO gates: its object KEY names a
+  // known sensitive field AND the value's string form matches that type's canonical detector
+  // (SSN / phone / Luhn card). Ambiguous numerics (business ids, order numbers, epochs, Luhn-
+  // valid non-cards), benign numerics under sensitive-SOUNDING keys (gift_card: 3), and pure-
+  // numeric object keys are PRESERVED unchanged. The existing string at-rest policy is untouched.
+  // This is NOT a claim that every PII representation is caught.
+
+  describe("redactDeep context-aware typed PII — PRESERVED (ambiguous numerics/ids)", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    it("preserves a 9-digit business id under a non-sensitive key", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ user_id: 123456789 });
+      expect(value).toEqual({ user_id: 123456789 });
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("preserves a 10-digit number under a non-sensitive key", () => {
+      const { value } = guard.redactDeep({ order_ref: 5552345678 });
+      expect((value as { order_ref: unknown }).order_ref).toBe(5552345678);
+    });
+
+    it("preserves a 13-digit epoch timestamp", () => {
+      const { value } = guard.redactDeep({ created_at_ms: 1_700_000_000_000 });
+      expect((value as { created_at_ms: unknown }).created_at_ms).toBe(1_700_000_000_000);
+    });
+
+    it("preserves a Luhn-valid 16-digit order id carried as a bigint (no irreversible masking)", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ order_id: 4111111111111111n });
+      expect((value as { order_id: unknown }).order_id).toBe(4111111111111111n);
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("preserves context-less numbers inside an array (no sensitive parent key)", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ values: [123456789, 5552345678] });
+      expect((value as { values: unknown[] }).values).toEqual([123456789, 5552345678]);
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("preserves pure-numeric object keys and their values", () => {
+      const { value, tagsToAdd } = guard.redactDeep({
+        "123456789": "a",
+        "5552345678": "b",
+        "4111111111111111": "c",
+      });
+      const out = value as Record<string, unknown>;
+      expect(Object.keys(out).sort()).toEqual(["123456789", "4111111111111111", "5552345678"]);
+      expect(out["123456789"]).toBe("a");
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("preserves a Date's original type (never corrupted to {})", () => {
+      const iso = "2026-07-15T00:00:00.000Z";
+      const { value } = guard.redactDeep({ when: new Date(iso) });
+      const when = (value as { when: unknown }).when;
+      expect(when).toBeInstanceOf(Date);
+      expect((when as Date).toISOString()).toBe(iso);
+    });
+
+    it("does not treat sensitive-look-alike keys as sensitive", () => {
+      const input = {
+        phone_count: 5552345678,
+        telemetry: 123456789,
+        cardinality: 5551234567,
+        scorecard: 987654321,
+      };
+      const { value, tagsToAdd } = guard.redactDeep(structuredClone(input));
+      expect(value).toEqual(input);
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("preserves benign numerics under sensitive-SOUNDING keys whose value is not type-shaped (value gate)", () => {
+      // The key's final normalized token equals a registry word, but the value is a small count
+      // / grade / quantity — not card/phone/SSN shaped — so the value gate preserves it. Under
+      // key-alone matching (pre-fix) every one of these was masked to a PII token.
+      const input = {
+        gift_card: 3,
+        sim_card: 2,
+        sd_card: 1,
+        memory_card: 8,
+        sound_card: 1,
+        graphics_card: 2,
+        score_card: 95,
+        report_card: 4,
+        time_card: 40,
+        wild_card: 7,
+        head_phone: 42,
+        auto_mobile: 9,
+        mega_phone: 3,
+        saxo_phone: 1,
+        dust_pan: 5,
+        sauce_pan: 2,
+        bed_pan: 6,
+        card: 3,
+        phone: 42,
+        pan: 5,
+        mobile: 7,
+        cards: 2,
+        phones: 1,
+      };
+      const { value, tagsToAdd } = guard.redactDeep(structuredClone(input));
+      expect(value).toEqual(input);
+      expect(tagsToAdd).toHaveLength(0);
+    });
+  });
+
+  describe("redactDeep context-aware typed PII — REDACTED (registry-keyed) [red-first]", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    it("redacts a numeric SSN under an `ssn` key", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ ssn: 123456789 });
+      expect((value as { ssn: unknown }).ssn).toBe("[SSN_US]");
+      expect(tagsToAdd).toContain("pii.ssn_us");
+    });
+
+    it("redacts a numeric phone under a `phone` key", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ phone: 5552345678 });
+      expect((value as { phone: unknown }).phone).toBe("[PHONE_US]");
+      expect(tagsToAdd).toContain("pii.phone_us");
+    });
+
+    it("redacts a bigint card under a `card` key", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ card: 4111111111111111n });
+      expect((value as { card: unknown }).card).toBe("[CREDIT_CARD]");
+      expect(tagsToAdd).toContain("pii.credit_card");
+    });
+
+    it("redacts under normalized key variants (social_security_number / mobileNumber / creditCardNumber / pan)", () => {
+      const { value, tagsToAdd } = guard.redactDeep({
+        social_security_number: 123456789,
+        mobileNumber: 5552345678,
+        creditCardNumber: 4111111111111111n,
+        pan: 4111111111111111n,
+      });
+      const out = value as Record<string, unknown>;
+      expect(out.social_security_number).toBe("[SSN_US]");
+      expect(out.mobileNumber).toBe("[PHONE_US]");
+      expect(out.creditCardNumber).toBe("[CREDIT_CARD]");
+      expect(out.pan).toBe("[CREDIT_CARD]");
+      expect(tagsToAdd).toEqual(
+        expect.arrayContaining(["pii.ssn_us", "pii.phone_us", "pii.credit_card"]),
+      );
+    });
+
+    it("redacts type-shaped numerics under sensitive keys (both key AND value gates pass)", () => {
+      const { value, tagsToAdd } = guard.redactDeep({
+        credit_card: 4111111111111111, // Luhn-16 (exactly representable as a number)
+        card_number: 4111111111111111,
+        creditCardNumber: 4111111111111111n, // bigint
+        ssn: 123456789, // 9-digit
+        social_security: 123456789,
+        phone: 5552345678, // valid US phone (area 555, exchange 234)
+        tel: 5552345678,
+        mobile: 5552345678,
+        home_phone: 5552345678,
+        mobileNumber: 5552345678,
+      });
+      const out = value as Record<string, unknown>;
+      expect(out.credit_card).toBe("[CREDIT_CARD]");
+      expect(out.card_number).toBe("[CREDIT_CARD]");
+      expect(out.creditCardNumber).toBe("[CREDIT_CARD]");
+      expect(out.ssn).toBe("[SSN_US]");
+      expect(out.social_security).toBe("[SSN_US]");
+      expect(out.phone).toBe("[PHONE_US]");
+      expect(out.tel).toBe("[PHONE_US]");
+      expect(out.mobile).toBe("[PHONE_US]");
+      expect(out.home_phone).toBe("[PHONE_US]");
+      expect(out.mobileNumber).toBe("[PHONE_US]");
+      expect(tagsToAdd).toEqual(
+        expect.arrayContaining(["pii.credit_card", "pii.ssn_us", "pii.phone_us"]),
+      );
+    });
+
+    it("redacts numeric elements of an array under a sensitive (plural) key", () => {
+      const { value } = guard.redactDeep({ phones: [5552345678, 5559876543] });
+      expect((value as { phones: unknown[] }).phones).toEqual(["[PHONE_US]", "[PHONE_US]"]);
+    });
+
+    it("does NOT propagate a sensitive key into a nested object (context re-established)", () => {
+      const { value } = guard.redactDeep({ ssn: { note: 123456789 } });
+      const out = value as { ssn: { note: unknown } };
+      expect(out.ssn.note).toBe(123456789);
+    });
+
+    it("redacts an email object KEY, preserving the value", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ "user@example.com": "hello" });
+      const out = value as Record<string, unknown>;
+      expect(Object.keys(out)).not.toContain("user@example.com");
+      expect(Object.keys(out)).toContain("[EMAIL]");
+      expect(out["[EMAIL]"]).toBe("hello");
+      expect(tagsToAdd).toContain("pii.email");
+    });
+
+    it("redacts an explicit formatted-SSN object KEY (separators present → not a pure-numeric id)", () => {
+      const { value } = guard.redactDeep({ "123-45-6789": 1 });
+      const out = value as Record<string, unknown>;
+      expect(Object.keys(out)).toContain("[SSN_US]");
+      expect(out["[SSN_US]"]).toBe(1);
+    });
+
+    it("redacts only the PII span of a compound object KEY, keeping surrounding text", () => {
+      // String value keeps this focused on KEY redaction (strings are unaffected by the key's
+      // inherited PII type; only number/bigint values inherit it).
+      const { value } = guard.redactDeep({ "ssn:123-45-6789": "keep" });
+      const out = value as Record<string, unknown>;
+      expect(Object.keys(out)).toContain("ssn:[SSN_US]");
+      expect(out["ssn:[SSN_US]"]).toBe("keep");
+    });
+
+    it("keeps BOTH values when two distinct PII keys collapse to the same token (lossless)", () => {
+      const { value } = guard.redactDeep({ "a@x.com": 1, "b@y.com": 2 });
+      const out = value as Record<string, unknown>;
+      expect(Object.keys(out)).not.toContain("a@x.com");
+      expect(Object.keys(out)).not.toContain("b@y.com");
+      expect(Object.values(out).sort()).toEqual([1, 2]);
+    });
+  });
+
+  describe("redactDeep — idempotence & PII modes", () => {
+    it("is idempotent over key-driven numeric redaction (second pass is a no-op)", () => {
+      const guard = createFridayMemoryPiiGuard("redact");
+      const once = guard.redactDeep({ ssn: 123456789 }).value;
+      const twice = guard.redactDeep(once).value;
+      expect(twice).toEqual(once);
+      expect(JSON.stringify(twice)).not.toContain("123456789");
+    });
+
+    it("tag mode: detects registry-keyed numeric PII WITHOUT altering the value", () => {
+      const tagGuard = createFridayMemoryPiiGuard("tag");
+      const { value, tagsToAdd } = tagGuard.redactDeep({ ssn: 123456789 });
+      expect((value as { ssn: unknown }).ssn).toBe(123456789);
+      expect(tagsToAdd).toContain("pii.ssn_us");
+    });
+
+    it("block mode: detects registry-keyed numeric PII without altering the value (blocking is enforced by the guard service)", () => {
+      const blockGuard = createFridayMemoryPiiGuard("block");
+      const { value, tagsToAdd } = blockGuard.redactDeep({ card: 4111111111111111n });
+      expect((value as { card: unknown }).card).toBe(4111111111111111n);
+      expect(tagsToAdd).toContain("pii.credit_card");
+    });
+  });
 });

--- a/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
+++ b/test/unit/memory/guard/services/friday-memory-pii-guard.test.ts
@@ -904,4 +904,97 @@ describe("FridayMemoryPiiGuard", () => {
       expect(Object.prototype.hasOwnProperty.call(twice as object, "__proto__")).toBe(true);
     });
   });
+
+  // ─── Advisor round 3 — pure-numeric object-KEY exemption is Unicode-width/script-consistent ───
+  //
+  // The pure-numeric object-KEY exemption ("a bare digit-only key is an ambiguous business id —
+  // preserve it verbatim") was tested with an ASCII-only /^\d+$/, but the PII matcher applies a
+  // full-width fold. So the ASCII key "4111111111111111" was preserved (correct) while its
+  // semantically-identical FULL-WIDTH form was folded, matched as a card, and IRREVERSIBLY renamed
+  // to "[CREDIT_CARD]" — silently breaking canonical-lookup identity (DATA-RETENTION-001 no
+  // corruption; PRIV-UNICODE-REDACTION-001 benign-multilingual no-degrade). The exemption is now
+  // Unicode-decimal-aware (/^\p{Nd}+$/u): a KEY composed ENTIRELY of Unicode decimal digits in ANY
+  // script (ASCII / full-width / Arabic-Indic / mixed) with NO separators is preserved; a FORMATTED
+  // PII key (separators/context present) STILL redacts; the VALUE path is unchanged (a full-width
+  // card VALUE still redacts). Red-first: tests [1] and [3] FAIL on the pre-fix ASCII-only check.
+  describe("redactDeep — pure-numeric object-KEY exemption is Unicode-width/script-consistent (Advisor round 3) [red-first]", () => {
+    const guard = createFridayMemoryPiiGuard("redact");
+
+    // ASCII 0x21–0x7E → full-width (U+FF01–FF5E); ASCII space → ideographic space.
+    const fw = (s: string): string =>
+      [...s]
+        .map((ch) => {
+          const c = ch.charCodeAt(0);
+          if (c === 0x20) return "　";
+          if (c >= 0x21 && c <= 0x7e) return String.fromCharCode(c + 0xfee0);
+          return ch;
+        })
+        .join("");
+    // ASCII digits → Arabic-Indic digits (U+0660–U+0669).
+    const ai = (s: string): string =>
+      [...s]
+        .map((ch) =>
+          ch >= "0" && ch <= "9" ? String.fromCharCode(0x0660 + (ch.charCodeAt(0) - 0x30)) : ch,
+        )
+        .join("");
+
+    const CARD = "4111111111111111"; // Luhn-valid Visa test number
+
+    it("[1] preserves a FULL-WIDTH pure-numeric KEY byte-identical (NOT renamed to [CREDIT_CARD])", () => {
+      const key = fw(CARD);
+      const { value, tagsToAdd } = guard.redactDeep({ [key]: "x" });
+      const out = value as Record<string, unknown>;
+      expect(Object.keys(out)).toContain(key); // byte-identical preservation of the business id
+      expect(Object.keys(out)).not.toContain("[CREDIT_CARD]");
+      expect(out[key]).toBe("x");
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("[2] preserves an ASCII pure-numeric KEY (regression)", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ [CARD]: "x" });
+      const out = value as Record<string, unknown>;
+      expect(Object.keys(out)).toContain(CARD);
+      expect(Object.keys(out)).not.toContain("[CREDIT_CARD]");
+      expect(out[CARD]).toBe("x");
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("[3] preserves a MIXED-WIDTH digit-only KEY (ASCII + full-width, no separators)", () => {
+      const key = "4111" + fw("111111111111"); // 16 digits, mixed width, no separators
+      const { value, tagsToAdd } = guard.redactDeep({ [key]: "x" });
+      const out = value as Record<string, unknown>;
+      expect(Object.keys(out)).toContain(key);
+      expect(Object.keys(out)).not.toContain("[CREDIT_CARD]");
+      expect(out[key]).toBe("x");
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("[4] preserves an ARABIC-INDIC digit-only KEY", () => {
+      const key = ai(CARD);
+      const { value, tagsToAdd } = guard.redactDeep({ [key]: "x" });
+      const out = value as Record<string, unknown>;
+      expect(Object.keys(out)).toContain(key);
+      expect(Object.keys(out)).not.toContain("[CREDIT_CARD]");
+      expect(out[key]).toBe("x");
+      expect(tagsToAdd).toHaveLength(0);
+    });
+
+    it("[5] CONTROL: a FORMATTED full-width card KEY (separators present) STILL redacts", () => {
+      const key = fw("4111-1111-1111-1111"); // full-width dashes → not a pure digit-only id → PII
+      const { value, tagsToAdd } = guard.redactDeep({ [key]: "x" });
+      const out = value as Record<string, unknown>;
+      expect(Object.keys(out)).not.toContain(key);
+      expect(Object.keys(out)).toContain("[CREDIT_CARD]");
+      expect(out["[CREDIT_CARD]"]).toBe("x");
+      expect(tagsToAdd).toContain("pii.credit_card");
+    });
+
+    it("[6] CONTROL: a full-width card as a VALUE still redacts (key-path change did not weaken values)", () => {
+      const { value, tagsToAdd } = guard.redactDeep({ note: fw(CARD) });
+      const out = value as { note: string };
+      expect(out.note).toBe("[CREDIT_CARD]");
+      expect(out.note).not.toContain(fw(CARD));
+      expect(tagsToAdd).toContain("pii.credit_card");
+    });
+  });
 });


### PR DESCRIPTION
## Scope (lane REDACTOR-TYPED-PII / #62) — head `d5500f90`

Shared PII redactor `src/memory/guard/services/friday-memory-pii-guard.ts`, the `redactDeep(value)` deep-walker. Used by the memory guard on WRITE (`redactDeep(metadata)`, at-rest — the output filter hardcodes redact mode) and READ (egress), and by the learned-fact egress (uix / asset-inventory / agent-tool).

## Advisor round 3 — pure-numeric object-KEY exemption made Unicode-width/script-consistent

`redactDeep` preserves a bare pure-numeric object KEY (an ambiguous business id) instead of renaming it, but the exemption tested an ASCII-only `/^\d+$/` while the PII matcher applies a full-width digit fold. So the ASCII key `"4111111111111111"` was preserved (correct policy) while its semantically-identical **FULL-WIDTH** form `"４１１１…"` FAILED the ASCII exemption → got folded → matched as a card → **irreversibly renamed to `[CREDIT_CARD]`** — silently corrupting a benign business id and breaking canonical-lookup identity (**DATA-RETENTION-001** no-corruption; **PRIV-UNICODE-REDACTION-001** benign-multilingual no-degrade). Reproduced directly, through the production `guard.store` seam (`core.store` received the renamed key), and through the production output filter.

**Fix.** The pure-digit key exemption is now **Unicode-decimal-aware** (`/^\p{Nd}+$/u`), not ASCII-only: a KEY composed ENTIRELY of Unicode decimal digits in ANY script (ASCII / full-width / Arabic-Indic / mixed) with NO separators reaches the SAME exempt outcome — width/script-consistent with the matcher's fold. A **FORMATTED** PII key (separators/context present, e.g. a full-width dashed card `"４１１１-…"` or a registered phrase `"ssn:123-45-6789"`) still contains a non-`Nd` char, so it STILL redacts. The **VALUE path is unchanged** — a full-width card VALUE is still redacted. One-line behavioral change (`/^\d+$/` → `/^\p{Nd}+$/u`) plus red-first tests.

Red-first (FAILED on `319cbcca`, PASS on `d5500f90`): full-width pure-numeric KEY preserved byte-identical + mixed-width digit-only KEY preserved — **directly**, through the REAL **guard/store** seam (`core.store` receives the ORIGINAL full-width key, no `pii.credit_card` tag fabricated), and through the REAL **output filter** read-back. Controls (green before + after): ASCII + Arabic-Indic digit-only keys preserved; a formatted full-width card KEY still redacts; a full-width card VALUE still redacts. F1 / F3 / the round-2 depth rewrite are untouched.

Honest scope (unchanged): this does **not** close SEC-EVENT-REDACTION-001 / PRIV-UNICODE-REDACTION-001; nested structured-phone under-coverage stays open; TS durable memory writes remain **test-only by default**.

## Advisor round 2 — depth handling rewritten to iterative, cycle-aware, full-scan (no cap / no sentinel)

The previous F2 fix replaced every subtree past a fixed depth-500 recursion cap with a `[REDACTED_DEPTH]` sentinel **in all modes**. The Advisor found that this silently corrupts valid user metadata and breaks two mode contracts:

- **Silent canonical-data loss (DATA-RETENTION-001).** A deep-but-BENIGN metadata object that serializes UNDER the 16 KiB metadata limit passes `validateMetadata`, but `redactDeep` then handed `core.store` the sentinel instead of the user's metadata — canonical data purged/corrupted with no user action. An independent `guard.store` probe confirmed `core.store` received the sentinel.
- **tag mode transformed data** despite its non-transforming contract (the sentinel replaced a deep subtree).
- **block mode** replaced a deep PII subtree but returned `tagsToAdd=[]`, so the documented blocker could not identify/reject it (an untagged sentinel read as "scanned clean").

**Fix (Advisor's preferred path).** `redactDeep`'s traversal is rewritten from recursive to **ITERATIVE** (explicit heap-allocated work stack), **CYCLE-AWARE** (an ancestor-path `WeakMap`: a back-edge is structurally shared, so a cyclic object never infinite-loops or stack-overflows and no data is lost), and **FULL-SCAN — no depth cap, no sentinel**. Because the work stack lives on the heap (not the ~2000–5000-frame JS call stack), arbitrarily deep byte-bounded input is scanned without overflow; the real resource bound is the upstream 16 KiB metadata byte-limit. Result:

- **No silent data loss** — deep BENIGN metadata round-trips BYTE-IDENTICAL through the guard/store seam; `core.store` receives the original.
- **No leak** — deep PII is always found + redacted/tagged at any depth (the original F2 leak stays closed).
- **Mode contracts preserved exactly** — `redact` transforms only leaf PII; `tag` transforms NOTHING (only collects tags), even deep; `block` collects `tagsToAdd` for PII at ANY depth so the guard service can reject with zero persistence.

No-regression is proven: a differential snapshot over 45 representative acyclic inputs × redact/tag/block is **byte-identical** to the old recursive walker, and the entire prior redactor suite stays green. F1 (keyed country-code phone) and F3 (`__proto__` own-property) are untouched.

Honest scope: this does **not** close SEC-EVENT-REDACTION-001 / PRIV-UNICODE-REDACTION-001; nested structured-phone under-coverage (e.g. `{phones:[{value:5552345678}]}`) stays open; TS durable memory writes remain **test-only by default**.

## Advisor round 1 — three defects fixed (all red-first)

- **F1 — keyed-numeric-phone leak (under-redaction).** A US number persisted as a numeric loses its leading `+`, becoming the 11-digit country-code form `1XXXXXXXXXX`, which the reused phone detector rejects (it only accepts `+1XXXXXXXXXX` or the bare 10-digit form), so `redactDeep({phone: 15552345678})` egressed the CLEAR value. `numericValueMatchesKeyedType` normalizes by stripping the leading country-code `1` to the 10-digit form and re-tests the SAME detector — **only under an already-phone-typed key**, so no shape-only redaction is introduced. Benign controls still preserved: `{phone: 42}`, `{gift_card: 15552345678}` (non-phone key), `{order_id: 15552345678}` (non-sensitive key). **(Unchanged in round 2.)**
- **F2 — deep coverage.** (Superseded by the round-2 rewrite above: iterative full-scan, no cap/sentinel.)
- **F3 — `__proto__` safe-assign.** Output keys are defined via `Object.defineProperty` as OWN enumerable data properties, so a JSON-originated own key `__proto__` / `constructor` / `prototype` round-trips and the output object's prototype is untouched (no prototype confusion, no field drop). **(Unchanged in round 2.)**

## What this PR fixes (and only this)

`redactDeep` previously scanned only STRING leaf values. Gaps closed:
1. **Typed number/bigint values** — a phone/SSN/card carried as a JS `number`/`bigint` bypassed the walker.
2. **`Date` values** — `Object.entries(date) === []` silently corrupted a Date into `{}`.
3. **Object KEYS** — PII in a key was never scanned; only values were.
4. **Deep structures** — now fully scanned at any depth without a cap/sentinel; benign deep data round-trips unchanged (round 2).

## Numeric policy — TWO gates (key AND value)

A `number`/`bigint` value is redacted only when BOTH hold:
1. **Key gate** — its object KEY names a known sensitive field. A normalized registry (ssn / social_security, phone / tel / mobile, card / credit_card / pan + variants) is matched by token SUFFIX after normalizing case / underscores / camelCase / trailing plural. So `home_phone`, `user_ssn`, `billing_card_number`, `mobileNumber`, `creditCardNumber` match; `phone_count`, `telemetry`, `order_id` do not.
2. **Value gate** — the value's string form ACTUALLY matches that type's canonical detector (SSN 9-digit / US phone / Luhn-gated 13–19 card), reusing the existing matchers. For phone, the numeric country-code form `1XXXXXXXXXX` is normalized (F1) before the detector runs, still key-gated.

This is strictly more conservative than key-alone: `gift_card: 3`, `sim_card: 2`, `head_phone: 42`, `dust_pan: 5`, bare `card`/`phone`/`pan`/`mobile` with a small count → **PRESERVED** (value not type-shaped). It does NOT reintroduce shape-alone inference: the value gate runs only after the key gate, so a Luhn-valid `order_id`/`amount` under a NON-sensitive key is still preserved.

Other behavior: array elements inherit a sensitive parent key (`phones: [n,n]`); nested objects re-establish their own key context. **Date** leaves preserve their type. **Object KEYS** that are themselves PII (email / formatted phone/ssn/card / compound `ssn:123-45-6789` → `ssn:[SSN_US]`) are redacted; a **pure-digit key (`/^\p{Nd}+$/u`, any script — ASCII/full-width/Arabic-Indic/mixed) is never shape-redacted** (round 3); key collisions are disambiguated losslessly + idempotently; (F3) each output key is an own data property. The **string at-rest policy is untouched**. Tag/block modes detect + tag without transforming; blocking is enforced by the guard service.

## The real boundary (honest — no absolute claims)

- **PRESERVED:** bare numbers/bigints under non-sensitive keys (business ids, order/invoice numbers, epoch timestamps, Luhn-valid non-cards); benign numerics under sensitive-SOUNDING keys whose value is not type-shaped; pure-numeric keys; context-less array numbers; look-alike keys; **and all benign data at any depth (round 2 — no cap/sentinel, byte-identical round-trip).**
- **REDACTED:** number/bigint under a registry key whose value matches the type's detector (incl. the F1 country-code phone form); object keys that are themselves PII; **deep PII at any depth (round 2 — full-scan, never a leak).**
- Only the already-implemented detectors (email / US phone / US SSN / Luhn card) are involved. NOT a claim that all PII everywhere is caught.

## Red-first (round 2) — at the REAL guard/store seam + mode contracts + cycle

`test/unit/memory/guard/services/friday-memory-guard-service-deep-pii-seam.test.ts` (new) wires the REAL PII guard into the REAL guard service:
- **No silent data loss:** a 501-level BENIGN metadata object (serializes < 16 KiB, passes validation) → `core.store` receives the ORIGINAL metadata byte-identical (no `[REDACTED_DEPTH]`, deep canonical value survives). Reproduces the Advisor's `guard.store` probe.
- **Deep PII still redacted on the store path:** a depth-600 PII leaf → `core.store` receives `[EMAIL]`/`[PHONE_US]`/`[SSN_US]`, no cleartext, PII surfaced as tags.

`test/unit/memory/guard/services/friday-memory-pii-guard.test.ts`:
- **F2 [red-first]:** deep PII at depth 501/1200/2000 redacted with **no sentinel, no leak**; BENIGN deep data at 501/1200/2000 round-trips **byte-identical** (no silent loss). Regression: depth 7 and 300 still redacted.
- **F2b [red-first]:** tag mode — deep subtree returned UNCHANGED (values untouched, PII still tagged); block mode — deep PII yields `pii.*` tags (blocker can reject), never an untagged sentinel.
- **F2c [red-first]:** cycle safety — direct self-cycle and mutual A→B→A cycle terminate (no hang / stack overflow), PII in the cycle is redacted, back-edges preserved as structural self-references.

Prior red-first matrices (F1 keyed country-code phone; typed numeric key/value gates; Date; object-KEY PII; collision/idempotence; F3 `__proto__`) and the store→read-back / HTTP-egress real-path suites remain green.

## Local gates (round 2)

- `npm run typecheck` → **0 errors** (src + operator-client + ui + contracts)
- `npm run lint` (`eslint .`) → **0 errors** (repo-wide warnings only, at baseline; no `--max-warnings` gate)
- `npx vitest run` redactor suite → **86 passed** (74 prior + 12 new red-first); every `redactDeep` consumer/egress path (guard tree + output-filter + learned-fact uix/memory-routes + namespace store→read-back integration + sensitive-read-gate) → **267 passed**
- Differential no-regression: NEW iterative walker output vs OLD recursive walker output over 45 acyclic inputs × redact/tag/block → **byte-identical**

Disjoint from lane R3a: touches only the shared redactor + its tests. No retention / sensitive-read / satellite-runtime files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48

