### PR TITLE
feat(retention): owner-bound retention Settings API + persistence + restart-readback (R3a; UI & observability readback deferred)

### DIFF
--- a/context/MEMORY.md
+++ b/context/MEMORY.md
@@ -18,4 +18,4 @@
 - Tool call summary (`src/agent/services/friday-tool-call-summary.ts`) captures privacy-safe tool execution metadata (arg keys only, no values) for observability and world model training data.
 - Warn-once pattern is used across 7+ modules (hub-bootstrap, auth, memory, system, http-server, workspace-context, unix-socket-bridge) to deduplicate runtime warnings without losing critical signals.
 - OpenAI Responses API (`openai-responses`) streaming is now supported alongside `openai-completions` in the agent LLM client.
-- Database migration count: 104 (latest: v104-setup-bootstrap-migration-state).
+- Database migration count: 105 (latest: v105-retention-settings).

--- a/src/api/http/friday-sensitive-read-routes.ts
+++ b/src/api/http/friday-sensitive-read-routes.ts
@@ -54,10 +54,11 @@
  *                    particular aggregates approvals + remote device/session posture, so leaving it
  *                    anonymous bypassed the /v1/system/remote/* floor. Mutations under /v1/system
  *                    (POST intents, PATCH approvals) are separately fenced and unaffected here.
- *   - /v1/uix/user-profile and /v1/uix/learned-facts  personal UX profile / learned preference
- *                    facts. These are already fail-closed at the route requireUserId helper
- *                    (cr02-03 / #1450); exact-path floor entries keep the central read
- *                    classification honest without over-flooring anonymous setup/template UX
+ *   - /v1/uix/user-profile, /v1/uix/learned-facts and /v1/uix/retention-policy  personal UX
+ *                    profile / learned preference facts / owner-bound retention Settings posture.
+ *                    These are already fail-closed at the route requireUserId helper
+ *                    (cr02-03 / #1450; RETENTION-R3a); exact-path floor entries keep the central
+ *                    read classification honest without over-flooring anonymous setup/template UX
  *                    surfaces under the broader /v1/uix prefix.
  *
  * Intentionally NOT gated here (kept anonymous): health, setup, onboarding, auth
@@ -109,6 +110,12 @@ export const FRIDAY_SENSITIVE_READ_ROUTE_PREFIXES: readonly string[] = [
   "/v1/system/session",
   "/v1/uix/user-profile",
   "/v1/uix/learned-facts",
+  // RETENTION-R3a: owner-bound per-category retention Settings (GET reads the
+  // owner's retention posture). Already fail-closed at the route requireUserId
+  // helper; the exact-path floor keeps the central read classification honest
+  // alongside the sibling personal /v1/uix/* surfaces without over-flooring the
+  // broader anonymous /v1/uix setup/template UX.
+  "/v1/uix/retention-policy",
 ];
 
 /**

--- a/src/api/http/routes/friday-retention-settings-routes.ts
+++ b/src/api/http/routes/friday-retention-settings-routes.ts
@@ -18,14 +18,37 @@ import {
  *     window `[FRIDAY_MIN_AFTER_DAYS, FRIDAY_MAX_AFTER_DAYS]`). Invalid or
  *     out-of-domain bodies are rejected with a typed 400 and NOTHING is persisted.
  *
- * Owner binding reuses the EXACT `requireUserId(principal)` pattern from
- * friday-uix-routes.ts: the owner id comes ONLY from the authenticated
- * principal — never from the request body or params — and both handlers scope
- * every read/write to that derived id (cross-owner isolation).
+ * Owner binding is CANONICAL-OWNER-scoped (SEC-NET-PRINCIPAL-001): the id comes
+ * ONLY from the authenticated principal — never from the request body or params —
+ * AND the authenticated principal's `userId` MUST MATCH the single canonical
+ * owner the production reaper is bound to (`resolveCanonicalOwnerId`). Owner/admin
+ * ROLE is a floor, not identity: a second, legitimately-authenticated admin is
+ * refused 403 so a persisted opt-in can never diverge from what the reaper reads
+ * (accept == honored). Both handlers scope every read/write to the resolved
+ * canonical-owner id, and fail closed (403, zero effect) if it cannot be resolved.
  */
 
 export interface FridayRetentionSettingsRoutesDeps {
   store: FridayRetentionSettingsStore;
+  /**
+   * Resolves the SINGLE canonical-owner identity that GOVERNS the reaper —
+   * i.e. the exact id the production per-sweep policy loader is bound to
+   * (`learningDefaultUserId` = `admin-001` in `friday-hub-bootstrap.ts`). Both
+   * GET and PUT require the authenticated principal's `userId` to MATCH this
+   * id (SEC-NET-PRINCIPAL-001): role/scope (owner/admin + hub.admin) is a floor,
+   * NOT canonical-owner identity — the repo schema permits multiple users and
+   * each role-derived `hub.admin` token would otherwise be accepted, persisting
+   * an override the canonical-owner-bound reaper NEVER reads (DATA-RETENTION-001
+   * truthfulness: accept must equal honored end-to-end).
+   *
+   * This is a PRODUCTION dependency threaded from the SAME source the reaper
+   * consumes — never a per-request caller value and never a route-local literal.
+   *
+   * FAIL-CLOSED: if this returns null/undefined/empty (or throws), the route
+   * denies (403, zero persistence, zero readback) rather than falling open to
+   * "any admin".
+   */
+  resolveCanonicalOwnerId: () => string | null | undefined;
 }
 
 interface FridayRetentionPolicyResponse {
@@ -61,6 +84,61 @@ function assertRetentionOwner(
     anyOfScopes: ["hub.admin"],
     anyOfRoles: ["owner", "admin"],
   });
+}
+
+/**
+ * CANONICAL-OWNER binding (SEC-NET-PRINCIPAL-001 / DATA-RETENTION-001). Beyond
+ * the bound-principal + owner/admin authority FLOOR (kept as defense in depth),
+ * retention config is governed by a SINGLE canonical owner — the exact identity
+ * the production reaper's policy loader is bound to. Role/scope alone is NOT
+ * canonical-owner identity (the schema permits multiple hub.admin users), so the
+ * authenticated principal's `userId` MUST MATCH the resolved canonical-owner id
+ * on BOTH reads and mutations. Anything an owner/admin-authorized-but-non-
+ * canonical principal (e.g. `admin-002`) submits would persist under an id the
+ * canonical-owner-bound reaper never reads (accept ≠ honored) — so it is refused.
+ *
+ * Returns the resolved canonical-owner id (== the caller's userId) that every
+ * read/write MUST be keyed to — never a caller-supplied value. FAIL-CLOSED: an
+ * unresolvable canonical-owner id (null/undefined/blank, or the provider throws)
+ * denies with a typed 403 and ZERO effect, rather than falling open to any admin.
+ */
+function assertCanonicalRetentionOwner(
+  principal: FridayAuthPrincipal | null,
+  operation: "retention.policy.read" | "retention.policy.update",
+  resolveCanonicalOwnerId: () => string | null | undefined,
+): string {
+  // Floor first (defense in depth): synthetic-public / disabled-device → 401;
+  // bound non-owner (viewer / operator) → 403.
+  assertRetentionOwner(principal, operation);
+  const userId = requireUserId(principal);
+
+  // Resolve the canonical-owner id the reaper actually consumes. FAIL-CLOSED on
+  // any resolution failure (throw or nullish/blank) — never fall open.
+  let canonicalOwnerId: string | null | undefined;
+  try {
+    canonicalOwnerId = resolveCanonicalOwnerId();
+  } catch {
+    canonicalOwnerId = null;
+  }
+  if (typeof canonicalOwnerId !== "string" || canonicalOwnerId.trim().length === 0) {
+    throw new FridayDomainError(
+      "RETENTION_CANONICAL_OWNER_UNRESOLVED",
+      "Retention policy is unavailable: the canonical owner identity could not be resolved.",
+      { httpStatus: 403 },
+    );
+  }
+
+  // The authenticated principal must BE the canonical owner (not merely hold
+  // owner/admin authority). A second, legitimately-authenticated admin is denied.
+  if (userId !== canonicalOwnerId) {
+    throw new FridayDomainError(
+      "RETENTION_NOT_CANONICAL_OWNER",
+      "Retention policy is governed by the single canonical owner; this principal is not the canonical owner.",
+      { httpStatus: 403 },
+    );
+  }
+
+  return canonicalOwnerId;
 }
 
 /**
@@ -113,9 +191,12 @@ export function createFridayRetentionSettingsRoutes(
       path: "/v1/uix/retention-policy",
       auth: { public: true },
       async handler(ctx): Promise<FridayRetentionPolicyResponse> {
-        assertRetentionOwner(ctx.principal ?? null, "retention.policy.read");
-        const userId = requireUserId(ctx.principal);
-        return { policy: deps.store.readOwnerContentPolicy({ principalId: userId }) };
+        const ownerId = assertCanonicalRetentionOwner(
+          ctx.principal ?? null,
+          "retention.policy.read",
+          deps.resolveCanonicalOwnerId,
+        );
+        return { policy: deps.store.readOwnerContentPolicy({ principalId: ownerId }) };
       },
     },
     {
@@ -124,8 +205,11 @@ export function createFridayRetentionSettingsRoutes(
       path: "/v1/uix/retention-policy",
       auth: { public: true },
       async handler(ctx): Promise<FridayRetentionPolicyResponse> {
-        assertRetentionOwner(ctx.principal ?? null, "retention.policy.update");
-        const userId = requireUserId(ctx.principal);
+        const ownerId = assertCanonicalRetentionOwner(
+          ctx.principal ?? null,
+          "retention.policy.update",
+          deps.resolveCanonicalOwnerId,
+        );
 
         const body = ctx.body;
         if (!body || typeof body !== "object" || Array.isArray(body)) {
@@ -148,7 +232,7 @@ export function createFridayRetentionSettingsRoutes(
         // Deriving them from the store keeps this handler decoupled from the
         // category list while still rejecting unknown keys.
         const known = new Set(
-          Object.keys(deps.store.readOwnerContentPolicy({ principalId: userId })),
+          Object.keys(deps.store.readOwnerContentPolicy({ principalId: ownerId })),
         );
 
         // Validate the WHOLE body FIRST (reject → 400, persist nothing), then apply.
@@ -165,7 +249,7 @@ export function createFridayRetentionSettingsRoutes(
         }
 
         return {
-          policy: deps.store.applyOwnerContentPolicy({ principalId: userId, updates }),
+          policy: deps.store.applyOwnerContentPolicy({ principalId: ownerId, updates }),
         };
       },
     },

--- a/src/api/http/routes/friday-retention-settings-routes.ts
+++ b/src/api/http/routes/friday-retention-settings-routes.ts
@@ -1,0 +1,142 @@
+import { FridayDomainError } from "#errors";
+import type { CategoryRetention, FridayRetentionSettingsStore } from "#jobs";
+import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
+import { isUnauthenticatedPublicPrincipal } from "../../../security/friday-owner-session-channel-capability.js";
+
+/**
+ * Owner-bound retention-Settings HTTP surface (RETENTION-R3a).
+ *
+ *   GET /v1/uix/retention-policy  → the caller-owner's effective per-content-
+ *     category policy (defaults every category to `{mode:"permanent"}`).
+ *   PUT /v1/uix/retention-policy  → the caller-owner sets each content category
+ *     to `{mode:"permanent"}` (clean "off" — the override is removed) or
+ *     `{mode:"after_days",days:N}` (N a positive integer). Invalid bodies are
+ *     rejected with a typed 400 and NOTHING is persisted.
+ *
+ * Owner binding reuses the EXACT `requireUserId(principal)` pattern from
+ * friday-uix-routes.ts: the owner id comes ONLY from the authenticated
+ * principal — never from the request body or params — and both handlers scope
+ * every read/write to that derived id (cross-owner isolation).
+ */
+
+export interface FridayRetentionSettingsRoutesDeps {
+  store: FridayRetentionSettingsStore;
+}
+
+interface FridayRetentionPolicyResponse {
+  policy: Record<string, CategoryRetention>;
+}
+
+function requireUserId(principal: { userId?: string } | null): string {
+  if (isUnauthenticatedPublicPrincipal(principal as never) || !principal?.userId) {
+    throw new FridayDomainError("UNAUTHORIZED", "A user-scoped assistant principal is required", {
+      httpStatus: 401,
+    });
+  }
+  return principal.userId;
+}
+
+/**
+ * Strictly parse ONE per-category `CategoryRetention` value from an untrusted
+ * request body. Rejects (typed 400) anything that is not exactly
+ * `{mode:"permanent"}` or `{mode:"after_days",days:<positive integer>}` — bad
+ * mode, missing/non-integer/≤0/NaN/Infinity `days`, or extraneous shapes. The
+ * caller MUST validate the WHOLE body before any persistence so an invalid
+ * entry persists nothing.
+ */
+function parseCategoryRetention(category: string, raw: unknown): CategoryRetention {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new FridayDomainError(
+      "RETENTION_POLICY_VALIDATION_FAILED",
+      `Invalid retention config for '${category}': expected an object with a 'mode'.`,
+      { httpStatus: 400 },
+    );
+  }
+  const mode = (raw as { mode?: unknown }).mode;
+  if (mode === "permanent") {
+    return { mode: "permanent" };
+  }
+  if (mode !== "after_days") {
+    throw new FridayDomainError(
+      "RETENTION_POLICY_VALIDATION_FAILED",
+      `Invalid retention config for '${category}': mode must be 'permanent' or 'after_days'.`,
+      { httpStatus: 400 },
+    );
+  }
+  const days = (raw as { days?: unknown }).days;
+  if (typeof days !== "number" || !Number.isInteger(days) || days <= 0) {
+    throw new FridayDomainError(
+      "RETENTION_POLICY_VALIDATION_FAILED",
+      `Invalid retention config for '${category}': 'after_days' requires a positive integer 'days'.`,
+      { httpStatus: 400 },
+    );
+  }
+  return { mode: "after_days", days };
+}
+
+export function createFridayRetentionSettingsRoutes(
+  deps: FridayRetentionSettingsRoutesDeps,
+): FridayRouteDefinition<unknown, unknown, unknown, unknown>[] {
+  return [
+    {
+      operationId: "uix.retention.policy.get",
+      method: "GET",
+      path: "/v1/uix/retention-policy",
+      auth: { public: true },
+      async handler(ctx): Promise<FridayRetentionPolicyResponse> {
+        const userId = requireUserId(ctx.principal);
+        return { policy: deps.store.readOwnerContentPolicy({ principalId: userId }) };
+      },
+    },
+    {
+      operationId: "uix.retention.policy.update",
+      method: "PUT",
+      path: "/v1/uix/retention-policy",
+      auth: { public: true },
+      async handler(ctx): Promise<FridayRetentionPolicyResponse> {
+        const userId = requireUserId(ctx.principal);
+
+        const body = ctx.body;
+        if (!body || typeof body !== "object" || Array.isArray(body)) {
+          throw new FridayDomainError(
+            "RETENTION_POLICY_VALIDATION_FAILED",
+            "Request body must be an object with a 'policy' map.",
+            { httpStatus: 400 },
+          );
+        }
+        const policyInput = (body as { policy?: unknown }).policy;
+        if (!policyInput || typeof policyInput !== "object" || Array.isArray(policyInput)) {
+          throw new FridayDomainError(
+            "RETENTION_POLICY_VALIDATION_FAILED",
+            "'policy' must be a map of content-category → retention config.",
+            { httpStatus: 400 },
+          );
+        }
+
+        // Known content categories = the keys of the effective policy (all 7).
+        // Deriving them from the store keeps this handler decoupled from the
+        // category list while still rejecting unknown keys.
+        const known = new Set(
+          Object.keys(deps.store.readOwnerContentPolicy({ principalId: userId })),
+        );
+
+        // Validate the WHOLE body FIRST (reject → 400, persist nothing), then apply.
+        const updates: Record<string, CategoryRetention> = {};
+        for (const [category, raw] of Object.entries(policyInput as Record<string, unknown>)) {
+          if (!known.has(category)) {
+            throw new FridayDomainError(
+              "RETENTION_POLICY_VALIDATION_FAILED",
+              `Unknown retention content category: '${category}'.`,
+              { httpStatus: 400 },
+            );
+          }
+          updates[category] = parseCategoryRetention(category, raw);
+        }
+
+        return {
+          policy: deps.store.applyOwnerContentPolicy({ principalId: userId, updates }),
+        };
+      },
+    },
+  ];
+}

--- a/src/api/http/routes/friday-retention-settings-routes.ts
+++ b/src/api/http/routes/friday-retention-settings-routes.ts
@@ -1,5 +1,6 @@
 import { FridayDomainError } from "#errors";
 import type { CategoryRetention, FridayRetentionSettingsStore } from "#jobs";
