### PR TITLE
RETENTION-R3c: real bounded rolling growth-rate measurement for #1613's 7-day exhaustion branch

### DIFF
--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -8256,6 +8256,12 @@ export async function createFridayHub(
         createFridayHealthLogDeduper,
         healthCheckStatusLabel,
       } = await import("../learning/services/friday-system-health-monitor.js");
+      // RETENTION-R3c: the bounded rolling growth-rate sampler that turns #1613's
+      // (R3b) 7-day projected-exhaustion branch from inert (constant null) into a
+      // real observable measurement. Report-only; in-memory; never deletes anything.
+      const { createFridayDiskGrowthRateSampler } = await import(
+        "../learning/services/friday-disk-growth-rate-sampler.js"
+      );
       // One-time setup (persists across ticks): a transition-only log deduper so
       // a persistently large table never spams a warning every 5 minutes. Per the
       // #1606 split, the report-only realtime_events growth reading is surfaced
@@ -8263,6 +8269,13 @@ export async function createFridayHub(
       // observability route / HTTP surface (owner-authorized readback is deferred
       // to R3). Report-only — none of this deletes anything.
       const systemHealthLogDeduper = createFridayHealthLogDeduper();
+      // RETENTION-R3c: created ONCE so the rolling window persists across ticks (the
+      // monitor itself is recreated every tick). Each tick's probeDiskSpace records a
+      // (now, freeBytes) sample; probeGrowthRateBytesPerDay serves the bounded-window
+      // least-squares consumption rate. Bounded both ways (count cap + age window), so
+      // memory stays bounded; NOT restart-durable (re-accrues after restart, reads
+      // `unknown` until enough samples — the correct fail-closed startup posture).
+      const diskGrowthRateSampler = createFridayDiskGrowthRateSampler();
       schedulerJobs.push({
         id: "system-health-monitor",
         intervalMs: 300_000, // every 5 min
@@ -8282,21 +8295,27 @@ export async function createFridayHub(
                 const freeBytes = st.bavail * st.bsize;
                 const totalBytes = st.blocks * st.bsize;
                 if (!Number.isFinite(freeBytes) || !Number.isFinite(totalBytes)) return null;
+                // RETENTION-R3c: feed the rolling growth-rate sampler with this tick's
+                // valid free-space reading. probeDiskSpace is called BEFORE
+                // probeGrowthRateBytesPerDay in the monitor's disk_growth check, so the
+                // sample is visible to the rate accessor within the same tick. Only
+                // finite readings reach here, so the buffer is never poisoned.
+                diskGrowthRateSampler.record(Date.now(), freeBytes);
                 return { freeBytes, totalBytes };
               } catch {
                 return null;
               }
             },
-            // U13 projected-exhaustion branch: no AUTHORITATIVE growth-window
-            // measurement exists in the TS runtime yet, so the growth rate is
-            // UNKNOWN today. Returning null is the HONEST fail-closed posture — per
-            // U13, above the max(10 GiB, 10%) free-space floor the disk_growth
-            // reading reports `unknown` (healthy=false), NEVER a false healthy `ok`;
-            // below the floor it still warns (the live authoritative signal). An
-            // authoritative bytes/day growth-window measurement is the named R3c
-            // follow-up; it will replace this null with a real rate so the 7-day
-            // projected-exhaustion warning becomes observable.
-            probeGrowthRateBytesPerDay: () => null,
+            // RETENTION-R3c: U13 projected-exhaustion branch, now backed by a REAL
+            // bounded rolling measurement. The sampler returns the net consumption
+            // rate (bytes/day) over its window: `null` while samples are insufficient/
+            // invalid (→ #1613 fail-closes `unknown`, healthy=false — the correct
+            // startup posture before enough samples accrue), `0` when free is stable/
+            // increasing (KNOWN no-growth → `ok`), or a positive rate for a genuine
+            // sustained decrease (→ #1613 projects `days = free/rate`, warns if ≤ 7).
+            // Passing Date.now() also age-prunes stale samples so a stalled loop can
+            // never serve a rate from stale data.
+            probeGrowthRateBytesPerDay: () => diskGrowthRateSampler.getGrowthRateBytesPerDay(Date.now()),
             onRunComplete: (summary) => {
               // Log an unhealthy/warn/critical/degraded check only on a status
               // TRANSITION; feed healthy statuses too so a recovery resets state

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -8271,10 +8271,12 @@ export async function createFridayHub(
       const systemHealthLogDeduper = createFridayHealthLogDeduper();
       // RETENTION-R3c: created ONCE so the rolling window persists across ticks (the
       // monitor itself is recreated every tick). Each tick's probeDiskSpace records a
-      // (now, freeBytes) sample; probeGrowthRateBytesPerDay serves the bounded-window
-      // least-squares consumption rate. Bounded both ways (count cap + age window), so
-      // memory stays bounded; NOT restart-durable (re-accrues after restart, reads
-      // `unknown` until enough samples — the correct fail-closed startup posture).
+      // freeBytes sample (timestamped by the sampler's own MONOTONIC clock, immune to
+      // wall-clock jumps); probeGrowthRateBytesPerDay serves the conservative
+      // (full-window vs recent-horizon) least-squares consumption rate. Bounded both
+      // ways (count cap + age window), so memory stays bounded; NOT restart-durable
+      // (re-accrues after restart, reads `unknown` until enough samples — the correct
+      // fail-closed startup posture).
       const diskGrowthRateSampler = createFridayDiskGrowthRateSampler();
       schedulerJobs.push({
         id: "system-health-monitor",
@@ -8299,23 +8301,27 @@ export async function createFridayHub(
                 // valid free-space reading. probeDiskSpace is called BEFORE
                 // probeGrowthRateBytesPerDay in the monitor's disk_growth check, so the
                 // sample is visible to the rate accessor within the same tick. Only
-                // finite readings reach here, so the buffer is never poisoned.
-                diskGrowthRateSampler.record(Date.now(), freeBytes);
+                // finite readings reach here, so the buffer is never poisoned. The
+                // sampler timestamps the sample with its own MONOTONIC clock (never
+                // Date.now) so a wall-clock jump cannot distort the rate.
+                diskGrowthRateSampler.record(freeBytes);
                 return { freeBytes, totalBytes };
               } catch {
                 return null;
               }
             },
             // RETENTION-R3c: U13 projected-exhaustion branch, now backed by a REAL
-            // bounded rolling measurement. The sampler returns the net consumption
-            // rate (bytes/day) over its window: `null` while samples are insufficient/
-            // invalid (→ #1613 fail-closes `unknown`, healthy=false — the correct
-            // startup posture before enough samples accrue), `0` when free is stable/
-            // increasing (KNOWN no-growth → `ok`), or a positive rate for a genuine
+            // bounded rolling measurement. The sampler returns the SAFETY-CONSERVATIVE
+            // net consumption rate (bytes/day) — the sooner-exhaustion max of its full
+            // window and a recent 6h horizon (so a fresh cliff on top of a rising trend
+            // still warns): `null` while neither horizon is observable (→ #1613
+            // fail-closes `unknown`, healthy=false — the correct startup posture before
+            // enough samples accrue), `0` when free is stable/increasing over BOTH
+            // horizons (KNOWN no-growth → `ok`), or a positive rate for a genuine
             // sustained decrease (→ #1613 projects `days = free/rate`, warns if ≤ 7).
-            // Passing Date.now() also age-prunes stale samples so a stalled loop can
-            // never serve a rate from stale data.
-            probeGrowthRateBytesPerDay: () => diskGrowthRateSampler.getGrowthRateBytesPerDay(Date.now()),
+            // Elapsed time and stale-sample pruning use the sampler's MONOTONIC clock
+            // (never Date.now), so a wall-clock jump cannot distort the rate.
+            probeGrowthRateBytesPerDay: () => diskGrowthRateSampler.getGrowthRateBytesPerDay(),
             onRunComplete: (summary) => {
               // Log an unhealthy/warn/critical/degraded check only on a status
               // TRANSITION; feed healthy statuses too so a recovery resets state

--- a/src/learning/services/friday-disk-growth-rate-sampler.ts
+++ b/src/learning/services/friday-disk-growth-rate-sampler.ts
@@ -11,39 +11,35 @@
  * distinction is exactly what #1613 depends on):
  *   • INSUFFICIENT / INVALID / non-monotonic / degenerate → `null` (UNKNOWN) →
  *     #1613 fail-closes the above-floor reading to `status='unknown'`, healthy=false.
- *     Never fabricate a rate from too little (or untrustworthy) data.
- *   • Free stable or INCREASING over BOTH horizons (net consumption ≤ 0) → `0`
- *     (MEASURED-ZERO, a KNOWN no-growth estimate) → #1613 treats it as KNOWN → `ok`.
+ *   • Free stable / recovering (no net depletion) → `0` (MEASURED-ZERO, KNOWN) → `ok`.
  *   • Genuine sustained DECREASE → a positive `bytes/day` rate → #1613 computes
  *     `days = free / rate`, `within = days ≤ 7`.
  *
- * TWO HARDENINGS over the first R3c cut (advisor NEEDS_CHANGES):
+ * HARDENINGS over successive cuts (advisor / reviewer NEEDS_CHANGES):
  *
- *  (1) MONOTONIC TIME ONLY. Elapsed-time math (least-squares slope AND age-pruning)
- *      is derived from an injected MONOTONIC clock (`monotonicNowMs`, default
- *      `performance.now()`), NEVER wall-clock. Wall-clock (`Date.now()`) can jump
- *      (NTP correction, VM migration, manual set); a forward jump would understate
- *      the rate and hide a real exhaustion. A monotonic clock is strictly increasing
- *      within the process, so it cannot be tricked AND insertion order == time order
- *      (making count-pruning by insertion order correct). A sample whose monotonic
- *      timestamp is ≤ the previous one is defensively rejected (fail-closed skip).
+ *  (1) MONOTONIC TIME ONLY. Elapsed-time math (all slopes AND age-pruning) uses an
+ *      injected MONOTONIC clock (`monotonicNowMs`, default `performance.now()`), NEVER
+ *      wall-clock — a wall-clock jump (NTP/VM/manual) cannot distort the rate. A sample
+ *      whose monotonic time is not strictly greater than the previous is rejected.
  *
- *  (2) CONSERVATIVE UNDER NON-STATIONARITY. A single full-window slope hides a recent
- *      cliff (e.g. days of rising free then a sudden large drop → a full-window fit
- *      still reads "increasing"). The rate is therefore the SAFETY-CONSERVATIVE max
- *      of the full-window consumption AND a RECENT-horizon consumption
- *      (`recentWindowMs`): whichever implies SOONER exhaustion wins. Measured-zero is
- *      returned ONLY when BOTH horizons show consumption ≤ 0. A false warn is
- *      fail-closed-safe; a hidden cliff is not.
+ *  (2) CONSERVATIVE UNDER NON-STATIONARITY, NOISE-ROBUST CHANGE-POINT. A fixed-window
+ *      least-squares slope — even a "recent" one — is diluted by preceding flat history
+ *      during a genuine SUSTAINED depletion (6h flat + a few minutes of decline → a slow
+ *      averaged slope → a dangerous false `ok`), AND a strict consecutive-decrease run is
+ *      silenced by a single tie (an exact-repeat statfs read is realistic granularity
+ *      noise) or a sub-tolerance uptick. The rate is therefore the SOONEST-exhaustion max
+ *      of THREE signals: the full-window slope, the recent-`recentWindowMs` slope, and a
+ *      NOISE-TOLERANT recent-decline signal — the net consumption measured from the most
+ *      recent local PEAK within a short `shortWindowMs` horizon to now (endpoint-based, so
+ *      leading flats do NOT dilute it and interior ties/upticks are ABSORBED, not reset).
+ *      It is folded into the max only when CORROBORATED (≥ 2 confirming decreases in the
+ *      segment) and implying exhaustion ≤ `exhaustionWarnDays`. A single unconfirmed fast
+ *      drop → `null` (UNKNOWN, fail-closed, not cry-wolf). Measured-zero `0` is returned
+ *      only when NOTHING shows depletion.
  *
- * DELIBERATELY PURE ESTIMATORS: `estimateConsumptionRateBytesPerDay` and
- * `estimateConservativeConsumptionRateBytesPerDay` are pure functions of the sample
- * array (no clock read inside — the monotonic timestamps are already on the samples).
- * The buffer is an in-memory rolling window — bounded BOTH ways (a hard count cap AND
- * age-pruning) so memory can never grow unbounded (U13 / DATA-RETENTION-001 spirit).
- * Report-only; it never deletes anything. NOT restart-durable (re-accrues after
- * restart; the reading is `unknown` until enough samples accumulate — the correct
- * fail-closed startup).
+ * DELIBERATELY PURE ESTIMATORS (no clock read inside — timestamps are on the samples).
+ * The buffer is an in-memory rolling window, bounded BOTH ways (count cap + age-prune),
+ * so memory can never grow unbounded. Report-only; never deletes. NOT restart-durable.
  */
 
 import { performance } from "node:perf_hooks";
@@ -57,7 +53,7 @@ export interface DiskUsageSample {
    * elapsed-time math is immune to wall-clock jumps.
    */
   monotonicMs: number;
-  /** Free bytes on the state volume at that instant. */
+  /** Free bytes on the state volume at that instant (integer byte count in production). */
   freeBytes: number;
 }
 
@@ -66,32 +62,33 @@ export interface DiskGrowthRateSamplerConfig {
   maxSamples: number;
   /** Age window: samples older than this (relative to the newest) are pruned. */
   windowMs: number;
-  /** Minimum samples before a rate is estimated (< this → null). Floored at 2. */
+  /** Minimum samples before a least-squares rate is estimated (< this → null). Floored at 2. */
   minSamples: number;
-  /** Minimum time span the window must cover before a rate is estimated (< this → null). */
+  /** Minimum span a least-squares window must cover before a rate is estimated (< this → null). */
   minSpanMs: number;
-  /**
-   * Recent-horizon span for the conservative non-stationarity check: consumption is
-   * also estimated over just the most-recent `recentWindowMs` of samples, and the
-   * SOONER-exhaustion (higher-consumption) of {full, recent} is reported.
-   */
+  /** Span of the "recent" least-squares horizon folded into the conservative max. */
   recentWindowMs: number;
   /**
-   * Projected-exhaustion horizon (days) that mirrors U13's 7-day warn window. Used
-   * ONLY by the change-point signal to decide whether a tail decline run is "fast"
-   * (implies exhaustion within this many days) — the threshold that both corroborates
-   * a warn and naturally filters minor fluctuations. Must equal #1613's
-   * `projectedExhaustionWarnDays`; the classifier remains the sole authority on status.
+   * Span of the SHORT horizon for the noise-tolerant change-point signal (≪
+   * `recentWindowMs`). The recent local peak is found within this horizon; net
+   * consumption from that peak to now is the undiluted short rate.
+   */
+  shortWindowMs: number;
+  /**
+   * Projected-exhaustion horizon (days) mirroring U13's 7-day warn window. The
+   * change-point signal fires only when the short rate implies exhaustion within this
+   * many days — the threshold that both corroborates a warn and filters minor
+   * fluctuations. Must equal #1613's `projectedExhaustionWarnDays`; the classifier
+   * remains the sole authority on status.
    */
   exhaustionWarnDays: number;
 }
 
 /**
- * Defaults tuned to the health monitor's 5-minute tick and U13's 7-day window:
- * an ~8-day age window (slightly beyond 7 days so the estimate is stable at the
- * boundary), a 1-hour minimum span (below which the slope is untrustworthy), a
- * 6-hour recent horizon (catches a fresh cliff without being twitchy), and a
- * 4096-sample hard cap (≈14 days at 5-min ticks; ~96 KB — trivially bounded).
+ * Defaults tuned to the health monitor's 5-minute tick and U13's 7-day window: an
+ * ~8-day age window, a 1-hour minimum LSQ span, a 6-hour recent LSQ horizon, a 1-hour
+ * short change-point horizon (enough ticks to corroborate; the peak anchor un-dilutes
+ * regardless of length), and a 4096-sample hard cap (~96 KB — trivially bounded).
  */
 export const DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG: DiskGrowthRateSamplerConfig = {
   maxSamples: 4096,
@@ -99,14 +96,14 @@ export const DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG: DiskGrowthRateSamplerConfi
   minSamples: 2,
   minSpanMs: 60 * 60 * 1000, // 1 hour
   recentWindowMs: 6 * 60 * 60 * 1000, // 6 hours
+  shortWindowMs: 60 * 60 * 1000, // 1 hour
   exhaustionWarnDays: 7, // mirrors U13 / #1613 projectedExhaustionWarnDays
 };
 
 /**
  * Production MONOTONIC clock adapter — `performance.now()` is backed by a monotonic
- * clock, so it is immune to wall-clock jumps (NTP correction, VM migration, manual
- * set). This is the default `monotonicNowMs` used by the sampler in production; it is
- * exported so the real adapter can be unit-tested directly.
+ * clock, so it is immune to wall-clock jumps. Exported so the real adapter can be
+ * unit-tested directly.
  */
 export function defaultMonotonicNowMs(): number {
   return performance.now();
@@ -118,18 +115,9 @@ function isNonNegativeFinite(x: unknown): x is number {
 
 /**
  * PURE robust estimator over a SINGLE window: net CONSUMPTION rate in bytes/day
- * (positive = free space DECREASING), via the least-squares slope of `freeBytes` vs
- * MONOTONIC time (consumption = −slope) — resists noise far better than a two-point
- * delta.
- *
- * Returns:
- *   • `null` (UNKNOWN, fail-closed) when: fewer than `minSamples`; any sample is
- *     invalid (NaN/±Inf/negative monotonic time or free); the span < `minSpanMs`; or
- *     the regression is degenerate (zero time variance).
- *   • `0` (MEASURED-ZERO, KNOWN no-growth) when free is stable or increasing
- *     (net consumption ≤ 0). NOT `null` — the distinction is load-bearing in #1613.
- *   • a positive bytes/day rate (capped to the safe-integer range so it stays a valid
- *     #1613 rate) for a genuine sustained decrease.
+ * (positive = free DECREASING), via the least-squares slope of `freeBytes` vs MONOTONIC
+ * time (consumption = −slope). Returns `null` for insufficient/invalid/short-span/
+ * degenerate; `0` for stable/increasing; a positive rate for a sustained decrease.
  */
 export function estimateConsumptionRateBytesPerDay(
   samples: readonly DiskUsageSample[],
@@ -147,9 +135,6 @@ export function estimateConsumptionRateBytesPerDay(
   }
   if (maxT - minT < config.minSpanMs) return null; // span too short → untrustworthy
 
-  // Least-squares slope of freeBytes vs time, time normalized to DAYS from minT for
-  // numerical stability (raw ms would inflate the sums). Iterate by value (no numeric
-  // indexing) so the loops stay free of object-injection lint noise.
   const n = samples.length;
   const points = samples.map((s) => ({ x: (s.monotonicMs - minT) / MS_PER_DAY, y: s.freeBytes }));
   let sumX = 0;
@@ -169,86 +154,81 @@ export function estimateConsumptionRateBytesPerDay(
   }
   if (!(sxx > 0) || !Number.isFinite(sxx) || !Number.isFinite(sxy)) return null; // degenerate
 
-  const slopeBytesPerDay = sxy / sxx; // free change per day (negative ⇒ consuming)
-  const consumptionBytesPerDay = -slopeBytesPerDay; // positive ⇒ free decreasing
+  const consumptionBytesPerDay = -(sxy / sxx); // positive ⇒ free decreasing
   if (!Number.isFinite(consumptionBytesPerDay)) return null;
-
-  // Stable or increasing free → measured no-growth (KNOWN 0), never null.
-  if (consumptionBytesPerDay <= 0) return 0;
-
-  // Genuine decrease → positive rate; cap to the safe-integer range so it remains a
-  // valid #1613 rate (finite, ≥ 0, ≤ MAX_SAFE_INTEGER).
+  if (consumptionBytesPerDay <= 0) return 0; // stable / increasing → measured no-growth
   return Math.min(consumptionBytesPerDay, Number.MAX_SAFE_INTEGER);
 }
 
 /**
- * Average consumption (bytes/day) over an already-time-sorted, strictly-decreasing
- * tail run — a CHANGE-POINT-AWARE short horizon that is NOT diluted by old flat
- * history and (deliberately) imposes NO `minSpanMs`, so a fresh sustained depletion
- * is measured on its own terms. Returns `null` unless there is a genuine decrease over
- * positive elapsed time.
+ * PURE noise-tolerant recent-decline signal (the change-point detector). Over the most
+ * recent `shortWindowMs`, anchors at the LATEST-occurring local PEAK (max free) and
+ * measures the NET consumption from that peak to the latest sample. This is
+ * endpoint-based, so:
+ *   • a leading flat prefix does NOT dilute the rate (the anchor is the last peak, i.e.
+ *     the point where the decline began, not the window start), and
+ *   • interior TIES (exact-repeat statfs reads) and sub-peak UPTICKS are ABSORBED — the
+ *     net from the peak is unaffected, and the run is never reset by a single tie.
+ * `confirmingDecreases` counts strictly-decreasing intervals in the peak→now segment so
+ * the caller can distinguish a single unconfirmed drop (→ unknown) from a corroborated
+ * one (→ warn). Returns `null` when the recent window shows no net depletion from a peak.
  */
-function runConsumptionRateBytesPerDay(sortedRun: readonly DiskUsageSample[]): number | null {
-  const first = sortedRun.at(0);
-  const last = sortedRun.at(-1);
-  if (!first || !last) return null;
-  const elapsedMs = last.monotonicMs - first.monotonicMs;
-  if (!(elapsedMs > 0) || !Number.isFinite(elapsedMs)) return null;
-  const consumed = first.freeBytes - last.freeBytes; // > 0 for a decline
-  const rate = (consumed / elapsedMs) * MS_PER_DAY;
-  if (!Number.isFinite(rate) || rate <= 0) return null;
-  return Math.min(rate, Number.MAX_SAFE_INTEGER);
-}
+export function recentDeclineSignal(
+  sorted: readonly DiskUsageSample[],
+  shortWindowMs: number,
+): { shortRateBytesPerDay: number; confirmingDecreases: number } | null {
+  const latest = sorted.at(-1);
+  if (!latest) return null;
+  const cutoff = latest.monotonicMs - shortWindowMs;
+  const window = sorted.filter((s) => s.monotonicMs >= cutoff);
+  if (window.length < 2) return null;
 
-/** Count consecutive strictly-decreasing steps at the TAIL of a time-sorted series. */
-function tailDeclineRunLength(sortedSamples: readonly DiskUsageSample[]): number {
-  let run = 0;
-  let prevFree: number | null = null;
-  for (let i = sortedSamples.length - 1; i >= 0; i--) {
-    const free = sortedSamples.at(i)!.freeBytes;
-    if (prevFree === null) {
-      prevFree = free;
-      continue;
-    }
-    if (prevFree < free) {
-      // newer sample is LOWER than this (older) one ⇒ a decrease at the tail
-      run++;
-      prevFree = free;
-    } else {
-      break;
+  // Anchor = the LATEST-occurring maximum free within the window (iterate ascending
+  // with `>=` so ties land on the most recent peak → the tightest, most-conservative,
+  // and un-diluted starting point for the net measurement).
+  let anchorFree = Number.NEGATIVE_INFINITY;
+  let anchorMono = Number.NEGATIVE_INFINITY;
+  for (const s of window) {
+    if (s.freeBytes >= anchorFree) {
+      anchorFree = s.freeBytes;
+      anchorMono = s.monotonicMs;
     }
   }
-  return run;
+
+  const elapsedMs = latest.monotonicMs - anchorMono;
+  const netConsumed = anchorFree - latest.freeBytes;
+  if (!(elapsedMs > 0) || !Number.isFinite(elapsedMs) || !(netConsumed > 0)) return null; // no net decline
+  const rate = (netConsumed / elapsedMs) * MS_PER_DAY;
+  if (!Number.isFinite(rate) || rate <= 0) return null;
+
+  // Count strictly-decreasing intervals within [anchor .. latest]; ties/upticks absorbed.
+  let confirming = 0;
+  let prev: number | null = null;
+  for (const s of window) {
+    if (s.monotonicMs < anchorMono) continue;
+    if (prev !== null && s.freeBytes < prev) confirming++;
+    prev = s.freeBytes;
+  }
+  return { shortRateBytesPerDay: Math.min(rate, Number.MAX_SAFE_INTEGER), confirmingDecreases: confirming };
 }
 
 /**
- * PURE conservative estimator (the one the sampler serves): the SAFETY-CONSERVATIVE
- * consumption rate under NON-STATIONARITY, hardened with a CHANGE-POINT-AWARE
- * short-horizon signal (advisor round-2). A fixed "recent" least-squares window is
- * still diluted by preceding flat history during a genuine SUSTAINED depletion (6h of
- * flat + a few minutes of decline → a slow averaged slope → a dangerous false `ok`).
+ * PURE conservative estimator (the one the sampler serves): the SOONEST-exhaustion max
+ * of the full-window slope, the recent-`recentWindowMs` slope, and the noise-tolerant
+ * recent-decline signal (folded in only when corroborated and warn-implying). The
+ * classifier remains the sole status authority; no new warn branch.
  *
- * The rate is the SOONEST-exhaustion max of THREE signals:
- *   • the full-window least-squares consumption,
- *   • the recent-`recentWindowMs` least-squares consumption,
- *   • a CONFIRMED short-horizon consumption over ONLY the strictly-decreasing tail run
- *     (undiluted), included ONLY when the run is CORROBORATED (≥ 2 consecutive
- *     production-cadence decreases) AND its rate implies exhaustion ≤ `exhaustionWarnDays`.
+ *   • any exposed signal implies exhaustion ≤ `exhaustionWarnDays` → return it (→ WARN);
+ *   • a SINGLE unconfirmed fast drop (exactly 1 confirming decrease implying ≤ warn-days,
+ *     nothing else warning) → `null` (UNKNOWN — never false-`ok`, but not cry-wolf);
+ *   • otherwise `0` (MEASURED-ZERO) when nothing depletes, a slow positive rate for a
+ *     slow decline, or `null` when neither slope window is observable. Minor fluctuations
+ *     imply ≫ warn-days so the change-point never fires; genuine recovery (rising tail /
+ *     no net decline from a peak) is never warned.
  *
- * Decision (soonest exhaustion wins; the classifier remains the sole status authority):
- *   • any exposed signal implies exhaustion ≤ warn-days → return it (→ classifier WARNS);
- *   • a SINGLE unconfirmed fast decrease (1 tail decrease implying ≤ warn-days, not yet
- *     corroborated, and no other signal warns) → `null` (UNKNOWN → fail-closed, NOT a
- *     false `ok`, but NOT cry-wolf `warn` either);
- *   • otherwise the max of the observable horizons: `0` (MEASURED-ZERO) only when
- *     NOTHING shows depletion, a slow positive rate for a slow decline, or `null` when
- *     neither horizon is observable. Minor fluctuations imply ≫ warn-days, so the
- *     change-point logic never fires for them → they stay `ok`. Genuine recovery
- *     (rising tail) has run length 0 → never warned.
- *
- * Preserves the round-1/round-2 behavior: recovery-then-sustained-cliff still warns
- * (the cliff is a long corroborated tail run), and all null-on-insufficient/invalid
- * cases hold.
+ * Preserves round-1/round-2 behavior (recovery-then-sustained-cliff still warns — the
+ * cliff is a corroborated, undiluted peak→now decline) and all null-on-insufficient/
+ * invalid/monotonic-violation cases.
  */
 export function estimateConservativeConsumptionRateBytesPerDay(
   samples: readonly DiskUsageSample[],
@@ -263,30 +243,24 @@ export function estimateConservativeConsumptionRateBytesPerDay(
   const maxMono = sorted.at(-1)!.monotonicMs;
 
   const fullRate = estimateConsumptionRateBytesPerDay(sorted, config);
-  const recentCutoff = maxMono - config.recentWindowMs;
   const recentRate = estimateConsumptionRateBytesPerDay(
-    sorted.filter((s) => s.monotonicMs >= recentCutoff),
+    sorted.filter((s) => s.monotonicMs >= maxMono - config.recentWindowMs),
     config,
   );
 
-  // Change-point: the undiluted consumption over the strictly-decreasing tail run.
-  const declineRun = tailDeclineRunLength(sorted);
-  let shortRate: number | null = null;
-  let shortImpliesWarn = false;
-  if (declineRun >= 1) {
-    shortRate = runConsumptionRateBytesPerDay(sorted.slice(sorted.length - 1 - declineRun));
-    if (shortRate !== null) {
-      const days = latestFree / shortRate;
-      shortImpliesWarn = Number.isFinite(days) && days <= config.exhaustionWarnDays;
-    }
-  }
+  const signal = recentDeclineSignal(sorted, config.shortWindowMs);
+  const shortRate = signal ? signal.shortRateBytesPerDay : null;
+  const confirming = signal ? signal.confirmingDecreases : 0;
+  const shortImpliesWarn =
+    shortRate !== null && shortRate > 0 && Number.isFinite(latestFree / shortRate) && latestFree / shortRate <= config.exhaustionWarnDays;
 
   const candidates: number[] = [];
   if (fullRate !== null) candidates.push(fullRate);
   if (recentRate !== null) candidates.push(recentRate);
-  // A CORROBORATED (≥2) fast tail run is exposed so the classifier warns — it must NOT
-  // be averaged away by hours of old flat data.
-  if (declineRun >= 2 && shortImpliesWarn && shortRate !== null) candidates.push(shortRate);
+  // A CORROBORATED (≥2 confirming decreases) fast, undiluted recent decline is exposed
+  // so the classifier warns — it must NOT be averaged away by old flat data or silenced
+  // by a tie.
+  if (confirming >= 2 && shortImpliesWarn && shortRate !== null) candidates.push(shortRate);
 
   const baseMax = candidates.length > 0 ? Math.max(...candidates) : null;
 
@@ -296,9 +270,9 @@ export function estimateConservativeConsumptionRateBytesPerDay(
   }
 
   // A SINGLE unconfirmed fast decrease → UNKNOWN (avoid both false-ok and cry-wolf).
-  if (declineRun === 1 && shortImpliesWarn) return null;
+  if (confirming === 1 && shortImpliesWarn) return null;
 
-  return baseMax; // 0 (measured-zero) / slow positive / null (neither horizon observable)
+  return baseMax; // 0 (measured-zero) / slow positive / null (neither slope window observable)
 }
 
 /** A bounded rolling sampler owning the in-memory window and a monotonic clock. */
@@ -310,11 +284,10 @@ export interface FridayDiskGrowthRateSampler {
    */
   record(freeBytes: number): void;
   /**
-   * Authoritative consumption rate (bytes/day) over the current window — the
-   * conservative max of the full-window and recent-horizon consumption — or `null`
-   * when neither horizon is observable (see the estimator contract). Age-prunes stale
-   * samples relative to the monotonic now, so a stalled tick loop cannot serve a rate
-   * computed from stale data.
+   * Authoritative consumption rate (bytes/day) over the current window — the conservative
+   * (full / recent / noise-tolerant change-point) max — or `null` when unobservable. Age-
+   * prunes stale samples relative to the monotonic now, so a stalled loop cannot serve a
+   * rate computed from stale data.
    */
   getGrowthRateBytesPerDay(): number | null;
   /** Current retained sample count (bounded by `maxSamples`). For tests/diagnostics. */
@@ -341,13 +314,10 @@ export function createFridayDiskGrowthRateSampler(
   let lastMono = -Infinity; // for strict-monotonic (out-of-order) rejection
 
   function prune(refMono: number): void {
-    // Age-prune: drop samples older than the window relative to the monotonic now.
     if (Number.isFinite(refMono)) {
       const cutoff = refMono - cfg.windowMs;
       if (Number.isFinite(cutoff)) samples = samples.filter((s) => s.monotonicMs >= cutoff);
     }
-    // Count-cap: monotonic time ⇒ insertion order == time order, so keeping the last
-    // `maxSamples` keeps the most-recent.
     if (samples.length > cfg.maxSamples) {
       samples = samples.slice(samples.length - cfg.maxSamples);
     }
@@ -356,9 +326,7 @@ export function createFridayDiskGrowthRateSampler(
   return {
     record(freeBytes) {
       const t = monotonicNowMs();
-      // Fail-closed skip of a non-finite or non-strictly-increasing monotonic reading
-      // (a real monotonic clock never regresses; this guards a misbehaving injection).
-      if (!Number.isFinite(t) || t <= lastMono) return;
+      if (!Number.isFinite(t) || t <= lastMono) return; // fail-closed skip of non-monotonic reading
       lastMono = t;
       samples.push({ monotonicMs: t, freeBytes });
       prune(t);

--- a/src/learning/services/friday-disk-growth-rate-sampler.ts
+++ b/src/learning/services/friday-disk-growth-rate-sampler.ts
@@ -9,27 +9,54 @@
  *
  * Contract alignment with #1613 (LOAD-BEARING — the null-vs-measured-zero
  * distinction is exactly what #1613 depends on):
- *   • INSUFFICIENT / INVALID data  → `null` (UNKNOWN) → #1613 fail-closes the
- *     above-floor reading to `status='unknown'`, healthy=false. Never fabricate a
- *     rate from too little data.
- *   • Free stable or INCREASING (net consumption ≤ 0) → `0` (MEASURED-ZERO, a KNOWN
- *     no-growth estimate) → #1613 treats it as KNOWN → `ok` on the exhaustion branch.
+ *   • INSUFFICIENT / INVALID / non-monotonic / degenerate → `null` (UNKNOWN) →
+ *     #1613 fail-closes the above-floor reading to `status='unknown'`, healthy=false.
+ *     Never fabricate a rate from too little (or untrustworthy) data.
+ *   • Free stable or INCREASING over BOTH horizons (net consumption ≤ 0) → `0`
+ *     (MEASURED-ZERO, a KNOWN no-growth estimate) → #1613 treats it as KNOWN → `ok`.
  *   • Genuine sustained DECREASE → a positive `bytes/day` rate → #1613 computes
  *     `days = free / rate`, `within = days ≤ 7`.
  *
- * DELIBERATELY PURE / IO-FREE: the estimator is a pure function of the sample array
- * (the caller supplies timestamps; no wall-clock is read here). The buffer is an
- * in-memory rolling window — bounded BOTH ways (a hard count cap AND age-pruning) so
- * memory can never grow unbounded (U13 / DATA-RETENTION-001 spirit). Report-only; it
- * never deletes anything. NOT restart-durable (re-accrues after restart; the reading
- * is `unknown` until enough samples accumulate — the correct fail-closed startup).
+ * TWO HARDENINGS over the first R3c cut (advisor NEEDS_CHANGES):
+ *
+ *  (1) MONOTONIC TIME ONLY. Elapsed-time math (least-squares slope AND age-pruning)
+ *      is derived from an injected MONOTONIC clock (`monotonicNowMs`, default
+ *      `performance.now()`), NEVER wall-clock. Wall-clock (`Date.now()`) can jump
+ *      (NTP correction, VM migration, manual set); a forward jump would understate
+ *      the rate and hide a real exhaustion. A monotonic clock is strictly increasing
+ *      within the process, so it cannot be tricked AND insertion order == time order
+ *      (making count-pruning by insertion order correct). A sample whose monotonic
+ *      timestamp is ≤ the previous one is defensively rejected (fail-closed skip).
+ *
+ *  (2) CONSERVATIVE UNDER NON-STATIONARITY. A single full-window slope hides a recent
+ *      cliff (e.g. days of rising free then a sudden large drop → a full-window fit
+ *      still reads "increasing"). The rate is therefore the SAFETY-CONSERVATIVE max
+ *      of the full-window consumption AND a RECENT-horizon consumption
+ *      (`recentWindowMs`): whichever implies SOONER exhaustion wins. Measured-zero is
+ *      returned ONLY when BOTH horizons show consumption ≤ 0. A false warn is
+ *      fail-closed-safe; a hidden cliff is not.
+ *
+ * DELIBERATELY PURE ESTIMATORS: `estimateConsumptionRateBytesPerDay` and
+ * `estimateConservativeConsumptionRateBytesPerDay` are pure functions of the sample
+ * array (no clock read inside — the monotonic timestamps are already on the samples).
+ * The buffer is an in-memory rolling window — bounded BOTH ways (a hard count cap AND
+ * age-pruning) so memory can never grow unbounded (U13 / DATA-RETENTION-001 spirit).
+ * Report-only; it never deletes anything. NOT restart-durable (re-accrues after
+ * restart; the reading is `unknown` until enough samples accumulate — the correct
+ * fail-closed startup).
  */
+
+import { performance } from "node:perf_hooks";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export interface DiskUsageSample {
-  /** Monotonic-ish wall-clock at sampling, in epoch milliseconds. */
-  timestampMs: number;
+  /**
+   * MONOTONIC timestamp in milliseconds (from `monotonicNowMs`, e.g.
+   * `performance.now()`) — NOT wall-clock. Strictly increasing within a process, so
+   * elapsed-time math is immune to wall-clock jumps.
+   */
+  monotonicMs: number;
   /** Free bytes on the state volume at that instant. */
   freeBytes: number;
 }
@@ -43,12 +70,19 @@ export interface DiskGrowthRateSamplerConfig {
   minSamples: number;
   /** Minimum time span the window must cover before a rate is estimated (< this → null). */
   minSpanMs: number;
+  /**
+   * Recent-horizon span for the conservative non-stationarity check: consumption is
+   * also estimated over just the most-recent `recentWindowMs` of samples, and the
+   * SOONER-exhaustion (higher-consumption) of {full, recent} is reported.
+   */
+  recentWindowMs: number;
 }
 
 /**
  * Defaults tuned to the health monitor's 5-minute tick and U13's 7-day window:
  * an ~8-day age window (slightly beyond 7 days so the estimate is stable at the
- * boundary), a 1-hour minimum span (below which the slope is untrustworthy), and a
+ * boundary), a 1-hour minimum span (below which the slope is untrustworthy), a
+ * 6-hour recent horizon (catches a fresh cliff without being twitchy), and a
  * 4096-sample hard cap (≈14 days at 5-min ticks; ~96 KB — trivially bounded).
  */
 export const DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG: DiskGrowthRateSamplerConfig = {
@@ -56,21 +90,33 @@ export const DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG: DiskGrowthRateSamplerConfi
   windowMs: 8 * MS_PER_DAY,
   minSamples: 2,
   minSpanMs: 60 * 60 * 1000, // 1 hour
+  recentWindowMs: 6 * 60 * 60 * 1000, // 6 hours
 };
+
+/**
+ * Production MONOTONIC clock adapter — `performance.now()` is backed by a monotonic
+ * clock, so it is immune to wall-clock jumps (NTP correction, VM migration, manual
+ * set). This is the default `monotonicNowMs` used by the sampler in production; it is
+ * exported so the real adapter can be unit-tested directly.
+ */
+export function defaultMonotonicNowMs(): number {
+  return performance.now();
+}
 
 function isNonNegativeFinite(x: unknown): x is number {
   return typeof x === "number" && Number.isFinite(x) && x >= 0;
 }
 
 /**
- * PURE robust estimator: net CONSUMPTION rate in bytes/day (positive = free space
- * DECREASING) over the supplied samples, via the least-squares slope of `freeBytes`
- * vs time (consumption = −slope) — resists noise far better than a two-point delta.
+ * PURE robust estimator over a SINGLE window: net CONSUMPTION rate in bytes/day
+ * (positive = free space DECREASING), via the least-squares slope of `freeBytes` vs
+ * MONOTONIC time (consumption = −slope) — resists noise far better than a two-point
+ * delta.
  *
  * Returns:
  *   • `null` (UNKNOWN, fail-closed) when: fewer than `minSamples`; any sample is
- *     invalid (NaN/±Inf/negative time or free); the window span < `minSpanMs`; or the
- *     regression is degenerate (zero time variance).
+ *     invalid (NaN/±Inf/negative monotonic time or free); the span < `minSpanMs`; or
+ *     the regression is degenerate (zero time variance).
  *   • `0` (MEASURED-ZERO, KNOWN no-growth) when free is stable or increasing
  *     (net consumption ≤ 0). NOT `null` — the distinction is load-bearing in #1613.
  *   • a positive bytes/day rate (capped to the safe-integer range so it stays a valid
@@ -86,17 +132,17 @@ export function estimateConsumptionRateBytesPerDay(
   let minT = Infinity;
   let maxT = -Infinity;
   for (const s of samples) {
-    if (!isNonNegativeFinite(s.timestampMs) || !isNonNegativeFinite(s.freeBytes)) return null;
-    if (s.timestampMs < minT) minT = s.timestampMs;
-    if (s.timestampMs > maxT) maxT = s.timestampMs;
+    if (!isNonNegativeFinite(s.monotonicMs) || !isNonNegativeFinite(s.freeBytes)) return null;
+    if (s.monotonicMs < minT) minT = s.monotonicMs;
+    if (s.monotonicMs > maxT) maxT = s.monotonicMs;
   }
   if (maxT - minT < config.minSpanMs) return null; // span too short → untrustworthy
 
   // Least-squares slope of freeBytes vs time, time normalized to DAYS from minT for
-  // numerical stability (raw epoch-ms would inflate the sums). Iterate by value (no
-  // numeric indexing) so the loops stay free of object-injection lint noise.
+  // numerical stability (raw ms would inflate the sums). Iterate by value (no numeric
+  // indexing) so the loops stay free of object-injection lint noise.
   const n = samples.length;
-  const points = samples.map((s) => ({ x: (s.timestampMs - minT) / MS_PER_DAY, y: s.freeBytes }));
+  const points = samples.map((s) => ({ x: (s.monotonicMs - minT) / MS_PER_DAY, y: s.freeBytes }));
   let sumX = 0;
   let sumY = 0;
   for (const p of points) {
@@ -126,59 +172,108 @@ export function estimateConsumptionRateBytesPerDay(
   return Math.min(consumptionBytesPerDay, Number.MAX_SAFE_INTEGER);
 }
 
-/** A bounded rolling sampler owning the in-memory window. */
+/**
+ * PURE conservative estimator (the one the sampler serves): the SAFETY-CONSERVATIVE
+ * consumption rate under non-stationarity. Estimates consumption over BOTH the full
+ * window AND the most-recent `recentWindowMs`, and returns whichever implies SOONER
+ * exhaustion (the HIGHER consumption):
+ *   • both horizons evaluable → `max(full, recent)` (so a recent cliff on top of a
+ *     rising full-window trend still WARNS, and measured-zero `0` is returned only
+ *     when BOTH are ≤ 0);
+ *   • the recent horizon lacks enough samples/span → fall back to the full window;
+ *   • the full window lacks enough samples/span but the recent horizon has a rate →
+ *     use the recent rate (conservative; a false warn is fail-closed-safe);
+ *   • neither horizon is evaluable → `null` (UNKNOWN).
+ */
+export function estimateConservativeConsumptionRateBytesPerDay(
+  samples: readonly DiskUsageSample[],
+  config: DiskGrowthRateSamplerConfig = DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG,
+): number | null {
+  const fullRate = estimateConsumptionRateBytesPerDay(samples, config);
+
+  let maxMono = -Infinity;
+  for (const s of samples) {
+    if (typeof s.monotonicMs === "number" && s.monotonicMs > maxMono) maxMono = s.monotonicMs;
+  }
+  let recentRate: number | null = null;
+  if (Number.isFinite(maxMono)) {
+    const cutoff = maxMono - config.recentWindowMs;
+    const recentSamples = samples.filter((s) => s.monotonicMs >= cutoff);
+    recentRate = estimateConsumptionRateBytesPerDay(recentSamples, config);
+  }
+
+  const candidates = [fullRate, recentRate].filter((r): r is number => r !== null);
+  if (candidates.length === 0) return null; // neither horizon observable → UNKNOWN
+  return Math.max(...candidates); // sooner exhaustion wins (0 only if BOTH ≤ 0)
+}
+
+/** A bounded rolling sampler owning the in-memory window and a monotonic clock. */
 export interface FridayDiskGrowthRateSampler {
-  /** Append a disk-usage sample; prunes to keep the buffer bounded (count + age). */
-  record(timestampMs: number, freeBytes: number): void;
   /**
-   * Authoritative consumption rate (bytes/day) over the current window, or `null`
-   * when insufficient/invalid (see the estimator contract). `nowMs`, when supplied,
-   * age-prunes stale samples relative to now (so a stalled tick loop cannot serve a
-   * rate computed from stale data).
+   * Append a disk-usage sample, timestamped with the injected MONOTONIC clock. A
+   * sample whose monotonic time is not strictly greater than the previous one is
+   * rejected (fail-closed skip). Prunes to keep the buffer bounded (count + age).
    */
-  getGrowthRateBytesPerDay(nowMs?: number): number | null;
+  record(freeBytes: number): void;
+  /**
+   * Authoritative consumption rate (bytes/day) over the current window — the
+   * conservative max of the full-window and recent-horizon consumption — or `null`
+   * when neither horizon is observable (see the estimator contract). Age-prunes stale
+   * samples relative to the monotonic now, so a stalled tick loop cannot serve a rate
+   * computed from stale data.
+   */
+  getGrowthRateBytesPerDay(): number | null;
   /** Current retained sample count (bounded by `maxSamples`). For tests/diagnostics. */
   size(): number;
   /** A copy of the current buffer. For tests/diagnostics. */
   snapshot(): DiskUsageSample[];
 }
 
+export interface DiskGrowthRateSamplerOptions extends Partial<DiskGrowthRateSamplerConfig> {
+  /**
+   * Injected MONOTONIC clock (ms). Defaults to `defaultMonotonicNowMs`
+   * (`performance.now()`). MUST be monotonic — the sampler derives all elapsed-time
+   * math from it and rejects any non-increasing reading. Injectable for tests.
+   */
+  monotonicNowMs?: () => number;
+}
+
 export function createFridayDiskGrowthRateSampler(
-  config: Partial<DiskGrowthRateSamplerConfig> = {},
+  options: DiskGrowthRateSamplerOptions = {},
 ): FridayDiskGrowthRateSampler {
-  const cfg: DiskGrowthRateSamplerConfig = { ...DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG, ...config };
+  const { monotonicNowMs = defaultMonotonicNowMs, ...cfgOverrides } = options;
+  const cfg: DiskGrowthRateSamplerConfig = { ...DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG, ...cfgOverrides };
   let samples: DiskUsageSample[] = [];
+  let lastMono = -Infinity; // for strict-monotonic (out-of-order) rejection
 
-  function latestTimestamp(): number {
-    let m = -Infinity;
-    for (const s of samples) if (s.timestampMs > m) m = s.timestampMs;
-    return m;
-  }
-
-  function prune(referenceNowMs: number): void {
-    // Age-prune: drop samples older than the window relative to the reference now.
-    if (Number.isFinite(referenceNowMs)) {
-      const cutoff = referenceNowMs - cfg.windowMs;
-      if (Number.isFinite(cutoff)) samples = samples.filter((s) => s.timestampMs >= cutoff);
+  function prune(refMono: number): void {
+    // Age-prune: drop samples older than the window relative to the monotonic now.
+    if (Number.isFinite(refMono)) {
+      const cutoff = refMono - cfg.windowMs;
+      if (Number.isFinite(cutoff)) samples = samples.filter((s) => s.monotonicMs >= cutoff);
     }
-    // Count-cap: keep only the most-recent `maxSamples` (insertion == time order in prod).
+    // Count-cap: monotonic time ⇒ insertion order == time order, so keeping the last
+    // `maxSamples` keeps the most-recent.
     if (samples.length > cfg.maxSamples) {
       samples = samples.slice(samples.length - cfg.maxSamples);
     }
   }
 
   return {
-    record(timestampMs, freeBytes) {
-      samples.push({ timestampMs, freeBytes });
-      // Prune relative to the newest observed timestamp — robust to out-of-order
-      // records (never drops the just-appended newest) and monotonic in production.
-      prune(Math.max(timestampMs, latestTimestamp()));
+    record(freeBytes) {
+      const t = monotonicNowMs();
+      // Fail-closed skip of a non-finite or non-strictly-increasing monotonic reading
+      // (a real monotonic clock never regresses; this guards a misbehaving injection).
+      if (!Number.isFinite(t) || t <= lastMono) return;
+      lastMono = t;
+      samples.push({ monotonicMs: t, freeBytes });
+      prune(t);
     },
-    getGrowthRateBytesPerDay(nowMs) {
-      const ref =
-        typeof nowMs === "number" && Number.isFinite(nowMs) ? Math.max(nowMs, latestTimestamp()) : latestTimestamp();
+    getGrowthRateBytesPerDay() {
+      const now = monotonicNowMs();
+      const ref = Number.isFinite(now) ? Math.max(now, lastMono) : lastMono;
       prune(ref);
-      return estimateConsumptionRateBytesPerDay(samples, cfg);
+      return estimateConservativeConsumptionRateBytesPerDay(samples, cfg);
     },
     size() {
       return samples.length;

--- a/src/learning/services/friday-disk-growth-rate-sampler.ts
+++ b/src/learning/services/friday-disk-growth-rate-sampler.ts
@@ -1,0 +1,190 @@
+/**
+ * RETENTION-R3c — bounded rolling disk-usage growth-rate measurement.
+ *
+ * Supplies the AUTHORITATIVE `bytes/day` consumption rate that RETENTION-R3b's
+ * (#1613) `classifyDiskGrowth` projected-exhaustion branch consumes. #1613 wired the
+ * rate to a constant `null` (honest fail-closed); R3c replaces that with a REAL
+ * bounded rolling measurement so the 7-day exhaustion warning becomes OBSERVABLE —
+ * WITHOUT changing any of #1613's merged classifier/evaluator logic.
+ *
+ * Contract alignment with #1613 (LOAD-BEARING — the null-vs-measured-zero
+ * distinction is exactly what #1613 depends on):
+ *   • INSUFFICIENT / INVALID data  → `null` (UNKNOWN) → #1613 fail-closes the
+ *     above-floor reading to `status='unknown'`, healthy=false. Never fabricate a
+ *     rate from too little data.
+ *   • Free stable or INCREASING (net consumption ≤ 0) → `0` (MEASURED-ZERO, a KNOWN
+ *     no-growth estimate) → #1613 treats it as KNOWN → `ok` on the exhaustion branch.
+ *   • Genuine sustained DECREASE → a positive `bytes/day` rate → #1613 computes
+ *     `days = free / rate`, `within = days ≤ 7`.
+ *
+ * DELIBERATELY PURE / IO-FREE: the estimator is a pure function of the sample array
+ * (the caller supplies timestamps; no wall-clock is read here). The buffer is an
+ * in-memory rolling window — bounded BOTH ways (a hard count cap AND age-pruning) so
+ * memory can never grow unbounded (U13 / DATA-RETENTION-001 spirit). Report-only; it
+ * never deletes anything. NOT restart-durable (re-accrues after restart; the reading
+ * is `unknown` until enough samples accumulate — the correct fail-closed startup).
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface DiskUsageSample {
+  /** Monotonic-ish wall-clock at sampling, in epoch milliseconds. */
+  timestampMs: number;
+  /** Free bytes on the state volume at that instant. */
+  freeBytes: number;
+}
+
+export interface DiskGrowthRateSamplerConfig {
+  /** Hard cap on retained samples (bounds memory regardless of tick cadence). */
+  maxSamples: number;
+  /** Age window: samples older than this (relative to the newest) are pruned. */
+  windowMs: number;
+  /** Minimum samples before a rate is estimated (< this → null). Floored at 2. */
+  minSamples: number;
+  /** Minimum time span the window must cover before a rate is estimated (< this → null). */
+  minSpanMs: number;
+}
+
+/**
+ * Defaults tuned to the health monitor's 5-minute tick and U13's 7-day window:
+ * an ~8-day age window (slightly beyond 7 days so the estimate is stable at the
+ * boundary), a 1-hour minimum span (below which the slope is untrustworthy), and a
+ * 4096-sample hard cap (≈14 days at 5-min ticks; ~96 KB — trivially bounded).
+ */
+export const DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG: DiskGrowthRateSamplerConfig = {
+  maxSamples: 4096,
+  windowMs: 8 * MS_PER_DAY,
+  minSamples: 2,
+  minSpanMs: 60 * 60 * 1000, // 1 hour
+};
+
+function isNonNegativeFinite(x: unknown): x is number {
+  return typeof x === "number" && Number.isFinite(x) && x >= 0;
+}
+
+/**
+ * PURE robust estimator: net CONSUMPTION rate in bytes/day (positive = free space
+ * DECREASING) over the supplied samples, via the least-squares slope of `freeBytes`
+ * vs time (consumption = −slope) — resists noise far better than a two-point delta.
+ *
+ * Returns:
+ *   • `null` (UNKNOWN, fail-closed) when: fewer than `minSamples`; any sample is
+ *     invalid (NaN/±Inf/negative time or free); the window span < `minSpanMs`; or the
+ *     regression is degenerate (zero time variance).
+ *   • `0` (MEASURED-ZERO, KNOWN no-growth) when free is stable or increasing
+ *     (net consumption ≤ 0). NOT `null` — the distinction is load-bearing in #1613.
+ *   • a positive bytes/day rate (capped to the safe-integer range so it stays a valid
+ *     #1613 rate) for a genuine sustained decrease.
+ */
+export function estimateConsumptionRateBytesPerDay(
+  samples: readonly DiskUsageSample[],
+  config: DiskGrowthRateSamplerConfig = DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG,
+): number | null {
+  const minSamples = Math.max(2, config.minSamples);
+  if (!Array.isArray(samples) || samples.length < minSamples) return null;
+
+  let minT = Infinity;
+  let maxT = -Infinity;
+  for (const s of samples) {
+    if (!isNonNegativeFinite(s.timestampMs) || !isNonNegativeFinite(s.freeBytes)) return null;
+    if (s.timestampMs < minT) minT = s.timestampMs;
+    if (s.timestampMs > maxT) maxT = s.timestampMs;
+  }
+  if (maxT - minT < config.minSpanMs) return null; // span too short → untrustworthy
+
+  // Least-squares slope of freeBytes vs time, time normalized to DAYS from minT for
+  // numerical stability (raw epoch-ms would inflate the sums). Iterate by value (no
+  // numeric indexing) so the loops stay free of object-injection lint noise.
+  const n = samples.length;
+  const points = samples.map((s) => ({ x: (s.timestampMs - minT) / MS_PER_DAY, y: s.freeBytes }));
+  let sumX = 0;
+  let sumY = 0;
+  for (const p of points) {
+    sumX += p.x;
+    sumY += p.y;
+  }
+  const xMean = sumX / n;
+  const yMean = sumY / n;
+  let sxx = 0;
+  let sxy = 0;
+  for (const p of points) {
+    const dx = p.x - xMean;
+    sxx += dx * dx;
+    sxy += dx * (p.y - yMean);
+  }
+  if (!(sxx > 0) || !Number.isFinite(sxx) || !Number.isFinite(sxy)) return null; // degenerate
+
+  const slopeBytesPerDay = sxy / sxx; // free change per day (negative ⇒ consuming)
+  const consumptionBytesPerDay = -slopeBytesPerDay; // positive ⇒ free decreasing
+  if (!Number.isFinite(consumptionBytesPerDay)) return null;
+
+  // Stable or increasing free → measured no-growth (KNOWN 0), never null.
+  if (consumptionBytesPerDay <= 0) return 0;
+
+  // Genuine decrease → positive rate; cap to the safe-integer range so it remains a
+  // valid #1613 rate (finite, ≥ 0, ≤ MAX_SAFE_INTEGER).
+  return Math.min(consumptionBytesPerDay, Number.MAX_SAFE_INTEGER);
+}
+
+/** A bounded rolling sampler owning the in-memory window. */
+export interface FridayDiskGrowthRateSampler {
+  /** Append a disk-usage sample; prunes to keep the buffer bounded (count + age). */
+  record(timestampMs: number, freeBytes: number): void;
+  /**
+   * Authoritative consumption rate (bytes/day) over the current window, or `null`
+   * when insufficient/invalid (see the estimator contract). `nowMs`, when supplied,
+   * age-prunes stale samples relative to now (so a stalled tick loop cannot serve a
+   * rate computed from stale data).
+   */
+  getGrowthRateBytesPerDay(nowMs?: number): number | null;
+  /** Current retained sample count (bounded by `maxSamples`). For tests/diagnostics. */
+  size(): number;
+  /** A copy of the current buffer. For tests/diagnostics. */
+  snapshot(): DiskUsageSample[];
+}
+
+export function createFridayDiskGrowthRateSampler(
+  config: Partial<DiskGrowthRateSamplerConfig> = {},
+): FridayDiskGrowthRateSampler {
+  const cfg: DiskGrowthRateSamplerConfig = { ...DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG, ...config };
+  let samples: DiskUsageSample[] = [];
+
+  function latestTimestamp(): number {
+    let m = -Infinity;
+    for (const s of samples) if (s.timestampMs > m) m = s.timestampMs;
+    return m;
+  }
+
+  function prune(referenceNowMs: number): void {
+    // Age-prune: drop samples older than the window relative to the reference now.
+    if (Number.isFinite(referenceNowMs)) {
+      const cutoff = referenceNowMs - cfg.windowMs;
+      if (Number.isFinite(cutoff)) samples = samples.filter((s) => s.timestampMs >= cutoff);
+    }
+    // Count-cap: keep only the most-recent `maxSamples` (insertion == time order in prod).
+    if (samples.length > cfg.maxSamples) {
+      samples = samples.slice(samples.length - cfg.maxSamples);
+    }
+  }
+
+  return {
+    record(timestampMs, freeBytes) {
+      samples.push({ timestampMs, freeBytes });
+      // Prune relative to the newest observed timestamp — robust to out-of-order
+      // records (never drops the just-appended newest) and monotonic in production.
+      prune(Math.max(timestampMs, latestTimestamp()));
+    },
+    getGrowthRateBytesPerDay(nowMs) {
+      const ref =
+        typeof nowMs === "number" && Number.isFinite(nowMs) ? Math.max(nowMs, latestTimestamp()) : latestTimestamp();
+      prune(ref);
+      return estimateConsumptionRateBytesPerDay(samples, cfg);
+    },
+    size() {
+      return samples.length;
+    },
+    snapshot() {
+      return samples.slice();
+    },
+  };
+}

--- a/src/learning/services/friday-disk-growth-rate-sampler.ts
+++ b/src/learning/services/friday-disk-growth-rate-sampler.ts
@@ -76,6 +76,14 @@ export interface DiskGrowthRateSamplerConfig {
    * SOONER-exhaustion (higher-consumption) of {full, recent} is reported.
    */
   recentWindowMs: number;
+  /**
+   * Projected-exhaustion horizon (days) that mirrors U13's 7-day warn window. Used
+   * ONLY by the change-point signal to decide whether a tail decline run is "fast"
+   * (implies exhaustion within this many days) — the threshold that both corroborates
+   * a warn and naturally filters minor fluctuations. Must equal #1613's
+   * `projectedExhaustionWarnDays`; the classifier remains the sole authority on status.
+   */
+  exhaustionWarnDays: number;
 }
 
 /**
@@ -91,6 +99,7 @@ export const DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG: DiskGrowthRateSamplerConfi
   minSamples: 2,
   minSpanMs: 60 * 60 * 1000, // 1 hour
   recentWindowMs: 6 * 60 * 60 * 1000, // 6 hours
+  exhaustionWarnDays: 7, // mirrors U13 / #1613 projectedExhaustionWarnDays
 };
 
 /**
@@ -173,38 +182,123 @@ export function estimateConsumptionRateBytesPerDay(
 }
 
 /**
+ * Average consumption (bytes/day) over an already-time-sorted, strictly-decreasing
+ * tail run — a CHANGE-POINT-AWARE short horizon that is NOT diluted by old flat
+ * history and (deliberately) imposes NO `minSpanMs`, so a fresh sustained depletion
+ * is measured on its own terms. Returns `null` unless there is a genuine decrease over
+ * positive elapsed time.
+ */
+function runConsumptionRateBytesPerDay(sortedRun: readonly DiskUsageSample[]): number | null {
+  const first = sortedRun.at(0);
+  const last = sortedRun.at(-1);
+  if (!first || !last) return null;
+  const elapsedMs = last.monotonicMs - first.monotonicMs;
+  if (!(elapsedMs > 0) || !Number.isFinite(elapsedMs)) return null;
+  const consumed = first.freeBytes - last.freeBytes; // > 0 for a decline
+  const rate = (consumed / elapsedMs) * MS_PER_DAY;
+  if (!Number.isFinite(rate) || rate <= 0) return null;
+  return Math.min(rate, Number.MAX_SAFE_INTEGER);
+}
+
+/** Count consecutive strictly-decreasing steps at the TAIL of a time-sorted series. */
+function tailDeclineRunLength(sortedSamples: readonly DiskUsageSample[]): number {
+  let run = 0;
+  let prevFree: number | null = null;
+  for (let i = sortedSamples.length - 1; i >= 0; i--) {
+    const free = sortedSamples.at(i)!.freeBytes;
+    if (prevFree === null) {
+      prevFree = free;
+      continue;
+    }
+    if (prevFree < free) {
+      // newer sample is LOWER than this (older) one ⇒ a decrease at the tail
+      run++;
+      prevFree = free;
+    } else {
+      break;
+    }
+  }
+  return run;
+}
+
+/**
  * PURE conservative estimator (the one the sampler serves): the SAFETY-CONSERVATIVE
- * consumption rate under non-stationarity. Estimates consumption over BOTH the full
- * window AND the most-recent `recentWindowMs`, and returns whichever implies SOONER
- * exhaustion (the HIGHER consumption):
- *   • both horizons evaluable → `max(full, recent)` (so a recent cliff on top of a
- *     rising full-window trend still WARNS, and measured-zero `0` is returned only
- *     when BOTH are ≤ 0);
- *   • the recent horizon lacks enough samples/span → fall back to the full window;
- *   • the full window lacks enough samples/span but the recent horizon has a rate →
- *     use the recent rate (conservative; a false warn is fail-closed-safe);
- *   • neither horizon is evaluable → `null` (UNKNOWN).
+ * consumption rate under NON-STATIONARITY, hardened with a CHANGE-POINT-AWARE
+ * short-horizon signal (advisor round-2). A fixed "recent" least-squares window is
+ * still diluted by preceding flat history during a genuine SUSTAINED depletion (6h of
+ * flat + a few minutes of decline → a slow averaged slope → a dangerous false `ok`).
+ *
+ * The rate is the SOONEST-exhaustion max of THREE signals:
+ *   • the full-window least-squares consumption,
+ *   • the recent-`recentWindowMs` least-squares consumption,
+ *   • a CONFIRMED short-horizon consumption over ONLY the strictly-decreasing tail run
+ *     (undiluted), included ONLY when the run is CORROBORATED (≥ 2 consecutive
+ *     production-cadence decreases) AND its rate implies exhaustion ≤ `exhaustionWarnDays`.
+ *
+ * Decision (soonest exhaustion wins; the classifier remains the sole status authority):
+ *   • any exposed signal implies exhaustion ≤ warn-days → return it (→ classifier WARNS);
+ *   • a SINGLE unconfirmed fast decrease (1 tail decrease implying ≤ warn-days, not yet
+ *     corroborated, and no other signal warns) → `null` (UNKNOWN → fail-closed, NOT a
+ *     false `ok`, but NOT cry-wolf `warn` either);
+ *   • otherwise the max of the observable horizons: `0` (MEASURED-ZERO) only when
+ *     NOTHING shows depletion, a slow positive rate for a slow decline, or `null` when
+ *     neither horizon is observable. Minor fluctuations imply ≫ warn-days, so the
+ *     change-point logic never fires for them → they stay `ok`. Genuine recovery
+ *     (rising tail) has run length 0 → never warned.
+ *
+ * Preserves the round-1/round-2 behavior: recovery-then-sustained-cliff still warns
+ * (the cliff is a long corroborated tail run), and all null-on-insufficient/invalid
+ * cases hold.
  */
 export function estimateConservativeConsumptionRateBytesPerDay(
   samples: readonly DiskUsageSample[],
   config: DiskGrowthRateSamplerConfig = DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG,
 ): number | null {
-  const fullRate = estimateConsumptionRateBytesPerDay(samples, config);
-
-  let maxMono = -Infinity;
+  if (!Array.isArray(samples) || samples.length < 2) return null;
   for (const s of samples) {
-    if (typeof s.monotonicMs === "number" && s.monotonicMs > maxMono) maxMono = s.monotonicMs;
+    if (!isNonNegativeFinite(s.monotonicMs) || !isNonNegativeFinite(s.freeBytes)) return null;
   }
-  let recentRate: number | null = null;
-  if (Number.isFinite(maxMono)) {
-    const cutoff = maxMono - config.recentWindowMs;
-    const recentSamples = samples.filter((s) => s.monotonicMs >= cutoff);
-    recentRate = estimateConsumptionRateBytesPerDay(recentSamples, config);
+  const sorted = [...samples].sort((a, b) => a.monotonicMs - b.monotonicMs);
+  const latestFree = sorted.at(-1)!.freeBytes;
+  const maxMono = sorted.at(-1)!.monotonicMs;
+
+  const fullRate = estimateConsumptionRateBytesPerDay(sorted, config);
+  const recentCutoff = maxMono - config.recentWindowMs;
+  const recentRate = estimateConsumptionRateBytesPerDay(
+    sorted.filter((s) => s.monotonicMs >= recentCutoff),
+    config,
+  );
+
+  // Change-point: the undiluted consumption over the strictly-decreasing tail run.
+  const declineRun = tailDeclineRunLength(sorted);
+  let shortRate: number | null = null;
+  let shortImpliesWarn = false;
+  if (declineRun >= 1) {
+    shortRate = runConsumptionRateBytesPerDay(sorted.slice(sorted.length - 1 - declineRun));
+    if (shortRate !== null) {
+      const days = latestFree / shortRate;
+      shortImpliesWarn = Number.isFinite(days) && days <= config.exhaustionWarnDays;
+    }
   }
 
-  const candidates = [fullRate, recentRate].filter((r): r is number => r !== null);
-  if (candidates.length === 0) return null; // neither horizon observable → UNKNOWN
-  return Math.max(...candidates); // sooner exhaustion wins (0 only if BOTH ≤ 0)
+  const candidates: number[] = [];
+  if (fullRate !== null) candidates.push(fullRate);
+  if (recentRate !== null) candidates.push(recentRate);
+  // A CORROBORATED (≥2) fast tail run is exposed so the classifier warns — it must NOT
+  // be averaged away by hours of old flat data.
+  if (declineRun >= 2 && shortImpliesWarn && shortRate !== null) candidates.push(shortRate);
+
+  const baseMax = candidates.length > 0 ? Math.max(...candidates) : null;
+
+  // Any exposed signal already implies exhaustion ≤ warn-days → return it (WARN).
+  if (baseMax !== null && baseMax > 0 && Number.isFinite(latestFree / baseMax) && latestFree / baseMax <= config.exhaustionWarnDays) {
+    return baseMax;
+  }
+
+  // A SINGLE unconfirmed fast decrease → UNKNOWN (avoid both false-ok and cry-wolf).
+  if (declineRun === 1 && shortImpliesWarn) return null;
+
+  return baseMax; // 0 (measured-zero) / slow positive / null (neither horizon observable)
 }
 
 /** A bounded rolling sampler owning the in-memory window and a monotonic clock. */

--- a/test/unit/learning/services/friday-disk-growth-rate-integration.test.ts
+++ b/test/unit/learning/services/friday-disk-growth-rate-integration.test.ts
@@ -159,4 +159,56 @@ describe("RETENTION-R3c integration — real sampler (monotonic-injected) → #1
     expect(d.withinExhaustionWindow).toBe(true);
     expect(d.projectedExhaustionDays!).toBeLessThanOrEqual(7);
   });
+
+  // ── Advisor round-2: a fixed 6h "recent" LSQ is still diluted by preceding flat
+  //    history during a genuine SUSTAINED depletion → false ok for several intervals.
+  const STEP = 5 * 60 * 1000; // production cadence
+
+  it("EXACT PROBE: 6h flat 500 GiB then −10 GiB/5min → 1st decrease UNKNOWN, then WARN — NEVER ok×5", () => {
+    const { warm, tick } = makeRig(makeDb());
+    let mono = 0;
+    for (; mono <= 6 * 60 * 60 * 1000; mono += STEP) warm(mono, 500 * GiB); // 6h flat
+    const statuses: string[] = [];
+    const withinFlags: Array<boolean | null> = [];
+    let free = 500 * GiB;
+    for (let i = 1; i <= 5; i++) {
+      mono += STEP;
+      free -= 10 * GiB; // sustained, continuing depletion (well above the 100 GiB floor on 1 TB)
+      const d = tick(mono, free, 1000 * GiB);
+      statuses.push(d.status);
+      withinFlags.push(d.withinExhaustionWindow);
+    }
+    expect(statuses).not.toContain("ok"); // a dangerous observed trend must never read healthy
+    expect(statuses[0]).toBe("unknown"); // 1 unconfirmed fast decrease → unknown (not a diluted ok, not cry-wolf)
+    expect(statuses.slice(1)).toEqual(["warn", "warn", "warn", "warn"]); // ≥2 corroborating → warn
+    expect(withinFlags.slice(1)).toEqual([true, true, true, true]);
+  });
+
+  it("TRANSIENT dip → UNKNOWN for one tick, then RECOVERY → back to ok (never stuck warned)", () => {
+    const { warm, tick } = makeRig(makeDb());
+    let mono = 0;
+    for (; mono <= 6 * 60 * 60 * 1000; mono += STEP) warm(mono, 500 * GiB);
+    mono += STEP;
+    expect(tick(mono, 460 * GiB, 1000 * GiB).status).toBe("unknown"); // single 40 GiB dip → unknown
+    mono += STEP;
+    expect(tick(mono, 500 * GiB, 1000 * GiB).status).toBe("ok"); // recovered → ok, not stuck
+  });
+
+  it("NOISY stable (small ± fluctuations) → stays ok, no false warn/unknown", () => {
+    const { warm, tick } = makeRig(makeDb());
+    let seed = 4242 >>> 0;
+    const rnd = (): number => ((seed = (1_664_525 * seed + 1_013_904_223) >>> 0), seed / 0xffff_ffff);
+    let mono = 0;
+    for (let i = 0; i < 250; i++, mono += STEP) warm(mono, 500 * GiB + (rnd() - 0.5) * 2 * 1024 * 1024); // ±1 MiB
+    const d = tick(mono + STEP, 500 * GiB, 1000 * GiB);
+    expect(d.status).toBe("ok");
+  });
+
+  it("GENUINE multi-day recovery (free rising for days) → ok, never warned", () => {
+    const { warm, tick } = makeRig(makeDb());
+    for (let t = 0; t < 3 * MS_PER_DAY; t += 60 * 60 * 1000) warm(t, 300 * GiB + (5 * GiB * t) / MS_PER_DAY); // rising
+    const d = tick(3 * MS_PER_DAY, 315 * GiB, 1000 * GiB);
+    expect(d.status).toBe("ok");
+    expect(d.withinExhaustionWindow).toBe(false);
+  });
 });

--- a/test/unit/learning/services/friday-disk-growth-rate-integration.test.ts
+++ b/test/unit/learning/services/friday-disk-growth-rate-integration.test.ts
@@ -6,22 +6,25 @@ import { createFridayDiskGrowthRateSampler } from "../../../../src/learning/serv
 import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
 
 /**
- * RETENTION-R3c — END-TO-END proof of the exact PRODUCTION seam: the real bounded
- * sampler wired the way bootstrap wires it (record the tick's free-space reading in
- * probeDiskSpace, which the monitor calls BEFORE probeGrowthRateBytesPerDay, then
- * serve the least-squares consumption rate), driving #1613's UNCHANGED classifier.
+ * RETENTION-R3c integration — the real bounded sampler wired into the REAL health
+ * monitor and driving #1613's UNCHANGED classifier, the same way bootstrap wires it:
+ * `probeDiskSpace` (called BEFORE `probeGrowthRateBytesPerDay`) records the tick's
+ * free reading into the sampler, and `probeGrowthRateBytesPerDay` serves the
+ * conservative consumption rate.
  *
- * Proves the observable transition the R3c goal is about: across ticks the disk_growth
- * reading moves null→0→positive, i.e. `unknown` (startup, insufficient samples) →
- * `ok` (measured no-growth or ample runway) → `warn` (genuine sustained decrease
- * projecting exhaustion within 7 days) — all ABOVE the absolute free-space floor, so
- * it is the GROWTH branch (not the floor branch) being exercised.
+ * NOTE (accurate scope, no overclaim): this exercises the sampler → real-monitor →
+ * classifier seam THROUGH the sampler's production `monotonicNowMs` INJECTION POINT
+ * (the exact dependency bootstrap relies on). It does NOT boot a full `createFridayHub`
+ * (impractical here); the production monotonic clock adapter itself
+ * (`defaultMonotonicNowMs`) is unit-tested separately in the sampler test. Long
+ * histories are pre-loaded via the same sampler the monitor uses; every STATUS is read
+ * through a real `monitor.runAll()` at the measurement tick.
  */
-describe("RETENTION-R3c integration — real sampler → #1613 classifier via the monitor", () => {
+describe("RETENTION-R3c integration — real sampler (monotonic-injected) → #1613 classifier via the monitor", () => {
   const dbs: FridaySqliteLayer[] = [];
   const GiB = 1024 ** 3;
+  const TiB = 1024 ** 4;
   const MS_PER_DAY = 24 * 60 * 60 * 1000;
-  const T0 = 1_700_000_000_000;
 
   afterEach(() => {
     for (const db of dbs.splice(0)) db.close();
@@ -44,92 +47,116 @@ describe("RETENTION-R3c integration — real sampler → #1613 classifier via th
   }
 
   /**
-   * Wire the monitor to a shared sampler + shared "current tick" state EXACTLY like
-   * bootstrap: probeDiskSpace records (clock, free) then returns {free, cap};
-   * probeGrowthRateBytesPerDay reads the sampler at the same clock.
+   * A rig sharing ONE sampler wired via its production `monotonicNowMs` injection
+   * point. `warm` pre-loads history into that same sampler (fast — no monitor run);
+   * `tick` runs the REAL monitor at a measurement point and returns the disk_growth
+   * detail. Both record through the identical sampler the monitor reads.
    */
   function makeRig(db: FridaySqliteLayer) {
-    const sampler = createFridayDiskGrowthRateSampler();
-    const cur = { clock: T0, free: 0, cap: 0 };
-    function tick(clock: number, free: number, cap: number): DiskDetail {
-      cur.clock = clock;
+    const cur = { mono: 0, free: 0, cap: 0 };
+    const sampler = createFridayDiskGrowthRateSampler({ monotonicNowMs: () => cur.mono });
+    function warm(monoMs: number, free: number): void {
+      cur.mono = monoMs;
+      sampler.record(free);
+    }
+    function tick(monoMs: number, free: number, cap: number): DiskDetail {
+      cur.mono = monoMs;
       cur.free = free;
       cur.cap = cap;
       const summary = createFridaySystemHealthMonitor({
         db,
-        nowIso: () => new Date(clock).toISOString(),
+        nowIso: () => "2026-07-16T12:00:00.000Z",
         probeDiskSpace: () => {
-          sampler.record(cur.clock, cur.free); // production records the valid reading here
+          sampler.record(cur.free); // production records the valid reading here
           return { freeBytes: cur.free, totalBytes: cur.cap };
         },
-        probeGrowthRateBytesPerDay: () => sampler.getGrowthRateBytesPerDay(cur.clock),
+        probeGrowthRateBytesPerDay: () => sampler.getGrowthRateBytesPerDay(),
       }).runAll();
       const disk = summary.checks.find((c) => c.name === "disk_growth")!;
       expect(disk).toBeDefined();
       return disk.detail as DiskDetail;
     }
-    return { sampler, tick };
+    return { warm, tick };
   }
 
   it("startup (first tick, 1 sample) → UNKNOWN, fail-closed, above the floor", () => {
     const { tick } = makeRig(makeDb());
-    // 200 GiB free on a 1000 GiB volume → floor = max(10 GiB, 100 GiB) = 100 GiB → above floor.
-    const d = tick(T0, 200 * GiB, 1000 * GiB);
-    expect(d.belowFloor).toBe(false); // floor branch alone would be ok
-    expect(d.status).toBe("unknown"); // but growth is UNOBSERVABLE with <2 samples
+    const d = tick(0, 200 * GiB, 1000 * GiB); // floor = max(10, 100) = 100 GiB → above
+    expect(d.belowFloor).toBe(false);
+    expect(d.status).toBe("unknown");
     expect(d.failClosed).toBe(true);
   });
 
   it("transition null→0: accumulating STABLE samples flips unknown → ok (measured no-growth)", () => {
     const { tick } = makeRig(makeDb());
-    const d1 = tick(T0, 200 * GiB, 1000 * GiB); // 1 sample
-    expect(d1.status).toBe("unknown");
-    // Second tick 2h later, same free → 2 samples spanning ≥ 1h, flat slope → rate 0.
-    const d2 = tick(T0 + 2 * 60 * 60 * 1000, 200 * GiB, 1000 * GiB);
+    expect(tick(0, 200 * GiB, 1000 * GiB).status).toBe("unknown"); // 1 sample
+    const d2 = tick(2 * 60 * 60 * 1000, 200 * GiB, 1000 * GiB); // 2h later, flat → rate 0
     expect(d2.status).toBe("ok");
-    expect(d2.withinExhaustionWindow).toBe(false); // KNOWN no-growth, never exhausts
+    expect(d2.withinExhaustionWindow).toBe(false);
     expect(d2.belowFloor).toBe(false);
   });
 
-  it("transition 0→positive with AMPLE runway → stays ok (KNOWN rate, > 7 days out)", () => {
-    const { tick } = makeRig(makeDb());
-    // Steady 1 GiB/day decrease, hourly ticks over 3 days, ending ~200 GiB free on 1000 GiB.
-    let last: DiskDetail | undefined;
-    const startFree = 203 * GiB;
-    for (let t = 0; t <= 3 * MS_PER_DAY; t += 60 * 60 * 1000) {
-      last = tick(T0 + t, startFree - (GiB * t) / MS_PER_DAY, 1000 * GiB);
-    }
-    expect(last!.status).toBe("ok"); // ~200 GiB free / 1 GiB/day = ~200 days ≫ 7
-    expect(last!.withinExhaustionWindow).toBe(false);
-    expect(last!.projectedExhaustionDays).not.toBeNull();
-    expect(last!.projectedExhaustionDays!).toBeGreaterThan(7);
-    expect(last!.belowFloor).toBe(false);
+  it("steady positive rate with AMPLE runway → ok (KNOWN rate, > 7 days out)", () => {
+    const { warm, tick } = makeRig(makeDb());
+    const start = 203 * GiB;
+    for (let t = 0; t < 3 * MS_PER_DAY; t += 60 * 60 * 1000) warm(t, start - (GiB * t) / MS_PER_DAY); // ~1 GiB/day
+    const d = tick(3 * MS_PER_DAY, 200 * GiB, 1000 * GiB);
+    expect(d.status).toBe("ok");
+    expect(d.withinExhaustionWindow).toBe(false);
+    expect(d.projectedExhaustionDays).not.toBeNull();
+    expect(d.projectedExhaustionDays!).toBeGreaterThan(7);
+    expect(d.belowFloor).toBe(false);
   });
 
-  it("transition to positive with SHORT runway → WARN, driven by the growth branch ABOVE the floor", () => {
-    const { tick } = makeRig(makeDb());
-    // Steady 5 GiB/day decrease, hourly ticks over 3 days, ending 20 GiB free on 100 GiB
-    // (floor = 10 GiB → ABOVE floor). Projected exhaustion ≈ 20/5 = 4 days ≤ 7 → warn.
-    let last: DiskDetail | undefined;
-    const startFree = 35 * GiB;
-    for (let t = 0; t <= 3 * MS_PER_DAY; t += 60 * 60 * 1000) {
-      last = tick(T0 + t, startFree - (5 * GiB * t) / MS_PER_DAY, 100 * GiB);
-    }
-    expect(last!.belowFloor).toBe(false); // 20 GiB > 10 GiB floor: it is NOT the floor branch
-    expect(last!.withinExhaustionWindow).toBe(true); // the growth branch drives the warning
-    expect(last!.status).toBe("warn");
-    expect(last!.projectedExhaustionDays).not.toBeNull();
-    expect(last!.projectedExhaustionDays!).toBeLessThanOrEqual(7);
+  it("positive rate with SHORT runway → WARN, driven by the growth branch ABOVE the floor", () => {
+    const { warm, tick } = makeRig(makeDb());
+    const start = 35 * GiB; // 5 GiB/day over 3 days → ends 20 GiB on 100 GiB (floor 10 GiB)
+    for (let t = 0; t < 3 * MS_PER_DAY; t += 60 * 60 * 1000) warm(t, start - (5 * GiB * t) / MS_PER_DAY);
+    const d = tick(3 * MS_PER_DAY, 20 * GiB, 100 * GiB);
+    expect(d.belowFloor).toBe(false); // 20 GiB > 10 GiB floor → NOT the floor branch
+    expect(d.withinExhaustionWindow).toBe(true); // growth branch drives the warn
+    expect(d.status).toBe("warn");
+    expect(d.projectedExhaustionDays!).toBeLessThanOrEqual(7);
   });
 
   it("free INCREASING (recovery) → measured-zero → ok, never a spurious warn", () => {
-    const { tick } = makeRig(makeDb());
-    let last: DiskDetail | undefined;
-    const startFree = 150 * GiB;
-    for (let t = 0; t <= 2 * MS_PER_DAY; t += 60 * 60 * 1000) {
-      last = tick(T0 + t, startFree + (3 * GiB * t) / MS_PER_DAY, 1000 * GiB); // free rising
+    const { warm, tick } = makeRig(makeDb());
+    const start = 150 * GiB;
+    for (let t = 0; t < 2 * MS_PER_DAY; t += 60 * 60 * 1000) warm(t, start + (3 * GiB * t) / MS_PER_DAY); // rising
+    const d = tick(2 * MS_PER_DAY, 156 * GiB, 1000 * GiB);
+    expect(d.status).toBe("ok");
+    expect(d.withinExhaustionWindow).toBe(false);
+  });
+
+  // ── Advisor Finding 2: recovery-then-rapid-depletion MUST resolve to warn ──────
+  it("7 DAYS RISING then a 1h 360 GiB CLIFF → WARN (non-stationarity), NEVER ok/measured-zero", () => {
+    const { warm, tick } = makeRig(makeDb());
+    const riseEnd = 7 * MS_PER_DAY - 60 * 60 * 1000;
+    for (let t = 0; t <= riseEnd; t += 60 * 60 * 1000) warm(t, 100 * GiB + (380 * GiB * t) / riseEnd); // 100 → 480 GiB
+    for (let t = riseEnd + 5 * 60 * 1000; t <= 7 * MS_PER_DAY; t += 5 * 60 * 1000) {
+      warm(t, 480 * GiB - (360 * GiB * (t - riseEnd)) / (60 * 60 * 1000)); // 480 → 120 GiB over the last hour
     }
-    expect(last!.status).toBe("ok");
-    expect(last!.withinExhaustionWindow).toBe(false); // consumption ≤ 0 → measured-zero
+    // 120 GiB free on a 1 TB volume → floor = max(10 GiB, ~102.4 GiB) = 102.4 GiB → ABOVE the floor.
+    const d = tick(7 * MS_PER_DAY + 5 * 60 * 1000, 120 * GiB, TiB);
+    expect(d.belowFloor).toBe(false); // above the floor: ONLY the 7-day growth branch could catch it
+    expect(d.status).not.toBe("ok"); // the recovery-then-depletion cliff must not read healthy
+    expect(d.status).toBe("warn");
+    expect(d.withinExhaustionWindow).toBe(true);
+  });
+
+  // ── Advisor Finding 1: wall-clock jump is irrelevant (monotonic elapsed) ───────
+  it("FORWARD wall-clock jump scenario: 50 GiB in 1h MONOTONIC → WARN (not the buggy ok)", () => {
+    const { warm, tick } = makeRig(makeDb());
+    // 200 → 150 GiB over ONE HOUR of monotonic elapsed on a 1 TB volume (floor ~102.4
+    // GiB → 150 GiB is ABOVE the floor). A wall clock could jump +8 days across this
+    // window; the sampler never reads it, so the rate reflects the true ~1h elapsed
+    // (~1200 GiB/day) → exhaustion ≪ 7 days → warn. The pre-fix wall-clock code would
+    // have computed ~6.25 GiB/day → ~24 days → a false ok.
+    for (let m = 0; m < 60 * 60 * 1000; m += 5 * 60 * 1000) warm(m, 200 * GiB - (50 * GiB * m) / (60 * 60 * 1000));
+    const d = tick(60 * 60 * 1000 + 5 * 60 * 1000, 150 * GiB, TiB);
+    expect(d.belowFloor).toBe(false);
+    expect(d.status).toBe("warn");
+    expect(d.withinExhaustionWindow).toBe(true);
+    expect(d.projectedExhaustionDays!).toBeLessThanOrEqual(7);
   });
 });

--- a/test/unit/learning/services/friday-disk-growth-rate-integration.test.ts
+++ b/test/unit/learning/services/friday-disk-growth-rate-integration.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+
+import { createFridaySystemHealthMonitor } from "../../../../src/learning/services/friday-system-health-monitor.js";
+import { createFridayDiskGrowthRateSampler } from "../../../../src/learning/services/friday-disk-growth-rate-sampler.js";
+import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
+
+/**
+ * RETENTION-R3c — END-TO-END proof of the exact PRODUCTION seam: the real bounded
+ * sampler wired the way bootstrap wires it (record the tick's free-space reading in
+ * probeDiskSpace, which the monitor calls BEFORE probeGrowthRateBytesPerDay, then
+ * serve the least-squares consumption rate), driving #1613's UNCHANGED classifier.
+ *
+ * Proves the observable transition the R3c goal is about: across ticks the disk_growth
+ * reading moves null→0→positive, i.e. `unknown` (startup, insufficient samples) →
+ * `ok` (measured no-growth or ample runway) → `warn` (genuine sustained decrease
+ * projecting exhaustion within 7 days) — all ABOVE the absolute free-space floor, so
+ * it is the GROWTH branch (not the floor branch) being exercised.
+ */
+describe("RETENTION-R3c integration — real sampler → #1613 classifier via the monitor", () => {
+  const dbs: FridaySqliteLayer[] = [];
+  const GiB = 1024 ** 3;
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+  const T0 = 1_700_000_000_000;
+
+  afterEach(() => {
+    for (const db of dbs.splice(0)) db.close();
+  });
+
+  function makeDb(): FridaySqliteLayer {
+    const db = createTestDb();
+    dbs.push(db);
+    return db;
+  }
+
+  interface DiskDetail {
+    status: string;
+    belowFloor: boolean | null;
+    withinExhaustionWindow: boolean | null;
+    projectedExhaustionDays: number | null;
+    failClosed?: boolean;
+    freeBytes: number | null;
+    totalCapacityBytes: number | null;
+  }
+
+  /**
+   * Wire the monitor to a shared sampler + shared "current tick" state EXACTLY like
+   * bootstrap: probeDiskSpace records (clock, free) then returns {free, cap};
+   * probeGrowthRateBytesPerDay reads the sampler at the same clock.
+   */
+  function makeRig(db: FridaySqliteLayer) {
+    const sampler = createFridayDiskGrowthRateSampler();
+    const cur = { clock: T0, free: 0, cap: 0 };
+    function tick(clock: number, free: number, cap: number): DiskDetail {
+      cur.clock = clock;
+      cur.free = free;
+      cur.cap = cap;
+      const summary = createFridaySystemHealthMonitor({
+        db,
+        nowIso: () => new Date(clock).toISOString(),
+        probeDiskSpace: () => {
+          sampler.record(cur.clock, cur.free); // production records the valid reading here
+          return { freeBytes: cur.free, totalBytes: cur.cap };
+        },
+        probeGrowthRateBytesPerDay: () => sampler.getGrowthRateBytesPerDay(cur.clock),
+      }).runAll();
+      const disk = summary.checks.find((c) => c.name === "disk_growth")!;
+      expect(disk).toBeDefined();
+      return disk.detail as DiskDetail;
+    }
+    return { sampler, tick };
+  }
+
+  it("startup (first tick, 1 sample) → UNKNOWN, fail-closed, above the floor", () => {
+    const { tick } = makeRig(makeDb());
+    // 200 GiB free on a 1000 GiB volume → floor = max(10 GiB, 100 GiB) = 100 GiB → above floor.
+    const d = tick(T0, 200 * GiB, 1000 * GiB);
+    expect(d.belowFloor).toBe(false); // floor branch alone would be ok
+    expect(d.status).toBe("unknown"); // but growth is UNOBSERVABLE with <2 samples
+    expect(d.failClosed).toBe(true);
+  });
+
+  it("transition null→0: accumulating STABLE samples flips unknown → ok (measured no-growth)", () => {
+    const { tick } = makeRig(makeDb());
+    const d1 = tick(T0, 200 * GiB, 1000 * GiB); // 1 sample
+    expect(d1.status).toBe("unknown");
+    // Second tick 2h later, same free → 2 samples spanning ≥ 1h, flat slope → rate 0.
+    const d2 = tick(T0 + 2 * 60 * 60 * 1000, 200 * GiB, 1000 * GiB);
+    expect(d2.status).toBe("ok");
+    expect(d2.withinExhaustionWindow).toBe(false); // KNOWN no-growth, never exhausts
+    expect(d2.belowFloor).toBe(false);
+  });
+
+  it("transition 0→positive with AMPLE runway → stays ok (KNOWN rate, > 7 days out)", () => {
+    const { tick } = makeRig(makeDb());
+    // Steady 1 GiB/day decrease, hourly ticks over 3 days, ending ~200 GiB free on 1000 GiB.
+    let last: DiskDetail | undefined;
+    const startFree = 203 * GiB;
+    for (let t = 0; t <= 3 * MS_PER_DAY; t += 60 * 60 * 1000) {
+      last = tick(T0 + t, startFree - (GiB * t) / MS_PER_DAY, 1000 * GiB);
+    }
+    expect(last!.status).toBe("ok"); // ~200 GiB free / 1 GiB/day = ~200 days ≫ 7
+    expect(last!.withinExhaustionWindow).toBe(false);
+    expect(last!.projectedExhaustionDays).not.toBeNull();
+    expect(last!.projectedExhaustionDays!).toBeGreaterThan(7);
+    expect(last!.belowFloor).toBe(false);
+  });
+
+  it("transition to positive with SHORT runway → WARN, driven by the growth branch ABOVE the floor", () => {
+    const { tick } = makeRig(makeDb());
+    // Steady 5 GiB/day decrease, hourly ticks over 3 days, ending 20 GiB free on 100 GiB
+    // (floor = 10 GiB → ABOVE floor). Projected exhaustion ≈ 20/5 = 4 days ≤ 7 → warn.
+    let last: DiskDetail | undefined;
+    const startFree = 35 * GiB;
+    for (let t = 0; t <= 3 * MS_PER_DAY; t += 60 * 60 * 1000) {
+      last = tick(T0 + t, startFree - (5 * GiB * t) / MS_PER_DAY, 100 * GiB);
+    }
+    expect(last!.belowFloor).toBe(false); // 20 GiB > 10 GiB floor: it is NOT the floor branch
+    expect(last!.withinExhaustionWindow).toBe(true); // the growth branch drives the warning
+    expect(last!.status).toBe("warn");
+    expect(last!.projectedExhaustionDays).not.toBeNull();
+    expect(last!.projectedExhaustionDays!).toBeLessThanOrEqual(7);
+  });
+
+  it("free INCREASING (recovery) → measured-zero → ok, never a spurious warn", () => {
+    const { tick } = makeRig(makeDb());
+    let last: DiskDetail | undefined;
+    const startFree = 150 * GiB;
+    for (let t = 0; t <= 2 * MS_PER_DAY; t += 60 * 60 * 1000) {
+      last = tick(T0 + t, startFree + (3 * GiB * t) / MS_PER_DAY, 1000 * GiB); // free rising
+    }
+    expect(last!.status).toBe("ok");
+    expect(last!.withinExhaustionWindow).toBe(false); // consumption ≤ 0 → measured-zero
+  });
+});

--- a/test/unit/learning/services/friday-disk-growth-rate-integration.test.ts
+++ b/test/unit/learning/services/friday-disk-growth-rate-integration.test.ts
@@ -199,16 +199,66 @@ describe("RETENTION-R3c integration — real sampler (monotonic-injected) → #1
     let seed = 4242 >>> 0;
     const rnd = (): number => ((seed = (1_664_525 * seed + 1_013_904_223) >>> 0), seed / 0xffff_ffff);
     let mono = 0;
-    for (let i = 0; i < 250; i++, mono += STEP) warm(mono, 500 * GiB + (rnd() - 0.5) * 2 * 1024 * 1024); // ±1 MiB
+    for (let i = 0; i < 250; i++, mono += STEP) warm(mono, 500 * GiB + Math.round((rnd() - 0.5) * 2 * 1024 * 1024)); // ±1 MiB, INTEGER
     const d = tick(mono + STEP, 500 * GiB, 1000 * GiB);
     expect(d.status).toBe("ok");
   });
 
   it("GENUINE multi-day recovery (free rising for days) → ok, never warned", () => {
     const { warm, tick } = makeRig(makeDb());
-    for (let t = 0; t < 3 * MS_PER_DAY; t += 60 * 60 * 1000) warm(t, 300 * GiB + (5 * GiB * t) / MS_PER_DAY); // rising
+    for (let t = 0; t < 3 * MS_PER_DAY; t += 60 * 60 * 1000) warm(t, 300 * GiB + Math.round((5 * GiB * t) / MS_PER_DAY)); // rising
     const d = tick(3 * MS_PER_DAY, 315 * GiB, 1000 * GiB);
     expect(d.status).toBe("ok");
     expect(d.withinExhaustionWindow).toBe(false);
+  });
+
+  // ── Reviewer round-3 P0: a STRICT consecutive-decrease run is silenced by a single
+  //    TIE (an exact-repeat statfs read) or sub-tolerance uptick → dilution → false ok.
+  //    Noise-tolerant net-trend corroboration must absorb interior ties/upticks. All
+  //    free values are INTEGER byte counts (classifyDiskGrowth validates integers).
+
+  it("(a) EXACT-REPEAT TIE mid-decline: 6h flat 500 GiB then −10/tick with tick2 a repeat → NEVER ok; corroborated → warn", () => {
+    const { warm, tick } = makeRig(makeDb());
+    let mono = 0;
+    for (; mono <= 6 * 60 * 60 * 1000; mono += STEP) warm(mono, 500 * GiB); // 6h flat
+    const freeSeq = [490, 490, 480, 470, 460].map((g) => g * GiB); // tick2 is an EXACT REPEAT of tick1
+    const statuses = freeSeq.map((free) => {
+      mono += STEP;
+      return tick(mono, free, 1000 * GiB).status;
+    });
+    expect(statuses).not.toContain("ok"); // the tie must NOT dilute back to a false ok
+    expect(statuses.slice(2)).toEqual(["warn", "warn", "warn"]); // ≥2 real decreases → warn
+  });
+
+  it("(b) ALTERNATING decrease/flat (−15 every other tick, sustained) → warn once corroborated, never ok mid-depletion", () => {
+    const { warm, tick } = makeRig(makeDb());
+    let mono = 0;
+    for (; mono <= 6 * 60 * 60 * 1000; mono += STEP) warm(mono, 500 * GiB);
+    const freeSeq = [485, 485, 470, 470, 455, 455, 440].map((g) => g * GiB); // decrease, tie, decrease, tie, ...
+    const statuses = freeSeq.map((free) => {
+      mono += STEP;
+      return tick(mono, free, 1000 * GiB).status;
+    });
+    expect(statuses).not.toContain("ok"); // ties never re-open a false ok
+    expect(statuses.slice(2)).toEqual(["warn", "warn", "warn", "warn", "warn"]); // corroborated → sustained warn
+  });
+
+  it("(c) REALISTIC 1-in-4 exact-repeat noise (3 decreases + 1 tie) → sustained warn, NO flip-flop, NEVER ok", () => {
+    const { warm, tick } = makeRig(makeDb());
+    let mono = 0;
+    for (; mono <= 6 * 60 * 60 * 1000; mono += STEP) warm(mono, 500 * GiB);
+    // ~2-day-exhaustion continuous depletion with a 1-in-4 exact-repeat tie pattern.
+    const gib: number[] = [];
+    let free = 500;
+    for (let i = 0; i < 16; i++) {
+      if (i % 4 === 3) gib.push(free); // exact-repeat tie every 4th tick
+      else gib.push((free -= 10)); // real decrease
+    }
+    const statuses = gib.map((g) => {
+      mono += STEP;
+      return tick(mono, g * GiB, 1000 * GiB).status;
+    });
+    expect(statuses).not.toContain("ok"); // never a false ok mid-depletion
+    expect(statuses.slice(1).every((s) => s === "warn")).toBe(true); // corroborated by tick2 → NO flip-flop, sustained warn
   });
 });

--- a/test/unit/learning/services/friday-disk-growth-rate-sampler.test.ts
+++ b/test/unit/learning/services/friday-disk-growth-rate-sampler.test.ts
@@ -5,6 +5,7 @@ import {
   defaultMonotonicNowMs,
   estimateConservativeConsumptionRateBytesPerDay,
   estimateConsumptionRateBytesPerDay,
+  recentDeclineSignal,
   DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG,
   type DiskUsageSample,
   type FridayDiskGrowthRateSampler,
@@ -230,7 +231,7 @@ describe("estimateConservativeConsumptionRateBytesPerDay — change-point / conf
   it("NOISY stable (small ± fluctuations, implies ≫ 7 days) → not null and never warn-implying", () => {
     const rnd = lcg(4242);
     const s: DiskUsageSample[] = [];
-    for (let i = 0; i < 300; i++) s.push({ monotonicMs: i * STEP, freeBytes: 500 * GIB + (rnd() - 0.5) * 2 * 1024 * 1024 }); // ±1 MiB
+    for (let i = 0; i < 300; i++) s.push({ monotonicMs: i * STEP, freeBytes: 500 * GIB + Math.round((rnd() - 0.5) * 2 * 1024 * 1024) }); // ±1 MiB, INTEGER
     const rate = estimateConservativeConsumptionRateBytesPerDay(s);
     expect(rate).not.toBeNull();
     expect(impliesWithin7d(rate, s.at(-1)!.freeBytes)).toBe(false);
@@ -240,6 +241,39 @@ describe("estimateConservativeConsumptionRateBytesPerDay — change-point / conf
     const rate = estimateConservativeConsumptionRateBytesPerDay(series(5000 * GIB, GIB, 3 * MS_PER_DAY, STEP)); // ~1 GiB/day
     expect(rate).not.toBeNull();
     expect(rate! / GIB).toBeCloseTo(1, 1);
+  });
+
+  // ── Reviewer round-3 P0: interior TIES / sub-tolerance upticks must NOT silence the
+  //    corroboration (a strict consecutive-decrease run does — this is the false-ok). ──
+  it("TIE mid-decline: 6h flat then [−10, TIE, −10, −10] still corroborates (≥2 confirming) → warn-implying, NOT diluted to ok", () => {
+    const s: DiskUsageSample[] = [];
+    let mono = 0;
+    for (let i = 0; i < FLAT_6H; i++, mono += STEP) s.push({ monotonicMs: mono, freeBytes: 500 * GIB });
+    for (const g of [490, 490, 480, 470]) {
+      // 490,490 = an exact-repeat tie in the middle of the decline
+      s.push({ monotonicMs: mono, freeBytes: g * GIB });
+      mono += STEP;
+    }
+    const rate = estimateConservativeConsumptionRateBytesPerDay(s);
+    expect(rate).not.toBeNull();
+    expect(impliesWithin7d(rate, s.at(-1)!.freeBytes)).toBe(true); // tie absorbed, corroboration survives
+  });
+
+  it("recentDeclineSignal absorbs interior ties/upticks (net from the recent peak, undiluted)", () => {
+    const s: DiskUsageSample[] = [];
+    let mono = 0;
+    for (let i = 0; i < FLAT_6H; i++, mono += STEP) s.push({ monotonicMs: mono, freeBytes: 500 * GIB }); // flat prefix
+    for (const g of [490, 490, 492, 480, 470]) {
+      // interior tie (490,490) AND a sub-peak uptick (490→492) — both must be absorbed
+      s.push({ monotonicMs: mono, freeBytes: g * GIB });
+      mono += STEP;
+    }
+    const sig = recentDeclineSignal(s, DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG.shortWindowMs)!;
+    expect(sig).not.toBeNull();
+    expect(sig.confirmingDecreases).toBeGreaterThanOrEqual(2); // not reset to 0/1 by the tie or uptick
+    // net from the last flat-500 peak to 470 GiB, NOT diluted by the 6h flat prefix
+    const latestFree = 470 * GIB;
+    expect(latestFree / sig.shortRateBytesPerDay).toBeLessThanOrEqual(7);
   });
 });
 

--- a/test/unit/learning/services/friday-disk-growth-rate-sampler.test.ts
+++ b/test/unit/learning/services/friday-disk-growth-rate-sampler.test.ts
@@ -43,6 +43,25 @@ function series(
   return out;
 }
 
+/** Flat readings for `flatCount` ticks, then a sustained decline of `declinePerStep` for `declineCount` ticks. */
+function flatThenDecline(opts: {
+  flatFree: number;
+  flatCount: number;
+  stepMs: number;
+  declinePerStep: number;
+  declineCount: number;
+}): DiskUsageSample[] {
+  const out: DiskUsageSample[] = [];
+  let mono = 0;
+  for (let i = 0; i < opts.flatCount; i++, mono += opts.stepMs) out.push({ monotonicMs: mono, freeBytes: opts.flatFree });
+  let free = opts.flatFree;
+  for (let i = 0; i < opts.declineCount; i++, mono += opts.stepMs) {
+    free -= opts.declinePerStep;
+    out.push({ monotonicMs: mono, freeBytes: free });
+  }
+  return out;
+}
+
 // Deterministic LCG so "noisy" cases are reproducible (no Math.random flake).
 function lcg(seed: number): () => number {
   let s = seed >>> 0;
@@ -172,6 +191,55 @@ describe("estimateConservativeConsumptionRateBytesPerDay (non-stationarity safet
   it("neither horizon observable → null", () => {
     expect(estimateConservativeConsumptionRateBytesPerDay([])).toBeNull();
     expect(estimateConservativeConsumptionRateBytesPerDay([{ monotonicMs: 0, freeBytes: 10 * GIB }])).toBeNull();
+  });
+});
+
+// ── Advisor round-2: change-point / confirmed-short-horizon (a fixed "recent" LSQ is
+//    still diluted by preceding flat history during a genuine SUSTAINED depletion) ──
+describe("estimateConservativeConsumptionRateBytesPerDay — change-point / confirmed short-horizon", () => {
+  const STEP = 5 * 60 * 1000; // production cadence
+  const FLAT_6H = (6 * 60) / 5 + 1; // 6 hours of 5-min ticks
+
+  const impliesWithin7d = (rate: number | null, latestFree: number): boolean =>
+    rate !== null && rate > 0 && Number.isFinite(latestFree / rate) && latestFree / rate <= 7;
+
+  it("EXACT PROBE: 6h flat 500 GiB then 1 UNCONFIRMED −10 GiB/5min decrease → null (UNKNOWN, never a diluted ok)", () => {
+    const s = flatThenDecline({ flatFree: 500 * GIB, flatCount: FLAT_6H, stepMs: STEP, declinePerStep: 10 * GIB, declineCount: 1 });
+    expect(estimateConservativeConsumptionRateBytesPerDay(s)).toBeNull();
+  });
+
+  it("EXACT PROBE: ≥2 CORROBORATING −10 GiB/5min decreases → a positive rate implying exhaustion ≤ 7 days (not diluted)", () => {
+    for (const declineCount of [2, 3, 4, 5]) {
+      const s = flatThenDecline({ flatFree: 500 * GIB, flatCount: FLAT_6H, stepMs: STEP, declinePerStep: 10 * GIB, declineCount });
+      const rate = estimateConservativeConsumptionRateBytesPerDay(s);
+      const latestFree = s.at(-1)!.freeBytes;
+      expect(rate).not.toBeNull();
+      expect(impliesWithin7d(rate, latestFree)).toBe(true);
+    }
+  });
+
+  it("SINGLE fast dip → null; then RECOVERY → not warn-implying, never stuck (measured no-growth)", () => {
+    const dip = flatThenDecline({ flatFree: 500 * GIB, flatCount: FLAT_6H, stepMs: STEP, declinePerStep: 40 * GIB, declineCount: 1 });
+    expect(estimateConservativeConsumptionRateBytesPerDay(dip)).toBeNull(); // ambiguous single step → unknown
+    const recovered: DiskUsageSample[] = [...dip, { monotonicMs: dip.at(-1)!.monotonicMs + STEP, freeBytes: 500 * GIB }];
+    const r = estimateConservativeConsumptionRateBytesPerDay(recovered);
+    expect(r).not.toBeNull();
+    expect(impliesWithin7d(r, 500 * GIB)).toBe(false); // rising tail clears the alarm
+  });
+
+  it("NOISY stable (small ± fluctuations, implies ≫ 7 days) → not null and never warn-implying", () => {
+    const rnd = lcg(4242);
+    const s: DiskUsageSample[] = [];
+    for (let i = 0; i < 300; i++) s.push({ monotonicMs: i * STEP, freeBytes: 500 * GIB + (rnd() - 0.5) * 2 * 1024 * 1024 }); // ±1 MiB
+    const rate = estimateConservativeConsumptionRateBytesPerDay(s);
+    expect(rate).not.toBeNull();
+    expect(impliesWithin7d(rate, s.at(-1)!.freeBytes)).toBe(false);
+  });
+
+  it("PRESERVE: steady SLOW decline (huge free, implies ≫ 7 days) stays a positive rate, not forced to null", () => {
+    const rate = estimateConservativeConsumptionRateBytesPerDay(series(5000 * GIB, GIB, 3 * MS_PER_DAY, STEP)); // ~1 GiB/day
+    expect(rate).not.toBeNull();
+    expect(rate! / GIB).toBeCloseTo(1, 1);
   });
 });
 

--- a/test/unit/learning/services/friday-disk-growth-rate-sampler.test.ts
+++ b/test/unit/learning/services/friday-disk-growth-rate-sampler.test.ts
@@ -2,29 +2,43 @@ import { describe, expect, it } from "vitest";
 
 import {
   createFridayDiskGrowthRateSampler,
+  defaultMonotonicNowMs,
+  estimateConservativeConsumptionRateBytesPerDay,
   estimateConsumptionRateBytesPerDay,
   DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG,
   type DiskUsageSample,
+  type FridayDiskGrowthRateSampler,
 } from "../../../../src/learning/services/friday-disk-growth-rate-sampler.js";
 
 /**
  * RETENTION-R3c — the bounded rolling growth-rate measurement that feeds #1613's
- * (RETENTION-R3b) projected-exhaustion branch. Two properties are proven here:
- *   (A) the PURE estimator's null-vs-measured-zero-vs-positive decision points align
- *       EXACTLY with #1613's contract (null=UNKNOWN→fail-closed; 0=KNOWN no-growth→ok;
- *       positive=genuine decrease→7-day projection), and
- *   (B) the buffer is BOUNDED both ways (count cap + age window) so memory can never
- *       grow without bound regardless of tick cadence or uptime.
+ * (RETENTION-R3b) projected-exhaustion branch, HARDENED per the advisor NEEDS_CHANGES:
+ *   (A) the PURE single-window estimator's null-vs-measured-zero-vs-positive decision
+ *       points align EXACTLY with #1613's contract;
+ *   (B) the PURE conservative estimator is safety-conservative under non-stationarity
+ *       (a recent cliff on top of a rising trend still yields a positive rate);
+ *   (C) the buffer is BOUNDED both ways (count cap + age window) and derives all
+ *       elapsed-time math from an injected MONOTONIC clock — a wall-clock jump cannot
+ *       distort the rate, and a non-monotonic sample is rejected.
  */
 
 const GIB = 1024 ** 3;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
-const T0 = 1_700_000_000_000; // fixed epoch base (deterministic)
 
-function steadyDecrease(startFree: number, perDay: number, days: number, stepMs: number): DiskUsageSample[] {
+/**
+ * Build a linear series. `perDayConsumption` > 0 ⇒ free DECREASING by that many
+ * bytes/day (net consumption); < 0 ⇒ free increasing. Monotonic timestamps from 0.
+ */
+function series(
+  startFree: number,
+  perDayConsumption: number,
+  spanMs: number,
+  stepMs: number,
+  monoStart = 0,
+): DiskUsageSample[] {
   const out: DiskUsageSample[] = [];
-  for (let t = 0; t <= days * MS_PER_DAY; t += stepMs) {
-    out.push({ timestampMs: T0 + t, freeBytes: startFree - (perDay * t) / MS_PER_DAY });
+  for (let t = 0; t <= spanMs; t += stepMs) {
+    out.push({ monotonicMs: monoStart + t, freeBytes: startFree - (perDayConsumption * t) / MS_PER_DAY });
   }
   return out;
 }
@@ -38,129 +52,223 @@ function lcg(seed: number): () => number {
   };
 }
 
-describe("estimateConsumptionRateBytesPerDay (pure estimator)", () => {
+/** A sampler wired to a controllable monotonic clock; `recordAt` sets the clock then records. */
+function makeSampler(cfg: Parameters<typeof createFridayDiskGrowthRateSampler>[0] = {}): {
+  sampler: FridayDiskGrowthRateSampler;
+  setMono: (m: number) => void;
+  recordAt: (monoMs: number, freeBytes: number) => void;
+} {
+  const state = { mono: 0 };
+  const sampler = createFridayDiskGrowthRateSampler({ ...cfg, monotonicNowMs: () => state.mono });
+  return {
+    sampler,
+    setMono: (m) => {
+      state.mono = m;
+    },
+    recordAt: (monoMs, freeBytes) => {
+      state.mono = monoMs;
+      sampler.record(freeBytes);
+    },
+  };
+}
+
+describe("estimateConsumptionRateBytesPerDay (pure single-window estimator, monotonic time)", () => {
   it("steady 1 GiB/day decrease over 7 days → ≈ 1 GiB/day consumption", () => {
-    const samples = steadyDecrease(500 * GIB, GIB, 7, 60 * 60 * 1000); // hourly
-    const rate = estimateConsumptionRateBytesPerDay(samples);
+    const rate = estimateConsumptionRateBytesPerDay(series(500 * GIB, GIB, 7 * MS_PER_DAY, 60 * 60 * 1000));
     expect(rate).not.toBeNull();
     expect(rate! / GIB).toBeCloseTo(1, 6);
   });
 
   it("free INCREASING (net consumption < 0) → measured-zero 0, NOT null", () => {
-    const samples = steadyDecrease(100 * GIB, -2 * GIB, 5, 60 * 60 * 1000); // negative perDay ⇒ increasing free
-    const rate = estimateConsumptionRateBytesPerDay(samples);
-    expect(rate).toBe(0);
+    expect(estimateConsumptionRateBytesPerDay(series(100 * GIB, -2 * GIB, 5 * MS_PER_DAY, 60 * 60 * 1000))).toBe(0);
   });
 
   it("free FLAT → measured-zero 0, NOT null", () => {
-    const samples: DiskUsageSample[] = [];
-    for (let d = 0; d < 6; d++) samples.push({ timestampMs: T0 + d * MS_PER_DAY, freeBytes: 42 * GIB });
-    const rate = estimateConsumptionRateBytesPerDay(samples);
-    expect(rate).toBe(0);
+    const flat: DiskUsageSample[] = [];
+    for (let d = 0; d < 6; d++) flat.push({ monotonicMs: d * MS_PER_DAY, freeBytes: 42 * GIB });
+    expect(estimateConsumptionRateBytesPerDay(flat)).toBe(0);
   });
 
-  it("fewer than MIN_SAMPLES → null (UNKNOWN, fail-closed)", () => {
+  it("fewer than MIN_SAMPLES → null", () => {
     expect(estimateConsumptionRateBytesPerDay([])).toBeNull();
-    expect(estimateConsumptionRateBytesPerDay([{ timestampMs: T0, freeBytes: 10 * GIB }])).toBeNull();
+    expect(estimateConsumptionRateBytesPerDay([{ monotonicMs: 0, freeBytes: 10 * GIB }])).toBeNull();
   });
 
   it("span shorter than MIN_SPAN_MS → null even with enough samples", () => {
-    const samples: DiskUsageSample[] = [];
-    // 10 samples across only 30 minutes (< 1h min span)
-    for (let i = 0; i < 10; i++) samples.push({ timestampMs: T0 + i * 3 * 60 * 1000, freeBytes: 10 * GIB - i * GIB });
-    expect(estimateConsumptionRateBytesPerDay(samples)).toBeNull();
+    const s: DiskUsageSample[] = [];
+    for (let i = 0; i < 10; i++) s.push({ monotonicMs: i * 3 * 60 * 1000, freeBytes: 10 * GIB - i * GIB }); // 30 min
+    expect(estimateConsumptionRateBytesPerDay(s)).toBeNull();
   });
 
   it("any invalid sample (NaN / +Inf / negative time / negative free) → null", () => {
     const base: DiskUsageSample[] = [
-      { timestampMs: T0, freeBytes: 10 * GIB },
-      { timestampMs: T0 + 2 * MS_PER_DAY, freeBytes: 9 * GIB },
+      { monotonicMs: 0, freeBytes: 10 * GIB },
+      { monotonicMs: 2 * MS_PER_DAY, freeBytes: 9 * GIB },
     ];
-    expect(estimateConsumptionRateBytesPerDay([...base, { timestampMs: T0 + 3 * MS_PER_DAY, freeBytes: Number.NaN }])).toBeNull();
+    expect(estimateConsumptionRateBytesPerDay([...base, { monotonicMs: 3 * MS_PER_DAY, freeBytes: Number.NaN }])).toBeNull();
     expect(
-      estimateConsumptionRateBytesPerDay([...base, { timestampMs: T0 + 3 * MS_PER_DAY, freeBytes: Number.POSITIVE_INFINITY }]),
+      estimateConsumptionRateBytesPerDay([...base, { monotonicMs: 3 * MS_PER_DAY, freeBytes: Number.POSITIVE_INFINITY }]),
     ).toBeNull();
-    expect(estimateConsumptionRateBytesPerDay([...base, { timestampMs: -1, freeBytes: 8 * GIB }])).toBeNull();
-    expect(estimateConsumptionRateBytesPerDay([...base, { timestampMs: T0 + 3 * MS_PER_DAY, freeBytes: -1 }])).toBeNull();
-    expect(estimateConsumptionRateBytesPerDay([...base, { timestampMs: Number.NaN, freeBytes: 8 * GIB }])).toBeNull();
+    expect(estimateConsumptionRateBytesPerDay([...base, { monotonicMs: -1, freeBytes: 8 * GIB }])).toBeNull();
+    expect(estimateConsumptionRateBytesPerDay([...base, { monotonicMs: 3 * MS_PER_DAY, freeBytes: -1 }])).toBeNull();
+    expect(estimateConsumptionRateBytesPerDay([...base, { monotonicMs: Number.NaN, freeBytes: 8 * GIB }])).toBeNull();
   });
 
   it("zero time-variance (all identical timestamps) → null (degenerate regression)", () => {
-    const samples: DiskUsageSample[] = [
-      { timestampMs: T0, freeBytes: 10 * GIB },
-      { timestampMs: T0, freeBytes: 8 * GIB },
-      { timestampMs: T0, freeBytes: 6 * GIB },
-    ];
-    expect(estimateConsumptionRateBytesPerDay(samples)).toBeNull();
+    expect(
+      estimateConsumptionRateBytesPerDay([
+        { monotonicMs: 5, freeBytes: 10 * GIB },
+        { monotonicMs: 5, freeBytes: 8 * GIB },
+        { monotonicMs: 5, freeBytes: 6 * GIB },
+      ]),
+    ).toBeNull();
   });
 
   it("noisy-but-trending decrease → robust estimate within tolerance", () => {
     const rnd = lcg(12345);
-    const perDay = 2 * GIB;
-    const samples: DiskUsageSample[] = [];
+    const s: DiskUsageSample[] = [];
     for (let t = 0; t <= 7 * MS_PER_DAY; t += 60 * 60 * 1000) {
-      const trend = 300 * GIB - (perDay * t) / MS_PER_DAY;
-      const noise = (rnd() - 0.5) * 0.5 * GIB; // ±0.25 GiB jitter
-      samples.push({ timestampMs: T0 + t, freeBytes: Math.max(0, trend + noise) });
+      const trend = 300 * GIB - (2 * GIB * t) / MS_PER_DAY;
+      s.push({ monotonicMs: t, freeBytes: Math.max(0, trend + (rnd() - 0.5) * 0.5 * GIB) });
     }
-    const rate = estimateConsumptionRateBytesPerDay(samples);
+    const rate = estimateConsumptionRateBytesPerDay(s);
     expect(rate).not.toBeNull();
-    expect(rate! / GIB).toBeCloseTo(2, 1); // within ~0.05 GiB/day despite noise
+    expect(rate! / GIB).toBeCloseTo(2, 1);
   });
 });
 
-describe("createFridayDiskGrowthRateSampler (bounded buffer)", () => {
-  it("record → getGrowthRateBytesPerDay reproduces the estimator over the window", () => {
-    const sampler = createFridayDiskGrowthRateSampler();
-    for (const s of steadyDecrease(500 * GIB, GIB, 7, 60 * 60 * 1000)) sampler.record(s.timestampMs, s.freeBytes);
+describe("estimateConservativeConsumptionRateBytesPerDay (non-stationarity safety)", () => {
+  it("both horizons stable/increasing → measured-zero 0", () => {
+    expect(estimateConservativeConsumptionRateBytesPerDay(series(200 * GIB, -1 * GIB, 3 * MS_PER_DAY, 30 * 60 * 1000))).toBe(0);
+  });
+
+  it("FULL window rising but RECENT horizon a cliff → positive (conservative max), NOT 0", () => {
+    // 7 days RISING free, then a 360 GiB drop in the LAST HOUR. The full-window slope
+    // still reads "increasing" (→ 0), but the recent 6h horizon captures the cliff.
+    const s: DiskUsageSample[] = [];
+    const riseEnd = 7 * MS_PER_DAY - 60 * 60 * 1000;
+    for (let t = 0; t <= riseEnd; t += 5 * 60 * 1000) {
+      s.push({ monotonicMs: t, freeBytes: 100 * GIB + (380 * GIB * t) / riseEnd }); // 100 → 480 GiB
+    }
+    for (let t = riseEnd + 5 * 60 * 1000; t <= 7 * MS_PER_DAY; t += 5 * 60 * 1000) {
+      const into = t - riseEnd;
+      s.push({ monotonicMs: t, freeBytes: 480 * GIB - (360 * GIB * into) / (60 * 60 * 1000) }); // 480 → 120 GiB
+    }
+    expect(estimateConsumptionRateBytesPerDay(s)).toBe(0); // full window alone hides the cliff
+    const conservative = estimateConservativeConsumptionRateBytesPerDay(s);
+    expect(conservative).not.toBeNull();
+    expect(conservative!).toBeGreaterThan(0); // recent horizon rescues it
+  });
+
+  it("recent horizon insufficient (sparse) → falls back to the full window", () => {
+    // Steady 1 GiB/day over 3 days, but only ONE sample in the last 6h → recent=null → use full.
+    const s = series(200 * GIB, GIB, 3 * MS_PER_DAY - 60 * 60 * 1000, 30 * 60 * 1000);
+    s.push({ monotonicMs: 3 * MS_PER_DAY, freeBytes: 200 * GIB - 3 * GIB }); // lone recent sample
+    const conservative = estimateConservativeConsumptionRateBytesPerDay(s);
+    expect(conservative).not.toBeNull();
+    expect(conservative! / GIB).toBeCloseTo(1, 1); // full-window ~1 GiB/day
+  });
+
+  it("neither horizon observable → null", () => {
+    expect(estimateConservativeConsumptionRateBytesPerDay([])).toBeNull();
+    expect(estimateConservativeConsumptionRateBytesPerDay([{ monotonicMs: 0, freeBytes: 10 * GIB }])).toBeNull();
+  });
+});
+
+describe("createFridayDiskGrowthRateSampler (bounded buffer + monotonic clock)", () => {
+  it("record → getGrowthRateBytesPerDay reproduces the conservative estimator", () => {
+    const { sampler, recordAt } = makeSampler();
+    for (const s of series(500 * GIB, GIB, 7 * MS_PER_DAY, 60 * 60 * 1000)) recordAt(s.monotonicMs, s.freeBytes);
     const rate = sampler.getGrowthRateBytesPerDay();
     expect(rate).not.toBeNull();
     expect(rate! / GIB).toBeCloseTo(1, 6);
   });
 
-  it("never exceeds MAX_SAMPLES (count cap) even under many in-window ticks", () => {
-    const sampler = createFridayDiskGrowthRateSampler({ maxSamples: 100, windowMs: 10_000 * MS_PER_DAY });
-    for (let i = 0; i < 5000; i++) sampler.record(T0 + i * 60 * 1000, 100 * GIB - i);
+  it("never exceeds MAX_SAMPLES (count cap) under many in-window ticks", () => {
+    const { sampler, recordAt } = makeSampler({ maxSamples: 100, windowMs: 10_000 * MS_PER_DAY });
+    for (let i = 0; i < 5000; i++) recordAt(i * 60 * 1000, 100 * GIB - i);
     expect(sampler.size()).toBeLessThanOrEqual(100);
   });
 
-  it("prunes samples older than WINDOW_MS (age cap)", () => {
+  it("prunes samples older than WINDOW_MS (age cap), by monotonic time", () => {
     const windowMs = 8 * MS_PER_DAY;
-    const sampler = createFridayDiskGrowthRateSampler({ windowMs, maxSamples: 100_000 });
-    // 30 daily samples; only those within the trailing 8-day window relative to newest survive.
-    for (let d = 0; d < 30; d++) sampler.record(T0 + d * MS_PER_DAY, 100 * GIB - d * GIB);
+    const { sampler, recordAt } = makeSampler({ windowMs, maxSamples: 100_000 });
+    for (let d = 0; d < 30; d++) recordAt(d * MS_PER_DAY, 100 * GIB - d * GIB);
     const snap = sampler.snapshot();
-    const newest = Math.max(...snap.map((s) => s.timestampMs));
-    expect(snap.every((s) => s.timestampMs >= newest - windowMs)).toBe(true);
-    expect(snap.length).toBeLessThanOrEqual(9); // 8-day window at daily cadence
+    const newest = Math.max(...snap.map((s) => s.monotonicMs));
+    expect(snap.every((s) => s.monotonicMs >= newest - windowMs)).toBe(true);
+    expect(snap.length).toBeLessThanOrEqual(9);
   });
 
   it("memory stays bounded under a very long tick history (both caps active)", () => {
-    const sampler = createFridayDiskGrowthRateSampler(); // defaults: 4096 cap, 8-day window
-    // Two years of 5-minute ticks — far exceeds both caps.
+    const { sampler, recordAt } = makeSampler();
     const stepMs = 5 * 60 * 1000;
-    for (let i = 0; i < 200_000; i++) sampler.record(T0 + i * stepMs, 1000 * GIB - i * 1000);
+    for (let i = 0; i < 200_000; i++) recordAt(i * stepMs, 1000 * GIB - i * 1000);
     expect(sampler.size()).toBeLessThanOrEqual(DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG.maxSamples);
-    // Age window (8 days) is the tighter bound at 5-min cadence: 8*288 = 2304 < 4096.
-    expect(sampler.size()).toBeLessThanOrEqual((8 * MS_PER_DAY) / stepMs + 1);
+    expect(sampler.size()).toBeLessThanOrEqual((8 * MS_PER_DAY) / stepMs + 1); // 8-day window is tighter here
   });
 
   it("startup: no samples → null; one sample → null; short span → null (fail-closed)", () => {
-    const sampler = createFridayDiskGrowthRateSampler();
-    expect(sampler.getGrowthRateBytesPerDay(T0)).toBeNull();
-    sampler.record(T0, 50 * GIB);
-    expect(sampler.getGrowthRateBytesPerDay(T0)).toBeNull();
-    sampler.record(T0 + 5 * 60 * 1000, 50 * GIB - 1000); // 5 min span < 1h
-    expect(sampler.getGrowthRateBytesPerDay(T0 + 5 * 60 * 1000)).toBeNull();
+    const { sampler, recordAt, setMono } = makeSampler();
+    setMono(0);
+    expect(sampler.getGrowthRateBytesPerDay()).toBeNull();
+    recordAt(0, 50 * GIB);
+    expect(sampler.getGrowthRateBytesPerDay()).toBeNull();
+    recordAt(5 * 60 * 1000, 50 * GIB - 1000); // 5 min span < 1h
+    expect(sampler.getGrowthRateBytesPerDay()).toBeNull();
   });
 
-  it("nowMs age-prunes stale samples so a stalled loop cannot serve stale data", () => {
-    const sampler = createFridayDiskGrowthRateSampler({ windowMs: 8 * MS_PER_DAY });
-    for (const s of steadyDecrease(500 * GIB, GIB, 7, 60 * 60 * 1000)) sampler.record(s.timestampMs, s.freeBytes);
+  // ── Advisor Finding 1: monotonic-clock trust ─────────────────────────────────
+  it("FORWARD wall-clock jump is irrelevant: rate reflects MONOTONIC elapsed → high consumption", () => {
+    // 50 GiB consumed over ONE HOUR of MONOTONIC elapsed. A wall clock could jump +8
+    // days here; the sampler never reads it, so the rate is ~50 GiB/h = 1200 GiB/day
+    // (the buggy wall-clock version would have read ~6.25 GiB/day and said "ok").
+    const { sampler, recordAt } = makeSampler();
+    for (let m = 0; m <= 60 * 60 * 1000; m += 5 * 60 * 1000) recordAt(m, 200 * GIB - (50 * GIB * m) / (60 * 60 * 1000));
+    const rate = sampler.getGrowthRateBytesPerDay();
+    expect(rate).not.toBeNull();
+    expect(rate! / GIB).toBeCloseTo(1200, 0); // ≈ 1200 GiB/day, NOT ~6.25
+  });
+
+  it("OUT-OF-ORDER monotonic sample is rejected (fail-closed skip), keeping order == time", () => {
+    const { sampler, recordAt } = makeSampler();
+    recordAt(100, 10 * GIB);
+    recordAt(200, 9 * GIB);
+    recordAt(150, 8 * GIB); // ≤ previous monotonic → REJECTED
+    recordAt(300, 7 * GIB);
+    const snap = sampler.snapshot();
+    expect(snap.map((s) => s.monotonicMs)).toEqual([100, 200, 300]); // 150 dropped
+    expect(sampler.size()).toBe(3);
+  });
+
+  it("STALLED loop: monotonic advances far beyond the window with no new samples → prune to null", () => {
+    const { sampler, recordAt, setMono } = makeSampler({ windowMs: 8 * MS_PER_DAY });
+    for (const s of series(500 * GIB, GIB, 7 * MS_PER_DAY, 60 * 60 * 1000)) recordAt(s.monotonicMs, s.freeBytes);
     expect(sampler.size()).toBeGreaterThan(0);
-    // Advance now far beyond the window with no new samples: all prune away → null.
-    const rate = sampler.getGrowthRateBytesPerDay(T0 + 100 * MS_PER_DAY);
+    setMono(7 * MS_PER_DAY + 100 * MS_PER_DAY); // now jumps far ahead, no records
+    const rate = sampler.getGrowthRateBytesPerDay();
     expect(sampler.size()).toBe(0);
     expect(rate).toBeNull();
+  });
+});
+
+// ── Advisor Finding 3: the REAL production clock adapter is exercised directly ───
+describe("defaultMonotonicNowMs (the production monotonic clock adapter)", () => {
+  it("returns finite, non-negative, monotonically non-decreasing readings", () => {
+    const a = defaultMonotonicNowMs();
+    const b = defaultMonotonicNowMs();
+    expect(Number.isFinite(a)).toBe(true);
+    expect(Number.isFinite(b)).toBe(true);
+    expect(a).toBeGreaterThanOrEqual(0);
+    expect(b).toBeGreaterThanOrEqual(a);
+  });
+
+  it("strictly increases across a busy interval (a real elapsed-time source)", () => {
+    const a = defaultMonotonicNowMs();
+    let acc = 0;
+    for (let i = 0; i < 5_000_000; i++) acc += i % 7; // burn a little wall time
+    const b = defaultMonotonicNowMs();
+    expect(b).toBeGreaterThan(a);
+    expect(acc).toBeGreaterThan(0); // keep the loop from being optimized away
   });
 });

--- a/test/unit/learning/services/friday-disk-growth-rate-sampler.test.ts
+++ b/test/unit/learning/services/friday-disk-growth-rate-sampler.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createFridayDiskGrowthRateSampler,
+  estimateConsumptionRateBytesPerDay,
+  DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG,
+  type DiskUsageSample,
+} from "../../../../src/learning/services/friday-disk-growth-rate-sampler.js";
+
+/**
+ * RETENTION-R3c — the bounded rolling growth-rate measurement that feeds #1613's
+ * (RETENTION-R3b) projected-exhaustion branch. Two properties are proven here:
+ *   (A) the PURE estimator's null-vs-measured-zero-vs-positive decision points align
+ *       EXACTLY with #1613's contract (null=UNKNOWN→fail-closed; 0=KNOWN no-growth→ok;
+ *       positive=genuine decrease→7-day projection), and
+ *   (B) the buffer is BOUNDED both ways (count cap + age window) so memory can never
+ *       grow without bound regardless of tick cadence or uptime.
+ */
+
+const GIB = 1024 ** 3;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const T0 = 1_700_000_000_000; // fixed epoch base (deterministic)
+
+function steadyDecrease(startFree: number, perDay: number, days: number, stepMs: number): DiskUsageSample[] {
+  const out: DiskUsageSample[] = [];
+  for (let t = 0; t <= days * MS_PER_DAY; t += stepMs) {
+    out.push({ timestampMs: T0 + t, freeBytes: startFree - (perDay * t) / MS_PER_DAY });
+  }
+  return out;
+}
+
+// Deterministic LCG so "noisy" cases are reproducible (no Math.random flake).
+function lcg(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (1_664_525 * s + 1_013_904_223) >>> 0;
+    return s / 0xffff_ffff;
+  };
+}
+
+describe("estimateConsumptionRateBytesPerDay (pure estimator)", () => {
+  it("steady 1 GiB/day decrease over 7 days → ≈ 1 GiB/day consumption", () => {
+    const samples = steadyDecrease(500 * GIB, GIB, 7, 60 * 60 * 1000); // hourly
+    const rate = estimateConsumptionRateBytesPerDay(samples);
+    expect(rate).not.toBeNull();
+    expect(rate! / GIB).toBeCloseTo(1, 6);
+  });
+
+  it("free INCREASING (net consumption < 0) → measured-zero 0, NOT null", () => {
+    const samples = steadyDecrease(100 * GIB, -2 * GIB, 5, 60 * 60 * 1000); // negative perDay ⇒ increasing free
+    const rate = estimateConsumptionRateBytesPerDay(samples);
+    expect(rate).toBe(0);
+  });
+
+  it("free FLAT → measured-zero 0, NOT null", () => {
+    const samples: DiskUsageSample[] = [];
+    for (let d = 0; d < 6; d++) samples.push({ timestampMs: T0 + d * MS_PER_DAY, freeBytes: 42 * GIB });
+    const rate = estimateConsumptionRateBytesPerDay(samples);
+    expect(rate).toBe(0);
+  });
+
+  it("fewer than MIN_SAMPLES → null (UNKNOWN, fail-closed)", () => {
+    expect(estimateConsumptionRateBytesPerDay([])).toBeNull();
+    expect(estimateConsumptionRateBytesPerDay([{ timestampMs: T0, freeBytes: 10 * GIB }])).toBeNull();
+  });
+
+  it("span shorter than MIN_SPAN_MS → null even with enough samples", () => {
+    const samples: DiskUsageSample[] = [];
+    // 10 samples across only 30 minutes (< 1h min span)
+    for (let i = 0; i < 10; i++) samples.push({ timestampMs: T0 + i * 3 * 60 * 1000, freeBytes: 10 * GIB - i * GIB });
+    expect(estimateConsumptionRateBytesPerDay(samples)).toBeNull();
+  });
+
+  it("any invalid sample (NaN / +Inf / negative time / negative free) → null", () => {
+    const base: DiskUsageSample[] = [
+      { timestampMs: T0, freeBytes: 10 * GIB },
+      { timestampMs: T0 + 2 * MS_PER_DAY, freeBytes: 9 * GIB },
+    ];
+    expect(estimateConsumptionRateBytesPerDay([...base, { timestampMs: T0 + 3 * MS_PER_DAY, freeBytes: Number.NaN }])).toBeNull();
+    expect(
+      estimateConsumptionRateBytesPerDay([...base, { timestampMs: T0 + 3 * MS_PER_DAY, freeBytes: Number.POSITIVE_INFINITY }]),
+    ).toBeNull();
+    expect(estimateConsumptionRateBytesPerDay([...base, { timestampMs: -1, freeBytes: 8 * GIB }])).toBeNull();
+    expect(estimateConsumptionRateBytesPerDay([...base, { timestampMs: T0 + 3 * MS_PER_DAY, freeBytes: -1 }])).toBeNull();
+    expect(estimateConsumptionRateBytesPerDay([...base, { timestampMs: Number.NaN, freeBytes: 8 * GIB }])).toBeNull();
+  });
+
+  it("zero time-variance (all identical timestamps) → null (degenerate regression)", () => {
+    const samples: DiskUsageSample[] = [
+      { timestampMs: T0, freeBytes: 10 * GIB },
+      { timestampMs: T0, freeBytes: 8 * GIB },
+      { timestampMs: T0, freeBytes: 6 * GIB },
+    ];
+    expect(estimateConsumptionRateBytesPerDay(samples)).toBeNull();
+  });
+
+  it("noisy-but-trending decrease → robust estimate within tolerance", () => {
+    const rnd = lcg(12345);
+    const perDay = 2 * GIB;
+    const samples: DiskUsageSample[] = [];
+    for (let t = 0; t <= 7 * MS_PER_DAY; t += 60 * 60 * 1000) {
+      const trend = 300 * GIB - (perDay * t) / MS_PER_DAY;
+      const noise = (rnd() - 0.5) * 0.5 * GIB; // ±0.25 GiB jitter
+      samples.push({ timestampMs: T0 + t, freeBytes: Math.max(0, trend + noise) });
+    }
+    const rate = estimateConsumptionRateBytesPerDay(samples);
+    expect(rate).not.toBeNull();
+    expect(rate! / GIB).toBeCloseTo(2, 1); // within ~0.05 GiB/day despite noise
+  });
+});
+
+describe("createFridayDiskGrowthRateSampler (bounded buffer)", () => {
+  it("record → getGrowthRateBytesPerDay reproduces the estimator over the window", () => {
+    const sampler = createFridayDiskGrowthRateSampler();
+    for (const s of steadyDecrease(500 * GIB, GIB, 7, 60 * 60 * 1000)) sampler.record(s.timestampMs, s.freeBytes);
+    const rate = sampler.getGrowthRateBytesPerDay();
+    expect(rate).not.toBeNull();
+    expect(rate! / GIB).toBeCloseTo(1, 6);
+  });
+
+  it("never exceeds MAX_SAMPLES (count cap) even under many in-window ticks", () => {
+    const sampler = createFridayDiskGrowthRateSampler({ maxSamples: 100, windowMs: 10_000 * MS_PER_DAY });
+    for (let i = 0; i < 5000; i++) sampler.record(T0 + i * 60 * 1000, 100 * GIB - i);
+    expect(sampler.size()).toBeLessThanOrEqual(100);
+  });
+
+  it("prunes samples older than WINDOW_MS (age cap)", () => {
+    const windowMs = 8 * MS_PER_DAY;
+    const sampler = createFridayDiskGrowthRateSampler({ windowMs, maxSamples: 100_000 });
+    // 30 daily samples; only those within the trailing 8-day window relative to newest survive.
+    for (let d = 0; d < 30; d++) sampler.record(T0 + d * MS_PER_DAY, 100 * GIB - d * GIB);
+    const snap = sampler.snapshot();
+    const newest = Math.max(...snap.map((s) => s.timestampMs));
+    expect(snap.every((s) => s.timestampMs >= newest - windowMs)).toBe(true);
+    expect(snap.length).toBeLessThanOrEqual(9); // 8-day window at daily cadence
+  });
+
+  it("memory stays bounded under a very long tick history (both caps active)", () => {
+    const sampler = createFridayDiskGrowthRateSampler(); // defaults: 4096 cap, 8-day window
+    // Two years of 5-minute ticks — far exceeds both caps.
+    const stepMs = 5 * 60 * 1000;
+    for (let i = 0; i < 200_000; i++) sampler.record(T0 + i * stepMs, 1000 * GIB - i * 1000);
+    expect(sampler.size()).toBeLessThanOrEqual(DEFAULT_DISK_GROWTH_RATE_SAMPLER_CONFIG.maxSamples);
+    // Age window (8 days) is the tighter bound at 5-min cadence: 8*288 = 2304 < 4096.
+    expect(sampler.size()).toBeLessThanOrEqual((8 * MS_PER_DAY) / stepMs + 1);
+  });
+
+  it("startup: no samples → null; one sample → null; short span → null (fail-closed)", () => {
+    const sampler = createFridayDiskGrowthRateSampler();
+    expect(sampler.getGrowthRateBytesPerDay(T0)).toBeNull();
+    sampler.record(T0, 50 * GIB);
+    expect(sampler.getGrowthRateBytesPerDay(T0)).toBeNull();
+    sampler.record(T0 + 5 * 60 * 1000, 50 * GIB - 1000); // 5 min span < 1h
+    expect(sampler.getGrowthRateBytesPerDay(T0 + 5 * 60 * 1000)).toBeNull();
+  });
+
+  it("nowMs age-prunes stale samples so a stalled loop cannot serve stale data", () => {
+    const sampler = createFridayDiskGrowthRateSampler({ windowMs: 8 * MS_PER_DAY });
+    for (const s of steadyDecrease(500 * GIB, GIB, 7, 60 * 60 * 1000)) sampler.record(s.timestampMs, s.freeBytes);
+    expect(sampler.size()).toBeGreaterThan(0);
+    // Advance now far beyond the window with no new samples: all prune away → null.
+    const rate = sampler.getGrowthRateBytesPerDay(T0 + 100 * MS_PER_DAY);
+    expect(sampler.size()).toBe(0);
+    expect(rate).toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

RETENTION-R3b (#1613, merged as `a459dedd`) landed the U13-STORAGE-PRESSURE projected-exhaustion branch but wired the growth rate to a constant `null`, so the **7-day exhaustion warning was inert**. R3c supplies a **REAL bounded rolling growth-rate measurement** so that branch becomes **observable**, **without changing any of #1613's merged classifier/evaluator logic** (its 86 focused tests pass byte-identical).

Carries four advisor/reviewer-hardening rounds on the first cut.

## Module — `src/learning/services/friday-disk-growth-rate-sampler.ts`

- **`estimateConsumptionRateBytesPerDay(samples)`** — PURE single-window least-squares slope of `freeBytes` vs **monotonic** time. insufficient/invalid/short-span/degenerate → `null`; stable/increasing → `0`; sustained decrease → positive bytes/day.
- **`recentDeclineSignal(sorted, shortWindowMs)`** — PURE **noise-tolerant change-point detector**: over the most recent `shortWindowMs` (1h), anchors at the **latest-occurring local peak** and measures **net consumption from that peak to now** (endpoint-based → leading flats don't dilute it, interior ties/upticks are absorbed), returning the short rate + `confirmingDecreases`.
- **`estimateConservativeConsumptionRateBytesPerDay(samples)`** — the rate the sampler serves: the **soonest-exhaustion max** of the full-window slope, the recent-6h slope, and the change-point signal (folded in only when corroborated + warn-implying).
- **`createFridayDiskGrowthRateSampler({ monotonicNowMs? })`** — in-memory rolling buffer bounded both ways (count cap 4096 + 8-day monotonic age-prune). Report-only; never deletes.
- **`defaultMonotonicNowMs()`** — production monotonic clock adapter (`performance.now()`), unit-tested directly.

## Hardenings

**Round-1 — measured-zero vs null + non-stationarity.** Conservative full-vs-recent max; `0` only when no horizon shows depletion.

**Round-2 Finding 1 — wall-clock trust.** Elapsed-time math (all slopes + age-pruning) uses an injected **MONOTONIC** clock, never `Date.now()`; non-strictly-increasing samples rejected (fail-closed skip).

**Round-2 Finding 3 — no seam overclaim.** `defaultMonotonicNowMs` unit-tested; integration drives the sampler → real monitor → classifier through the production `monotonicNowMs` injection point.

**Round-2 change-point.** A fixed 6h "recent" LSQ is diluted by preceding flat history during a fresh sustained depletion → added an undiluted short-horizon signal.

**Round-3 (this commit) — NOISE-TOLERANT change-point.** The round-3 signal used a STRICT consecutive-decrease run, so a single **tie** (an exact byte-for-byte statfs repeat — realistic read-granularity noise) or sub-tolerance uptick reset the run to 0, silenced corroboration, and fell back to the diluted average → a false `ok` mid-depletion (reviewer repros: exact-repeat tie → `ok`; alternating decrease/flat → `ok` at even ticks; 1-in-4 tie noise → warn/ok **flip-flop** for ~140 min). Fixed by replacing the strict run with the **recent-peak-anchored net-trend** signal above: interior ties/upticks are absorbed, only a sustained **net recovery** clears corroboration. Folded into the conservative max only when **corroborated** (≥2 confirming decreases) and implying exhaustion ≤ 7 days → **warns**; a single unconfirmed fast drop → `null` (**unknown**, not cry-wolf); minor fluctuations imply ≫7 days → `ok`. No new warn branch; the classifier remains the sole status authority.

## Bootstrap wiring — `src/hub/friday-hub-bootstrap.ts`

Sampler created **once** (persists across ticks). Each tick's `probeDiskSpace` calls `record(freeBytes)` (monotonic-timestamped); `probeGrowthRateBytesPerDay: () => null` → `() => diskGrowthRateSampler.getGrowthRateBytesPerDay()`. Untouched since round-2.

## Preserved exactly (byte-identical)

`classifyDiskGrowth`, `evaluateLargeWriteSafety`, `ceilDiv`, fail-closed-on-unknown, measured-zero-vs-null, non-integer-count fail-closed, continuous `isValidRate`, the independent BigInt oracle, and the monitor. **#1613's 86 focused tests pass unchanged.** Round-2 monotonic injection + non-monotonic rejection, recovery-then-cliff → warn, bounded buffer + stalled→null, single-unconfirmed→unknown, and the real-seam integration test all preserved.

## Tests (red-first) — full matrix, INTEGER byte values

(a) exact-repeat tie mid-decline → never `ok`, corroborated → `warn`; (b) alternating decrease/flat → `warn`, never `ok`; (c) 1-in-4 tie noise → sustained `warn`, **no flip-flop**, never `ok`; (d) single transient dip → `unknown` one tick → recovery → `ok`; (e) noisy-but-stable → `ok`; (f) multi-day recovery → `ok`; (g) slow decline (>7d) → slow positive rate → `ok`; (h) monotonic probe (−10/5min) → sample1 `unknown`, ≥2 → `warn`. Plus unit tie/uptick-absorption tests, the round-2 wall-clock/monotonic/recovery-cliff suite, and `defaultMonotonicNowMs` monotonicity. **(a)/(b)/(c) confirmed RED on 42abff4, green after.**

**43 R3c tests** (29 sampler + 14 integration) + **86 #1613 unchanged** = **129 green**.

## Gates

typecheck 0; lint 0 errors (new file 0 warnings); `git diff --check` clean; detect-secrets NONE; no migrations touched.

## Honest non-goals

Makes the 7-day branch **observable** but does **not** close DATA-RETENTION-001 (large-write-verdict prod wiring + Settings UI + restart-durable persistence still pending). Buffer is **in-memory, not restart-durable** (re-accrues after restart; reads `unknown` until enough samples — correct fail-closed startup). Report-only, no deletion. **Friday remains NO_GO.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48