### PR TITLE
SEC: converge execution-control emitter error scrub onto canonical detector

### DIFF
--- a/src/api/realtime/friday-execution-control-event-emitter.ts
+++ b/src/api/realtime/friday-execution-control-event-emitter.ts
@@ -20,6 +20,7 @@ import type {
 import type { FridayRealtimeEventBus } from "./friday-realtime-event-bus.types.js";
 import type { FridayAuditRecord } from "../../security/friday-audit-log.js";
 import { redactEventPayload } from "./friday-event-payload-redactor.js";
+import { redactSecretShapesInString } from "../../security/friday-secret-shape-redactor.js";
 
 const DEFAULT_EMITTED_EVENTS_LIMIT = 1_000;
 const DEFAULT_AUDIT_SINK_FAILURES_LIMIT = 100;
@@ -129,8 +130,21 @@ function clampPositiveInteger(value: number | undefined, fallback: number): numb
 
 function auditSinkErrorMessage(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err);
-  return raw
-    .replace(/\b(sk-|key-|pk-|rk-|xai-|gsk_|aip-|whsk-|sess-|ssm-)[A-Za-z0-9_-]{8,}\b/g, "[REDACTED]")
+  // Secret-shape scrubbing converges onto the CANONICAL detector — the single source of truth for
+  // provider-credential shapes (`hf_` / `glpat-` / `ghp_` / `gh?_` / `github_pat_` / `sk-` / `gsk_` /
+  // AWS `AKIA…` / JWT / PEM / `AIza…` / `ya29.` / `GOCSPX-` / `SG.` / `sq0…` / `dop_v1_` / `npm_` /
+  // Slack / `Bearer …` / generic `key=value` assignments — see friday-secret-shape-redactor.ts). The
+  // previous LOCAL prefix list was divergent: it covered `gsk_` but MISSED `hf_` / `glpat-` / `ghp_` /
+  // AWS / JWT / PEM, so a raw token in the sink's exception message leaked to the process logs.
+  //
+  // Two DISPLAY-only extras are kept, layered ON TOP, precisely because the canonical persistence /
+  // egress detector DELIBERATELY EXCLUDES them (see that module's header): (1) the generic /
+  // unverified-provenance error-message prefixes `key-` / `pk-` / `aip-` / `whsk-` / `sess-` / `ssm-`
+  // that canonical drops as over-redactors, and (2) any long base64 blob. This is a logs-only
+  // exception-message display sink that TOLERATES over-redaction where the canonical detector must
+  // not — so the scrub is never LESS aggressive than before, only strictly more (no coverage lost).
+  return redactSecretShapesInString(raw, "[REDACTED]")
+    .replace(/\b(key-|pk-|aip-|whsk-|sess-|ssm-)[A-Za-z0-9_-]{8,}\b/g, "[REDACTED]")
     .replace(/\b[A-Za-z0-9/+]{40,}={0,2}\b/g, "[REDACTED]");
 }
 

--- a/src/api/realtime/friday-execution-control-event-emitter.ts
+++ b/src/api/realtime/friday-execution-control-event-emitter.ts
@@ -130,21 +130,27 @@ function clampPositiveInteger(value: number | undefined, fallback: number): numb
 
 function auditSinkErrorMessage(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err);
-  // Secret-shape scrubbing converges onto the CANONICAL detector — the single source of truth for
-  // provider-credential shapes (`hf_` / `glpat-` / `ghp_` / `gh?_` / `github_pat_` / `sk-` / `gsk_` /
-  // AWS `AKIA…` / JWT / PEM / `AIza…` / `ya29.` / `GOCSPX-` / `SG.` / `sq0…` / `dop_v1_` / `npm_` /
-  // Slack / `Bearer …` / generic `key=value` assignments — see friday-secret-shape-redactor.ts). The
-  // previous LOCAL prefix list was divergent: it covered `gsk_` but MISSED `hf_` / `glpat-` / `ghp_` /
-  // AWS / JWT / PEM, so a raw token in the sink's exception message leaked to the process logs.
+  // Secret-shape scrubbing for this logs-only exception-message DISPLAY sink is the UNION of two
+  // passes, so its recall is a STRICT SUPERSET of both:
   //