+import { FRIDAY_MAX_AFTER_DAYS, FRIDAY_MIN_AFTER_DAYS, isValidAfterDays } from "#jobs";
 import type { FridayAuthPrincipal, FridayRouteDefinition } from "../../model/friday-api-common.types.js";
 import {
   assertBoundPrincipalAuthorityForOperation,
@@ -13,8 +14,9 @@ import {
  *     category policy (defaults every category to `{mode:"permanent"}`).
  *   PUT /v1/uix/retention-policy  → the caller-owner sets each content category
  *     to `{mode:"permanent"}` (clean "off" — the override is removed) or
- *     `{mode:"after_days",days:N}` (N a positive integer). Invalid bodies are
- *     rejected with a typed 400 and NOTHING is persisted.
+ *     `{mode:"after_days",days:N}` (N an integer inside the canonical honored
+ *     window `[FRIDAY_MIN_AFTER_DAYS, FRIDAY_MAX_AFTER_DAYS]`). Invalid or
+ *     out-of-domain bodies are rejected with a typed 400 and NOTHING is persisted.
  *
  * Owner binding reuses the EXACT `requireUserId(principal)` pattern from
  * friday-uix-routes.ts: the owner id comes ONLY from the authenticated
@@ -64,10 +66,12 @@ function assertRetentionOwner(
 /**
  * Strictly parse ONE per-category `CategoryRetention` value from an untrusted
  * request body. Rejects (typed 400) anything that is not exactly
- * `{mode:"permanent"}` or `{mode:"after_days",days:<positive integer>}` — bad
- * mode, missing/non-integer/≤0/NaN/Infinity `days`, or extraneous shapes. The
- * caller MUST validate the WHOLE body before any persistence so an invalid
- * entry persists nothing.
+ * `{mode:"permanent"}` or `{mode:"after_days",days:<N>}` where N is inside the
+ * canonical honored window `[FRIDAY_MIN_AFTER_DAYS, FRIDAY_MAX_AFTER_DAYS]` — bad
+ * mode, missing/non-integer/NaN/Infinity `days`, `days ≤ 0`, or an OUT-OF-RANGE
+ * window the reaper would silently treat as permanent (accept ⊆ honored). The
+ * caller MUST validate the WHOLE body before any persistence so an invalid entry
+ * persists nothing.
  */
 function parseCategoryRetention(category: string, raw: unknown): CategoryRetention {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
@@ -89,10 +93,10 @@ function parseCategoryRetention(category: string, raw: unknown): CategoryRetenti
     );
   }
   const days = (raw as { days?: unknown }).days;
-  if (typeof days !== "number" || !Number.isInteger(days) || days <= 0) {
+  if (!isValidAfterDays(days)) {
     throw new FridayDomainError(
       "RETENTION_POLICY_VALIDATION_FAILED",
-      `Invalid retention config for '${category}': 'after_days' requires a positive integer 'days'.`,
+      `Invalid retention config for '${category}': 'after_days' requires an integer 'days' in [${FRIDAY_MIN_AFTER_DAYS}, ${FRIDAY_MAX_AFTER_DAYS}].`,
       { httpStatus: 400 },
     );
   }

--- a/src/api/http/routes/friday-retention-settings-routes.ts
+++ b/src/api/http/routes/friday-retention-settings-routes.ts
@@ -1,7 +1,10 @@
 import { FridayDomainError } from "#errors";
 import type { CategoryRetention, FridayRetentionSettingsStore } from "#jobs";
-import type { FridayRouteDefinition } from "../../model/friday-api-common.types.js";
-import { isUnauthenticatedPublicPrincipal } from "../../../security/friday-owner-session-channel-capability.js";
+import type { FridayAuthPrincipal, FridayRouteDefinition } from "../../model/friday-api-common.types.js";
+import {
+  assertBoundPrincipalAuthorityForOperation,
+  isUnauthenticatedPublicPrincipal,
+} from "../../../security/friday-owner-session-channel-capability.js";
 
 /**
  * Owner-bound retention-Settings HTTP surface (RETENTION-R3a).
@@ -34,6 +37,28 @@ function requireUserId(principal: { userId?: string } | null): string {
     });
   }
   return principal.userId;
+}
+
+/**
+ * Retention config is CANONICAL-LOCAL-OWNER-only (SEC-NET-PRINCIPAL-001): it
+ * governs global content deletion, so both READS and MUTATIONS require owner
+ * authority — a non-owner (viewer / operator) or synthetic-public / release-
+ * disabled-device principal must never read or activate it. Reuses the SAME
+ * mechanism as the owner-only runtime.secret.* routes
+ * (`assertBoundPrincipalAuthorityForOperation`): the synthetic-public / disabled-
+ * device principal is refused 401 (bound-principal required) and a bound but
+ * non-owner principal is refused 403 (owner/admin authority required). The
+ * canonical owner authenticates as role owner/admin (which carries the hub.admin
+ * scope) via the local passphrase → bearer flow.
+ */
+function assertRetentionOwner(
+  principal: FridayAuthPrincipal | null,
+  operation: "retention.policy.read" | "retention.policy.update",
+): void {
+  assertBoundPrincipalAuthorityForOperation(principal, operation, "api", {
+    anyOfScopes: ["hub.admin"],
+    anyOfRoles: ["owner", "admin"],
+  });
 }
 
 /**
@@ -84,6 +109,7 @@ export function createFridayRetentionSettingsRoutes(
       path: "/v1/uix/retention-policy",
       auth: { public: true },
       async handler(ctx): Promise<FridayRetentionPolicyResponse> {
+        assertRetentionOwner(ctx.principal ?? null, "retention.policy.read");
         const userId = requireUserId(ctx.principal);
         return { policy: deps.store.readOwnerContentPolicy({ principalId: userId }) };
       },
@@ -94,6 +120,7 @@ export function createFridayRetentionSettingsRoutes(
       path: "/v1/uix/retention-policy",
       auth: { public: true },
       async handler(ctx): Promise<FridayRetentionPolicyResponse> {
+        assertRetentionOwner(ctx.principal ?? null, "retention.policy.update");
         const userId = requireUserId(ctx.principal);
 
         const body = ctx.body;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -246,6 +246,8 @@ export { createFridayGuideLensRoutes } from "./http/routes/friday-guide-lens-rou
 export type { FridayGuideLensRoutesDeps } from "./http/routes/friday-guide-lens-routes.js";
 export { createFridayUixRoutes } from "./http/routes/friday-uix-routes.js";
 export type { FridayUixRoutesDeps } from "./http/routes/friday-uix-routes.js";
+export { createFridayRetentionSettingsRoutes } from "./http/routes/friday-retention-settings-routes.js";
+export type { FridayRetentionSettingsRoutesDeps } from "./http/routes/friday-retention-settings-routes.js";
 export { createFridayMissionSpineRoutes } from "./http/routes/friday-mission-spine-routes.js";
 export type { FridayMissionSpineRoutesDeps } from "./http/routes/friday-mission-spine-routes.js";
 export { createFridayMemorySpineRoutes } from "./http/routes/friday-memory-spine-routes.js";

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -126,6 +126,7 @@ import { createFridayGrantRoutes } from "../http/routes/friday-grant-routes.js";
 import { createFridaySystemRoutes } from "../http/routes/friday-system-routes.js";
 import { createFridayGuideLensRoutes } from "../http/routes/friday-guide-lens-routes.js";
 import { createFridayUixRoutes } from "../http/routes/friday-uix-routes.js";
+import { createFridayRetentionSettingsRoutes } from "../http/routes/friday-retention-settings-routes.js";
 import {
   createFridayMissionSpineRoutes,
   type FridayMissionSpineRoutesDeps,
@@ -4395,6 +4396,12 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
 
   if (deps.uix) {
     for (const route of createFridayUixRoutes(deps.uix)) {
+      routes.register(route);
+    }
+  }
+
+  if (deps.retentionSettings) {
+    for (const route of createFridayRetentionSettingsRoutes(deps.retentionSettings)) {
       routes.register(route);
     }
   }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -83,6 +83,7 @@ import type { FridayAgentLoopRoutesDeps } from "../http/routes/friday-agent-loop
 import type { FridaySystemRoutesDeps } from "../http/routes/friday-system-routes.js";
 import type { FridayGuideLensRoutesDeps } from "../http/routes/friday-guide-lens-routes.js";
 import type { FridayUixRoutesDeps } from "../http/routes/friday-uix-routes.js";
+import type { FridayRetentionSettingsRoutesDeps } from "../http/routes/friday-retention-settings-routes.js";
 import type { FridayMissionSpineRoutesDeps } from "../http/routes/friday-mission-spine-routes.js";
 import type { FridayMemorySpineRoutesDeps } from "../http/routes/friday-memory-spine-routes.js";
 import type { FridayRunOutcomeLearningRoutesDeps } from "../http/routes/friday-run-outcome-learning-routes.js";
@@ -663,6 +664,8 @@ export interface CreateFridayApiRuntimeDeps {
   canonicalMutatingActionGate?: boolean;
   /** Optional: beginner-friendly UIX route surface. */
   uix?: FridayUixRoutesDeps;
+  /** Optional: owner-bound retention-Settings route surface (RETENTION-R3a). */
+  retentionSettings?: FridayRetentionSettingsRoutesDeps;
   /**
    * Optional Mission Spine workbench projection route surface.
    *

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -6750,7 +6750,11 @@ export async function createFridayHub(
     tokenSecret,
     idGenerator,
     nowIso,
-    retentionPolicy: retentionPolicyLoader.load(),
+    // RETENTION-R3a live-revocation fix: the hourly reaper re-reads the CURRENT
+    // persisted owner policy at the START of every sweep (fail-closed to
+    // all-permanent). A startup snapshot let the running reaper keep deleting
+    // under an opt-in the owner had since set back to permanent, until restart.
+    retentionPolicyProvider: () => retentionPolicyLoader.load(),
     learningEventWriter,
     remoteNodeResultWriter: async (input) => {
       await workflowRuntime.execution.reportRemoteNodeResult({

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -7474,7 +7474,15 @@ export async function createFridayHub(
     memorySpine: memorySpineDispatch ? { dispatch: memorySpineDispatch } : undefined,
     runOutcomeLearning: runOutcomeLearningDispatch ? { dispatch: runOutcomeLearningDispatch } : undefined,
     // RETENTION-R3a: owner-bound retention-Settings surface (GET|PUT /v1/uix/retention-policy).
-    retentionSettings: { store: retentionSettingsStore },
+    // The route binds GET/PUT to the SINGLE canonical owner the reaper's policy
+    // loader is bound to (learningDefaultUserId = admin-001) — the SAME source, so
+    // what the API accepts is exactly what the per-sweep reaper reads (accept ==
+    // honored). Role/scope alone is NOT canonical-owner identity: a second
+    // legitimately-authenticated admin is refused. Fail-closed if unresolvable.
+    retentionSettings: {
+      store: retentionSettingsStore,
+      resolveCanonicalOwnerId: () => learningDefaultUserId,
+    },
     uix: {
       service: uixService,
       readSetupCompletedAt,

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -336,6 +336,9 @@ import {
   createFridayJobSchedulerRepository,
   createFridayJobSchedulerService,
   createFridayLearningMetricsJob,
+  createFridayRetentionPolicyLoader,
+  createFridayRetentionSettingsRepository,
+  createFridayRetentionSettingsStore,
   createFridaySessionMemoryExtractionWorkerJob,
   createFridayWorkflowCronTriggerJob,
   createFridayWorkflowTimeoutJob,
@@ -6720,6 +6723,26 @@ export async function createFridayHub(
     });
   };
 
+  // ─── Owner-bound retention Settings (RETENTION-R3a) ───
+  // Persisted per-content-category opt-ins for the single hub owner. The loader
+  // resolves the reaper's policy FAIL-CLOSED (all-permanent) on any unreadable /
+  // missing / invalid persisted state; the store backs GET|PUT
+  // /v1/uix/retention-policy. The owner id is the seeded single-owner user
+  // (learningDefaultUserId) — the SAME principal_id the API writes under
+  // (requireUserId → principal.userId), so a restart re-reads what the owner set.
+  const retentionSettingsRepository = createFridayRetentionSettingsRepository();
+  const retentionSettingsStore = createFridayRetentionSettingsStore({
+    db: stateRuntime.sqlite,
+    repo: retentionSettingsRepository,
+    idGenerator,
+    nowIso,
+  });
+  const retentionPolicyLoader = createFridayRetentionPolicyLoader({
+    db: stateRuntime.sqlite,
+    repo: retentionSettingsRepository,
+    principalId: learningDefaultUserId,
+  });
+
   // ─── Satellite runtime ───
   const satelliteRuntime = createFridaySatelliteRuntime({
     db: stateRuntime.sqlite,
@@ -6727,6 +6750,7 @@ export async function createFridayHub(
     tokenSecret,
     idGenerator,
     nowIso,
+    retentionPolicy: retentionPolicyLoader.load(),
     learningEventWriter,
     remoteNodeResultWriter: async (input) => {
       await workflowRuntime.execution.reportRemoteNodeResult({
@@ -7445,6 +7469,8 @@ export async function createFridayHub(
     // (`MEMORY_SPINE_DISPATCH_UNAVAILABLE`) → byte-identical to today.
     memorySpine: memorySpineDispatch ? { dispatch: memorySpineDispatch } : undefined,
     runOutcomeLearning: runOutcomeLearningDispatch ? { dispatch: runOutcomeLearningDispatch } : undefined,
+    // RETENTION-R3a: owner-bound retention-Settings surface (GET|PUT /v1/uix/retention-policy).
+    retentionSettings: { store: retentionSettingsStore },
     uix: {
       service: uixService,
       readSetupCompletedAt,

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -2,13 +2,33 @@ export type {
   CategoryRetention,
   FridayRetentionPolicy,
   FridayRetentionJobResult,
+  FridayRetentionContentCategory,
+  FridayRetentionContentPolicy,
 } from "./retention/friday-retention.types.js";
 export {
   FRIDAY_DEFAULT_RETENTION_POLICY,
   FRIDAY_BOOTSTRAP_NONCE_SWEEP_BATCH_LIMIT,
+  FRIDAY_RETENTION_CONTENT_CATEGORIES,
 } from "./retention/friday-retention.types.js";
 export { createFridayRetentionJob, resolveCutoff } from "./retention/friday-retention-job.js";
 export type { FridayRetentionJob } from "./retention/friday-retention-job.js";
+
+// ─── Owner-bound retention SETTINGS (RETENTION-R3a) ───
+export { createFridayRetentionSettingsRepository } from "./retention/friday-retention-settings-repository.js";
+export type {
+  FridayRetentionSettingsRepository,
+  FridayRetentionSettingOverride,
+} from "./retention/friday-retention-settings-repository.js";
+export { createFridayRetentionSettingsStore } from "./retention/friday-retention-settings-store.js";
+export type {
+  FridayRetentionSettingsStore,
+  CreateFridayRetentionSettingsStoreDeps,
+} from "./retention/friday-retention-settings-store.js";
+export { createFridayRetentionPolicyLoader } from "./retention/friday-retention-policy-loader.js";
+export type {
+  FridayRetentionPolicyLoader,
+  CreateFridayRetentionPolicyLoaderDeps,
+} from "./retention/friday-retention-policy-loader.js";
 
 export type {
   FridayLearningMetricsJobResult,

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -9,6 +9,9 @@ export {
   FRIDAY_DEFAULT_RETENTION_POLICY,
   FRIDAY_BOOTSTRAP_NONCE_SWEEP_BATCH_LIMIT,
   FRIDAY_RETENTION_CONTENT_CATEGORIES,
+  FRIDAY_MIN_AFTER_DAYS,
+  FRIDAY_MAX_AFTER_DAYS,
+  isValidAfterDays,
 } from "./retention/friday-retention.types.js";
 export { createFridayRetentionJob, resolveCutoff } from "./retention/friday-retention-job.js";
 export type { FridayRetentionJob } from "./retention/friday-retention-job.js";

--- a/src/jobs/retention/friday-retention-job.ts
+++ b/src/jobs/retention/friday-retention-job.ts
@@ -26,7 +26,22 @@ export interface CreateRetentionJobDeps {
   learningLedger: FridayLearningEventLedger;
   skillRunStore: FridaySkillRunStore;
   bootstrapNonceRepo: FridaySetupBootstrapNonceRepository;
+  /**
+   * Static startup policy. Retained for existing callers; when `loadPolicy` is
+   * provided it takes precedence and this is ignored.
+   */
   policy?: FridayRetentionPolicy;
+  /**
+   * RETENTION-R3a live-revocation fix. When provided, the reaper re-reads the
+   * CURRENT persisted retention policy at the START of EVERY sweep instead of
+   * capturing a startup snapshot. This makes an owner's opt-in/opt-OUT
+   * authoritative for the already-running reaper WITHOUT a process restart
+   * (DATA-RETENTION-001): setting a category back to permanent stops the very
+   * next sweep from deleting it. Must fail closed — return all-permanent on any
+   * read failure; the job additionally guards the call with try/catch so a throw
+   * or nullish result also resolves to all-permanent (delete nothing).
+   */
+  loadPolicy?: () => FridayRetentionPolicy;
   nowIso: () => string;
 }
 
@@ -75,11 +90,25 @@ export function resolveCutoff(
 }
 
 export function createFridayRetentionJob(deps: CreateRetentionJobDeps): FridayRetentionJob {
-  const policy = deps.policy ?? FRIDAY_DEFAULT_RETENTION_POLICY;
+  // RETENTION-R3a: resolve the governing policy PER SWEEP (not once at
+  // construction) so live owner opt-in/opt-OUT changes are authoritative for the
+  // running reaper. FAIL-CLOSED: any error / nullish live read ⇒ all-permanent ⇒
+  // delete nothing.
+  function resolvePolicy(): FridayRetentionPolicy {
+    if (deps.loadPolicy) {
+      try {
+        return deps.loadPolicy() ?? FRIDAY_DEFAULT_RETENTION_POLICY;
+      } catch {
+        return FRIDAY_DEFAULT_RETENTION_POLICY;
+      }
+    }
+    return deps.policy ?? FRIDAY_DEFAULT_RETENTION_POLICY;
+  }
 
   return {
     run(nowIsoOverride?) {
       const nowIso = nowIsoOverride ?? deps.nowIso();
+      const policy = resolvePolicy();
 
       const result: FridayRetentionJobResult = {
         markedPairingExpired: 0,

--- a/src/jobs/retention/friday-retention-policy-loader.ts
+++ b/src/jobs/retention/friday-retention-policy-loader.ts
@@ -4,6 +4,7 @@ import type { CategoryRetention, FridayRetentionPolicy } from "./friday-retentio
 import {
   FRIDAY_DEFAULT_RETENTION_POLICY,
   FRIDAY_RETENTION_CONTENT_CATEGORIES,
+  isValidAfterDays,
 } from "./friday-retention.types.js";
 import type { FridayRetentionSettingsRepository } from "./friday-retention-settings-repository.js";
 
@@ -37,10 +38,6 @@ export interface CreateFridayRetentionPolicyLoaderDeps {
 
 const CONTENT_CATEGORY_SET: ReadonlySet<string> = new Set(FRIDAY_RETENTION_CONTENT_CATEGORIES);
 
-function isPositiveInteger(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value > 0;
-}
-
 export function createFridayRetentionPolicyLoader(
   deps: CreateFridayRetentionPolicyLoaderDeps,
 ): FridayRetentionPolicyLoader {
@@ -63,14 +60,17 @@ export function createFridayRetentionPolicyLoader(
         for (const override of overrides) {
           if (
             CONTENT_CATEGORY_SET.has(override.contentCategory) &&
-            isPositiveInteger(override.afterDays)
+            isValidAfterDays(override.afterDays)
           ) {
             content[override.contentCategory] = {
               mode: "after_days",
               days: override.afterDays,
             };
           }
-          // else: unknown category / malformed window ⇒ leave permanent (fail closed).
+          // else: unknown category / malformed or out-of-domain (legacy) window ⇒
+          // leave permanent (fail closed). An after_days outside the canonical
+          // [MIN, MAX] domain is one the reaper would not honor, so the loader must
+          // never surface it active — mirrors the store + route validation.
         }
       } catch {
         // Unreadable store ⇒ all-permanent (delete nothing).

--- a/src/jobs/retention/friday-retention-policy-loader.ts
+++ b/src/jobs/retention/friday-retention-policy-loader.ts
@@ -1,0 +1,96 @@
+import type { FridaySqliteLayer } from "#state";
+
+import type { CategoryRetention, FridayRetentionPolicy } from "./friday-retention.types.js";
+import {
+  FRIDAY_DEFAULT_RETENTION_POLICY,
+  FRIDAY_RETENTION_CONTENT_CATEGORIES,
+} from "./friday-retention.types.js";
+import type { FridayRetentionSettingsRepository } from "./friday-retention-settings-repository.js";
+
+/**
+ * RETENTION-R3a — reads the persisted OWNER retention policy at wiring/startup
+ * and resolves it into a full `FridayRetentionPolicy` for the reaper.
+ *
+ * FAIL-CLOSED (DATA-RETENTION-001): the loader NEVER throws and NEVER widens the
+ * deletion surface on uncertainty. On an unreadable store, a missing owner
+ * policy, or a partial/invalid/unknown override row, the affected content
+ * category resolves to `{mode:"permanent"}` (delete nothing). A total read
+ * failure resolves to `FRIDAY_DEFAULT_RETENTION_POLICY` (all-permanent). The
+ * user-configurable CONTENT categories are the only thing an owner opt-in can
+ * ENABLE; the SECURITY-LIFECYCLE terminal TTLs (`pairingRequestsDays` /
+ * `outboxTerminalDays` / `bootstrapNoncesConsumedDays`) are ALWAYS taken from
+ * the default policy and can never be altered through this surface.
+ */
+export interface FridayRetentionPolicyLoader {
+  /** Resolve the effective retention policy for the reaper (never throws). */
+  load(): FridayRetentionPolicy;
+}
+
+export interface CreateFridayRetentionPolicyLoaderDeps {
+  db: FridaySqliteLayer;
+  repo: FridayRetentionSettingsRepository;
+  /** The owner principal whose persisted policy governs the (single-owner) reaper. */
+  principalId: string;
+  /** Override for tests; defaults to the all-permanent production default. */
+  defaultPolicy?: FridayRetentionPolicy;
+}
+
+const CONTENT_CATEGORY_SET: ReadonlySet<string> = new Set(FRIDAY_RETENTION_CONTENT_CATEGORIES);
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+export function createFridayRetentionPolicyLoader(
+  deps: CreateFridayRetentionPolicyLoaderDeps,
+): FridayRetentionPolicyLoader {
+  const defaultPolicy = deps.defaultPolicy ?? FRIDAY_DEFAULT_RETENTION_POLICY;
+
+  return {
+    load(): FridayRetentionPolicy {
+      // Start from the all-permanent content defaults + the (immutable-here)
+      // security-lifecycle TTLs. Any override we cannot fully trust is left at
+      // the permanent default.
+      const content: Record<string, CategoryRetention> = {};
+      for (const category of FRIDAY_RETENTION_CONTENT_CATEGORIES) {
+        content[category] = { mode: "permanent" };
+      }
+
+      try {
+        const overrides = deps.db.withReadConnection((db) =>
+          deps.repo.listByPrincipal(db, { principalId: deps.principalId }),
+        );
+        for (const override of overrides) {
+          if (
+            CONTENT_CATEGORY_SET.has(override.contentCategory) &&
+            isPositiveInteger(override.afterDays)
+          ) {
+            content[override.contentCategory] = {
+              mode: "after_days",
+              days: override.afterDays,
+            };
+          }
+          // else: unknown category / malformed window ⇒ leave permanent (fail closed).
+        }
+      } catch {
+        // Unreadable store ⇒ all-permanent (delete nothing).
+        return { ...defaultPolicy };
+      }
+
+      return {
+        learningEvents: content.learningEvents,
+        heartbeats: content.heartbeats,
+        skillRunTerminal: content.skillRunTerminal,
+        auditLogs: content.auditLogs,
+        agentRuns: content.agentRuns,
+        llmUsageRecords: content.llmUsageRecords,
+        errorIncidents: content.errorIncidents,
+        // Security-lifecycle TTLs are NEVER owner-configurable via retention
+        // Settings; always taken from the default policy.
+        pairingRequestsDays: defaultPolicy.pairingRequestsDays,
+        outboxTerminalDays: defaultPolicy.outboxTerminalDays,
+        bootstrapNoncesConsumedDays: defaultPolicy.bootstrapNoncesConsumedDays,
+      };
+    },
+  };
+}

--- a/src/jobs/retention/friday-retention-settings-repository.ts
+++ b/src/jobs/retention/friday-retention-settings-repository.ts
@@ -1,0 +1,117 @@
+import type Database from "better-sqlite3";
+
+/**
+ * Owner-scoped persistence for per-content-category retention SETTINGS
+ * (RETENTION-R3a). Every query is scoped by `principal_id`; a row's existence
+ * means the owner enabled a time-based sweep for that content category with
+ * `after_days = N` (N a positive integer, enforced by the table `CHECK`). The
+ * ABSENCE of a row is the clean disabled state = PERMANENT ("off") — there is
+ * NO sentinel number.
+ *
+ * Mirrors the owner-scoping shape of `uix_user_preferences`
+ * (friday-uix-user-preference-repository.ts): principal-scoped reads/writes,
+ * unique `(principal_id, content_category)`, upsert-on-conflict.
+ */
+export interface FridayRetentionSettingOverride {
+  readonly contentCategory: string;
+  readonly afterDays: number;
+}
+
+interface FridayRetentionSettingRow {
+  content_category: string;
+  after_days: number;
+}
+
+export interface FridayRetentionSettingsRepository {
+  /** All enabled (after_days) overrides for one owner. Absent categories = permanent. */
+  listByPrincipal(
+    db: Database.Database,
+    input: { principalId: string },
+  ): FridayRetentionSettingOverride[];
+  /**
+   * Enable a time-based sweep for one content category (upsert). `days` MUST be
+   * a positive integer; the table CHECK rejects anything else fail-closed.
+   */
+  upsertAfterDays(
+    db: Database.Database,
+    input: {
+      id: string;
+      principalId: string;
+      contentCategory: string;
+      days: number;
+      nowIso: string;
+    },
+  ): void;
+  /**
+   * Remove the override for one content category, returning it to the clean
+   * disabled state = PERMANENT ("off"). Idempotent.
+   */
+  deleteCategory(
+    db: Database.Database,
+    input: { principalId: string; contentCategory: string },
+  ): boolean;
+}
+
+export function createFridayRetentionSettingsRepository(): FridayRetentionSettingsRepository {
+  return {
+    listByPrincipal(db, input) {
+      const rows = db
+        .prepare(
+          `SELECT content_category, after_days
+             FROM friday_retention_settings
+            WHERE principal_id = ?
+            ORDER BY content_category ASC`,
+        )
+        .all(input.principalId) as FridayRetentionSettingRow[];
+      return rows.map((row) => ({
+        contentCategory: row.content_category,
+        afterDays: row.after_days,
+      }));
+    },
+
+    upsertAfterDays(db, input) {
+      const existing = db
+        .prepare(
+          `SELECT id, created_at
+             FROM friday_retention_settings
+            WHERE principal_id = ? AND content_category = ?`,
+        )
+        .get(input.principalId, input.contentCategory) as
+        | { id: string; created_at: string }
+        | undefined;
+
+      const id = existing?.id ?? input.id;
+      const createdAt = existing?.created_at ?? input.nowIso;
+      db.prepare(
+        `INSERT INTO friday_retention_settings (
+           id,
+           principal_id,
+           content_category,
+           after_days,
+           created_at,
+           updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(principal_id, content_category) DO UPDATE SET
+           after_days = excluded.after_days,
+           updated_at = excluded.updated_at`,
+      ).run(
+        id,
+        input.principalId,
+        input.contentCategory,
+        input.days,
+        createdAt,
+        input.nowIso,
+      );
+    },
+
+    deleteCategory(db, input) {
+      const result = db
+        .prepare(
+          `DELETE FROM friday_retention_settings
+            WHERE principal_id = ? AND content_category = ?`,
+        )
+        .run(input.principalId, input.contentCategory);
+      return result.changes > 0;
+    },
+  };
+}

--- a/src/jobs/retention/friday-retention-settings-store.ts
+++ b/src/jobs/retention/friday-retention-settings-store.ts
@@ -1,7 +1,7 @@
 import type { FridaySqliteLayer } from "#state";
 
 import type { CategoryRetention, FridayRetentionContentPolicy } from "./friday-retention.types.js";
-import { FRIDAY_RETENTION_CONTENT_CATEGORIES } from "./friday-retention.types.js";
+import { FRIDAY_RETENTION_CONTENT_CATEGORIES, isValidAfterDays } from "./friday-retention.types.js";
 import type { FridayRetentionSettingsRepository } from "./friday-retention-settings-repository.js";
 
 /**
@@ -24,7 +24,8 @@ export interface FridayRetentionSettingsStore {
    * Apply owner-supplied per-category updates transactionally (validate-then-
    * apply: on ANY invalid entry nothing is persisted). `{mode:"permanent"}`
    * removes the override (clean "off"); `{mode:"after_days",days:N}` upserts a
-   * positive-integer window. Returns the fresh effective policy.
+   * window inside the canonical `[FRIDAY_MIN_AFTER_DAYS, FRIDAY_MAX_AFTER_DAYS]`
+   * domain (`isValidAfterDays`). Returns the fresh effective policy.
    */
   applyOwnerContentPolicy(input: {
     principalId: string;
@@ -33,10 +34,6 @@ export interface FridayRetentionSettingsStore {
 }
 
 const CONTENT_CATEGORY_SET: ReadonlySet<string> = new Set(FRIDAY_RETENTION_CONTENT_CATEGORIES);
-
-function isPositiveInteger(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value > 0;
-}
 
 function allPermanentPolicy(): FridayRetentionContentPolicy {
   const policy = {} as FridayRetentionContentPolicy;
@@ -63,11 +60,13 @@ export function createFridayRetentionSettingsStore(
     );
     for (const override of overrides) {
       // Defensive: only surface a well-formed opt-in for a known content
-      // category; anything else falls back to the permanent default
-      // (fail-closed read — mirrors the reaper's resolveCutoff).
+      // category whose window is inside the canonical honored domain; anything
+      // else (unknown category, or an out-of-domain / legacy after_days the
+      // reaper would silently treat as permanent) falls back to the permanent
+      // default — fail-closed read, never report a policy production won't honor.
       if (
         CONTENT_CATEGORY_SET.has(override.contentCategory) &&
-        isPositiveInteger(override.afterDays)
+        isValidAfterDays(override.afterDays)
       ) {
         policy[override.contentCategory as keyof FridayRetentionContentPolicy] = {
           mode: "after_days",
@@ -101,7 +100,7 @@ export function createFridayRetentionSettingsStore(
             });
             continue;
           }
-          if (retention.mode === "after_days" && isPositiveInteger(retention.days)) {
+          if (retention.mode === "after_days" && isValidAfterDays(retention.days)) {
             deps.repo.upsertAfterDays(db, {
               id: deps.idGenerator(),
               principalId: input.principalId,

--- a/src/jobs/retention/friday-retention-settings-store.ts
+++ b/src/jobs/retention/friday-retention-settings-store.ts
@@ -1,0 +1,120 @@
+import type { FridaySqliteLayer } from "#state";
+
+import type { CategoryRetention, FridayRetentionContentPolicy } from "./friday-retention.types.js";
+import { FRIDAY_RETENTION_CONTENT_CATEGORIES } from "./friday-retention.types.js";
+import type { FridayRetentionSettingsRepository } from "./friday-retention-settings-repository.js";
+
+/**
+ * Owner-bound per-content-category retention SETTINGS store (RETENTION-R3a).
+ *
+ * The single read/write authority behind `GET|PUT /v1/uix/retention-policy`.
+ * Every method is scoped by the caller-owner's `principalId` (which the route
+ * derives ONLY from the authenticated principal — never from the request body
+ * or params). Persists "off" as the CLEAN disabled state (permanent = the
+ * override row is removed); NEVER a sentinel number.
+ */
+export interface FridayRetentionSettingsStore {
+  /**
+   * The caller-owner's effective per-content-category policy. Defaults every
+   * category to `{mode:"permanent"}`; a persisted opt-in surfaces as
+   * `{mode:"after_days",days:N}`.
+   */
+  readOwnerContentPolicy(input: { principalId: string }): FridayRetentionContentPolicy;
+  /**
+   * Apply owner-supplied per-category updates transactionally (validate-then-
+   * apply: on ANY invalid entry nothing is persisted). `{mode:"permanent"}`
+   * removes the override (clean "off"); `{mode:"after_days",days:N}` upserts a
+   * positive-integer window. Returns the fresh effective policy.
+   */
+  applyOwnerContentPolicy(input: {
+    principalId: string;
+    updates: Record<string, CategoryRetention>;
+  }): FridayRetentionContentPolicy;
+}
+
+const CONTENT_CATEGORY_SET: ReadonlySet<string> = new Set(FRIDAY_RETENTION_CONTENT_CATEGORIES);
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function allPermanentPolicy(): FridayRetentionContentPolicy {
+  const policy = {} as FridayRetentionContentPolicy;
+  for (const category of FRIDAY_RETENTION_CONTENT_CATEGORIES) {
+    policy[category] = { mode: "permanent" };
+  }
+  return policy;
+}
+
+export interface CreateFridayRetentionSettingsStoreDeps {
+  db: FridaySqliteLayer;
+  repo: FridayRetentionSettingsRepository;
+  idGenerator: () => string;
+  nowIso: () => string;
+}
+
+export function createFridayRetentionSettingsStore(
+  deps: CreateFridayRetentionSettingsStoreDeps,
+): FridayRetentionSettingsStore {
+  function readOwnerContentPolicy(input: { principalId: string }): FridayRetentionContentPolicy {
+    const policy = allPermanentPolicy();
+    const overrides = deps.db.withReadConnection((db) =>
+      deps.repo.listByPrincipal(db, { principalId: input.principalId }),
+    );
+    for (const override of overrides) {
+      // Defensive: only surface a well-formed opt-in for a known content
+      // category; anything else falls back to the permanent default
+      // (fail-closed read — mirrors the reaper's resolveCutoff).
+      if (
+        CONTENT_CATEGORY_SET.has(override.contentCategory) &&
+        isPositiveInteger(override.afterDays)
+      ) {
+        policy[override.contentCategory as keyof FridayRetentionContentPolicy] = {
+          mode: "after_days",
+          days: override.afterDays,
+        };
+      }
+    }
+    return policy;
+  }
+
+  return {
+    readOwnerContentPolicy,
+
+    applyOwnerContentPolicy(input) {
+      const entries = Object.entries(input.updates);
+      // Validate-then-apply, all inside ONE write transaction: any invalid entry
+      // throws and rolls the whole apply back ⇒ nothing persisted.
+      deps.db.withWriteTransaction((db) => {
+        for (const [category, retention] of entries) {
+          if (!CONTENT_CATEGORY_SET.has(category)) {
+            throw new Error(`Unknown retention content category: ${category}`);
+          }
+          if (!retention || typeof retention !== "object") {
+            throw new Error(`Invalid retention config for ${category}`);
+          }
+          if (retention.mode === "permanent") {
+            // Clean "off": remove the override row (absence = permanent).
+            deps.repo.deleteCategory(db, {
+              principalId: input.principalId,
+              contentCategory: category,
+            });
+            continue;
+          }
+          if (retention.mode === "after_days" && isPositiveInteger(retention.days)) {
+            deps.repo.upsertAfterDays(db, {
+              id: deps.idGenerator(),
+              principalId: input.principalId,
+              contentCategory: category,
+              days: retention.days,
+              nowIso: deps.nowIso(),
+            });
+            continue;
+          }
+          throw new Error(`Invalid retention config for ${category}`);
+        }
+      });
+      return readOwnerContentPolicy({ principalId: input.principalId });
+    },
+  };
+}

--- a/src/jobs/retention/friday-retention.types.ts
+++ b/src/jobs/retention/friday-retention.types.ts
@@ -64,6 +64,41 @@ export const FRIDAY_DEFAULT_RETENTION_POLICY: FridayRetentionPolicy = {
 };
 
 /**
+ * The user-configurable CONTENT categories (RETENTION-R3a).
+ *
+ * These are exactly the `CategoryRetention`-typed fields of
+ * `FridayRetentionPolicy` — the ones that are default-PERMANENT and opt-in per
+ * DATA-RETENTION-001. The SECURITY-LIFECYCLE terminal TTLs
+ * (`pairingRequestsDays` / `outboxTerminalDays` / `bootstrapNoncesConsumedDays`)
+ * are intentionally EXCLUDED: they are not content retention and are never
+ * exposed on the owner-bound retention-Settings surface.
+ */
+export const FRIDAY_RETENTION_CONTENT_CATEGORIES = [
+  "learningEvents",
+  "heartbeats",
+  "skillRunTerminal",
+  "auditLogs",
+  "agentRuns",
+  "llmUsageRecords",
+  "errorIncidents",
+] as const;
+
+/** One of the seven user-configurable CONTENT retention categories. */
+export type FridayRetentionContentCategory =
+  (typeof FRIDAY_RETENTION_CONTENT_CATEGORIES)[number];
+
+/**
+ * The effective per-content-category retention policy for a single owner:
+ * every content category mapped to its `CategoryRetention` (default
+ * `{mode:"permanent"}`). This is the shape the owner-bound retention-Settings
+ * API returns and accepts (it never surfaces the security-lifecycle TTLs).
+ */
+export type FridayRetentionContentPolicy = Record<
+  FridayRetentionContentCategory,
+  CategoryRetention
+>;
+
+/**
  * Max setup-bootstrap nonce rows deleted PER class (expired-unconsumed /
  * consumed-retired) per retention pass. Bounds the reaper's work so it cannot
  * hold a long write lock; any backlog drains across successive scheduled runs.

--- a/src/jobs/retention/friday-retention.types.ts
+++ b/src/jobs/retention/friday-retention.types.ts
@@ -12,6 +12,46 @@ export type CategoryRetention =
   | { mode: "permanent" }
   | { mode: "after_days"; days: number };
 
+/**
+ * The ONE canonical valid `after_days` domain (RETENTION-R3a hardening).
+ *
+ * DATA-RETENTION-001 truthfulness invariant: the API must NEVER accept /
+ * persist / report-active a window the production reaper won't honor. The reaper
+ * evaluator (`resolveCutoff`) fails closed to PERMANENT for any window whose
+ * cutoff date overflows JS `Date`'s ±8.64e15 ms range — i.e. `after_days` beyond
+ * roughly 1e8 days. Rather than track that fragile, `now`-dependent internal
+ * bound, we pin a SANE PRODUCT CEILING well inside it: `[1, 36500]` days
+ * (36500 days ≈ 100 years). `resolveCutoff` returns a NON-null cutoff for every
+ * value in this closed interval for any realistic `now` (≥ 1970), so the ACCEPTED
+ * domain is a strict SUBSET of the HONORED domain (accept ⊆ honored). Every layer
+ * — request parsing, the store read/write, the loader, and the DB `CHECK` — MUST
+ * enforce exactly this interval; anything outside it is malformed ⇒ fail closed
+ * to PERMANENT (delete nothing) and is never surfaced as an active policy.
+ *
+ * NB: the migration's `CHECK (after_days >= 1 AND after_days <= 36500)` inlines
+ * these literals (a migration's SQL/checksum is a frozen historical artifact and
+ * must not interpolate a mutable constant); a guard test asserts the CHECK bound
+ * agrees with these constants.
+ */
+export const FRIDAY_MIN_AFTER_DAYS = 1;
+export const FRIDAY_MAX_AFTER_DAYS = 36500;
+
+/**
+ * Canonical predicate for a valid `after_days` window: a positive integer inside
+ * the honored `[FRIDAY_MIN_AFTER_DAYS, FRIDAY_MAX_AFTER_DAYS]` interval. Shared by
+ * request parsing, the store, and the loader so the accepted domain is identical
+ * everywhere (and ⊆ what `resolveCutoff` honors). Rejects NaN, Infinity,
+ * non-integers, ≤ 0, and any out-of-range / overflowing window.
+ */
+export function isValidAfterDays(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= FRIDAY_MIN_AFTER_DAYS &&
+    value <= FRIDAY_MAX_AFTER_DAYS
+  );
+}
+
 export interface FridayRetentionPolicy {
   // ── CONTENT categories (canonical + derived-content) ──────────────────────
   // Default PERMANENT. Auto-deletion is opt-in per category via `after_days`;

--- a/src/satellites/runtime/friday-satellite-runtime.ts
+++ b/src/satellites/runtime/friday-satellite-runtime.ts
@@ -36,7 +36,15 @@ export interface CreateFridaySatelliteRuntimeOptions {
   tokenSecret: string;
   idGenerator: () => string;
   nowIso: () => string;
+  /** Static startup policy (legacy). Ignored when `retentionPolicyProvider` is set. */
   retentionPolicy?: FridayRetentionPolicy;
+  /**
+   * RETENTION-R3a live-revocation: when provided, the reaper re-reads the CURRENT
+   * persisted policy at the start of EVERY sweep (via this provider) instead of a
+   * startup snapshot, so owner opt-in/opt-OUT takes effect without a restart. Must
+   * fail closed (return all-permanent on read failure).
+   */
+  retentionPolicyProvider?: () => FridayRetentionPolicy;
   pairingTtlMs?: number;
   expectedHeartbeatIntervalMs?: number;
   learningEventWriter?: (events: FridayLearningEventAppendInput[]) => void;
@@ -81,6 +89,7 @@ export function createFridaySatelliteRuntime(
     idGenerator,
     nowIso,
     retentionPolicy,
+    retentionPolicyProvider,
     pairingTtlMs,
     expectedHeartbeatIntervalMs,
     learningEventWriter,
@@ -216,6 +225,9 @@ export function createFridaySatelliteRuntime(
     skillRunStore,
     bootstrapNonceRepo,
     policy: retentionPolicy,
+    // RETENTION-R3a: live per-sweep policy re-read (opt-out stops deletion without
+    // a restart). Takes precedence over the static `policy` snapshot when set.
+    loadPolicy: retentionPolicyProvider,
     nowIso,
   });
 

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -122,7 +122,14 @@ export type FridayPublicMutationOperation =
   // mutating route: refuse the synthetic public principal; only a bound owner can
   // confirm/reject (and the Rust side ALSO scopes the decision to the candidate's
   // owning principal).
-  | "memory.spine.decide";
+  | "memory.spine.decide"
+  // RETENTION-R3a (SEC-NET-PRINCIPAL-001): owner-bound retention Settings. Reading
+  // AND mutating the per-category retention policy is canonical-local-owner-only —
+  // it controls global content deletion, so a non-owner (viewer/operator) principal
+  // must never read or activate it. Gated via assertBoundPrincipalAuthorityForOperation
+  // with owner/admin authority (the same mechanism as runtime.secret.*).
+  | "retention.policy.read"
+  | "retention.policy.update";
 
 export type FridayBoundPrincipalSource = "api" | "session" | "channel" | "satellite" | "device";
 

--- a/src/state/sqlite/migrations/index.ts
+++ b/src/state/sqlite/migrations/index.ts
@@ -103,6 +103,7 @@ import { V101_TELEGRAM_INBOX_MIGRATION } from "./v101-telegram-inbox.js";
 import { V102_PROVIDER_CALL_RECEIPT_MIGRATION } from "./v102-provider-call-receipt.js";
 import { V103_SETUP_BOOTSTRAP_DEVICE_CLAIM_MIGRATION } from "./v103-setup-bootstrap-device-claim.js";
 import { V104_SETUP_BOOTSTRAP_MIGRATION_STATE_MIGRATION } from "./v104-setup-bootstrap-migration-state.js";
+import { V105_RETENTION_SETTINGS_MIGRATION } from "./v105-retention-settings.js";
 
 /**
  * Ordered migration list, always ascending by version.
@@ -212,6 +213,7 @@ export const FRIDAY_SQLITE_MIGRATIONS: readonly FridaySqliteMigration[] = [
   V102_PROVIDER_CALL_RECEIPT_MIGRATION,
   V103_SETUP_BOOTSTRAP_DEVICE_CLAIM_MIGRATION,
   V104_SETUP_BOOTSTRAP_MIGRATION_STATE_MIGRATION,
+  V105_RETENTION_SETTINGS_MIGRATION,
 ];
 
 export { V003_PROVIDER_USAGE_COST_ROUTING_MIGRATION };

--- a/src/state/sqlite/migrations/v105-retention-settings.ts
+++ b/src/state/sqlite/migrations/v105-retention-settings.ts
@@ -9,12 +9,22 @@ import type { FridaySqliteMigration } from "./friday-migration.types.js";
  * PER CONTENT CATEGORY. This table stores ONLY the explicit owner opt-ins:
  *
  *   - A row's mere EXISTENCE means the owner enabled a time-based sweep for that
- *     content category with `after_days = N` (N a POSITIVE integer, enforced by
- *     `CHECK (after_days > 0)`).
+ *     content category with `after_days = N`, where N is an integer inside the
+ *     canonical honored window `[1, 36500]` (≈ 1 day … 100 years), enforced by
+ *     `CHECK (after_days >= 1 AND after_days <= 36500)`. The upper bound keeps the
+ *     PERSISTED domain a strict subset of what the reaper's `resolveCutoff` will
+ *     honor (windows beyond ~1e8 days overflow JS `Date` and fail closed to
+ *     permanent), so the DB can never hold a window the API would report active
+ *     but production silently ignores (DATA-RETENTION-001 truthfulness).
  *   - The ABSENCE of a row is the clean disabled state = PERMANENT ("off").
  *     "Off" is therefore represented by row-absence — NEVER by a magic sentinel
  *     number (not 0, -1, 30, nor an oversized value). The schema makes a sentinel
- *     structurally impossible: `after_days` is NOT NULL and must be `> 0`.
+ *     structurally impossible: `after_days` is NOT NULL and must be in `[1, 36500]`.
+ *
+ * The `[1, 36500]` literals mirror `FRIDAY_MIN_AFTER_DAYS` / `FRIDAY_MAX_AFTER_DAYS`
+ * in `friday-retention.types.ts` (inlined here on purpose — a migration's SQL and
+ * checksum are a frozen historical artifact and must not interpolate a mutable
+ * constant; a guard test asserts the CHECK bound agrees with those constants).
  *
  * Owner scoping mirrors `uix_user_preferences` (v051): every row is keyed by
  * `principal_id`; the unique `(principal_id, content_category)` index gives one
@@ -31,7 +41,7 @@ CREATE TABLE IF NOT EXISTS friday_retention_settings (
   id TEXT PRIMARY KEY,
   principal_id TEXT NOT NULL,
   content_category TEXT NOT NULL,
-  after_days INTEGER NOT NULL CHECK (after_days > 0),
+  after_days INTEGER NOT NULL CHECK (after_days >= 1 AND after_days <= 36500),
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );

--- a/src/state/sqlite/migrations/v105-retention-settings.ts
+++ b/src/state/sqlite/migrations/v105-retention-settings.ts
@@ -1,0 +1,53 @@
+import { computeFridayMigrationChecksum } from "./friday-migration.types.js";
+import type { FridaySqliteMigration } from "./friday-migration.types.js";
+
+/**
+ * V105: owner-bound per-category retention SETTINGS (RETENTION-R3a).
+ *
+ * DATA-RETENTION-001 / U9-DATA-RETENTION: local data is default-PERMANENT until
+ * the user deletes it; automatic time-based cleanup is default-OFF and opt-in
+ * PER CONTENT CATEGORY. This table stores ONLY the explicit owner opt-ins:
+ *
+ *   - A row's mere EXISTENCE means the owner enabled a time-based sweep for that
+ *     content category with `after_days = N` (N a POSITIVE integer, enforced by
+ *     `CHECK (after_days > 0)`).
+ *   - The ABSENCE of a row is the clean disabled state = PERMANENT ("off").
+ *     "Off" is therefore represented by row-absence — NEVER by a magic sentinel
+ *     number (not 0, -1, 30, nor an oversized value). The schema makes a sentinel
+ *     structurally impossible: `after_days` is NOT NULL and must be `> 0`.
+ *
+ * Owner scoping mirrors `uix_user_preferences` (v051): every row is keyed by
+ * `principal_id`; the unique `(principal_id, content_category)` index gives one
+ * override per owner per category with upsert-on-conflict. Deliberately a
+ * DEDICATED table (not a reserved `uix_user_preferences` category) so the typed,
+ * validated retention control surface is fully isolated from the generic
+ * `/v1/uix/preferences` list/delete endpoints (which cast a raw `?category=`
+ * string) and from the closed `FridayUserPreferenceCategory` union.
+ *
+ * Additive + idempotent (CREATE ... IF NOT EXISTS): removes/alters nothing.
+ */
+export const V105_RETENTION_SETTINGS_SQL = `
+CREATE TABLE IF NOT EXISTS friday_retention_settings (
+  id TEXT PRIMARY KEY,
+  principal_id TEXT NOT NULL,
+  content_category TEXT NOT NULL,
+  after_days INTEGER NOT NULL CHECK (after_days > 0),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_friday_retention_settings_principal_category
+ON friday_retention_settings(principal_id, content_category);
+
+CREATE INDEX IF NOT EXISTS idx_friday_retention_settings_principal
+ON friday_retention_settings(principal_id);
+`;
+
+const V105_CHECKSUM = computeFridayMigrationChecksum(V105_RETENTION_SETTINGS_SQL);
+
+export const V105_RETENTION_SETTINGS_MIGRATION: FridaySqliteMigration = {
+  version: 105,
+  name: "v105-retention-settings",
+  sql: V105_RETENTION_SETTINGS_SQL,
+  checksum: V105_CHECKSUM,
+};

--- a/test/integration/friday-retention-restart-readback.test.ts
+++ b/test/integration/friday-retention-restart-readback.test.ts
@@ -82,7 +82,7 @@ describe("RETENTION-R3a restart-readback (integration)", () => {
   it("policy written via PUT survives a store re-open and drives the reaper", () => {
     // ── Session 1: write via the PUT route, then close the store. ──
     const layer1 = openLayer(dbPath);
-    const routes1 = createFridayRetentionSettingsRoutes({ store: makeStore(layer1) });
+    const routes1 = createFridayRetentionSettingsRoutes({ store: makeStore(layer1), resolveCanonicalOwnerId: () => OWNER });
     const put1 = routes1.find((r) => r.operationId === "uix.retention.policy.update")!;
     const get1 = routes1.find((r) => r.operationId === "uix.retention.policy.get")!;
 
@@ -109,7 +109,7 @@ describe("RETENTION-R3a restart-readback (integration)", () => {
       // ── Session 2: re-open a FRESH store on the SAME on-disk db. ──
       const layer2 = openLayer(dbPath);
       try {
-        const routes2 = createFridayRetentionSettingsRoutes({ store: makeStore(layer2) });
+        const routes2 = createFridayRetentionSettingsRoutes({ store: makeStore(layer2), resolveCanonicalOwnerId: () => OWNER });
         const get2 = routes2.find((r) => r.operationId === "uix.retention.policy.get")!;
 
         const after = (await get2.handler(makeCtx())) as { policy: Record<string, unknown> };
@@ -167,7 +167,7 @@ describe("RETENTION-R3a restart-readback (integration)", () => {
 
     // ── Session 1: write the boundary window via the PUT route, then close. ──
     const layer1 = openLayer(dbPath);
-    const routes1 = createFridayRetentionSettingsRoutes({ store: makeStore(layer1) });
+    const routes1 = createFridayRetentionSettingsRoutes({ store: makeStore(layer1), resolveCanonicalOwnerId: () => OWNER });
     const put1 = routes1.find((r) => r.operationId === "uix.retention.policy.update")!;
     const putResult = (await put1.handler(
       makeCtx({ body: { policy: { auditLogs: { mode: "after_days", days: MAX } } } }),
@@ -178,7 +178,7 @@ describe("RETENTION-R3a restart-readback (integration)", () => {
     // ── Session 2: re-open a FRESH store on the SAME on-disk db. ──
     const layer2 = openLayer(dbPath);
     try {
-      const routes2 = createFridayRetentionSettingsRoutes({ store: makeStore(layer2) });
+      const routes2 = createFridayRetentionSettingsRoutes({ store: makeStore(layer2), resolveCanonicalOwnerId: () => OWNER });
       const get2 = routes2.find((r) => r.operationId === "uix.retention.policy.get")!;
       const after = (await get2.handler(makeCtx())) as { policy: Record<string, unknown> };
 

--- a/test/integration/friday-retention-restart-readback.test.ts
+++ b/test/integration/friday-retention-restart-readback.test.ts
@@ -18,6 +18,7 @@ import {
   createFridayRetentionPolicyLoader,
   createFridayRetentionSettingsRepository,
   createFridayRetentionSettingsStore,
+  resolveCutoff,
 } from "#jobs";
 
 /**
@@ -159,5 +160,42 @@ describe("RETENTION-R3a restart-readback (integration)", () => {
         layer2.close();
       }
     })();
+  });
+
+  it("BOUNDARY: a MAX (36500-day) window persists, survives a store re-open, and is HONORED (Advisor R2)", async () => {
+    const MAX = 36_500; // == FRIDAY_MAX_AFTER_DAYS (accept ⊆ honored at the boundary)
+
+    // ── Session 1: write the boundary window via the PUT route, then close. ──
+    const layer1 = openLayer(dbPath);
+    const routes1 = createFridayRetentionSettingsRoutes({ store: makeStore(layer1) });
+    const put1 = routes1.find((r) => r.operationId === "uix.retention.policy.update")!;
+    const putResult = (await put1.handler(
+      makeCtx({ body: { policy: { auditLogs: { mode: "after_days", days: MAX } } } }),
+    )) as { policy: Record<string, unknown> };
+    expect(putResult.policy.auditLogs).toEqual({ mode: "after_days", days: MAX });
+    layer1.close();
+
+    // ── Session 2: re-open a FRESH store on the SAME on-disk db. ──
+    const layer2 = openLayer(dbPath);
+    try {
+      const routes2 = createFridayRetentionSettingsRoutes({ store: makeStore(layer2) });
+      const get2 = routes2.find((r) => r.operationId === "uix.retention.policy.get")!;
+      const after = (await get2.handler(makeCtx())) as { policy: Record<string, unknown> };
+
+      // Byte-identical readback of the boundary window across the restart.
+      expect(after.policy.auditLogs).toEqual({ mode: "after_days", days: MAX });
+
+      // The loader picks it up AND the reaper's evaluator honors it (non-null cutoff)
+      // — proving the accepted maximum is inside the honored domain.
+      const loader = createFridayRetentionPolicyLoader({
+        db: layer2,
+        repo: createFridayRetentionSettingsRepository(),
+        principalId: OWNER,
+      });
+      expect(loader.load().auditLogs).toEqual({ mode: "after_days", days: MAX });
+      expect(resolveCutoff(NOW, { mode: "after_days", days: MAX })).not.toBeNull();
+    } finally {
+      layer2.close();
+    }
   });
 });

--- a/test/integration/friday-retention-restart-readback.test.ts
+++ b/test/integration/friday-retention-restart-readback.test.ts
@@ -41,7 +41,8 @@ function makeCtx(
     query: {},
     body: {},
     headers: {},
-    principal: { userId: OWNER } as never,
+    // Retention config is owner-only: the caller must carry owner/admin authority.
+    principal: { userId: OWNER, principalId: OWNER, role: "admin", scopes: ["hub.admin"] } as never,
     ...overrides,
   };
 }

--- a/test/integration/friday-retention-restart-readback.test.ts
+++ b/test/integration/friday-retention-restart-readback.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { createFridaySqliteLayer } from "#state";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridaySatellitePairingRequestRepository,
+  createFridaySatelliteHeartbeatRepository,
+  createFridayOutboxMessageRepository,
+} from "#satellites";
+import { createFridayLearningEventLedger, createFridaySkillRunStore } from "#ledger";
+import { createFridaySetupBootstrapNonceRepository } from "#api";
+import { createFridayRetentionSettingsRoutes } from "#api";
+import type { FridayHttpContext } from "#api";
+import {
+  createFridayRetentionJob,
+  createFridayRetentionPolicyLoader,
+  createFridayRetentionSettingsRepository,
+  createFridayRetentionSettingsStore,
+} from "#jobs";
+
+/**
+ * RETENTION-R3a restart-readback (durable persistence proof).
+ *
+ * Write an owner retention policy via the PUT route → close the store / process
+ * → re-open a fresh store on the SAME on-disk db → GET returns the byte-
+ * identical policy → the loader/reaper picks up the persisted opt-in.
+ */
+const OWNER = "admin-001";
+const NOW = "2026-07-15T10:00:00.000Z";
+const AGED = "2024-01-01T00:00:00.000Z";
+
+function makeCtx(
+  overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {},
+): FridayHttpContext<unknown, unknown, unknown> {
+  return {
+    requestId: "req-1",
+    receivedAt: NOW,
+    params: {},
+    query: {},
+    body: {},
+    headers: {},
+    principal: { userId: OWNER } as never,
+    ...overrides,
+  };
+}
+
+function openLayer(dbPath: string): FridaySqliteLayer {
+  return createFridaySqliteLayer({
+    dbPath,
+    readPoolSize: 1,
+    pragmas: { busyTimeoutMs: 5000, synchronous: "NORMAL" },
+  });
+}
+
+function makeStore(layer: FridaySqliteLayer) {
+  let idc = 0;
+  return createFridayRetentionSettingsStore({
+    db: layer,
+    repo: createFridayRetentionSettingsRepository(),
+    idGenerator: () => `ret-${++idc}`,
+    nowIso: () => NOW,
+  });
+}
+
+describe("RETENTION-R3a restart-readback (integration)", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "friday-retention-r3a-"));
+    dbPath = path.join(tmpDir, "friday.db");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("policy written via PUT survives a store re-open and drives the reaper", () => {
+    // ── Session 1: write via the PUT route, then close the store. ──
+    const layer1 = openLayer(dbPath);
+    const routes1 = createFridayRetentionSettingsRoutes({ store: makeStore(layer1) });
+    const put1 = routes1.find((r) => r.operationId === "uix.retention.policy.update")!;
+    const get1 = routes1.find((r) => r.operationId === "uix.retention.policy.get")!;
+
+    let writtenPolicy: unknown;
+    return (async () => {
+      const putResult = (await put1.handler(
+        makeCtx({
+          body: {
+            policy: {
+              auditLogs: { mode: "after_days", days: 90 },
+              agentRuns: { mode: "permanent" },
+            },
+          },
+        }),
+      )) as { policy: Record<string, unknown> };
+      writtenPolicy = putResult.policy;
+
+      const before = (await get1.handler(makeCtx())) as { policy: Record<string, unknown> };
+      expect(before.policy).toEqual(writtenPolicy);
+
+      // Simulate a restart: drop all in-memory/session state.
+      layer1.close();
+
+      // ── Session 2: re-open a FRESH store on the SAME on-disk db. ──
+      const layer2 = openLayer(dbPath);
+      try {
+        const routes2 = createFridayRetentionSettingsRoutes({ store: makeStore(layer2) });
+        const get2 = routes2.find((r) => r.operationId === "uix.retention.policy.get")!;
+
+        const after = (await get2.handler(makeCtx())) as { policy: Record<string, unknown> };
+
+        // Byte-identical readback across the restart.
+        expect(after.policy).toEqual(writtenPolicy);
+        expect(JSON.stringify(after.policy)).toBe(JSON.stringify(writtenPolicy));
+        expect(after.policy.auditLogs).toEqual({ mode: "after_days", days: 90 });
+        expect(after.policy.agentRuns).toEqual({ mode: "permanent" });
+
+        // The loader picks up the persisted opt-in for the reaper.
+        const loader = createFridayRetentionPolicyLoader({
+          db: layer2,
+          repo: createFridayRetentionSettingsRepository(),
+          principalId: OWNER,
+        });
+        const policy = loader.load();
+        expect(policy.auditLogs).toEqual({ mode: "after_days", days: 90 });
+        expect(policy.agentRuns).toEqual({ mode: "permanent" });
+
+        // And the reaper ACTS on it: an aged audit log is deleted; nothing else.
+        layer2.writer
+          .prepare(
+            `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+             VALUES ('al-aged', ?, 'user', 'u1', 'create', 'skill', 's1')`,
+          )
+          .run(AGED);
+
+        const job = createFridayRetentionJob({
+          db: layer2,
+          pairingRequestRepo: createFridaySatellitePairingRequestRepository(),
+          heartbeatRepo: createFridaySatelliteHeartbeatRepository(),
+          outboxRepo: createFridayOutboxMessageRepository(),
+          learningLedger: createFridayLearningEventLedger({ db: layer2 }),
+          skillRunStore: createFridaySkillRunStore({ db: layer2 }),
+          bootstrapNonceRepo: createFridaySetupBootstrapNonceRepository(),
+          nowIso: () => NOW,
+          policy,
+        });
+        const result = job.run(NOW);
+        expect(result.deletedAuditLogs).toBe(1);
+        expect(result.deletedAgentRuns).toBe(0);
+        expect(result.deletedLearningEvents).toBe(0);
+        expect(
+          (layer2.writer.prepare("SELECT COUNT(*) c FROM audit_logs").get() as { c: number }).c,
+        ).toBe(0);
+      } finally {
+        layer2.close();
+      }
+    })();
+  });
+});

--- a/test/unit/api/http/friday-http-server-retention-canonical-owner-authz.test.ts
+++ b/test/unit/api/http/friday-http-server-retention-canonical-owner-authz.test.ts
@@ -1,0 +1,343 @@
+import * as net from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createFridayHttpRouteRegistry,
+  createFridayHttpServer,
+  createFridayRetentionSettingsRoutes,
+  createFridaySetupBootstrapNonceRepository,
+  type FridayAuthMiddlewareFactory,
+  type FridayHttpServer,
+  type FridayRealtimeWsGateway,
+} from "#api";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridayRetentionJob,
+  createFridayRetentionPolicyLoader,
+  createFridayRetentionSettingsRepository,
+  createFridayRetentionSettingsStore,
+} from "#jobs";
+import type { FridayRetentionSettingsStore } from "#jobs";
+import {
+  createFridaySatelliteHeartbeatRepository,
+  createFridayOutboxMessageRepository,
+  createFridaySatellitePairingRequestRepository,
+} from "#satellites";
+import { createFridayLearningEventLedger, createFridaySkillRunStore } from "#ledger";
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * RETENTION-R3a — CANONICAL-OWNER binding (Advisor round 3 P0).
+ *
+ * The finding: the route authorized ANY owner/admin-role principal and then keyed
+ * the retention-policy row to the caller's arbitrary `principal.userId`. But the
+ * product fixes a SINGLE canonical owner (`admin-001` = hub-bootstrap's
+ * `learningDefaultUserId`) and the production reaper's loader reads ONLY that id.
+ * A DIFFERENT legitimately-authenticated admin (`admin-002`) was accepted → 200
+ * active-policy readback → persisted an `admin-002` override the reaper never
+ * reads, while the canonical loader stayed permanent (deletes 0).
+ *
+ * These tests drive the REAL `createFridayHttpServer` + REAL store + the REAL
+ * per-sweep reaper loader and assert the canonical-owner binding: only the
+ * principal whose userId MATCHES the canonical-owner id the reaper consumes may
+ * read or mutate; a second admin is denied 403 with ZERO effect; and if the
+ * canonical-owner id cannot be resolved the route fails closed (403, zero effect)
+ * rather than falling open to "any admin".
+ */
+
+const ROUTE = "/v1/uix/retention-policy";
+const NOW = "2026-07-15T10:00:00.000Z";
+const AGED = "2024-01-01T00:00:00.000Z";
+
+// The canonical owner id the production reaper's policy loader is bound to
+// (hub-bootstrap wires `principalId: learningDefaultUserId = "admin-001"`).
+const CANONICAL_OWNER_ID = "admin-001";
+
+type StubPrincipal = {
+  principalId: string;
+  userId: string;
+  tenantId: string;
+  role: string;
+  scopes: string[];
+  tokenId: string;
+  principalType?: string;
+};
+
+// The CANONICAL owner: userId === the id the reaper reads. role admin (grants the
+// hub.admin scope) via the local passphrase → bearer flow.
+const CANONICAL_OWNER: StubPrincipal = {
+  principalId: "user:admin-001",
+  userId: CANONICAL_OWNER_ID,
+  tenantId: "admin-001",
+  role: "admin",
+  scopes: ["hub.admin", "session.read"],
+  tokenId: "tok-admin-001",
+};
+
+// A SECOND, legitimately-authenticated admin — a DISTINCT userId with a REAL
+// role-derived hub.admin token (email/password login mints each user a
+// role-derived admin token, so the schema permits multiple such principals).
+// Role/scope alone is NOT canonical-owner identity → must be DENIED.
+const SECOND_ADMIN: StubPrincipal = {
+  principalId: "user:admin-002",
+  userId: "admin-002",
+  tenantId: "admin-002",
+  role: "admin",
+  scopes: ["hub.admin", "session.read"],
+  tokenId: "tok-admin-002",
+};
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      if (!addr || typeof addr === "string") {
+        srv.close();
+        reject(new Error("failed to allocate free port"));
+        return;
+      }
+      const p = addr.port;
+      srv.close((closeErr) => (closeErr ? reject(closeErr) : resolve(p)));
+    });
+    srv.on("error", reject);
+  });
+}
+
+function makeStubWsGateway(): FridayRealtimeWsGateway {
+  return {
+    handleClientFrame: () => ({ handled: false }),
+    addConnection: () => {},
+    removeConnection: () => {},
+    broadcastEvent: () => {},
+  } as unknown as FridayRealtimeWsGateway;
+}
+
+function makeBearerStubMiddleware(
+  validTokens: Record<string, StubPrincipal>,
+): FridayAuthMiddlewareFactory {
+  return {
+    requireAuth: (ctx) => {
+      if (ctx.principal) return { passed: true as const };
+      const auth = ctx.headers["authorization"] ?? ctx.headers["Authorization"];
+      if (!auth) return { passed: false as const, statusCode: 401, code: "UNAUTHORIZED", message: "missing token" };
+      const parts = auth.split(" ");
+      if (parts.length !== 2 || parts[0] !== "Bearer") {
+        return { passed: false as const, statusCode: 401, code: "UNAUTHORIZED", message: "malformed header" };
+      }
+      const principal = validTokens[parts[1]];
+      if (!principal) return { passed: false as const, statusCode: 401, code: "UNAUTHORIZED", message: "invalid token" };
+      (ctx as { principal: unknown }).principal = principal;
+      return { passed: true as const };
+    },
+    requireAnyScope: () => ({ passed: true as const }),
+    requireAnyRole: () => ({ passed: true as const }),
+    enforceRateLimit: () => ({ passed: true as const }),
+  };
+}
+
+describe("FridayHttpServer — /v1/uix/retention-policy canonical-owner binding (RETENTION-R3a Advisor R3)", () => {
+  let server: FridayHttpServer | null = null;
+  let db: FridaySqliteLayer | null = null;
+  let store: FridayRetentionSettingsStore;
+  let port = 0;
+  let baseUrl = "";
+  let idc = 0;
+
+  beforeEach(async () => {
+    port = await findFreePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    idc = 0;
+    db = createTestDb();
+    store = createFridayRetentionSettingsStore({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      idGenerator: () => `ret-${String(++idc).padStart(4, "0")}`,
+      nowIso: () => NOW,
+    });
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+    if (db) {
+      db.close();
+      db = null;
+    }
+  });
+
+  function startServer(
+    tokens: Record<string, StubPrincipal>,
+    resolveCanonicalOwnerId: () => string | null | undefined = () => CANONICAL_OWNER_ID,
+  ) {
+    const routes = createFridayHttpRouteRegistry();
+    for (const route of createFridayRetentionSettingsRoutes({ store, resolveCanonicalOwnerId })) {
+      routes.register(route);
+    }
+    server = createFridayHttpServer({
+      routes,
+      wsGateway: makeStubWsGateway(),
+      middleware: makeBearerStubMiddleware(tokens),
+      port,
+      host: "127.0.0.1",
+    });
+    return server.listen();
+  }
+
+  function rowsFor(principalId: string): Array<{ content_category: string; after_days: number }> {
+    return db!.writer
+      .prepare(
+        "SELECT content_category, after_days FROM friday_retention_settings WHERE principal_id = ? ORDER BY content_category",
+      )
+      .all(principalId) as Array<{ content_category: string; after_days: number }>;
+  }
+
+  function totalRows(): number {
+    return (
+      db!.writer.prepare("SELECT COUNT(*) AS c FROM friday_retention_settings").get() as { c: number }
+    ).c;
+  }
+
+  async function get(headers: Record<string, string>) {
+    return fetch(`${baseUrl}${ROUTE}`, { headers });
+  }
+  async function put(headers: Record<string, string>, bodyObj: unknown) {
+    return fetch(`${baseUrl}${ROUTE}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(bodyObj),
+    });
+  }
+
+  // Run the REAL per-sweep reaper with a loader bound to the CANONICAL owner id
+  // (exactly as hub-bootstrap wires it) and return its audit-log deletion count.
+  function canonicalReaperDeletedAuditLogs(): number {
+    const loader = createFridayRetentionPolicyLoader({
+      db: db!,
+      repo: createFridayRetentionSettingsRepository(),
+      principalId: CANONICAL_OWNER_ID,
+    });
+    return createFridayRetentionJob({
+      db: db!,
+      pairingRequestRepo: createFridaySatellitePairingRequestRepository(),
+      heartbeatRepo: createFridaySatelliteHeartbeatRepository(),
+      outboxRepo: createFridayOutboxMessageRepository(),
+      learningLedger: createFridayLearningEventLedger({ db: db! }),
+      skillRunStore: createFridaySkillRunStore({ db: db! }),
+      bootstrapNonceRepo: createFridaySetupBootstrapNonceRepository(),
+      nowIso: () => NOW,
+      loadPolicy: () => loader.load(),
+    }).run(NOW).deletedAuditLogs;
+  }
+
+  // ── TEST 1: a SECOND legitimately-authenticated admin is DENIED (403) with
+  //           ZERO persistence, ZERO readback, ZERO deletion effect. ───────────
+  it("second admin (admin-002, real hub.admin token) → 403 on GET+PUT; zero rows; zero reaper effect", async () => {
+    await startServer({ "tok-admin-002": SECOND_ADMIN });
+
+    // Seed an aged audit row so a wrongful opt-in would visibly delete it.
+    db!.writer
+      .prepare(
+        `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+         VALUES ('al-aged', ?, 'user', 'u1', 'create', 'skill', 's1')`,
+      )
+      .run(AGED);
+
+    const getRes = await get({ Authorization: "Bearer tok-admin-002" });
+    expect(getRes.status).toBe(403);
+
+    const putRes = await put(
+      { Authorization: "Bearer tok-admin-002" },
+      { policy: { auditLogs: { mode: "after_days", days: 1 } } },
+    );
+    expect(putRes.status).toBe(403);
+
+    // ZERO persistence: neither under admin-002 nor anywhere.
+    expect(rowsFor("admin-002")).toHaveLength(0);
+    expect(totalRows()).toBe(0);
+
+    // ZERO deletion effect: the canonical reaper still deletes nothing (the
+    // aged audit row survives — the second admin had NO destructive reach).
+    expect(canonicalReaperDeletedAuditLogs()).toBe(0);
+    expect((db!.writer.prepare("SELECT COUNT(*) c FROM audit_logs").get() as { c: number }).c).toBe(1);
+  });
+
+  // ── TEST 2: the CANONICAL owner's opt-in is persisted AND honored by the SAME
+  //           per-sweep production loader the reaper consumes (accept==honored). ─
+  it("canonical owner (admin-001) PUT persists and the reaper's loader honors it end-to-end", async () => {
+    await startServer({ "tok-admin-001": CANONICAL_OWNER });
+
+    const putRes = await put(
+      { Authorization: "Bearer tok-admin-001" },
+      { policy: { auditLogs: { mode: "after_days", days: 90 } } },
+    );
+    expect(putRes.status).toBe(200);
+    const putBody = (await putRes.json()) as { ok: true; data: { policy: Record<string, { mode: string; days?: number }> } };
+    expect(putBody.data.policy.auditLogs).toEqual({ mode: "after_days", days: 90 });
+
+    // Persisted under the canonical owner id (the id the reaper reads).
+    expect(rowsFor(CANONICAL_OWNER_ID)).toEqual([{ content_category: "auditLogs", after_days: 90 }]);
+
+    // GET reads it back active.
+    const getRes = await get({ Authorization: "Bearer tok-admin-001" });
+    expect(getRes.status).toBe(200);
+    const getBody = (await getRes.json()) as { ok: true; data: { policy: Record<string, { mode: string; days?: number }> } };
+    expect(getBody.data.policy.auditLogs).toEqual({ mode: "after_days", days: 90 });
+
+    // The SAME production loader the reaper uses honors the write: an aged audit
+    // row is deleted (accept == honored: the canonical owner's policy DRIVES the
+    // reaper).
+    db!.writer
+      .prepare(
+        `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+         VALUES ('al-aged', ?, 'user', 'u1', 'create', 'skill', 's1')`,
+      )
+      .run(AGED);
+    expect(canonicalReaperDeletedAuditLogs()).toBe(1);
+    expect((db!.writer.prepare("SELECT COUNT(*) c FROM audit_logs").get() as { c: number }).c).toBe(0);
+  });
+
+  // ── TEST 3: fail-closed if the canonical-owner id cannot be resolved. Even the
+  //           canonical owner principal is denied — NEVER fall open to any admin. ─
+  it("provider returns null → 403 on GET+PUT even for the canonical owner; zero persistence", async () => {
+    await startServer({ "tok-admin-001": CANONICAL_OWNER }, () => null);
+
+    const getRes = await get({ Authorization: "Bearer tok-admin-001" });
+    expect(getRes.status).toBe(403);
+    const putRes = await put(
+      { Authorization: "Bearer tok-admin-001" },
+      { policy: { auditLogs: { mode: "after_days", days: 30 } } },
+    );
+    expect(putRes.status).toBe(403);
+    expect(totalRows()).toBe(0);
+  });
+
+  it("provider throws → 403 on GET+PUT even for the canonical owner; zero persistence", async () => {
+    await startServer({ "tok-admin-001": CANONICAL_OWNER }, () => {
+      throw new Error("canonical-owner resolution failed");
+    });
+
+    const getRes = await get({ Authorization: "Bearer tok-admin-001" });
+    expect(getRes.status).toBe(403);
+    const putRes = await put(
+      { Authorization: "Bearer tok-admin-001" },
+      { policy: { auditLogs: { mode: "after_days", days: 30 } } },
+    );
+    expect(putRes.status).toBe(403);
+    expect(totalRows()).toBe(0);
+  });
+
+  it("provider returns empty/whitespace string → 403 (fail closed, not 'any admin')", async () => {
+    await startServer({ "tok-admin-001": CANONICAL_OWNER }, () => "   ");
+    const getRes = await get({ Authorization: "Bearer tok-admin-001" });
+    expect(getRes.status).toBe(403);
+    const putRes = await put(
+      { Authorization: "Bearer tok-admin-001" },
+      { policy: { auditLogs: { mode: "after_days", days: 30 } } },
+    );
+    expect(putRes.status).toBe(403);
+    expect(totalRows()).toBe(0);
+  });
+});

--- a/test/unit/api/http/friday-http-server-retention-settings-authz.test.ts
+++ b/test/unit/api/http/friday-http-server-retention-settings-authz.test.ts
@@ -1,0 +1,348 @@
+import * as net from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createFridayHttpRouteRegistry,
+  createFridayHttpServer,
+  createFridayRetentionSettingsRoutes,
+  createFridaySetupBootstrapNonceRepository,
+  type FridayAuthMiddlewareFactory,
+  type FridayHttpServer,
+  type FridayRealtimeWsGateway,
+} from "#api";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridayRetentionJob,
+  createFridayRetentionPolicyLoader,
+  createFridayRetentionSettingsRepository,
+  createFridayRetentionSettingsStore,
+} from "#jobs";
+import type { FridayRetentionSettingsStore } from "#jobs";
+import {
+  createFridaySatelliteHeartbeatRepository,
+  createFridayOutboxMessageRepository,
+  createFridaySatellitePairingRequestRepository,
+} from "#satellites";
+import { createFridayLearningEventLedger, createFridaySkillRunStore } from "#ledger";
+import { ERROR_CODE_BOUND_PRINCIPAL_REQUIRED } from "../../../../src/security/friday-owner-session-channel-capability.js";
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * RETENTION-R3a — REAL end-to-end HTTP authz + cross-owner isolation proof.
+ *
+ * The #1606 lesson: handler-level authz stubs do NOT prove the auth composition
+ * through the real pipeline. These tests drive the REAL `createFridayHttpServer`
+ * (public-mutation floor + sensitive-read floor + bearer middleware) against
+ * `/v1/uix/retention-policy` backed by a REAL store over an in-memory sqlite.
+ *
+ * Load-bearing: breaking the repo's `WHERE principal_id = ?` scoping makes the
+ * two-owner isolation test go RED (owner B would read owner A's opt-in).
+ */
+
+const ROUTE = "/v1/uix/retention-policy";
+const NOW = "2026-07-15T10:00:00.000Z";
+const AGED = "2024-01-01T00:00:00.000Z";
+
+type StubPrincipal = {
+  principalId: string;
+  userId: string;
+  tenantId: string;
+  role: string;
+  scopes: string[];
+  tokenId: string;
+};
+
+const OWNER_A: StubPrincipal = {
+  principalId: "user:alice",
+  userId: "11111111-1111-1111-1111-111111111111",
+  tenantId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  role: "viewer",
+  scopes: ["session.read"],
+  tokenId: "33333333-3333-3333-3333-333333333333",
+};
+const OWNER_B: StubPrincipal = {
+  principalId: "user:bob",
+  userId: "22222222-2222-2222-2222-222222222222",
+  tenantId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  role: "viewer",
+  scopes: ["session.read"],
+  tokenId: "44444444-4444-4444-4444-444444444444",
+};
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      if (!addr || typeof addr === "string") {
+        srv.close();
+        reject(new Error("failed to allocate free port"));
+        return;
+      }
+      const p = addr.port;
+      srv.close((closeErr) => (closeErr ? reject(closeErr) : resolve(p)));
+    });
+    srv.on("error", reject);
+  });
+}
+
+function makeStubWsGateway(): FridayRealtimeWsGateway {
+  return {
+    handleClientFrame: () => ({ handled: false }),
+    addConnection: () => {},
+    removeConnection: () => {},
+    broadcastEvent: () => {},
+  } as unknown as FridayRealtimeWsGateway;
+}
+
+// Missing/invalid Authorization leaves ctx.principal untouched (server falls back
+// to the synthetic public principal); a valid bearer sets the real bound principal.
+function makeBearerStubMiddleware(
+  validTokens: Record<string, StubPrincipal>,
+): FridayAuthMiddlewareFactory {
+  return {
+    requireAuth: (ctx) => {
+      if (ctx.principal) return { passed: true as const };
+      const auth = ctx.headers["authorization"] ?? ctx.headers["Authorization"];
+      if (!auth) return { passed: false as const, statusCode: 401, code: "UNAUTHORIZED", message: "missing token" };
+      const parts = auth.split(" ");
+      if (parts.length !== 2 || parts[0] !== "Bearer") {
+        return { passed: false as const, statusCode: 401, code: "UNAUTHORIZED", message: "malformed header" };
+      }
+      const principal = validTokens[parts[1]];
+      if (!principal) return { passed: false as const, statusCode: 401, code: "UNAUTHORIZED", message: "invalid token" };
+      (ctx as { principal: unknown }).principal = principal;
+      return { passed: true as const };
+    },
+    requireAnyScope: () => ({ passed: true as const }),
+    requireAnyRole: () => ({ passed: true as const }),
+    enforceRateLimit: () => ({ passed: true as const }),
+  };
+}
+
+describe("FridayHttpServer — /v1/uix/retention-policy real-HTTP authz + cross-owner isolation (RETENTION-R3a)", () => {
+  let server: FridayHttpServer | null = null;
+  let db: FridaySqliteLayer | null = null;
+  let store: FridayRetentionSettingsStore;
+  let port = 0;
+  let baseUrl = "";
+  let idc = 0;
+
+  beforeEach(async () => {
+    port = await findFreePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    idc = 0;
+    db = createTestDb();
+    store = createFridayRetentionSettingsStore({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      idGenerator: () => `ret-${String(++idc).padStart(4, "0")}`,
+      nowIso: () => NOW,
+    });
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+    if (db) {
+      db.close();
+      db = null;
+    }
+  });
+
+  function startServer(tokens: Record<string, StubPrincipal> = {}) {
+    const routes = createFridayHttpRouteRegistry();
+    for (const route of createFridayRetentionSettingsRoutes({ store })) {
+      routes.register(route);
+    }
+    server = createFridayHttpServer({
+      routes,
+      wsGateway: makeStubWsGateway(),
+      middleware: makeBearerStubMiddleware(tokens),
+      port,
+      host: "127.0.0.1",
+    });
+    return server.listen();
+  }
+
+  function rowsFor(principalId: string): Array<{ content_category: string; after_days: number }> {
+    return db!.writer
+      .prepare(
+        "SELECT content_category, after_days FROM friday_retention_settings WHERE principal_id = ? ORDER BY content_category",
+      )
+      .all(principalId) as Array<{ content_category: string; after_days: number }>;
+  }
+
+  function totalRows(): number {
+    return (
+      db!.writer.prepare("SELECT COUNT(*) AS c FROM friday_retention_settings").get() as { c: number }
+    ).c;
+  }
+
+  async function put(headers: Record<string, string>, bodyObj: unknown) {
+    return fetch(`${baseUrl}${ROUTE}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(bodyObj),
+    });
+  }
+
+  // ── AUTH NEGATIVES: anonymous / synthetic-public / invalid-bearer → 401 ────
+  it("anonymous GET → 401 (sensitive-read floor) before the handler runs", async () => {
+    await startServer();
+    const res = await fetch(`${baseUrl}${ROUTE}`);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { ok: false; error: { code: string } };
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe(ERROR_CODE_BOUND_PRINCIPAL_REQUIRED);
+    expect(totalRows()).toBe(0);
+  });
+
+  it("anonymous PUT → 401 (public-mutation floor); nothing persisted", async () => {
+    await startServer();
+    const res = await put({}, { policy: { auditLogs: { mode: "after_days", days: 30 } } });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { ok: false; error: { code: string } };
+    expect(body.error.code).toBe(ERROR_CODE_BOUND_PRINCIPAL_REQUIRED);
+    expect(totalRows()).toBe(0);
+  });
+
+  it("invalid/malformed bearer → 401 on BOTH GET and PUT (falls back to synthetic public); nothing persisted", async () => {
+    await startServer({ "good-token": OWNER_A }); // the bogus bearer below is NOT this token
+    const getRes = await fetch(`${baseUrl}${ROUTE}`, { headers: { Authorization: "Bearer not-a-real-token" } });
+    expect(getRes.status).toBe(401);
+    expect(((await getRes.json()) as { error: { code: string } }).error.code).toBe(
+      ERROR_CODE_BOUND_PRINCIPAL_REQUIRED,
+    );
+
+    const putRes = await put(
+      { Authorization: "Bearer not-a-real-token" },
+      { policy: { auditLogs: { mode: "after_days", days: 30 } } },
+    );
+    expect(putRes.status).toBe(401);
+    expect(((await putRes.json()) as { error: { code: string } }).error.code).toBe(
+      ERROR_CODE_BOUND_PRINCIPAL_REQUIRED,
+    );
+
+    // A malformed (non-"Bearer x") header also falls back → gated.
+    const malformed = await fetch(`${baseUrl}${ROUTE}`, { headers: { Authorization: "Token abc" } });
+    expect(malformed.status).toBe(401);
+
+    expect(totalRows()).toBe(0);
+  });
+
+  // ── CROSS-OWNER ISOLATION (the class missed in #1606) ─────────────────────
+  it("two authenticated owners: A's opt-in is invisible to B; body-supplied owner id is ignored; rows are principal-scoped", async () => {
+    await startServer({ "token-a": OWNER_A, "token-b": OWNER_B });
+
+    // A PUTs an opt-in — and the body ALSO tries to target owner B (userId /
+    // principalId / ownerId). The handler must ignore the body ids and write
+    // under the AUTHENTICATED principal (A) only.
+    const putRes = await put(
+      { Authorization: "Bearer token-a" },
+      {
+        userId: OWNER_B.userId,
+        principalId: OWNER_B.principalId,
+        ownerId: OWNER_B.userId,
+        policy: { auditLogs: { mode: "after_days", days: 30 } },
+      },
+    );
+    expect(putRes.status).toBe(200);
+    const putBody = (await putRes.json()) as { ok: true; data: { policy: Record<string, { mode: string; days?: number }> } };
+    expect(putBody.data.policy.auditLogs).toEqual({ mode: "after_days", days: 30 });
+
+    // B GETs → every category permanent (A's opt-in is NOT visible to B).
+    const bGet = await fetch(`${baseUrl}${ROUTE}`, { headers: { Authorization: "Bearer token-b" } });
+    expect(bGet.status).toBe(200);
+    const bBody = (await bGet.json()) as { ok: true; data: { policy: Record<string, { mode: string; days?: number }> } };
+    for (const retention of Object.values(bBody.data.policy)) {
+      expect(retention.mode).toBe("permanent");
+    }
+    expect(bBody.data.policy.auditLogs).toEqual({ mode: "permanent" });
+
+    // A GETs → sees its own opt-in.
+    const aGet = await fetch(`${baseUrl}${ROUTE}`, { headers: { Authorization: "Bearer token-a" } });
+    const aBody = (await aGet.json()) as { ok: true; data: { policy: Record<string, { mode: string; days?: number }> } };
+    expect(aBody.data.policy.auditLogs).toEqual({ mode: "after_days", days: 30 });
+
+    // Physical persistence is principal-scoped: the row lands under A's userId,
+    // NOT under B's (despite the body attempting to target B).
+    expect(rowsFor(OWNER_A.userId)).toEqual([{ content_category: "auditLogs", after_days: 30 }]);
+    expect(rowsFor(OWNER_B.userId)).toHaveLength(0);
+    expect(totalRows()).toBe(1);
+  });
+
+  // ── CORRECTNESS: the reaper honors an owner opt-in submitted via the real API.
+  it("reaper honors an owner opt-in submitted via the real API (single-owner id linkage)", async () => {
+    // OWNER = admin-001. This id is the SAME across the whole chain in the
+    // single-owner product, which is exactly why the reaper reads what the API
+    // wrote:
+    //   * hub-bootstrap seeds the owner user with id "admin-001";
+    //   * friday-auth-service.generateTokenPair mints principal.userId = user.id
+    //     (so the authenticated owner principal carries userId "admin-001");
+    //   * the API scopes persistence by requireUserId(principal) = principal.userId;
+    //   * hub-bootstrap wires the loader with principalId = learningDefaultUserId
+    //     = "admin-001".
+    // API-write id == reaper-read id ⇒ the owner's opt-in is honored.
+    const ownerToken = "owner-admin-token";
+    const ownerPrincipal: StubPrincipal = {
+      principalId: "admin-001",
+      userId: "admin-001",
+      tenantId: "admin-001",
+      role: "admin",
+      scopes: ["session.read"],
+      tokenId: "tok-admin-001",
+    };
+    await startServer({ [ownerToken]: ownerPrincipal });
+
+    // 1) PUT the opt-in via the REAL HTTP API under the owner principal.
+    const putRes = await put(
+      { Authorization: `Bearer ${ownerToken}` },
+      { policy: { auditLogs: { mode: "after_days", days: 90 } } },
+    );
+    expect(putRes.status).toBe(200);
+
+    // 2) Seed an aged audit_logs row and resolve the reaper policy with the SAME
+    //    id the hub wires (learningDefaultUserId = "admin-001").
+    db!.writer
+      .prepare(
+        `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+         VALUES ('al-aged', ?, 'user', 'u1', 'create', 'skill', 's1')`,
+      )
+      .run(AGED);
+    const loader = createFridayRetentionPolicyLoader({
+      db: db!,
+      repo: createFridayRetentionSettingsRepository(),
+      principalId: "admin-001",
+    });
+    const policy = loader.load();
+    expect(policy.auditLogs).toEqual({ mode: "after_days", days: 90 });
+
+    // 3) Run the reaper → the owner's opt-in is honored (aged row deleted);
+    //    every other content category stays permanent (0 deletes) = fail-closed.
+    const result = createFridayRetentionJob({
+      db: db!,
+      pairingRequestRepo: createFridaySatellitePairingRequestRepository(),
+      heartbeatRepo: createFridaySatelliteHeartbeatRepository(),
+      outboxRepo: createFridayOutboxMessageRepository(),
+      learningLedger: createFridayLearningEventLedger({ db: db! }),
+      skillRunStore: createFridaySkillRunStore({ db: db! }),
+      bootstrapNonceRepo: createFridaySetupBootstrapNonceRepository(),
+      nowIso: () => NOW,
+      policy,
+    }).run(NOW);
+
+    expect(result.deletedAuditLogs).toBe(1);
+    expect(result.deletedAgentRuns).toBe(0);
+    expect(result.deletedLearningEvents).toBe(0);
+    expect(result.deletedLlmUsageRecords).toBe(0);
+    expect(result.deletedErrorIncidents).toBe(0);
+    expect(result.deletedSkillRuns).toBe(0);
+    expect(result.deletedHeartbeats).toBe(0);
+    expect(
+      (db!.writer.prepare("SELECT COUNT(*) c FROM audit_logs").get() as { c: number }).c,
+    ).toBe(0);
+  });
+});

--- a/test/unit/api/http/friday-http-server-retention-settings-authz.test.ts
+++ b/test/unit/api/http/friday-http-server-retention-settings-authz.test.ts
@@ -50,23 +50,57 @@ type StubPrincipal = {
   role: string;
   scopes: string[];
   tokenId: string;
+  principalType?: string;
 };
 
+// Canonical OWNERS: role "admin" (grants the hub.admin scope) via the local
+// passphrase → bearer flow. Two distinct owner userIds exercise cross-owner
+// isolation even among authorized owners.
 const OWNER_A: StubPrincipal = {
   principalId: "user:alice",
   userId: "11111111-1111-1111-1111-111111111111",
   tenantId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-  role: "viewer",
-  scopes: ["session.read"],
+  role: "admin",
+  scopes: ["hub.admin", "session.read"],
   tokenId: "33333333-3333-3333-3333-333333333333",
 };
 const OWNER_B: StubPrincipal = {
   principalId: "user:bob",
   userId: "22222222-2222-2222-2222-222222222222",
   tenantId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-  role: "viewer",
-  scopes: ["session.read"],
+  role: "admin",
+  scopes: ["hub.admin", "session.read"],
   tokenId: "44444444-4444-4444-4444-444444444444",
+};
+
+// NON-OWNER principals that must be REFUSED (owner-only retention config).
+const VIEWER: StubPrincipal = {
+  principalId: "user:viewer",
+  userId: "55555555-5555-5555-5555-555555555555",
+  tenantId: "cccccccc-cccc-cccc-cccc-cccccccccccc",
+  role: "viewer",
+  scopes: ["session.read"], // exactly the Advisor's probe principal
+  tokenId: "66666666-6666-6666-6666-666666666666",
+};
+const OPERATOR: StubPrincipal = {
+  principalId: "user:operator",
+  userId: "77777777-7777-7777-7777-777777777777",
+  tenantId: "dddddddd-dddd-dddd-dddd-dddddddddddd",
+  role: "operator", // no hub.admin scope, not owner/admin
+  scopes: ["workflow.write", "agent.run", "session.read"],
+  tokenId: "88888888-8888-8888-8888-888888888888",
+};
+// A device-bound OWNER principal while device-owner authority is DISABLED (the
+// default profile / a revoked-or-expired device). isReleaseDisabledDevicePrincipal
+// treats it exactly like the synthetic public principal ⇒ 401.
+const DEVICE_OWNER_DISABLED: StubPrincipal = {
+  principalType: "device",
+  principalId: "device-owner:revoked",
+  userId: "admin-001",
+  tenantId: "admin-001",
+  role: "admin",
+  scopes: ["hub.admin"],
+  tokenId: "99999999-9999-9999-9999-999999999999",
 };
 
 function findFreePort(): Promise<number> {
@@ -274,6 +308,75 @@ describe("FridayHttpServer — /v1/uix/retention-policy real-HTTP authz + cross-
     expect(totalRows()).toBe(1);
   });
 
+  // ── OWNER-AUTHORITY MATRIX (SEC-NET-PRINCIPAL-001): retention config is
+  //    canonical-local-owner-only. Only the owner may READ or MUTATE it. ──────
+  it("owner-authority matrix: non-owner principals are refused on GET+PUT with ZERO writes and ZERO deletion effect; only the owner succeeds", async () => {
+    await startServer({
+      "tok-viewer": VIEWER,
+      "tok-operator": OPERATOR,
+      "tok-device": DEVICE_OWNER_DISABLED,
+      "tok-owner": OWNER_A,
+    });
+
+    // DENIED matrix: [label, authHeader, expectedStatus]. Anonymous / synthetic
+    // and release-disabled-device → 401 (bound-principal floor); bound non-owner
+    // (viewer / operator) → 403 (owner authority required).
+    const denied: Array<[string, Record<string, string>, number]> = [
+      ["anonymous", {}, 401],
+      ["invalid-bearer (synthetic fallback)", { Authorization: "Bearer nope" }, 401],
+      ["viewer (session.read only)", { Authorization: "Bearer tok-viewer" }, 403],
+      ["operator (no owner authority)", { Authorization: "Bearer tok-operator" }, 403],
+      ["revoked/disabled device-owner", { Authorization: "Bearer tok-device" }, 401],
+    ];
+
+    for (const [, headers, expected] of denied) {
+      const getRes = await fetch(`${baseUrl}${ROUTE}`, { headers });
+      expect(getRes.status).toBe(expected);
+      const putRes = await put(headers, { policy: { auditLogs: { mode: "after_days", days: 1 } } });
+      expect(putRes.status).toBe(expected);
+    }
+
+    // ZERO WRITES: no denied principal persisted any override.
+    expect(totalRows()).toBe(0);
+
+    // ZERO DELETION EFFECT: with no persisted override, the live reaper policy is
+    // all-permanent ⇒ an aged audit row survives a sweep (denied principals had
+    // no destructive effect).
+    db!.writer
+      .prepare(
+        `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+         VALUES ('al-untouched', ?, 'user', 'u1', 'create', 'skill', 's1')`,
+      )
+      .run(AGED);
+    const loader = createFridayRetentionPolicyLoader({
+      db: db!,
+      repo: createFridayRetentionSettingsRepository(),
+      principalId: OWNER_A.userId,
+    });
+    const deniedSweep = createFridayRetentionJob({
+      db: db!,
+      pairingRequestRepo: createFridaySatellitePairingRequestRepository(),
+      heartbeatRepo: createFridaySatelliteHeartbeatRepository(),
+      outboxRepo: createFridayOutboxMessageRepository(),
+      learningLedger: createFridayLearningEventLedger({ db: db! }),
+      skillRunStore: createFridaySkillRunStore({ db: db! }),
+      bootstrapNonceRepo: createFridaySetupBootstrapNonceRepository(),
+      nowIso: () => NOW,
+      loadPolicy: () => loader.load(),
+    }).run(NOW);
+    expect(deniedSweep.deletedAuditLogs).toBe(0);
+
+    // ONLY the canonical owner succeeds: GET 200 + PUT 200 (opt-in persisted).
+    const ownerGet = await fetch(`${baseUrl}${ROUTE}`, { headers: { Authorization: "Bearer tok-owner" } });
+    expect(ownerGet.status).toBe(200);
+    const ownerPut = await put(
+      { Authorization: "Bearer tok-owner" },
+      { policy: { auditLogs: { mode: "after_days", days: 30 } } },
+    );
+    expect(ownerPut.status).toBe(200);
+    expect(rowsFor(OWNER_A.userId)).toEqual([{ content_category: "auditLogs", after_days: 30 }]);
+  });
+
   // ── CORRECTNESS: the reaper honors an owner opt-in submitted via the real API.
   it("reaper honors an owner opt-in submitted via the real API (single-owner id linkage)", async () => {
     // OWNER = admin-001. This id is the SAME across the whole chain in the
@@ -292,7 +395,7 @@ describe("FridayHttpServer — /v1/uix/retention-policy real-HTTP authz + cross-
       userId: "admin-001",
       tenantId: "admin-001",
       role: "admin",
-      scopes: ["session.read"],
+      scopes: ["hub.admin", "session.read"],
       tokenId: "tok-admin-001",
     };
     await startServer({ [ownerToken]: ownerPrincipal });

--- a/test/unit/api/http/friday-http-server-retention-settings-authz.test.ts
+++ b/test/unit/api/http/friday-http-server-retention-settings-authz.test.ts
@@ -35,13 +35,19 @@ import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js
  * (public-mutation floor + sensitive-read floor + bearer middleware) against
  * `/v1/uix/retention-policy` backed by a REAL store over an in-memory sqlite.
  *
- * Load-bearing: breaking the repo's `WHERE principal_id = ?` scoping makes the
- * two-owner isolation test go RED (owner B would read owner A's opt-in).
+ * Load-bearing: the canonical-owner binding (Advisor R3) requires the
+ * authenticated principal's userId to MATCH the single canonical-owner id the
+ * reaper consumes; a second legitimately-authenticated admin is refused, and the
+ * repo's `WHERE principal_id = ?` scoping keys every row to that canonical id.
  */
 
 const ROUTE = "/v1/uix/retention-policy";
 const NOW = "2026-07-15T10:00:00.000Z";
 const AGED = "2024-01-01T00:00:00.000Z";
+
+// The single canonical-owner id the production reaper's policy loader is bound to
+// (hub-bootstrap wires `principalId: learningDefaultUserId = "admin-001"`).
+const CANONICAL_OWNER_ID = "admin-001";
 
 type StubPrincipal = {
   principalId: string;
@@ -53,21 +59,26 @@ type StubPrincipal = {
   principalType?: string;
 };
 
-// Canonical OWNERS: role "admin" (grants the hub.admin scope) via the local
-// passphrase → bearer flow. Two distinct owner userIds exercise cross-owner
-// isolation even among authorized owners.
+// The CANONICAL owner: role "admin" (grants the hub.admin scope) via the local
+// passphrase → bearer flow, AND userId == the single canonical-owner id the
+// production reaper's policy loader is bound to (learningDefaultUserId).
 const OWNER_A: StubPrincipal = {
-  principalId: "user:alice",
-  userId: "11111111-1111-1111-1111-111111111111",
-  tenantId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  principalId: "user:admin-001",
+  userId: CANONICAL_OWNER_ID,
+  tenantId: "admin-001",
   role: "admin",
   scopes: ["hub.admin", "session.read"],
   tokenId: "33333333-3333-3333-3333-333333333333",
 };
+// A SECOND, legitimately-authenticated admin — a DISTINCT userId with a REAL
+// role-derived hub.admin token (the schema permits multiple such users). Role/
+// scope is NOT canonical-owner identity, so this principal is REFUSED 403 on the
+// canonical-owner-bound retention surface (Advisor R3): it must never receive an
+// active-policy readback nor persist an override the canonical reaper won't read.
 const OWNER_B: StubPrincipal = {
-  principalId: "user:bob",
-  userId: "22222222-2222-2222-2222-222222222222",
-  tenantId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  principalId: "user:admin-002",
+  userId: "admin-002",
+  tenantId: "admin-002",
   role: "admin",
   scopes: ["hub.admin", "session.read"],
   tokenId: "44444444-4444-4444-4444-444444444444",
@@ -186,9 +197,12 @@ describe("FridayHttpServer — /v1/uix/retention-policy real-HTTP authz + cross-
     }
   });
 
-  function startServer(tokens: Record<string, StubPrincipal> = {}) {
+  function startServer(
+    tokens: Record<string, StubPrincipal> = {},
+    resolveCanonicalOwnerId: () => string | null | undefined = () => CANONICAL_OWNER_ID,
+  ) {
     const routes = createFridayHttpRouteRegistry();
-    for (const route of createFridayRetentionSettingsRoutes({ store })) {
+    for (const route of createFridayRetentionSettingsRoutes({ store, resolveCanonicalOwnerId })) {
       routes.register(route);
     }
     server = createFridayHttpServer({
@@ -267,13 +281,15 @@ describe("FridayHttpServer — /v1/uix/retention-policy real-HTTP authz + cross-
     expect(totalRows()).toBe(0);
   });
 
-  // ── CROSS-OWNER ISOLATION (the class missed in #1606) ─────────────────────
-  it("two authenticated owners: A's opt-in is invisible to B; body-supplied owner id is ignored; rows are principal-scoped", async () => {
+  // ── CANONICAL-OWNER BINDING (Advisor R3): a second legitimately-authenticated
+  //    admin is REFUSED; the canonical owner writes under its own id; a body-
+  //    supplied owner id is ignored; rows are canonical-scoped. ────────────────
+  it("second admin (B) is denied 403 on GET+PUT; canonical owner (A) writes; body-supplied owner id ignored; rows canonical-scoped", async () => {
     await startServer({ "token-a": OWNER_A, "token-b": OWNER_B });
 
-    // A PUTs an opt-in — and the body ALSO tries to target owner B (userId /
-    // principalId / ownerId). The handler must ignore the body ids and write
-    // under the AUTHENTICATED principal (A) only.
+    // The CANONICAL owner (A = admin-001) PUTs an opt-in — the body ALSO tries to
+    // target the second admin B (userId / principalId / ownerId). The handler must
+    // ignore the body ids and write under the resolved CANONICAL owner only.
     const putRes = await put(
       { Authorization: "Bearer token-a" },
       {
@@ -287,22 +303,24 @@ describe("FridayHttpServer — /v1/uix/retention-policy real-HTTP authz + cross-
     const putBody = (await putRes.json()) as { ok: true; data: { policy: Record<string, { mode: string; days?: number }> } };
     expect(putBody.data.policy.auditLogs).toEqual({ mode: "after_days", days: 30 });
 
-    // B GETs → every category permanent (A's opt-in is NOT visible to B).
+    // The SECOND admin (B) — a distinct userId with a real hub.admin token — is
+    // REFUSED on BOTH GET and PUT: role/scope is NOT canonical-owner identity.
     const bGet = await fetch(`${baseUrl}${ROUTE}`, { headers: { Authorization: "Bearer token-b" } });
-    expect(bGet.status).toBe(200);
-    const bBody = (await bGet.json()) as { ok: true; data: { policy: Record<string, { mode: string; days?: number }> } };
-    for (const retention of Object.values(bBody.data.policy)) {
-      expect(retention.mode).toBe("permanent");
-    }
-    expect(bBody.data.policy.auditLogs).toEqual({ mode: "permanent" });
+    expect(bGet.status).toBe(403);
+    const bPut = await put(
+      { Authorization: "Bearer token-b" },
+      { policy: { auditLogs: { mode: "after_days", days: 1 } } },
+    );
+    expect(bPut.status).toBe(403);
 
     // A GETs → sees its own opt-in.
     const aGet = await fetch(`${baseUrl}${ROUTE}`, { headers: { Authorization: "Bearer token-a" } });
     const aBody = (await aGet.json()) as { ok: true; data: { policy: Record<string, { mode: string; days?: number }> } };
     expect(aBody.data.policy.auditLogs).toEqual({ mode: "after_days", days: 30 });
 
-    // Physical persistence is principal-scoped: the row lands under A's userId,
-    // NOT under B's (despite the body attempting to target B).
+    // Physical persistence is canonical-scoped: the row lands under the canonical
+    // owner id (== admin-001), NOT under B's id (despite the body targeting B),
+    // and B's denied PUT wrote nothing.
     expect(rowsFor(OWNER_A.userId)).toEqual([{ content_category: "auditLogs", after_days: 30 }]);
     expect(rowsFor(OWNER_B.userId)).toHaveLength(0);
     expect(totalRows()).toBe(1);
@@ -315,18 +333,21 @@ describe("FridayHttpServer — /v1/uix/retention-policy real-HTTP authz + cross-
       "tok-viewer": VIEWER,
       "tok-operator": OPERATOR,
       "tok-device": DEVICE_OWNER_DISABLED,
+      "tok-admin-2": OWNER_B,
       "tok-owner": OWNER_A,
     });
 
     // DENIED matrix: [label, authHeader, expectedStatus]. Anonymous / synthetic
     // and release-disabled-device → 401 (bound-principal floor); bound non-owner
-    // (viewer / operator) → 403 (owner authority required).
+    // (viewer / operator) → 403 (owner authority required); a bound owner/admin
+    // that is NOT the canonical owner (second admin) → 403 (canonical binding).
     const denied: Array<[string, Record<string, string>, number]> = [
       ["anonymous", {}, 401],
       ["invalid-bearer (synthetic fallback)", { Authorization: "Bearer nope" }, 401],
       ["viewer (session.read only)", { Authorization: "Bearer tok-viewer" }, 403],
       ["operator (no owner authority)", { Authorization: "Bearer tok-operator" }, 403],
       ["revoked/disabled device-owner", { Authorization: "Bearer tok-device" }, 401],
+      ["second admin (owner/admin role, NOT canonical owner)", { Authorization: "Bearer tok-admin-2" }, 403],
     ];
 
     for (const [, headers, expected] of denied) {

--- a/test/unit/api/http/routes/friday-retention-settings-routes.test.ts
+++ b/test/unit/api/http/routes/friday-retention-settings-routes.test.ts
@@ -12,6 +12,15 @@ import { createTestDb } from "../../../satellites/_helpers/create-test-db.helper
 
 const NOW = "2026-07-15T10:00:00.000Z";
 
+// Retention config is canonical-owner-only: a principal must carry owner/admin
+// authority (role owner/admin, which grants the hub.admin scope) to read or
+// mutate it. These handler-level tests use bound OWNER principals; the real auth
+// composition (anonymous/synthetic/viewer/operator denied) is proven end-to-end
+// against the REAL server in friday-http-server-retention-settings-authz.test.ts.
+function owner(userId: string): never {
+  return { userId, principalId: userId, role: "admin", scopes: ["hub.admin"] } as never;
+}
+
 function makeCtx(
   overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {},
 ): FridayHttpContext<unknown, unknown, unknown> {
@@ -22,7 +31,7 @@ function makeCtx(
     query: {},
     body: {},
     headers: {},
-    principal: { userId: "owner-a" } as never,
+    principal: owner("owner-a"),
     ...overrides,
   };
 }
@@ -91,18 +100,31 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
     expect(rowsFor("00000000-0000-0000-0000-000000000001")).toHaveLength(0);
   });
 
+  it("a bound NON-OWNER (viewer) is refused 403 on GET and PUT (owner-only); nothing persisted", async () => {
+    const viewer = { userId: "viewer-1", principalId: "viewer-1", role: "viewer", scopes: ["session.read"] } as never;
+    await expect(
+      getRoute().handler(makeCtx({ principal: viewer })),
+    ).rejects.toMatchObject({ httpStatus: 403 });
+    await expect(
+      putRoute().handler(
+        makeCtx({ principal: viewer, body: { policy: { auditLogs: { mode: "after_days", days: 30 } } } }),
+      ),
+    ).rejects.toMatchObject({ httpStatus: 403 });
+    expect(rowsFor("viewer-1")).toHaveLength(0);
+  });
+
   // ── 2. CROSS-OWNER ISOLATION (the class missed in #1606) ──────────────────
   it("owner A's PUT is invisible to owner B's GET; B sees only defaults", async () => {
     await putRoute().handler(
       makeCtx({
-        principal: { userId: "owner-a" } as never,
+        principal: owner("owner-a"),
         body: { policy: { auditLogs: { mode: "after_days", days: 30 } } },
       }),
     );
 
     // Owner B reads: every category permanent (no leakage of A's opt-in).
     const bResult = (await getRoute().handler(
-      makeCtx({ principal: { userId: "owner-b" } as never }),
+      makeCtx({ principal: owner("owner-b") }),
     )) as { policy: Record<string, { mode: string; days?: number }> };
     for (const [, retention] of Object.entries(bResult.policy)) {
       expect(retention.mode).toBe("permanent");
@@ -111,7 +133,7 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
 
     // Owner A reads back its own opt-in.
     const aResult = (await getRoute().handler(
-      makeCtx({ principal: { userId: "owner-a" } as never }),
+      makeCtx({ principal: owner("owner-a") }),
     )) as { policy: Record<string, { mode: string; days?: number }> };
     expect(aResult.policy.auditLogs).toEqual({ mode: "after_days", days: 30 });
 
@@ -124,7 +146,7 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
     // Body tries to target owner-b; handler must write under the principal (owner-a).
     await putRoute().handler(
       makeCtx({
-        principal: { userId: "owner-a" } as never,
+        principal: owner("owner-a"),
         body: {
           userId: "owner-b",
           principalId: "owner-b",

--- a/test/unit/api/http/routes/friday-retention-settings-routes.test.ts
+++ b/test/unit/api/http/routes/friday-retention-settings-routes.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { createFridayRetentionSettingsRoutes } from "#api";
+import type { FridayHttpContext } from "#api";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridayRetentionSettingsRepository,
+  createFridayRetentionSettingsStore,
+} from "#jobs";
+import type { FridayRetentionSettingsStore } from "#jobs";
+import { createFridayDefaultPublicHttpPrincipal } from "../../../../../src/api/http/friday-default-public-principal.js";
+import { createTestDb } from "../../../satellites/_helpers/create-test-db.helper.js";
+
+const NOW = "2026-07-15T10:00:00.000Z";
+
+function makeCtx(
+  overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {},
+): FridayHttpContext<unknown, unknown, unknown> {
+  return {
+    requestId: "req-1",
+    receivedAt: NOW,
+    params: {},
+    query: {},
+    body: {},
+    headers: {},
+    principal: { userId: "owner-a" } as never,
+    ...overrides,
+  };
+}
+
+describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
+  let db: FridaySqliteLayer;
+  let store: FridayRetentionSettingsStore;
+  let routes: ReturnType<typeof createFridayRetentionSettingsRoutes>;
+
+  let idCounter = 0;
+
+  function getRoute() {
+    return routes.find((r) => r.operationId === "uix.retention.policy.get")!;
+  }
+  function putRoute() {
+    return routes.find((r) => r.operationId === "uix.retention.policy.update")!;
+  }
+
+  function rowsFor(principalId: string): Array<{ content_category: string; after_days: number }> {
+    return db.writer
+      .prepare(
+        "SELECT content_category, after_days FROM friday_retention_settings WHERE principal_id = ? ORDER BY content_category",
+      )
+      .all(principalId) as Array<{ content_category: string; after_days: number }>;
+  }
+
+  beforeEach(() => {
+    db = createTestDb();
+    idCounter = 0;
+    store = createFridayRetentionSettingsStore({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      idGenerator: () => `ret-${String(++idCounter).padStart(4, "0")}`,
+      nowIso: () => NOW,
+    });
+    routes = createFridayRetentionSettingsRoutes({ store });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ── 1. AUTH: synthetic-public / anonymous principal is refused on GET + PUT ──
+  it("GET rejects the synthetic public principal with 401", async () => {
+    await expect(
+      getRoute().handler(makeCtx({ principal: createFridayDefaultPublicHttpPrincipal() })),
+    ).rejects.toMatchObject({ httpStatus: 401 });
+  });
+
+  it("GET rejects a null (unauthenticated) principal with 401", async () => {
+    await expect(
+      getRoute().handler(makeCtx({ principal: null })),
+    ).rejects.toMatchObject({ httpStatus: 401 });
+  });
+
+  it("PUT rejects the synthetic public principal with 401 (nothing persisted)", async () => {
+    await expect(
+      putRoute().handler(
+        makeCtx({
+          principal: createFridayDefaultPublicHttpPrincipal(),
+          body: { policy: { auditLogs: { mode: "after_days", days: 30 } } },
+        }),
+      ),
+    ).rejects.toMatchObject({ httpStatus: 401 });
+    // The synthetic public user id must not have persisted anything.
+    expect(rowsFor("00000000-0000-0000-0000-000000000001")).toHaveLength(0);
+  });
+
+  // ── 2. CROSS-OWNER ISOLATION (the class missed in #1606) ──────────────────
+  it("owner A's PUT is invisible to owner B's GET; B sees only defaults", async () => {
+    await putRoute().handler(
+      makeCtx({
+        principal: { userId: "owner-a" } as never,
+        body: { policy: { auditLogs: { mode: "after_days", days: 30 } } },
+      }),
+    );
+
+    // Owner B reads: every category permanent (no leakage of A's opt-in).
+    const bResult = (await getRoute().handler(
+      makeCtx({ principal: { userId: "owner-b" } as never }),
+    )) as { policy: Record<string, { mode: string; days?: number }> };
+    for (const [, retention] of Object.entries(bResult.policy)) {
+      expect(retention.mode).toBe("permanent");
+    }
+    expect(bResult.policy.auditLogs).toEqual({ mode: "permanent" });
+
+    // Owner A reads back its own opt-in.
+    const aResult = (await getRoute().handler(
+      makeCtx({ principal: { userId: "owner-a" } as never }),
+    )) as { policy: Record<string, { mode: string; days?: number }> };
+    expect(aResult.policy.auditLogs).toEqual({ mode: "after_days", days: 30 });
+
+    // Persistence is physically scoped: A has a row, B has none.
+    expect(rowsFor("owner-a")).toEqual([{ content_category: "auditLogs", after_days: 30 }]);
+    expect(rowsFor("owner-b")).toHaveLength(0);
+  });
+
+  it("owner id comes ONLY from the principal — a body-supplied owner id is ignored", async () => {
+    // Body tries to target owner-b; handler must write under the principal (owner-a).
+    await putRoute().handler(
+      makeCtx({
+        principal: { userId: "owner-a" } as never,
+        body: {
+          userId: "owner-b",
+          principalId: "owner-b",
+          ownerId: "owner-b",
+          policy: { agentRuns: { mode: "after_days", days: 10 } },
+        } as never,
+      }),
+    );
+    expect(rowsFor("owner-a")).toEqual([{ content_category: "agentRuns", after_days: 10 }]);
+    expect(rowsFor("owner-b")).toHaveLength(0);
+  });
+
+  // ── 3. "OFF" = clean disabled (permanent / no row) — NEVER a sentinel ─────
+  it("setting a category OFF (permanent) removes the override row — no sentinel persisted", async () => {
+    // Enable, then disable ("off").
+    await putRoute().handler(
+      makeCtx({ body: { policy: { learningEvents: { mode: "after_days", days: 45 } } } }),
+    );
+    expect(rowsFor("owner-a")).toHaveLength(1);
+
+    const offResult = (await putRoute().handler(
+      makeCtx({ body: { policy: { learningEvents: { mode: "permanent" } } } }),
+    )) as { policy: Record<string, { mode: string; days?: number }> };
+
+    // Read back = permanent; the override row is GONE (absence = permanent).
+    expect(offResult.policy.learningEvents).toEqual({ mode: "permanent" });
+    expect(rowsFor("owner-a")).toHaveLength(0);
+
+    // No sentinel number is EVER present in persisted rows: every stored
+    // after_days is a positive integer, and "off" is never a magic number.
+    for (const row of rowsFor("owner-a")) {
+      expect(Number.isInteger(row.after_days)).toBe(true);
+      expect(row.after_days).toBeGreaterThan(0);
+    }
+    // And the read-back never surfaces a sentinel days for a permanent category.
+    expect(offResult.policy.learningEvents).not.toHaveProperty("days");
+  });
+
+  it("a fresh owner GET defaults every content category to permanent (default-OFF)", async () => {
+    const result = (await getRoute().handler(makeCtx())) as {
+      policy: Record<string, { mode: string; days?: number }>;
+    };
+    const categories = Object.keys(result.policy);
+    expect(categories).toEqual(
+      expect.arrayContaining([
+        "learningEvents",
+        "heartbeats",
+        "skillRunTerminal",
+        "auditLogs",
+        "agentRuns",
+        "llmUsageRecords",
+        "errorIncidents",
+      ]),
+    );
+    for (const cat of categories) {
+      expect(result.policy[cat]).toEqual({ mode: "permanent" });
+    }
+    expect(rowsFor("owner-a")).toHaveLength(0);
+  });
+
+  // ── 4. INVALID PUT bodies → typed 400, nothing persisted ─────────────────
+  const invalidPolicies: Array<[string, unknown]> = [
+    ["bad mode", { auditLogs: { mode: "forever" } }],
+    ["days = 0", { auditLogs: { mode: "after_days", days: 0 } }],
+    ["days = -1", { auditLogs: { mode: "after_days", days: -1 } }],
+    ["days = 1.5", { auditLogs: { mode: "after_days", days: 1.5 } }],
+    ["days = NaN", { auditLogs: { mode: "after_days", days: Number.NaN } }],
+    ["days = Infinity", { auditLogs: { mode: "after_days", days: Number.POSITIVE_INFINITY } }],
+    ["days = string", { auditLogs: { mode: "after_days", days: "30" } }],
+    ["days missing", { auditLogs: { mode: "after_days" } }],
+    ["retention not object", { auditLogs: 30 }],
+    ["unknown category", { totallyBogusCategory: { mode: "after_days", days: 30 } }],
+    ["category value null", { auditLogs: null }],
+  ];
+
+  it.each(invalidPolicies)(
+    "PUT with %s → 400 and persists nothing",
+    async (_label, policy) => {
+      await expect(
+        putRoute().handler(makeCtx({ body: { policy } as never })),
+      ).rejects.toMatchObject({ httpStatus: 400 });
+      expect(rowsFor("owner-a")).toHaveLength(0);
+    },
+  );
+
+  it("a MIXED body with one invalid entry persists NOTHING (validate-then-apply)", async () => {
+    await expect(
+      putRoute().handler(
+        makeCtx({
+          body: {
+            policy: {
+              auditLogs: { mode: "after_days", days: 30 }, // valid
+              agentRuns: { mode: "after_days", days: 0 }, // invalid → whole PUT rejected
+            },
+          } as never,
+        }),
+      ),
+    ).rejects.toMatchObject({ httpStatus: 400 });
+    // Neither the valid nor the invalid entry was written.
+    expect(rowsFor("owner-a")).toHaveLength(0);
+  });
+
+  it("PUT with a non-object / missing policy → 400", async () => {
+    await expect(
+      putRoute().handler(makeCtx({ body: {} as never })),
+    ).rejects.toMatchObject({ httpStatus: 400 });
+    await expect(
+      putRoute().handler(makeCtx({ body: { policy: [] } as never })),
+    ).rejects.toMatchObject({ httpStatus: 400 });
+    await expect(
+      putRoute().handler(makeCtx({ body: null as never })),
+    ).rejects.toMatchObject({ httpStatus: 400 });
+  });
+});

--- a/test/unit/api/http/routes/friday-retention-settings-routes.test.ts
+++ b/test/unit/api/http/routes/friday-retention-settings-routes.test.ts
@@ -13,11 +13,17 @@ import { createTestDb } from "../../../satellites/_helpers/create-test-db.helper
 
 const NOW = "2026-07-15T10:00:00.000Z";
 
+// The single canonical-owner id the production reaper's policy loader is bound to
+// (hub-bootstrap wires principalId = learningDefaultUserId = "admin-001"). The
+// route binds GET/PUT to THIS id, so these handler-level tests act as it.
+const CANON = "admin-001";
+
 // Retention config is canonical-owner-only: a principal must carry owner/admin
-// authority (role owner/admin, which grants the hub.admin scope) to read or
-// mutate it. These handler-level tests use bound OWNER principals; the real auth
-// composition (anonymous/synthetic/viewer/operator denied) is proven end-to-end
-// against the REAL server in friday-http-server-retention-settings-authz.test.ts.
+// authority (role owner/admin, which grants the hub.admin scope) AND be the
+// canonical owner to read or mutate it. These handler-level tests use bound OWNER
+// principals; the real auth composition (anonymous/synthetic/viewer/operator/
+// second-admin denied) is proven end-to-end against the REAL server in
+// friday-http-server-retention-settings-authz.test.ts.
 function owner(userId: string): never {
   return { userId, principalId: userId, role: "admin", scopes: ["hub.admin"] } as never;
 }
@@ -32,7 +38,7 @@ function makeCtx(
     query: {},
     body: {},
     headers: {},
-    principal: owner("owner-a"),
+    principal: owner(CANON),
     ...overrides,
   };
 }
@@ -68,7 +74,7 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
       idGenerator: () => `ret-${String(++idCounter).padStart(4, "0")}`,
       nowIso: () => NOW,
     });
-    routes = createFridayRetentionSettingsRoutes({ store });
+    routes = createFridayRetentionSettingsRoutes({ store, resolveCanonicalOwnerId: () => CANON });
   });
 
   afterEach(() => {
@@ -114,50 +120,58 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
     expect(rowsFor("viewer-1")).toHaveLength(0);
   });
 
-  // ── 2. CROSS-OWNER ISOLATION (the class missed in #1606) ──────────────────
-  it("owner A's PUT is invisible to owner B's GET; B sees only defaults", async () => {
+  // ── 2. CANONICAL-OWNER BINDING (Advisor R3): only the canonical owner may
+  //       read/mutate; a second, distinct admin is refused; rows are canonical-
+  //       scoped and never keyed to a caller-supplied id. ────────────────────
+  it("a second admin (distinct userId, real hub.admin) is refused 403 on GET+PUT; the canonical owner's opt-in is canonical-scoped", async () => {
+    // Canonical owner writes an opt-in.
     await putRoute().handler(
       makeCtx({
-        principal: owner("owner-a"),
+        principal: owner(CANON),
         body: { policy: { auditLogs: { mode: "after_days", days: 30 } } },
       }),
     );
 
-    // Owner B reads: every category permanent (no leakage of A's opt-in).
-    const bResult = (await getRoute().handler(
-      makeCtx({ principal: owner("owner-b") }),
-    )) as { policy: Record<string, { mode: string; days?: number }> };
-    for (const [, retention] of Object.entries(bResult.policy)) {
-      expect(retention.mode).toBe("permanent");
-    }
-    expect(bResult.policy.auditLogs).toEqual({ mode: "permanent" });
+    // A SECOND admin (owner/admin role + hub.admin scope) with a DISTINCT userId
+    // is denied on BOTH GET and PUT — role/scope is not canonical-owner identity.
+    const secondAdmin = owner("admin-002");
+    await expect(
+      getRoute().handler(makeCtx({ principal: secondAdmin })),
+    ).rejects.toMatchObject({ httpStatus: 403 });
+    await expect(
+      putRoute().handler(
+        makeCtx({ principal: secondAdmin, body: { policy: { auditLogs: { mode: "after_days", days: 1 } } } }),
+      ),
+    ).rejects.toMatchObject({ httpStatus: 403 });
 
-    // Owner A reads back its own opt-in.
+    // The canonical owner reads back its own opt-in.
     const aResult = (await getRoute().handler(
-      makeCtx({ principal: owner("owner-a") }),
+      makeCtx({ principal: owner(CANON) }),
     )) as { policy: Record<string, { mode: string; days?: number }> };
     expect(aResult.policy.auditLogs).toEqual({ mode: "after_days", days: 30 });
 
-    // Persistence is physically scoped: A has a row, B has none.
-    expect(rowsFor("owner-a")).toEqual([{ content_category: "auditLogs", after_days: 30 }]);
-    expect(rowsFor("owner-b")).toHaveLength(0);
+    // Persistence is canonical-scoped: the row lands under the canonical id, and
+    // the second admin's denied PUT wrote nothing.
+    expect(rowsFor(CANON)).toEqual([{ content_category: "auditLogs", after_days: 30 }]);
+    expect(rowsFor("admin-002")).toHaveLength(0);
   });
 
-  it("owner id comes ONLY from the principal — a body-supplied owner id is ignored", async () => {
-    // Body tries to target owner-b; handler must write under the principal (owner-a).
+  it("the row is keyed to the resolved canonical owner id — a body-supplied owner id is ignored", async () => {
+    // Body tries to target a different id; the handler must write under the
+    // resolved canonical owner id (never the body, never any caller-supplied value).
     await putRoute().handler(
       makeCtx({
-        principal: owner("owner-a"),
+        principal: owner(CANON),
         body: {
-          userId: "owner-b",
-          principalId: "owner-b",
-          ownerId: "owner-b",
+          userId: "admin-002",
+          principalId: "admin-002",
+          ownerId: "admin-002",
           policy: { agentRuns: { mode: "after_days", days: 10 } },
         } as never,
       }),
     );
-    expect(rowsFor("owner-a")).toEqual([{ content_category: "agentRuns", after_days: 10 }]);
-    expect(rowsFor("owner-b")).toHaveLength(0);
+    expect(rowsFor(CANON)).toEqual([{ content_category: "agentRuns", after_days: 10 }]);
+    expect(rowsFor("admin-002")).toHaveLength(0);
   });
 
   // ── 3. "OFF" = clean disabled (permanent / no row) — NEVER a sentinel ─────
@@ -166,7 +180,7 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
     await putRoute().handler(
       makeCtx({ body: { policy: { learningEvents: { mode: "after_days", days: 45 } } } }),
     );
-    expect(rowsFor("owner-a")).toHaveLength(1);
+    expect(rowsFor(CANON)).toHaveLength(1);
 
     const offResult = (await putRoute().handler(
       makeCtx({ body: { policy: { learningEvents: { mode: "permanent" } } } }),
@@ -174,11 +188,11 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
 
     // Read back = permanent; the override row is GONE (absence = permanent).
     expect(offResult.policy.learningEvents).toEqual({ mode: "permanent" });
-    expect(rowsFor("owner-a")).toHaveLength(0);
+    expect(rowsFor(CANON)).toHaveLength(0);
 
     // No sentinel number is EVER present in persisted rows: every stored
     // after_days is a positive integer, and "off" is never a magic number.
-    for (const row of rowsFor("owner-a")) {
+    for (const row of rowsFor(CANON)) {
       expect(Number.isInteger(row.after_days)).toBe(true);
       expect(row.after_days).toBeGreaterThan(0);
     }
@@ -205,7 +219,7 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
     for (const cat of categories) {
       expect(result.policy[cat]).toEqual({ mode: "permanent" });
     }
-    expect(rowsFor("owner-a")).toHaveLength(0);
+    expect(rowsFor(CANON)).toHaveLength(0);
   });
 
   // ── 4. INVALID PUT bodies → typed 400, nothing persisted ─────────────────
@@ -229,7 +243,7 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
       await expect(
         putRoute().handler(makeCtx({ body: { policy } as never })),
       ).rejects.toMatchObject({ httpStatus: 400 });
-      expect(rowsFor("owner-a")).toHaveLength(0);
+      expect(rowsFor(CANON)).toHaveLength(0);
     },
   );
 
@@ -247,7 +261,7 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
       ),
     ).rejects.toMatchObject({ httpStatus: 400 });
     // Neither the valid nor the invalid entry was written.
-    expect(rowsFor("owner-a")).toHaveLength(0);
+    expect(rowsFor(CANON)).toHaveLength(0);
   });
 
   it("PUT with a non-object / missing policy → 400", async () => {
@@ -285,7 +299,7 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
         ),
       ).rejects.toMatchObject({ httpStatus: 400 });
       // No row was written under the owner.
-      expect(rowsFor("owner-a")).toHaveLength(0);
+      expect(rowsFor(CANON)).toHaveLength(0);
       // GET must not report the rejected window as active.
       const after = (await getRoute().handler(makeCtx())) as {
         policy: Record<string, { mode: string; days?: number }>;
@@ -305,7 +319,7 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
         }),
       ),
     ).rejects.toMatchObject({ httpStatus: 400 });
-    expect(rowsFor("owner-a")).toHaveLength(0);
+    expect(rowsFor(CANON)).toHaveLength(0);
   });
 
   it("BOUNDARY: days = 36500 (MAX) persists, reads back, and is HONORED by resolveCutoff", async () => {
@@ -315,7 +329,7 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
     )) as { policy: Record<string, { mode: string; days?: number }> };
     // Accepted + persisted at the exact boundary.
     expect(putResult.policy.auditLogs).toEqual({ mode: "after_days", days: MAX });
-    expect(rowsFor("owner-a")).toEqual([{ content_category: "auditLogs", after_days: MAX }]);
+    expect(rowsFor(CANON)).toEqual([{ content_category: "auditLogs", after_days: MAX }]);
     // Reads back active.
     const after = (await getRoute().handler(makeCtx())) as {
       policy: Record<string, { mode: string; days?: number }>;

--- a/test/unit/api/http/routes/friday-retention-settings-routes.test.ts
+++ b/test/unit/api/http/routes/friday-retention-settings-routes.test.ts
@@ -5,6 +5,7 @@ import type { FridaySqliteLayer } from "#state";
 import {
   createFridayRetentionSettingsRepository,
   createFridayRetentionSettingsStore,
+  resolveCutoff,
 } from "#jobs";
 import type { FridayRetentionSettingsStore } from "#jobs";
 import { createFridayDefaultPublicHttpPrincipal } from "../../../../../src/api/http/friday-default-public-principal.js";
@@ -259,5 +260,68 @@ describe("friday-retention-settings-routes (RETENTION-R3a)", () => {
     await expect(
       putRoute().handler(makeCtx({ body: null as never })),
     ).rejects.toMatchObject({ httpStatus: 400 });
+  });
+
+  // ── 5. OUT-OF-DOMAIN / OVERFLOW after_days → typed 400, ZERO persistence ───
+  // Advisor R2: the ACCEPTED domain must be a SUBSET of what the reaper honors.
+  // These windows are all > FRIDAY_MAX_AFTER_DAYS (36500); the largest ones the
+  // reaper's resolveCutoff silently treats as PERMANENT (null cutoff) — so if the
+  // route accepted them the API would report an ACTIVE policy production ignores.
+  // The 36500 literals below mirror FRIDAY_MAX_AFTER_DAYS (kept in sync by the
+  // domain guard test); a change to that ceiling makes these tests go RED.
+  const outOfDomainDays: Array<[string, number]> = [
+    ["100000000 (1e8 — the Advisor's boundary example)", 100_000_000],
+    ["1000000000 (1e9 — resolveCutoff returns null ⇒ unhonored)", 1_000_000_000],
+    ["Number.MAX_SAFE_INTEGER (bigint-ish)", Number.MAX_SAFE_INTEGER],
+    ["36501 (MAX + 1 — just over the product ceiling)", 36_501],
+  ];
+
+  it.each(outOfDomainDays)(
+    "PUT with days = %s → 400 and persists NOTHING (accept ⊆ honored)",
+    async (_label, days) => {
+      await expect(
+        putRoute().handler(
+          makeCtx({ body: { policy: { auditLogs: { mode: "after_days", days } } } as never }),
+        ),
+      ).rejects.toMatchObject({ httpStatus: 400 });
+      // No row was written under the owner.
+      expect(rowsFor("owner-a")).toHaveLength(0);
+      // GET must not report the rejected window as active.
+      const after = (await getRoute().handler(makeCtx())) as {
+        policy: Record<string, { mode: string; days?: number }>;
+      };
+      expect(after.policy.auditLogs).toEqual({ mode: "permanent" });
+    },
+  );
+
+  it("directly demonstrates the finding: 1e9 is unhonored (resolveCutoff null) yet must be rejected", async () => {
+    // The reaper would treat this window as permanent (null cutoff) → the route
+    // MUST refuse it so the API never reports a policy production won't honor.
+    expect(resolveCutoff(NOW, { mode: "after_days", days: 1_000_000_000 })).toBeNull();
+    await expect(
+      putRoute().handler(
+        makeCtx({
+          body: { policy: { auditLogs: { mode: "after_days", days: 1_000_000_000 } } } as never,
+        }),
+      ),
+    ).rejects.toMatchObject({ httpStatus: 400 });
+    expect(rowsFor("owner-a")).toHaveLength(0);
+  });
+
+  it("BOUNDARY: days = 36500 (MAX) persists, reads back, and is HONORED by resolveCutoff", async () => {
+    const MAX = 36_500; // == FRIDAY_MAX_AFTER_DAYS (guarded by the domain test)
+    const putResult = (await putRoute().handler(
+      makeCtx({ body: { policy: { auditLogs: { mode: "after_days", days: MAX } } } as never }),
+    )) as { policy: Record<string, { mode: string; days?: number }> };
+    // Accepted + persisted at the exact boundary.
+    expect(putResult.policy.auditLogs).toEqual({ mode: "after_days", days: MAX });
+    expect(rowsFor("owner-a")).toEqual([{ content_category: "auditLogs", after_days: MAX }]);
+    // Reads back active.
+    const after = (await getRoute().handler(makeCtx())) as {
+      policy: Record<string, { mode: string; days?: number }>;
+    };
+    expect(after.policy.auditLogs).toEqual({ mode: "after_days", days: MAX });
+    // accept == honored at the boundary: the reaper WILL honor this window.
+    expect(resolveCutoff(NOW, { mode: "after_days", days: MAX })).not.toBeNull();
   });
 });

--- a/test/unit/jobs/retention/friday-retention-after-days-domain.test.ts
+++ b/test/unit/jobs/retention/friday-retention-after-days-domain.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { runFridayMigrations, FRIDAY_SQLITE_MIGRATIONS } from "#state";
+import {
+  FRIDAY_MIN_AFTER_DAYS,
+  FRIDAY_MAX_AFTER_DAYS,
+  isValidAfterDays,
+  resolveCutoff,
+} from "#jobs";
+
+/**
+ * RETENTION-R3a Advisor round-2 — the ONE canonical `after_days` domain.
+ *
+ * Invariant: the ACCEPTED window domain `[FRIDAY_MIN_AFTER_DAYS,
+ * FRIDAY_MAX_AFTER_DAYS]` must be a SUBSET of what the reaper's `resolveCutoff`
+ * HONORS (returns a non-null cutoff for), and the v105 `CHECK` must enforce
+ * exactly that interval — so no layer can accept/persist/report-active a window
+ * production silently ignores (DATA-RETENTION-001 truthfulness). This test is the
+ * single-source-of-truth guard binding the predicate, the constants, the reaper
+ * evaluator, and the DB CHECK together.
+ */
+describe("retention after_days canonical domain (accept ⊆ honored)", () => {
+  it("isValidAfterDays accepts exactly the closed integer interval [MIN, MAX]", () => {
+    expect(FRIDAY_MIN_AFTER_DAYS).toBe(1);
+    expect(FRIDAY_MAX_AFTER_DAYS).toBe(36500);
+
+    // Inside the interval → valid.
+    for (const v of [FRIDAY_MIN_AFTER_DAYS, 30, 3650, FRIDAY_MAX_AFTER_DAYS]) {
+      expect(isValidAfterDays(v)).toBe(true);
+    }
+    // Outside / malformed → invalid.
+    for (const v of [
+      FRIDAY_MIN_AFTER_DAYS - 1, // 0
+      -1,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      FRIDAY_MAX_AFTER_DAYS + 1, // 36501
+      100_000_000,
+      1_000_000_000,
+      Number.MAX_SAFE_INTEGER,
+      "30",
+      null,
+      undefined,
+      {},
+    ]) {
+      expect(isValidAfterDays(v as never)).toBe(false);
+    }
+  });
+
+  it("every accepted window is HONORED by resolveCutoff for any realistic now (accept ⊆ honored)", () => {
+    // resolveCutoff is monotonic in `days` (larger days ⇒ more-negative cutoff ⇒
+    // closer to Date overflow), so if the MAX boundary is honored, so is every
+    // smaller accepted value. Check the extremes across a wide span of `now`.
+    const nows = [
+      "1970-01-02T00:00:00.000Z",
+      "2000-01-01T00:00:00.000Z",
+      "2026-07-15T10:00:00.000Z",
+      "2100-01-01T00:00:00.000Z",
+    ];
+    for (const now of nows) {
+      for (const days of [FRIDAY_MIN_AFTER_DAYS, 3650, FRIDAY_MAX_AFTER_DAYS]) {
+        expect(resolveCutoff(now, { mode: "after_days", days })).not.toBeNull();
+      }
+    }
+  });
+
+  it("the v105 CHECK enforces exactly [MIN, MAX] (migration bound == constants)", () => {
+    const db = new Database(":memory:");
+    try {
+      runFridayMigrations({ db, migrations: FRIDAY_SQLITE_MIGRATIONS });
+      const insert = (afterDays: number) =>
+        db
+          .prepare(
+            `INSERT INTO friday_retention_settings
+               (id, principal_id, content_category, after_days, created_at, updated_at)
+             VALUES (?, 'owner-x', 'auditLogs', ?, '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')`,
+          )
+          .run(`row-${afterDays}`, afterDays);
+
+      // Boundary-valid values are accepted by the CHECK.
+      expect(() => insert(FRIDAY_MIN_AFTER_DAYS)).not.toThrow();
+      db.prepare("DELETE FROM friday_retention_settings").run();
+      expect(() => insert(FRIDAY_MAX_AFTER_DAYS)).not.toThrow();
+      db.prepare("DELETE FROM friday_retention_settings").run();
+
+      // Out-of-domain values are rejected fail-closed by the CHECK. Using the
+      // constants here ties the migration bound to them: if the ceiling constant
+      // and the migration CHECK ever diverge, one of these assertions goes RED.
+      expect(() => insert(FRIDAY_MAX_AFTER_DAYS + 1)).toThrow(/CHECK/i);
+      expect(() => insert(FRIDAY_MIN_AFTER_DAYS - 1)).toThrow(/CHECK/i);
+      expect(() => insert(-1)).toThrow(/CHECK/i);
+      expect(() => insert(1_000_000_000)).toThrow(/CHECK/i);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/test/unit/jobs/retention/friday-retention-live-policy-reload.test.ts
+++ b/test/unit/jobs/retention/friday-retention-live-policy-reload.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridaySatellitePairingRequestRepository,
+  createFridaySatelliteHeartbeatRepository,
+  createFridayOutboxMessageRepository,
+} from "#satellites";
+import { createFridayLearningEventLedger, createFridaySkillRunStore } from "#ledger";
+import { createFridaySetupBootstrapNonceRepository } from "#api";
+import {
+  createFridayRetentionJob,
+  createFridayRetentionPolicyLoader,
+  createFridayRetentionSettingsRepository,
+  createFridayRetentionSettingsStore,
+  FRIDAY_DEFAULT_RETENTION_POLICY,
+} from "#jobs";
+import type { FridayRetentionJob, FridayRetentionSettingsStore } from "#jobs";
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * RETENTION-R3a P0-1 — LIVE-REVOCATION (opt-out stops deletion without restart).
+ *
+ * The reaper must obtain the CURRENT persisted policy at each sweep (not a startup
+ * snapshot). When the owner sets a category back to permanent, the VERY NEXT sweep
+ * must delete 0 for it — the destructive scenario the Advisor reproduced. All
+ * proofs go through the REAL job + REAL store + REAL loader (no mocks). FAIL-CLOSED
+ * is preserved: any live-read failure ⇒ all-permanent ⇒ 0 deletes.
+ */
+describe("FridayRetentionJob — LIVE per-sweep policy re-read (opt-out stops deletion)", () => {
+  let db: FridaySqliteLayer;
+  const OWNER = "admin-001";
+  const NOW = "2025-06-15T10:00:00.000Z";
+  const AGED = "2024-01-01T00:00:00.000Z";
+
+  const pairingRequestRepo = createFridaySatellitePairingRequestRepository();
+  const heartbeatRepo = createFridaySatelliteHeartbeatRepository();
+  const outboxRepo = createFridayOutboxMessageRepository();
+  const bootstrapNonceRepo = createFridaySetupBootstrapNonceRepository();
+
+  let store: FridayRetentionSettingsStore;
+  let idc = 0;
+
+  function seedAgedAudit(id: string) {
+    db.writer
+      .prepare(
+        `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+         VALUES (?, ?, 'user', 'u1', 'create', 'skill', 's1')`,
+      )
+      .run(id, AGED);
+  }
+  function auditCount(): number {
+    return (db.writer.prepare("SELECT COUNT(*) c FROM audit_logs").get() as { c: number }).c;
+  }
+
+  /** A job wired the way production wires it: live per-sweep policy re-read. */
+  function makeLiveJob(loadPolicy: () => ReturnType<ReturnType<typeof createFridayRetentionPolicyLoader>["load"]>): FridayRetentionJob {
+    return createFridayRetentionJob({
+      db,
+      pairingRequestRepo,
+      heartbeatRepo,
+      outboxRepo,
+      learningLedger: createFridayLearningEventLedger({ db }),
+      skillRunStore: createFridaySkillRunStore({ db }),
+      bootstrapNonceRepo,
+      nowIso: () => NOW,
+      loadPolicy,
+    });
+  }
+
+  function liveLoader() {
+    const loader = createFridayRetentionPolicyLoader({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      principalId: OWNER,
+    });
+    return () => loader.load();
+  }
+
+  beforeEach(() => {
+    db = createTestDb();
+    idc = 0;
+    store = createFridayRetentionSettingsStore({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      idGenerator: () => `ret-${String(++idc).padStart(4, "0")}`,
+      nowIso: () => NOW,
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("(a)->(b) enable deletes; then opt-OUT (permanent) → the VERY NEXT sweep deletes 0 (no restart)", () => {
+    const job = makeLiveJob(liveLoader());
+
+    // (a) OPT-IN: enable a 90-day window for auditLogs → next sweep deletes aged.
+    store.applyOwnerContentPolicy({
+      principalId: OWNER,
+      updates: { auditLogs: { mode: "after_days", days: 90 } },
+    });
+    seedAgedAudit("al-1");
+    expect(job.run(NOW).deletedAuditLogs).toBe(1);
+    expect(auditCount()).toBe(0);
+
+    // (b) OPT-OUT: set it back to permanent. The SAME already-running job's next
+    // sweep must delete 0 (this is the destructive case, now fixed).
+    store.applyOwnerContentPolicy({
+      principalId: OWNER,
+      updates: { auditLogs: { mode: "permanent" } },
+    });
+    seedAgedAudit("al-2");
+    expect(job.run(NOW).deletedAuditLogs).toBe(0);
+    expect(auditCount()).toBe(1); // the aged row SURVIVES the opt-out
+  });
+
+  it("(f) rollback round-trip: enable→delete, disable→0, re-enable→delete — all on ONE running job", () => {
+    const job = makeLiveJob(liveLoader());
+
+    store.applyOwnerContentPolicy({ principalId: OWNER, updates: { auditLogs: { mode: "after_days", days: 90 } } });
+    seedAgedAudit("r1");
+    expect(job.run(NOW).deletedAuditLogs).toBe(1);
+
+    store.applyOwnerContentPolicy({ principalId: OWNER, updates: { auditLogs: { mode: "permanent" } } });
+    seedAgedAudit("r2");
+    expect(job.run(NOW).deletedAuditLogs).toBe(0);
+    expect(auditCount()).toBe(1);
+
+    store.applyOwnerContentPolicy({ principalId: OWNER, updates: { auditLogs: { mode: "after_days", days: 90 } } });
+    expect(job.run(NOW).deletedAuditLogs).toBe(1); // r2 now swept
+    expect(auditCount()).toBe(0);
+  });
+
+  it("(d) race: whichever value is COMMITTED before a sweep is honored (no stale delete)", () => {
+    const job = makeLiveJob(liveLoader());
+
+    // Commit an opt-in, then commit an opt-OUT just before the sweep → sweep
+    // honors the committed (permanent) value → 0 deletes.
+    store.applyOwnerContentPolicy({ principalId: OWNER, updates: { auditLogs: { mode: "after_days", days: 90 } } });
+    store.applyOwnerContentPolicy({ principalId: OWNER, updates: { auditLogs: { mode: "permanent" } } });
+    seedAgedAudit("race-1");
+    expect(job.run(NOW).deletedAuditLogs).toBe(0);
+
+    // Now commit an opt-in just before the sweep → sweep honors it → deletes.
+    store.applyOwnerContentPolicy({ principalId: OWNER, updates: { auditLogs: { mode: "after_days", days: 90 } } });
+    expect(job.run(NOW).deletedAuditLogs).toBe(1);
+  });
+
+  it("(c) no in-memory staleness: a freshly-built loader after opt-out also yields permanent → 0 deletes", () => {
+    store.applyOwnerContentPolicy({ principalId: OWNER, updates: { auditLogs: { mode: "after_days", days: 90 } } });
+    seedAgedAudit("c-1");
+    expect(makeLiveJob(liveLoader()).run(NOW).deletedAuditLogs).toBe(1);
+
+    store.applyOwnerContentPolicy({ principalId: OWNER, updates: { auditLogs: { mode: "permanent" } } });
+    seedAgedAudit("c-2");
+    // A brand-new loader/job (as if reconstructed) must not resurrect the old opt-in.
+    expect(makeLiveJob(liveLoader()).run(NOW).deletedAuditLogs).toBe(0);
+    expect(auditCount()).toBe(1);
+  });
+
+  it("(e) FAIL-CLOSED: a live loadPolicy that THROWS mid-run ⇒ all-permanent ⇒ 0 deletes (never throws)", () => {
+    const job = makeLiveJob(() => {
+      throw new Error("simulated live policy read failure");
+    });
+    seedAgedAudit("e-1");
+    let deleted = -1;
+    expect(() => {
+      deleted = job.run(NOW).deletedAuditLogs;
+    }).not.toThrow();
+    expect(deleted).toBe(0);
+    expect(auditCount()).toBe(1);
+  });
+
+  it("(e) FAIL-CLOSED: an unreadable store (dropped table) live-read ⇒ all-permanent ⇒ 0 deletes", () => {
+    // Enable first, then corrupt the store: the live loader must fail closed.
+    store.applyOwnerContentPolicy({ principalId: OWNER, updates: { auditLogs: { mode: "after_days", days: 90 } } });
+    seedAgedAudit("e-2");
+    db.writer.exec("DROP TABLE friday_retention_settings");
+    const result = makeLiveJob(liveLoader()).run(NOW);
+    expect(result.deletedAuditLogs).toBe(0);
+    expect(auditCount()).toBe(1);
+  });
+
+  it("sanity: the live default (no opt-in) equals the all-permanent production default ⇒ 0 deletes", () => {
+    seedAgedAudit("s-1");
+    const policy = createFridayRetentionPolicyLoader({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      principalId: OWNER,
+    }).load();
+    expect(policy).toEqual(FRIDAY_DEFAULT_RETENTION_POLICY);
+    expect(makeLiveJob(liveLoader()).run(NOW).deletedAuditLogs).toBe(0);
+  });
+});

--- a/test/unit/jobs/retention/friday-retention-policy-loader.test.ts
+++ b/test/unit/jobs/retention/friday-retention-policy-loader.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridaySatellitePairingRequestRepository,
+  createFridaySatelliteHeartbeatRepository,
+  createFridayOutboxMessageRepository,
+} from "#satellites";
+import { createFridayLearningEventLedger, createFridaySkillRunStore } from "#ledger";
+import { createFridaySetupBootstrapNonceRepository } from "#api";
+import {
+  createFridayRetentionJob,
+  createFridayRetentionPolicyLoader,
+  createFridayRetentionSettingsRepository,
+  createFridayRetentionSettingsStore,
+  FRIDAY_DEFAULT_RETENTION_POLICY,
+} from "#jobs";
+import type { FridayRetentionPolicy, FridayRetentionSettingsRepository } from "#jobs";
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+
+/**
+ * RETENTION-R3a loader fail-closed proof.
+ *
+ * The loader resolves the reaper's `FridayRetentionPolicy` from persisted owner
+ * settings. On any missing / unreadable / partial / invalid state it MUST fall
+ * back to all-permanent so a run over aged fixtures deletes ZERO rows.
+ */
+describe("createFridayRetentionPolicyLoader — FAIL-CLOSED", () => {
+  let db: FridaySqliteLayer;
+  const OWNER = "owner-x";
+  const NOW = "2025-06-15T10:00:00.000Z";
+  const FAR_FUTURE = "2099-01-01T00:00:00.000Z";
+  const AGED = "2024-01-01T00:00:00.000Z";
+
+  const pairingRequestRepo = createFridaySatellitePairingRequestRepository();
+  const heartbeatRepo = createFridaySatelliteHeartbeatRepository();
+  const outboxRepo = createFridayOutboxMessageRepository();
+  const bootstrapNonceRepo = createFridaySetupBootstrapNonceRepository();
+
+  function insertSatellite(id: string) {
+    db.writer
+      .prepare(
+        `INSERT INTO satellites (id, type, display_name, pairing_status, trust_level, public_key,
+         token_version, transport, platform, arch, app_version, node_version, tags_json, created_at, updated_at)
+         VALUES (?, 'phone', 'Test', 'online', 'restricted', 'pk', 1, 'ws', 'linux', 'arm64', '1.0', '22.0', '[]', ?, ?)`,
+      )
+      .run(id, NOW, NOW);
+  }
+
+  function seedAllContentCategories() {
+    db.writer
+      .prepare(
+        `INSERT INTO audit_logs (id, ts, actor_type, actor_id, action, resource_type, resource_id)
+         VALUES ('al-old', ?, 'user', 'u1', 'create', 'skill', 's1')`,
+      )
+      .run(AGED);
+    db.writer
+      .prepare(
+        `INSERT INTO friday_agent_runs (id, session_key, task, status, created_at)
+         VALUES ('run-old', 'cli:u1:chat', 'old task', 'completed', ?)`,
+      )
+      .run(AGED);
+    createFridaySkillRunStore({ db }).upsertRun({
+      runId: "srun-old",
+      skillId: "s",
+      version: "1.0",
+      status: "completed",
+      currentStepId: "step",
+      attemptsByStep: {},
+      state: {},
+      startedAt: AGED,
+      updatedAt: AGED,
+      sessionId: "sess",
+      userId: "test-user",
+      channel: "discord",
+      lastTransitionAt: AGED,
+    });
+    db.writer
+      .prepare(
+        `INSERT INTO learning_events (event_id, ts, user_id, kind, payload_json, created_at)
+         VALUES ('evt-old', ?, 'test-user', 'user_message', '{}', ?)`,
+      )
+      .run(AGED, AGED);
+    db.writer
+      .prepare(
+        `INSERT INTO llm_usage_records (id, occurred_at, usage_day, usage_month, provider_id, provider_kind, provider_api, model,
+         route_strategy, task_complexity, input_tokens, output_tokens, total_tokens, cost_usd, created_at)
+         VALUES ('llm-old', ?, '2024-01-01', '2024-01', 'p1', 'api', 'anthropic', 'm1',
+         'configured', 'simple', 100, 50, 150, 0.01, ?)`,
+      )
+      .run(AGED, AGED);
+    db.writer
+      .prepare(
+        `INSERT INTO error_incidents (incident_id, user_id, ts, category, severity, signature, context_json, status, created_at, updated_at)
+         VALUES ('ei-old', 'test-user', ?, 'tool', 'low', 'sig1', '{}', 'resolved', ?, ?)`,
+      )
+      .run(AGED, AGED, AGED);
+    db.writer
+      .prepare(
+        `INSERT INTO satellite_heartbeats (id, satellite_id, ts, status)
+         VALUES ('hb-old', 'sat-1', ?, 'online')`,
+      )
+      .run(AGED);
+  }
+
+  function makeJob(policy: FridayRetentionPolicy) {
+    return createFridayRetentionJob({
+      db,
+      pairingRequestRepo,
+      heartbeatRepo,
+      outboxRepo,
+      learningLedger: createFridayLearningEventLedger({ db }),
+      skillRunStore: createFridaySkillRunStore({ db }),
+      bootstrapNonceRepo,
+      nowIso: () => NOW,
+      policy,
+    });
+  }
+
+  function expectZeroContentDeletes(policy: FridayRetentionPolicy) {
+    const result = makeJob(policy).run(FAR_FUTURE);
+    expect(result.deletedAuditLogs).toBe(0);
+    expect(result.deletedAgentRuns).toBe(0);
+    expect(result.deletedSkillRuns).toBe(0);
+    expect(result.deletedLearningEvents).toBe(0);
+    expect(result.deletedLlmUsageRecords).toBe(0);
+    expect(result.deletedErrorIncidents).toBe(0);
+    expect(result.deletedHeartbeats).toBe(0);
+  }
+
+  beforeEach(() => {
+    db = createTestDb();
+    insertSatellite("sat-1");
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("FRESH INSTALL (no persisted policy) ⇒ all-permanent ⇒ reaper deletes 0 (default-OFF)", () => {
+    seedAllContentCategories();
+    const loader = createFridayRetentionPolicyLoader({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      principalId: OWNER,
+    });
+    const policy = loader.load();
+    // Every content category resolves permanent; security TTLs = defaults.
+    expect(policy).toEqual(FRIDAY_DEFAULT_RETENTION_POLICY);
+    expectZeroContentDeletes(policy);
+  });
+
+  it("UNREADABLE store (table dropped) ⇒ all-permanent ⇒ reaper deletes 0", () => {
+    seedAllContentCategories();
+    // Corrupt the store: the settings table no longer exists.
+    db.writer.exec("DROP TABLE friday_retention_settings");
+    const loader = createFridayRetentionPolicyLoader({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      principalId: OWNER,
+    });
+    const policy = loader.load();
+    expect(policy).toEqual(FRIDAY_DEFAULT_RETENTION_POLICY);
+    expectZeroContentDeletes(policy);
+  });
+
+  it("repo that THROWS on read ⇒ loader never throws, returns all-permanent", () => {
+    seedAllContentCategories();
+    const throwingRepo: FridayRetentionSettingsRepository = {
+      listByPrincipal: () => {
+        throw new Error("simulated unreadable store");
+      },
+      upsertAfterDays: () => {
+        /* unused */
+      },
+      deleteCategory: () => false,
+    };
+    const loader = createFridayRetentionPolicyLoader({ db, repo: throwingRepo, principalId: OWNER });
+    let policy: FridayRetentionPolicy | undefined;
+    expect(() => {
+      policy = loader.load();
+    }).not.toThrow();
+    expect(policy).toEqual(FRIDAY_DEFAULT_RETENTION_POLICY);
+    expectZeroContentDeletes(policy!);
+  });
+
+  it("PARTIAL / unknown-category row ⇒ ignored (fail closed) ⇒ reaper deletes 0", () => {
+    seedAllContentCategories();
+    // A row for a category the loader does not recognise must be ignored.
+    db.writer
+      .prepare(
+        `INSERT INTO friday_retention_settings (id, principal_id, content_category, after_days, created_at, updated_at)
+         VALUES ('bogus-1', ?, 'totallyBogusCategory', 5, ?, ?)`,
+      )
+      .run(OWNER, NOW, NOW);
+    const loader = createFridayRetentionPolicyLoader({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      principalId: OWNER,
+    });
+    const policy = loader.load();
+    expect(policy).toEqual(FRIDAY_DEFAULT_RETENTION_POLICY);
+    expectZeroContentDeletes(policy);
+  });
+
+  it("VALID persisted opt-in IS loaded and drives ONLY that category (loader wired, not trivially permanent)", () => {
+    seedAllContentCategories();
+    // Persist a real opt-in for auditLogs via the production store.
+    let idc = 0;
+    const store = createFridayRetentionSettingsStore({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      idGenerator: () => `ret-${++idc}`,
+      nowIso: () => NOW,
+    });
+    store.applyOwnerContentPolicy({
+      principalId: OWNER,
+      updates: { auditLogs: { mode: "after_days", days: 90 } },
+    });
+
+    const loader = createFridayRetentionPolicyLoader({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      principalId: OWNER,
+    });
+    const policy = loader.load();
+    expect(policy.auditLogs).toEqual({ mode: "after_days", days: 90 });
+    // Everything else stayed permanent.
+    expect(policy.agentRuns).toEqual({ mode: "permanent" });
+    expect(policy.learningEvents).toEqual({ mode: "permanent" });
+    // Security-lifecycle TTLs are never owner-touchable.
+    expect(policy.pairingRequestsDays).toBe(FRIDAY_DEFAULT_RETENTION_POLICY.pairingRequestsDays);
+    expect(policy.outboxTerminalDays).toBe(FRIDAY_DEFAULT_RETENTION_POLICY.outboxTerminalDays);
+    expect(policy.bootstrapNoncesConsumedDays).toBe(
+      FRIDAY_DEFAULT_RETENTION_POLICY.bootstrapNoncesConsumedDays,
+    );
+
+    // Reaper at NOW (aged rows are > 90d old) deletes ONLY auditLogs.
+    const result = makeJob(policy).run(NOW);
+    expect(result.deletedAuditLogs).toBe(1);
+    expect(result.deletedAgentRuns).toBe(0);
+    expect(result.deletedLearningEvents).toBe(0);
+    expect(result.deletedLlmUsageRecords).toBe(0);
+    expect(result.deletedErrorIncidents).toBe(0);
+    expect(result.deletedSkillRuns).toBe(0);
+    expect(result.deletedHeartbeats).toBe(0);
+  });
+});

--- a/test/unit/jobs/retention/friday-retention-policy-loader.test.ts
+++ b/test/unit/jobs/retention/friday-retention-policy-loader.test.ts
@@ -12,6 +12,7 @@ import {
   createFridayRetentionPolicyLoader,
   createFridayRetentionSettingsRepository,
   createFridayRetentionSettingsStore,
+  resolveCutoff,
   FRIDAY_DEFAULT_RETENTION_POLICY,
 } from "#jobs";
 import type { FridayRetentionPolicy, FridayRetentionSettingsRepository } from "#jobs";
@@ -199,6 +200,49 @@ describe("createFridayRetentionPolicyLoader — FAIL-CLOSED", () => {
     });
     const policy = loader.load();
     expect(policy).toEqual(FRIDAY_DEFAULT_RETENTION_POLICY);
+    expectZeroContentDeletes(policy);
+  });
+
+  it("OUT-OF-DOMAIN (legacy) row ⇒ loader + store fail closed to permanent; reaper deletes 0 (Advisor R2)", () => {
+    seedAllContentCategories();
+    // Inject a persisted after_days the reaper will NOT honor (resolveCutoff → null):
+    // 1e9 days overflows JS Date. Bypass the tightened v105 CHECK with
+    // ignore_check_constraints to simulate a legacy / corrupt row that predates the
+    // domain bound (defense-in-depth: the loader must fail closed even if such a row
+    // ever exists).
+    const HUGE = 1_000_000_000;
+    expect(resolveCutoff(NOW, { mode: "after_days", days: HUGE })).toBeNull(); // proven UNHONORED
+    db.writer.pragma("ignore_check_constraints = ON");
+    db.writer
+      .prepare(
+        `INSERT INTO friday_retention_settings (id, principal_id, content_category, after_days, created_at, updated_at)
+         VALUES ('legacy-huge', ?, 'auditLogs', ?, ?, ?)`,
+      )
+      .run(OWNER, HUGE, NOW, NOW);
+    db.writer.pragma("ignore_check_constraints = OFF");
+
+    // Loader (reaper side) must treat the out-of-domain window as PERMANENT.
+    const loader = createFridayRetentionPolicyLoader({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      principalId: OWNER,
+    });
+    const policy = loader.load();
+    expect(policy.auditLogs).toEqual({ mode: "permanent" });
+    expect(policy).toEqual(FRIDAY_DEFAULT_RETENTION_POLICY);
+
+    // GET (store read) must NOT surface it as active either.
+    const store = createFridayRetentionSettingsStore({
+      db,
+      repo: createFridayRetentionSettingsRepository(),
+      idGenerator: () => "unused",
+      nowIso: () => NOW,
+    });
+    expect(store.readOwnerContentPolicy({ principalId: OWNER }).auditLogs).toEqual({
+      mode: "permanent",
+    });
+
+    // Reaper deletes 0 for that category (the aged audit row survives).
     expectZeroContentDeletes(policy);
   });
 


### PR DESCRIPTION
Deployment restart required: Rust services must be restarted after additive SQLite migration v105 (`friday_retention_settings`) lands, so the deployed hub applies the new schema and the retention-Settings loader/routes take effect before the `/v1/uix/retention-policy` surface is exercised in production. Concrete sequence: redeploy the freshly built hub, then kickstart the launchd job with `launchctl kickstart -k gui/$(id -u)/com.friday.hub`, then verify `/healthz` is up and the migration runner reports version 105.

## Summary

Adds an **owner-bound, per-content-category retention Settings** read+write API with durable persistence and restart-readback (lane **RETENTION-R3a**), governed by **DATA-RETENTION-001**: local data is default-permanent, auto-cleanup is default-OFF, opt-in per content category, "off" is a clean disabled state (never a sentinel), and the reaper stays fail-closed.

**Scope — backend only.** Desktop/Mobile UI wiring is **OUT/deferred**. No `/v1/observability/*` growth-readback surface is added or touched. **This PR does NOT by itself close DATA-RETENTION-001** — it adds the per-category opt-in *control surface* that a later UI + operator review builds on.

## Review follow-up — two P0 fixes (Advisor audit)

**P0-1 — live-revocation (no destructive stale deletion).** The running hourly reaper now re-reads the **current** persisted policy at the **start of every sweep** instead of a startup snapshot. When the owner sets a category back to permanent (opt-out), the **very next sweep deletes 0** for it — no process restart needed. Wiring: `createFridayRetentionJob` gained a `loadPolicy` provider (per-run resolve); the satellite runtime forwards a `retentionPolicyProvider`; hub-bootstrap passes `() => retentionPolicyLoader.load()`. **Reaper deletion logic is otherwise unchanged.** FAIL-CLOSED preserved at two layers: the loader returns all-permanent on any read failure, and the job additionally wraps the live read in try/catch (throw/nullish ⇒ all-permanent ⇒ 0 deletes).

**P0-2 — canonical-owner authorization (SEC-NET-PRINCIPAL-001).** Retention config governs global content deletion, so **both GET and PUT are now owner-only**. Reuses the **exact** mechanism the owner-only `runtime.secret.*` routes use — `assertBoundPrincipalAuthorityForOperation(principal, op, "api", {anyOfScopes:["hub.admin"], anyOfRoles:["owner","admin"]})` — no new authz model. Synthetic-public / release-disabled-or-revoked device principals → **401** (bound-principal floor); a bound but non-owner principal (viewer / operator) → **403**. The canonical local owner authenticates as role owner/admin (which carries the `hub.admin` scope) via the local passphrase → bearer flow. Two new operations (`retention.policy.read` / `retention.policy.update`) were added to `FridayPublicMutationOperation`. **This owner/admin-role floor is retained as defense in depth but is NOT sufficient on its own — see Advisor round 3, which binds to the exact canonical-owner identity the reaper consumes.**

## Advisor round 2 — unified `after_days` valid-domain (accept ⊆ honored)

**Finding.** The ACCEPTED Settings domain was WIDER than the reaper's HONORED domain: request parsing and the DB `CHECK` accepted **every** positive integer, but `resolveCutoff` fails closed to permanent for windows whose cutoff overflows JS `Date` (`after_days` beyond ~1e8 days). So a large window (e.g. `1_000_000_000`) persisted + read back **active**, yet the reaper silently performed **permanent** retention — the API reported a policy production does not honor (DATA-RETENTION-001 truthfulness violation).

**Fix — ONE canonical valid domain, enforced at every layer (accept ⊆ honored).** New shared `FRIDAY_MIN_AFTER_DAYS = 1` / `FRIDAY_MAX_AFTER_DAYS = 36500` (≈ 100 years) + `isValidAfterDays()` in `friday-retention.types.ts` — a sane product ceiling well inside what `resolveCutoff` honors for any realistic `now` (≥ 1970), so no accepted value is ever unhonored. `resolveCutoff` is unchanged and remains the source of truth.
- **Request parsing** (`friday-retention-settings-routes.ts` PUT): out-of-domain `after_days` → typed **400**, **zero persistence**.
- **DB `CHECK`** (migration v105 — NEW and not yet applied to prod, so tightened in place): `CHECK (after_days >= 1 AND after_days <= 36500)`, still NOT NULL, additive/idempotent; a guard test ties the CHECK bound to the constants (migration SQL keeps the literals frozen).
- **Store + loader read-back**: an out-of-domain / legacy row fails closed to `{mode:"permanent"}` — never surfaced active (defense in depth).

**Red-first:** the overflow/out-of-range and loader-fail-closed tests were written first and confirmed **RED on the prior head** (`days = 1e8 / 1e9 / MAX_SAFE / 36501` persisted + read back active), then **GREEN after the fix**. A boundary test proves `days = 36500` persists + reloads across a store reopen + `resolveCutoff(36500)` is non-null (accept == honored at the boundary), and `36501` is rejected. New `test/unit/jobs/retention/friday-retention-after-days-domain.test.ts` guards the domain (predicate, accept ⊆ honored at the boundary, and the migration CHECK bound). **Backend-only; UI still OUT; does not by itself close DATA-RETENTION-001.**

## Advisor round 3 — bind GET/PUT to the exact canonical-owner identity the reaper consumes (P0)

New head: `b894b6bbbaa7d2ace94812f290c86538329b8879` (additive commit on `f4a5b63000518f6bcddabbc387d14c86269a9fde`; base main unchanged).

**Finding.** The round-2/P0-2 floor authorized **any** owner/admin-role principal and then keyed the retention-policy row to the caller's **arbitrary** `principal.userId`. But the product fixes a **single canonical owner** (`learningDefaultUserId = admin-001`) and production's reaper reads **only** that id. A **different**, legitimately-authenticated admin (`admin-002` — the schema permits multiple users, and email/password login mints each a role-derived `hub.admin` token) was **accepted → 200 active-policy readback → persisted an `admin-002` override**, while the production-equivalent `admin-001` loader stayed permanent and deleted **zero** rows. Role/scope is NOT canonical-owner identity (SEC-NET-PRINCIPAL-001), and accept ≠ honored end-to-end (DATA-RETENTION-001 truthfulness).

**Fix (this direction; role/scope floor kept as defense in depth).**
- **Canonical-owner identity is resolved from the SAME source the reaper consumes.** A `resolveCanonicalOwnerId` provider is threaded into `FridayRetentionSettingsRoutesDeps`; hub-bootstrap wires it as `() => learningDefaultUserId` — the exact binding the reaper's policy loader already uses (`principalId: learningDefaultUserId`). Not a per-request caller value, not a route literal.
- **Both GET and PUT now require `principal.userId === resolveCanonicalOwnerId()`** (in addition to the bound-principal + owner/admin floor). A second, legitimately-authenticated admin → **403**, **zero persistence, zero readback**.
- **Policy rows are keyed to the resolved canonical owner id**, never a caller-supplied value — so what is accepted/persisted is exactly what the per-sweep reaper reads (accept == honored).
- **FAIL-CLOSED** if the canonical owner id cannot be resolved (provider returns null/undefined/blank or throws) → **403** typed error, zero effect; never falls open to "any admin".

**Red-first (through the REAL `createFridayHttpServer` + real store + real reaper loader).** New `test/unit/api/http/friday-http-server-retention-canonical-owner-authz.test.ts` (5 tests): on the prior head `f4a5b630` the `admin-002` probe received **200** and every fail-closed case received **200** (RED confirmed: 4 failed, canonical-positive passed as a regression guard); after the fix `admin-002` → **403** with zero rows and zero deletion effect, the canonical owner's opt-in is **honored by the same per-sweep loader** the reaper uses, and null/throwing/blank providers → **403** zero-effect. The gap-institutionalizing tests that treated two distinct admins as valid canonical owners were **corrected** (authz + handler-level routes tests): the second admin is now denied; the canonical owner (`admin-001`) is the only accepted principal; rows are canonical-scoped. Round-1 (live-revocation) and round-2 (`after_days` domain) suites stay **green and load-bearing**.

**Backend-only; UI still OUT; does NOT by itself close DATA-RETENTION-001.**

## New surface

- `GET /v1/uix/retention-policy` → the caller-owner's effective per-content-category policy (defaults every category to `{mode:"permanent"}`).
- `PUT /v1/uix/retention-policy` → owner sets each content category to `{mode:"permanent"}` (clean "off" — the override row is removed) or `{mode:"after_days",days:N}` (N a **positive integer**). Invalid bodies → typed **400**, nothing persisted (validate-then-apply in one transaction).

Both handlers derive the owner id **only** from `requireUserId(ctx.principal)` — the exact pattern reused verbatim from `friday-uix-routes.ts` — never from the request body or params, and scope every read/write to that id.

## Persistence choice — dedicated table (not reused `uix_user_preferences`)

I chose a **dedicated owner-scoped table** (`v105-retention-settings`) rather than a reserved `uix_user_preferences` category, because reuse is **unclean** for concrete schema/type reasons:

1. `FridayUserPreferenceCategory` is a **closed union** with no `retention`. Storing retention rows through the shared repo forces either adding `retention` to that union (making it a first-class *generic* preference category) or a type-cast.
2. The table would be **shared**: the generic `GET /v1/uix/preferences?category=` handler does a **raw-string cast** on the query param, so retention rows would be **readable** through the generic listing and a discovered row id would be **deletable** via `DELETE /v1/uix/preferences/:id` — coupling the typed, validated retention control surface to an unvalidated sibling path.

The dedicated table `friday_retention_settings` (unique `(principal_id, content_category)`, mirroring the `uix_user_preferences` owner-scoping shape) gives a purpose-built schema where **row-absence = permanent** (natural clean "off") and `CHECK (after_days >= 1 AND after_days <= 36500)` makes both a sentinel and an out-of-domain (unhonored) window **structurally impossible** to persist. The typed API is the only write path, fully isolated from the generic prefs surface. Migration is additive + idempotent (`CREATE TABLE IF NOT EXISTS` + indexes), removes/alters nothing.

"No sentinel, accept ⊆ honored" is thus enforced at **four layers**: API validation (`isValidAfterDays` → out-of-domain / ≤0 / non-integer / NaN / Infinity → 400), the store write guard, the store/loader read-back guard (fail closed to permanent), and the DB `CHECK` — all pinned to the single canonical `[FRIDAY_MIN_AFTER_DAYS, FRIDAY_MAX_AFTER_DAYS]` domain.

## Owner-binding reuse

- `requireUserId(principal)` copied verbatim from `friday-uix-routes.ts` (throws `UNAUTHORIZED` / 401 for the synthetic-public or unauthenticated principal, or when `principal.userId` is absent).
- Persistence mirrors `friday-uix-user-preference-repository.ts`: every query scoped by `principal_id`, upsert-on-conflict.
- Route classified in `FRIDAY_SENSITIVE_READ_ROUTE_PREFIXES` (exact path `/v1/uix/retention-policy`) alongside the sibling personal `/v1/uix/user-profile` and `/v1/uix/learned-facts` entries.

## Loader + wiring (fail-closed)

- `friday-retention-policy-loader.ts` resolves the reaper's `FridayRetentionPolicy` from the persisted owner policy at wiring/startup. **Never throws.** On unreadable / missing / partial / unknown-category / invalid state → the affected content category resolves to `{mode:"permanent"}`; a total read failure returns `FRIDAY_DEFAULT_RETENTION_POLICY`. The security-lifecycle TTLs (`pairingRequestsDays` / `outboxTerminalDays` / `bootstrapNoncesConsumedDays`) are **never** owner-configurable through this surface — always taken from the default policy.
- Wired in `friday-hub-bootstrap.ts`: the loader result feeds the `retentionPolicy` param of `createFridaySatelliteRuntime` (previously always defaulted to all-permanent). **Reaper logic is unchanged.** The owner id is the seeded single-owner user (`learningDefaultUserId` = `admin-001`), which is the same `principal_id` the API writes under (`requireUserId` → `principal.userId`), so a restart re-reads exactly what the owner set.

## Negative-test matrix (acceptance criteria)

`test/unit/api/http/routes/friday-retention-settings-routes.test.ts` (27 tests, incl. round-2 out-of-domain / boundary; round-3 corrected):
- **401** for anonymous / synthetic-public principal on **GET and PUT** (and PUT persists nothing).
- **Canonical-owner binding** (round-3, corrected from the earlier two-owner isolation test): the canonical owner writes; a **second, distinct admin** (real `hub.admin` token) → **403** on GET and PUT (role/scope is not canonical-owner identity); the row is keyed to the resolved canonical owner id and a **body-supplied owner id is ignored**.
- **"off" ⇒ permanent/absent** — the override row is removed; asserts no persisted `after_days` is ever ≤0 and the read-back never carries a sentinel `days`.
- **Invalid PUT** (bad mode; `days` = 0 / -1 / 1.5 / NaN / Infinity / string / missing; non-object; unknown category; null) → typed **400**, nothing persisted. A mixed valid+invalid body persists **nothing**.

`test/unit/jobs/retention/friday-retention-policy-loader.test.ts` (6 tests): fresh-install / dropped-table / throwing-repo / unknown-category-row / **out-of-domain (legacy) row** ⇒ all-permanent ⇒ a reaper run over aged fixtures in all 7 content tables deletes **0** (every `deleted*` count asserted 0); plus a positive proof that a valid persisted opt-in *is* loaded and drives only that category. The out-of-domain case injects `after_days = 1e9` past the CHECK (via `PRAGMA ignore_check_constraints`), proves `resolveCutoff` returns null (unhonored), and asserts both the loader and the store read-back fail closed to permanent.

`test/integration/friday-retention-restart-readback.test.ts` (2 tests): write policy via the PUT route → close the store → re-open a fresh store on the **same on-disk db** → GET returns the **byte-identical** policy → the loader picks up the opt-in and the reaper deletes the aged fixture. A second test proves the **boundary window** (`days = 36500`) persists, survives the reopen, is read back identically, and is honored by `resolveCutoff` (non-null cutoff).

`test/unit/api/http/friday-http-server-retention-settings-authz.test.ts` (6 tests) — **REAL end-to-end HTTP** driving `createFridayHttpServer` (public-mutation floor + sensitive-read floor + bearer middleware), not handler stubs (the #1606 lesson): anonymous / synthetic-public / invalid-and-malformed-bearer → **401 on both GET and PUT**, nothing persisted; **canonical-owner binding (round-3)** — the canonical owner (`admin-001`) writes while a **second admin** (`admin-002`, real `hub.admin` token) is **refused 403** on GET+PUT with zero rows, rows are canonical-scoped, and a body-supplied `userId`/`principalId`/`ownerId` targeting the second admin is **ignored**; plus an end-to-end proof that the reaper honors an opt-in submitted via the real API under the canonical owner.

`test/unit/api/http/friday-http-server-retention-canonical-owner-authz.test.ts` (5 tests, round-3 red-first) — the same REAL server + real store + real reaper loader: the **`admin-002` second-admin probe → 403 GET+PUT with zero persistence and zero reaper deletion effect**; the **canonical owner (`admin-001`) opt-in is honored end-to-end by the same per-sweep loader the reaper consumes** (accept == honored); and the canonical-owner id being **unresolvable** (provider returns null / throws / blank) → **403 zero-effect** for even the canonical owner (never falls open to "any admin").

**Reaper-linkage finding (single-owner invariant, verified same-id):** the seeded owner user id is `admin-001` (hub-bootstrap); `friday-auth-service.generateTokenPair` mints `principal.userId = user.id`; the API scopes persistence by `requireUserId(principal) = principal.userId`; and the hub wires the loader with `principalId = learningDefaultUserId = "admin-001"`. API-write id **==** reaper-read id ⇒ the owner's opt-in is honored (proven end-to-end in the real-HTTP test). No wiring change was needed; fail-closed is preserved.

`test/unit/jobs/retention/friday-retention-live-policy-reload.test.ts` (7 tests, P0-1) — through the **real job + real store + real loader** (no mocks): opt-in → sweep deletes aged rows; **opt-OUT (permanent) → the very next sweep deletes 0** (the destructive scenario, now fixed); full rollback round-trip (enable→delete, disable→0, re-enable→delete on one running job); commit-before-sweep race honors the committed value; and FAIL-CLOSED (a throwing live read, and an unreadable/dropped-table read) ⇒ all-permanent ⇒ 0 deletes, never throws.

`test/unit/api/http/friday-http-server-retention-settings-authz.test.ts` also carries the **owner-authority matrix** (P0-2 + round-3) through the real server: anonymous / invalid-bearer / **revoked-or-disabled device-owner** → 401; **viewer (session.read only)** / **operator (no owner authority)** → 403; **a second admin (owner/admin role, NOT the canonical owner)** → 403 (round-3); all with **zero writes and zero deletion effect** (a subsequent live sweep over an aged fixture deletes 0); **only the canonical owner** (`admin-001` — role admin + `hub.admin` AND matching the reaper's canonical id) succeeds on GET+PUT.

**Red-first / falsification evidence (all reverted; final suite green):**
- Breaking the repo's `WHERE principal_id = ?` → **both** the handler-level and the real-HTTP two-owner tests go RED.
- Making the loader default-ON → the fail-closed/default-OFF tests go RED.
- **P0-1:** reintroducing a memoized startup snapshot in the job → the opt-OUT / rollback / race tests go RED.
- **P0-2:** weakening the owner check (empty authority requirement) → the real-HTTP owner-authority matrix and the handler-level viewer-403 test go RED.
- **Round-2:** on the prior head, `days = 1e8 / 1e9 / MAX_SAFE / 36501` persisted + read back **active** (route + store + loader) → the new out-of-domain and loader-fail-closed tests go RED (confirmed: 6 tests failed by assertion on `1d7aa57a`); with the unified-domain fix they return **400 / permanent**.
- **Round-3:** on head `f4a5b630`, a second admin (`admin-002`) received **200** GET/PUT and persisted an override, and null/throwing/blank canonical-owner providers still returned **200** (confirmed: 4 of 5 new canonical-owner tests failed by assertion; the canonical-positive passed as a regression guard). With the canonical-owner match-check + fail-closed resolution they all return **403 zero-effect**, and the canonical owner remains honored end-to-end.

## Local gates
- `npm run typecheck` → **0 errors**.
- `npm run lint` (`eslint .`) → **0 errors** (pre-existing warnings only).
- `npx vitest run` over the new tests + affected paths (retention, uix routes, sensitive-read gate, api-runtime registration, state/sqlite, hub bootstrap integration) → **all green**.

`context/MEMORY.md` migration-count fact updated (104 → 105) to satisfy the `workspace-memory-facts` doc-sync guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48