-  // Two DISPLAY-only extras are kept, layered ON TOP, precisely because the canonical persistence /
-  // egress detector DELIBERATELY EXCLUDES them (see that module's header): (1) the generic /
-  // unverified-provenance error-message prefixes `key-` / `pk-` / `aip-` / `whsk-` / `sess-` / `ssm-`
-  // that canonical drops as over-redactors, and (2) any long base64 blob. This is a logs-only
-  // exception-message display sink that TOLERATES over-redaction where the canonical detector must
-  // not — so the scrub is never LESS aggressive than before, only strictly more (no coverage lost).
+  //   1. the CANONICAL secret detector `redactSecretShapesInString` — the single source of truth for
+  //      provider-credential shapes the old local list MISSED: `hf_` / `glpat-` / `ghp_` / `gh?_` /
+  //      `github_pat_` / AWS `AKIA…` / JWT / PEM / `AIza…` / `ya29.` / `GOCSPX-` / `SG.` / `sq0…` /
+  //      `dop_v1_` / `npm_` / Slack / `Bearer …` / generic `key=value` assignments (see
+  //      friday-secret-shape-redactor.ts);
+  //   2. the FULL UNCHANGED legacy display regex, retained VERBATIM as a display-only over-redactor.
+  //
+  // The legacy expression is kept in full — including `sk-` / `rk-` / `xai-` / `gsk_` — because the
+  // canonical detector only matches those at their REAL credential lengths (`{16,}` / `{40,}`), so a
+  // SUB-THRESHOLD body (8–15 chars) that the legacy `{8,}` regex redacts would otherwise SURVIVE into
+  // `auditSinkFailures` + `console.warn`. The legacy pass also carries the generic / unverified
+  // prefixes (`key-` / `pk-` / `aip-` / `whsk-` / `sess-` / `ssm-`) + any long base64 blob that the
+  // canonical persistence/egress detector DELIBERATELY EXCLUDES as over-redactors. Over-redaction is
+  // fine for THIS logs-only display sink (its existing design) where the canonical detector must not.
+  // Net: every shape + threshold the old scrub redacted still redacts, PLUS the canonical shapes it
+  // previously missed — a true coverage superset, no legacy prefix or threshold dropped.
   return redactSecretShapesInString(raw, "[REDACTED]")
-    .replace(/\b(key-|pk-|aip-|whsk-|sess-|ssm-)[A-Za-z0-9_-]{8,}\b/g, "[REDACTED]")
+    .replace(/\b(sk-|key-|pk-|rk-|xai-|gsk_|aip-|whsk-|sess-|ssm-)[A-Za-z0-9_-]{8,}\b/g, "[REDACTED]")
     .replace(/\b[A-Za-z0-9/+]{40,}={0,2}\b/g, "[REDACTED]");
 }
 

--- a/test/integration/api/friday-execution-control-events.test.ts
+++ b/test/integration/api/friday-execution-control-events.test.ts
@@ -467,54 +467,89 @@ describe("Audit Sink Integration", () => {
   });
 });
 
-// ─── Audit-Sink Failure Message Scrubbing (canonical secret detector) ───
+// ─── Audit-Sink Failure Message Scrubbing (canonical detector ∪ full legacy display regex) ───
 
-// SEC — the audit-sink exception message (surfaced to `auditSinkFailures` + `console.warn`) is scrubbed
-// by the CANONICAL secret-shape detector (`redactSecretShapesInString`), NOT a divergent local prefix
-// list. The old local regex covered `gsk_` but MISSED `hf_` / `glpat-` / `ghp_` / AWS / JWT / PEM etc.
-// RED on the pre-fix emitter (hf_/glpat- passed through verbatim to the logs); GREEN once the scrub
-// converges onto the single canonical detector.
+// SEC — the audit-sink exception message reaches BOTH `auditSinkFailures[0].message` and the process
+// logs via `console.warn`. It is scrubbed by the CANONICAL secret-shape detector
+// (`redactSecretShapesInString`) UNIONED with the FULL unchanged legacy display regex. The canonical
+// detector adds the shapes the old local list MISSED (`hf_` / `glpat-` / `ghp_` / AWS / JWT / PEM …);
+// the full legacy regex is retained as a display-only over-redactor so EVERY shape + threshold the old
+// scrub redacted still redacts — including SUB-THRESHOLD `sk-`/`rk-`/`xai-`/`gsk_` bodies (8–15 chars)
+// that canonical (which requires the real credential length `{16,}`/`{40,}`) does NOT match. Both are
+// asserted on BOTH sinks (surfaced message + spied `console.warn`).
 describe("Audit Sink Failure Message Scrubbing", () => {
   // Build secret-shaped fixtures at runtime so no contiguous literal token ever appears in SOURCE
   // (GitHub push protection scans source text and does NOT honor the detect-secrets pragma — same
-  // rationale as the redactor unit test's `stripeShaped` helper). At runtime each concatenation
-  // produces the exact provider shape the canonical redactor recognizes.
+  // rationale as the redactor unit test's `stripeShaped` helper).
   const hfToken = "hf_" + "AbCdEfGhIjKlMnOpQrStUvWx0123456789yZ"; // pragma: allowlist secret
   const glpatToken = "glpat-" + "AbCdEfGhIjKlMnOpQrStUv"; // pragma: allowlist secret
   const gskToken = "gsk_" + "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789abcd"; // pragma: allowlist secret
+  // SUB-THRESHOLD legacy-only shapes: 8-char bodies the OLD `{8,}` regex redacted but canonical
+  // (`sk-`/`rk-`/`xai-` need `{16,}`, `gsk_` needs `{40,}`) does NOT — these MUST stay redacted.
+  const shortSk = "sk-" + "AbCdEf12"; // pragma: allowlist secret
+  const shortRk = "rk-" + "AbCdEf12"; // pragma: allowlist secret
+  const shortXai = "xai-" + "AbCdEf12"; // pragma: allowlist secret
+  const shortGsk = "gsk_" + "AbCdEf12"; // pragma: allowlist secret
 
-  function scrubbedFailureMessage(errorMessage: string): string {
-    const bus = freshBus();
-    const emitter = createExecutionControlEventEmitter({
-      eventBus: bus,
-      nowIso,
-      auditSink: () => {
-        throw new Error(errorMessage);
-      },
-    });
-    emitter.emit("rules.bundle.created", { bundleId: "pb-1", name: "test" });
-    expect(emitter.auditSinkFailures).toHaveLength(1);
-    return emitter.auditSinkFailures[0].message;
+  // Drive the audit-sink-throws path and capture what reaches BOTH sinks: the surfaced
+  // `auditSinkFailures[0].message` AND the process-log line emitted via `console.warn` (spied).
+  function driveAuditSinkFailure(errorMessage: string): { surfaced: string; warned: string } {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const bus = freshBus();
+      const emitter = createExecutionControlEventEmitter({
+        eventBus: bus,
+        nowIso,
+        auditSink: () => {
+          throw new Error(errorMessage);
+        },
+      });
+      emitter.emit("rules.bundle.created", { bundleId: "pb-1", name: "test" });
+      expect(emitter.auditSinkFailures).toHaveLength(1);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      return {
+        surfaced: emitter.auditSinkFailures[0].message,
+        warned: warnSpy.mock.calls[0].map(String).join(" "),
+      };
+    } finally {
+      warnSpy.mockRestore();
+    }
+  }
+
+  function expectRedactedNotLeaked(errorMessage: string, ...rawTokens: string[]): void {
+    const { surfaced, warned } = driveAuditSinkFailure(errorMessage);
+    for (const raw of rawTokens) {
+      expect(surfaced, `surfaced leaked ${raw.slice(0, 6)}`).not.toContain(raw);
+      expect(warned, `console.warn leaked ${raw.slice(0, 6)}`).not.toContain(raw);
+    }
+    expect(surfaced).toContain("[REDACTED]");
+    expect(warned).toContain("[REDACTED]");
   }
 
   it("redacts hf_ / glpat- tokens the old local prefix list MISSED (canonical convergence)", () => {
-    const scrubbed = scrubbedFailureMessage(
+    expectRedactedNotLeaked(
       `Audit persistence failed for hf=${hfToken} gitlab=${glpatToken}`,
+      hfToken,
+      glpatToken,
     );
-    expect(scrubbed).not.toContain(hfToken);
-    expect(scrubbed).not.toContain(glpatToken);
-    expect(scrubbed).toContain("[REDACTED]");
   });
 
-  it("still redacts a gsk_ token the local regex already covered (no regression)", () => {
-    const scrubbed = scrubbedFailureMessage(`Audit persistence failed for token=${gskToken}`);
-    expect(scrubbed).not.toContain(gskToken);
-    expect(scrubbed).toContain("[REDACTED]");
+  it("redacts SUB-THRESHOLD sk-/rk-/xai-/gsk_ bodies the legacy regex covered but canonical does not (no recall regression)", () => {
+    expectRedactedNotLeaked(`fail sk=${shortSk}`, shortSk);
+    expectRedactedNotLeaked(`fail rk=${shortRk}`, shortRk);
+    expectRedactedNotLeaked(`fail xai=${shortXai}`, shortXai);
+    expectRedactedNotLeaked(`fail gsk=${shortGsk}`, shortGsk);
   });
 
-  it("leaves a benign exception message byte-identical (no over-redaction)", () => {
+  it("still redacts a realistic-length gsk_ token (no regression on the previously-covered prefix)", () => {
+    expectRedactedNotLeaked(`Audit persistence failed for token=${gskToken}`, gskToken);
+  });
+
+  it("leaves a benign exception message byte-identical on both sinks (no over-redaction)", () => {
     const benign = "Audit sink unavailable: connection refused (ECONNREFUSED) after 3 retries";
-    expect(scrubbedFailureMessage(benign)).toBe(benign);
+    const { surfaced, warned } = driveAuditSinkFailure(benign);
+    expect(surfaced).toBe(benign);
+    expect(warned).toContain(benign);
   });
 });
 

--- a/test/integration/api/friday-execution-control-events.test.ts
+++ b/test/integration/api/friday-execution-control-events.test.ts
@@ -467,6 +467,57 @@ describe("Audit Sink Integration", () => {
   });
 });
 
+// ─── Audit-Sink Failure Message Scrubbing (canonical secret detector) ───
+
+// SEC — the audit-sink exception message (surfaced to `auditSinkFailures` + `console.warn`) is scrubbed
+// by the CANONICAL secret-shape detector (`redactSecretShapesInString`), NOT a divergent local prefix
+// list. The old local regex covered `gsk_` but MISSED `hf_` / `glpat-` / `ghp_` / AWS / JWT / PEM etc.
+// RED on the pre-fix emitter (hf_/glpat- passed through verbatim to the logs); GREEN once the scrub
+// converges onto the single canonical detector.
+describe("Audit Sink Failure Message Scrubbing", () => {
+  // Build secret-shaped fixtures at runtime so no contiguous literal token ever appears in SOURCE
+  // (GitHub push protection scans source text and does NOT honor the detect-secrets pragma — same
+  // rationale as the redactor unit test's `stripeShaped` helper). At runtime each concatenation
+  // produces the exact provider shape the canonical redactor recognizes.
+  const hfToken = "hf_" + "AbCdEfGhIjKlMnOpQrStUvWx0123456789yZ"; // pragma: allowlist secret
+  const glpatToken = "glpat-" + "AbCdEfGhIjKlMnOpQrStUv"; // pragma: allowlist secret
+  const gskToken = "gsk_" + "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789abcd"; // pragma: allowlist secret
+
+  function scrubbedFailureMessage(errorMessage: string): string {
+    const bus = freshBus();
+    const emitter = createExecutionControlEventEmitter({
+      eventBus: bus,
+      nowIso,
+      auditSink: () => {
+        throw new Error(errorMessage);
+      },
+    });
+    emitter.emit("rules.bundle.created", { bundleId: "pb-1", name: "test" });
+    expect(emitter.auditSinkFailures).toHaveLength(1);
+    return emitter.auditSinkFailures[0].message;
+  }
+
+  it("redacts hf_ / glpat- tokens the old local prefix list MISSED (canonical convergence)", () => {
+    const scrubbed = scrubbedFailureMessage(
+      `Audit persistence failed for hf=${hfToken} gitlab=${glpatToken}`,
+    );
+    expect(scrubbed).not.toContain(hfToken);
+    expect(scrubbed).not.toContain(glpatToken);
+    expect(scrubbed).toContain("[REDACTED]");
+  });
+
+  it("still redacts a gsk_ token the local regex already covered (no regression)", () => {
+    const scrubbed = scrubbedFailureMessage(`Audit persistence failed for token=${gskToken}`);
+    expect(scrubbed).not.toContain(gskToken);
+    expect(scrubbed).toContain("[REDACTED]");
+  });
+
+  it("leaves a benign exception message byte-identical (no over-redaction)", () => {
+    const benign = "Audit sink unavailable: connection refused (ECONNREFUSED) after 3 retries";
+    expect(scrubbedFailureMessage(benign)).toBe(benign);
+  });
+});
+
 // ─── PII Redaction in Events ───
 
 describe("PII Redaction in Event Payloads", () => {


### PR DESCRIPTION
## The drift

`src/api/realtime/friday-execution-control-event-emitter.ts` scrubbed the audit-sink
exception message with a **divergent LOCAL secret regex**:

```
/\b(sk-|key-|pk-|rk-|xai-|gsk_|aip-|whsk-|sess-|ssm-)[A-Za-z0-9_-]{8,}\b/g
```

That local list covered `gsk_` but **MISSED** the many shapes the canonical detector
`redactSecretShapesInString` (`src/security/friday-secret-shape-redactor.ts`) already
catches: `hf_`, `glpat-`, `ghp_` / `gh?_` / `github_pat_`, AWS `AKIA…`, JWT (`eyJ…`),
PEM blocks, `AIza…`, `ya29.`, `GOCSPX-`, `SG.`, `sq0…`, `dop_v1_`, `npm_`, Slack,
`Bearer …`, generic `key=value` assignments. So a raw `hf_<token>` embedded in the audit
sink's exception `err.message` reached `console.warn` + `auditSinkFailures` **unredacted**.

## The fix (canonical ∪ FULL legacy display regex — a true superset)

The display-sink scrub is now the **UNION** of two passes, applied in order:

```
return redactSecretShapesInString(raw, "[REDACTED]")
  .replace(/\b(sk-|key-|pk-|rk-|xai-|gsk_|aip-|whsk-|sess-|ssm-)[A-Za-z0-9_-]{8,}\b/g, "[REDACTED]")
  .replace(/\b[A-Za-z0-9/+]{40,}={0,2}\b/g, "[REDACTED]");
```

1. the **canonical** detector adds every shape the old list missed (`hf_`/`glpat-`/`ghp_`/AWS/JWT/PEM/…);
2. the **FULL, unchanged legacy display regex** is retained verbatim as a display-only over-redactor.

### Why the full legacy regex is kept (Advisor catch — corrects an earlier claim)

An earlier revision of this PR **dropped** `sk-`/`rk-`/`xai-`/`gsk_` from the residual regex,
on the theory that canonical "owns" those prefixes. That was **wrong**: canonical matches
`sk-`/`rk-`/`xai-` only at `{16,}` and `gsk_` at `{40,}`, so **sub-threshold** bodies
(`sk-AbCdEf12` 8-char body, `rk-…`, `xai-…` 8–15; `gsk_…` 8–39) that the old `{8,}` regex
redacted would have **survived verbatim** into `auditSinkFailures` + `console.warn`. That
was a display-sink recall regression, and the previous "strict superset / no coverage lost"
framing was false. The fix keeps the legacy expression **in full** — no legacy prefix or
threshold dropped — so the union is a genuine coverage superset:

- **canonical ∪ full-legacy ⊇ legacy (base)** — every shape + threshold the old scrub
  redacted still redacts (empirically verified across all 10 prefixes × {8,16,40}-char
  bodies + the base64 blob), **plus** the previously-missed canonical shapes.

Over-redaction is fine for this **logs-only display sink** (its existing design), where the
canonical persistence/egress detector must not over-redact — which is exactly why canonical
deliberately excludes the generic/unverified prefixes and the base64 blob, and why the
display sink keeps them.

## RED-FIRST

`test/integration/api/friday-execution-control-events.test.ts` → `Audit Sink Failure
Message Scrubbing`: drives the audit-sink-throws path and asserts on **both** sinks —
`auditSinkFailures[0].message` **and** a spied `console.warn` — that tokens are `[REDACTED]`
and NOT leaked.

- `hf_` / `glpat-` (canonical additions the old list missed) → redacted. RED on the original base, GREEN now.
- **Sub-threshold** `sk-AbCdEf12` / `rk-AbCdEf12` / `xai-AbCdEf12` / `gsk_AbCdEf12` → redacted.
  RED on the intermediate head `6f87e186` (they leaked verbatim), GREEN after restoring the full legacy regex.
- realistic-length `gsk_` still redacts — no regression.
- a benign exception message is byte-identical on the surfaced sink and present in the log line — no over-redaction.

## Scope / severity (honest)

**Low severity**: logs-only, exception path, and the event payload itself was already
canonically redacted upstream. This is a divergent-detector **hygiene** fix (one canonical
detector for the missed shapes, layered with the retained legacy display over-redactor).

## Gates

- `npx tsc --noEmit` = 0
- `npx eslint .` = 0 errors
- emitter integration suite 39/39 green (+4 new); related realtime/redactor/pipeline suites 76/76 green; no `.only` / `.skip`
- `detect-secrets-hook` (exact CI command + baseline) → ✅ No new secrets detected
- diff = source + test only (no migration / lockfile / `.secrets.baseline`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhCDTLngxAf6MDh4Bfcd48
