### PR TITLE
SEC/ART-NONPROD-001: gate FRIDAY_ALLOW_TEST_ONLY_* switches behind protected-release profile (no activatable mock lane in release)

### DIFF
--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -46,6 +46,10 @@ import type { FridayStateRuntime } from "#state";
 import { createFridayLocalDaemonService } from "#daemon";
 import { createFridayMutatingActionGate } from "../security/friday-mutating-action-gate.js";
 import {
+  fridayProtectedProfileTestOnlySwitchMessage,
+  isFridayProtectedReleaseProfile,
+} from "../security/friday-protected-profile.js";
+import {
   buildFridayRuntimeCapabilityMatrix,
   createFridayProviderCostCalculator,
   createFridayProviderPricingCatalog,
@@ -870,10 +874,14 @@ export function resolveFridayHubConfig(
   const allowTestOnlyPluginExecution = resolveTestOnlyFlagFromEnv(
     input.allowTestOnlyPluginExecution,
     env.FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION,
+    "FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION",
+    env,
   );
   const allowTestOnlyAutonomyLifecycleExecution = resolveTestOnlyFlagFromEnv(
     input.allowTestOnlyAutonomyLifecycleExecution,
     env.FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION,
+    "FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION",
+    env,
   );
   const pluginRuntimeModeRaw = input.pluginRuntimeMode ?? env.FRIDAY_PLUGIN_RUNTIME_MODE ?? "stub";
   const pluginRuntimeMode = pluginRuntimeModeRaw === "full"
@@ -917,22 +925,42 @@ export function resolveFridayHubConfig(
 }
 
 function isFridayCanonicalGateProtectedProfile(env: NodeJS.ProcessEnv): boolean {
-  return env.NODE_ENV?.trim().toLowerCase() === "production"
-    || Boolean(env.FRIDAY_RELEASE_TAG?.trim());
+  // Single source of truth (shared with secret-crypto) — see friday-protected-profile.ts.
+  return isFridayProtectedReleaseProfile(env);
 }
 
+/**
+ * Resolve a test-only activation flag from an EXPLICIT config boolean or, as a
+ * fallback, its `FRIDAY_ALLOW_TEST_ONLY_*` ENV var.
+ *
+ * ART-NONPROD-001 (fail-closed): a test/mock lane MUST NOT be activatable in a
+ * production / tagged-release build. When the resolved value would be `true`
+ * AND the runtime is a protected profile, THROW instead of activating. This
+ * mirrors the `resolveFridayCanonicalMutatingActionGate` throw precedent. The
+ * throw covers BOTH the env-sourced path (the primary defect) and, as
+ * defense-in-depth, an explicit `configValue === true`.
+ */
 function resolveTestOnlyFlagFromEnv(
   configValue: boolean | undefined,
   envValue: string | undefined,
+  envVarName: string,
+  env: NodeJS.ProcessEnv,
 ): boolean | undefined {
   if (typeof configValue === "boolean") {
+    if (configValue === true && isFridayCanonicalGateProtectedProfile(env)) {
+      throw new Error(fridayProtectedProfileTestOnlySwitchMessage(envVarName));
+    }
     return configValue;
   }
   const raw = (envValue ?? "").trim().toLowerCase();
   if (raw === "") {
     return undefined;
   }
-  return raw === "1" || raw === "true";
+  const enabled = raw === "1" || raw === "true";
+  if (enabled && isFridayCanonicalGateProtectedProfile(env)) {
+    throw new Error(fridayProtectedProfileTestOnlySwitchMessage(envVarName));
+  }
+  return enabled;
 }
 
 export function resolveFridayCanonicalMutatingActionGate(
@@ -1514,10 +1542,14 @@ export async function createFridayHub(
   const configuredAllowTestOnlyPluginExecution = resolveTestOnlyFlagFromEnv(
     config.allowTestOnlyPluginExecution,
     process.env.FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION,
+    "FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION",
+    process.env,
   );
   const configuredAllowTestOnlyAutonomyLifecycleExecution = resolveTestOnlyFlagFromEnv(
     config.allowTestOnlyAutonomyLifecycleExecution,
     process.env.FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION,
+    "FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION",
+    process.env,
   );
   const configuredPluginRuntimeModeRaw = (
     config.pluginRuntimeMode ??

--- a/src/security/friday-protected-profile.ts
+++ b/src/security/friday-protected-profile.ts
@@ -1,0 +1,83 @@
+/**
+ * ART-NONPROD-001 — protected-release-profile predicate + the canonical registry
+ * of test-only ENV switches, shared by the hub bootstrap and secret-crypto so a
+ * mock/test lane can NEVER be activatable in a production / tagged-release build.
+ *
+ * This is a LEAF module: it imports nothing from the Friday tree (only the
+ * ambient `NodeJS.ProcessEnv` type), so both `friday-hub-bootstrap.ts` (`#hub`)
+ * and `friday-secret-crypto.ts` (`#providers`) can import it WITHOUT creating an
+ * import cycle. Keep it dependency-free.
+ */
+
+/**
+ * A "protected" runtime profile is a production build (`NODE_ENV=production`) or
+ * any tagged-release build (`FRIDAY_RELEASE_TAG` non-empty). Test-only switches
+ * and mock lanes MUST fail closed in these profiles.
+ *
+ * This is the SINGLE source of truth for the protected-profile predicate; the
+ * hub bootstrap's `isFridayCanonicalGateProtectedProfile` delegates to it so the
+ * canonical mutating-action gate and the test-only switch gate agree exactly.
+ */
+export function isFridayProtectedReleaseProfile(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return env.NODE_ENV?.trim().toLowerCase() === "production"
+    || Boolean(env.FRIDAY_RELEASE_TAG?.trim());
+}
+
+/**
+ * Canonical, CLOSED registry of every `FRIDAY_ALLOW_TEST_ONLY_*` ENV switch that
+ * activates a test/mock lane. Every entry MUST be refused in a protected profile.
+ *
+ * OPEN-WORLD GUARD: `test/unit/security/friday-protected-profile.test.ts`
+ * enumerates every `FRIDAY_ALLOW_TEST_ONLY_*` literal referenced under `src/`
+ * and asserts each is registered here AND refused in a protected profile — so a
+ * future un-gated test-only switch fails the guard rather than silently shipping
+ * an activatable mock lane in a release build.
+ *
+ * NOTE: the REAL signed-artifact / release-manifest observation scan is release
+ * gated and intentionally OUT OF SCOPE here (mirrors the deferred real-observation
+ * boundary documented in `tools/inventory/reconcile.mjs`); this registry is the
+ * source-level, code-only guard.
+ */
+export const FRIDAY_TEST_ONLY_ENV_SWITCHES = [
+  "FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION",
+  "FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION",
+  "FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION",
+] as const;
+
+export type FridayTestOnlyEnvSwitch = (typeof FRIDAY_TEST_ONLY_ENV_SWITCHES)[number];
+
+const FRIDAY_TEST_ONLY_ENV_SWITCH_SET: ReadonlySet<string> = new Set(
+  FRIDAY_TEST_ONLY_ENV_SWITCHES,
+);
+
+/** True when `name` is a registered test-only ENV switch. */
+export function isRegisteredFridayTestOnlyEnvSwitch(name: string): boolean {
+  return FRIDAY_TEST_ONLY_ENV_SWITCH_SET.has(name);
+}
+
+/**
+ * Canonical fail-closed message. Names the SPECIFIC switch so an operator sees
+ * exactly which env var must be removed from a release build.
+ */
+export function fridayProtectedProfileTestOnlySwitchMessage(envVarName: string): string {
+  return (
+    `[friday] ${envVarName} (a FRIDAY_ALLOW_TEST_ONLY_* switch) cannot be enabled in `
+    + "production/release profiles (NODE_ENV=production or FRIDAY_RELEASE_TAG set). "
+    + "Use a development or test profile for mock lanes."
+  );
+}
+
+/**
+ * Fail closed if the named test-only switch would activate in a protected
+ * profile. No-op in dev/test profiles (dev/test lanes stay unaffected).
+ */
+export function assertFridayTestOnlyEnvSwitchAllowed(
+  envVarName: string,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (isFridayProtectedReleaseProfile(env)) {
+    throw new Error(fridayProtectedProfileTestOnlySwitchMessage(envVarName));
+  }
+}

--- a/src/security/friday-secret-crypto.ts
+++ b/src/security/friday-secret-crypto.ts
@@ -5,6 +5,10 @@ import * as os from "node:os";
 import { execFileSync } from "node:child_process";
 
 import { FridayDomainError } from "#errors";
+import {
+  fridayProtectedProfileTestOnlySwitchMessage,
+  isFridayProtectedReleaseProfile,
+} from "./friday-protected-profile.js";
 
 // ─── Encrypted envelope ───
 
@@ -393,6 +397,22 @@ export function getMasterKey(): Buffer {
       "VALIDATION_ERROR",
       "FRIDAY_MASTER_KEY_SOURCE=keychain requires a pre-provisioned macOS keychain item; Friday will not pass generated master keys through process arguments",
       { httpStatus: 400 },
+    );
+  }
+
+  // ART-NONPROD-001 (fail-closed): the test-only master-key GENERATION escape
+  // hatch must NEVER be activatable in a production / tagged-release profile —
+  // even as a leftover env var — so the release path can never silently mint a
+  // fresh encryption root. Refuse BEFORE it is honored below (fail-open persisted
+  // read at `failClosed` and the generation branch).
+  if (
+    process.env[TEST_ONLY_MASTER_KEY_GENERATION_ENV] === "1"
+    && isFridayProtectedReleaseProfile(process.env)
+  ) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      fridayProtectedProfileTestOnlySwitchMessage(TEST_ONLY_MASTER_KEY_GENERATION_ENV),
+      { httpStatus: 503 },
     );
   }
 

--- a/test/unit/hub/friday-hub-bootstrap-test-only-switch-gate.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-test-only-switch-gate.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { resolveFridayHubConfig } from "#hub";
+import type { FridayHubConfig } from "#hub";
+
+/**
+ * ART-NONPROD-001 (P0) — a test/mock activation switch must NOT be activatable
+ * in the default/production (release) path.
+ *
+ * `resolveFridayHubConfig` honors the ENV-sourced test-only switches
+ * `FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION` and
+ * `FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION` (which drive
+ * `pluginRuntimeMode = "full"`). In a protected profile (NODE_ENV=production or
+ * FRIDAY_RELEASE_TAG set) they must FAIL CLOSED (throw), not activate.
+ *
+ * `resolveFridayHubConfig` is pure w.r.t. the passed `env` (it never reads
+ * process.env for these flags), so these cases need no process.env mutation.
+ */
+
+function makeConfig(overrides: Partial<FridayHubConfig> = {}): FridayHubConfig {
+  return {
+    skillDirs: [],
+    ...overrides,
+  };
+}
+
+const GATE_MESSAGE = /cannot be enabled in production\/release profiles/;
+
+describe("resolveFridayHubConfig test-only switch protected-profile gate", () => {
+  // ─── FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION ───
+
+  it("throws when the plugin-execution switch is set with NODE_ENV=production", () => {
+    expect(() =>
+      resolveFridayHubConfig(makeConfig(), {
+        NODE_ENV: "production",
+        FRIDAY_PLUGIN_RUNTIME_MODE: "full",
+        FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION: "1",
+      }),
+    ).toThrow(GATE_MESSAGE);
+    expect(() =>
+      resolveFridayHubConfig(makeConfig(), {
+        NODE_ENV: "production",
+        FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION: "1",
+      }),
+    ).toThrow(/FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION/);
+  });
+
+  it("throws when the plugin-execution switch is set with a release tag", () => {
+    expect(() =>
+      resolveFridayHubConfig(makeConfig(), {
+        FRIDAY_RELEASE_TAG: "v1.2.3",
+        FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION: "true",
+      }),
+    ).toThrow(GATE_MESSAGE);
+  });
+
+  it("still activates the plugin-execution switch in a non-protected (dev/test) profile", () => {
+    const resolved = resolveFridayHubConfig(makeConfig(), {
+      FRIDAY_PLUGIN_RUNTIME_MODE: "full",
+      FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION: "1",
+    });
+    expect(resolved.allowTestOnlyPluginExecution).toBe(true);
+    expect(resolved.pluginRuntimeMode).toBe("full");
+  });
+
+  it("does not throw when the plugin-execution switch is absent in production", () => {
+    const resolved = resolveFridayHubConfig(makeConfig(), { NODE_ENV: "production" });
+    expect(resolved.allowTestOnlyPluginExecution).toBeUndefined();
+    expect(resolved.pluginRuntimeMode).toBe("stub");
+  });
+
+  // ─── FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION ───
+
+  it("throws when the autonomy-lifecycle switch is set with NODE_ENV=production", () => {
+    expect(() =>
+      resolveFridayHubConfig(makeConfig(), {
+        NODE_ENV: "production",
+        FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION: "1",
+      }),
+    ).toThrow(/FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION/);
+  });
+
+  it("throws when the autonomy-lifecycle switch is set with a release tag", () => {
+    expect(() =>
+      resolveFridayHubConfig(makeConfig(), {
+        FRIDAY_RELEASE_TAG: "2026.07.19",
+        FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION: "true",
+      }),
+    ).toThrow(GATE_MESSAGE);
+  });
+
+  it("still activates the autonomy-lifecycle switch in a non-protected (dev/test) profile", () => {
+    const resolved = resolveFridayHubConfig(makeConfig(), {
+      FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION: "1",
+    });
+    expect(resolved.allowTestOnlyAutonomyLifecycleExecution).toBe(true);
+  });
+
+  // ─── Defense-in-depth: explicit config boolean is also refused ───
+
+  it("throws when an explicit config allowTestOnlyPluginExecution=true is used in production", () => {
+    expect(() =>
+      resolveFridayHubConfig(
+        makeConfig({ pluginRuntimeMode: "full", allowTestOnlyPluginExecution: true }),
+        { NODE_ENV: "production" },
+      ),
+    ).toThrow(GATE_MESSAGE);
+  });
+
+  it("throws when an explicit config allowTestOnlyAutonomyLifecycleExecution=true is used with a release tag", () => {
+    expect(() =>
+      resolveFridayHubConfig(
+        makeConfig({ allowTestOnlyAutonomyLifecycleExecution: true }),
+        { FRIDAY_RELEASE_TAG: "v9.9.9" },
+      ),
+    ).toThrow(GATE_MESSAGE);
+  });
+
+  it("still honors an explicit config test-only flag in a non-protected profile", () => {
+    const resolved = resolveFridayHubConfig(
+      makeConfig({ pluginRuntimeMode: "full", allowTestOnlyPluginExecution: true }),
+      {},
+    );
+    expect(resolved.allowTestOnlyPluginExecution).toBe(true);
+    expect(resolved.pluginRuntimeMode).toBe("full");
+  });
+});

--- a/test/unit/providers/security/friday-secret-crypto-protected-profile.test.ts
+++ b/test/unit/providers/security/friday-secret-crypto-protected-profile.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as crypto from "node:crypto";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getMasterKey, resetMasterKeyCache } from "#providers";
+
+/**
+ * ART-NONPROD-001 (P0) — the test-only master-key GENERATION escape hatch
+ * `FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION=1` must NOT be activatable in a
+ * protected profile (NODE_ENV=production or FRIDAY_RELEASE_TAG set). In a release
+ * build it must FAIL CLOSED (throw) rather than mint a fresh encryption root.
+ */
+
+describe("getMasterKey test-only generation protected-profile gate", () => {
+  const KEYS = [
+    "FRIDAY_MASTER_KEY",
+    "FRIDAY_MASTER_KEY_SOURCE",
+    "FRIDAY_MASTER_KEY_FILE",
+    "FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION",
+    "NODE_ENV",
+    "FRIDAY_RELEASE_TAG",
+  ] as const;
+
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of KEYS) saved[k] = process.env[k];
+    resetMasterKeyCache();
+    // Start from a clean slate: no key material, no profile markers.
+    for (const k of KEYS) delete process.env[k];
+    // Point at a guaranteed-missing key file so the generation path is reached.
+    process.env.FRIDAY_MASTER_KEY_FILE = path.join(
+      os.tmpdir(),
+      `friday-art-nonprod-${crypto.randomUUID()}`,
+      "master.key",
+    );
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    resetMasterKeyCache();
+  });
+
+  it("throws when generation is enabled with NODE_ENV=production", () => {
+    process.env.NODE_ENV = "production";
+    process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION = "1";
+    expect(() => getMasterKey()).toThrow(/FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION/);
+    expect(() => getMasterKey()).toThrow(/cannot be enabled in production\/release profiles/);
+  });
+
+  it("throws when generation is enabled with a release tag", () => {
+    process.env.FRIDAY_RELEASE_TAG = "v1.2.3";
+    process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION = "1";
+    expect(() => getMasterKey()).toThrow(/cannot be enabled in production\/release profiles/);
+  });
+
+  it("still generates a key when the escape hatch is set in a non-protected (dev/test) profile", () => {
+    delete process.env.NODE_ENV;
+    delete process.env.FRIDAY_RELEASE_TAG;
+    process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION = "1";
+    const key = getMasterKey();
+    expect(key).toBeInstanceOf(Buffer);
+    expect(key.length).toBe(32);
+  });
+
+  it("targeted gate: a real FRIDAY_MASTER_KEY is still honored in production even if the hatch is set (generation path never reached)", () => {
+    const real = crypto.randomBytes(32);
+    process.env.NODE_ENV = "production";
+    process.env.FRIDAY_MASTER_KEY = real.toString("hex");
+    process.env.FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION = "1";
+    // The env-key path returns before the generation hatch is honored, so the
+    // gate is correctly scoped to the generation path and does not throw here.
+    expect(getMasterKey()).toEqual(real);
+  });
+});

--- a/test/unit/security/friday-protected-profile.test.ts
+++ b/test/unit/security/friday-protected-profile.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  FRIDAY_TEST_ONLY_ENV_SWITCHES,
+  assertFridayTestOnlyEnvSwitchAllowed,
+  isFridayProtectedReleaseProfile,
+  isRegisteredFridayTestOnlyEnvSwitch,
+} from "../../../src/security/friday-protected-profile.js";
+
+/**
+ * ART-NONPROD-001 (P0) — shared protected-profile predicate + open-world guard.
+ *
+ * Enumerates EVERY `FRIDAY_ALLOW_TEST_ONLY_*` literal referenced under `src/`
+ * and asserts each is registered AND refused in a protected profile, so a future
+ * un-gated test-only switch fails this guard rather than shipping an activatable
+ * mock lane in a release build.
+ *
+ * OUT OF SCOPE (release-gated, documented): the real signed-artifact / release-
+ * manifest observation scan — this is the source-level, code-only guard.
+ */
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../src");
+const TEST_ONLY_LITERAL = /FRIDAY_ALLOW_TEST_ONLY_[A-Z0-9_]+/g;
+
+function walkTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkTsFiles(full));
+    } else if (entry.isFile() && (full.endsWith(".ts") || full.endsWith(".mts"))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function discoverTestOnlySwitchesUnderSrc(): Set<string> {
+  const discovered = new Set<string>();
+  for (const file of walkTsFiles(SRC_ROOT)) {
+    const text = fs.readFileSync(file, "utf8");
+    for (const match of text.matchAll(TEST_ONLY_LITERAL)) {
+      discovered.add(match[0]);
+    }
+  }
+  return discovered;
+}
+
+describe("isFridayProtectedReleaseProfile", () => {
+  it("is true for NODE_ENV=production (case-insensitive, trimmed)", () => {
+    expect(isFridayProtectedReleaseProfile({ NODE_ENV: "production" })).toBe(true);
+    expect(isFridayProtectedReleaseProfile({ NODE_ENV: "  PRODUCTION  " })).toBe(true);
+  });
+
+  it("is true when FRIDAY_RELEASE_TAG is non-empty", () => {
+    expect(isFridayProtectedReleaseProfile({ FRIDAY_RELEASE_TAG: "v1.2.3" })).toBe(true);
+    expect(isFridayProtectedReleaseProfile({ FRIDAY_RELEASE_TAG: " 2026.07.19 " })).toBe(true);
+  });
+
+  it("is false for dev/test profiles and empty markers", () => {
+    expect(isFridayProtectedReleaseProfile({})).toBe(false);
+    expect(isFridayProtectedReleaseProfile({ NODE_ENV: "test" })).toBe(false);
+    expect(isFridayProtectedReleaseProfile({ NODE_ENV: "development" })).toBe(false);
+    expect(isFridayProtectedReleaseProfile({ FRIDAY_RELEASE_TAG: "" })).toBe(false);
+    expect(isFridayProtectedReleaseProfile({ FRIDAY_RELEASE_TAG: "   " })).toBe(false);
+  });
+});
+
+describe("assertFridayTestOnlyEnvSwitchAllowed", () => {
+  it("throws (naming the switch) in a protected profile", () => {
+    expect(() =>
+      assertFridayTestOnlyEnvSwitchAllowed("FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION", {
+        NODE_ENV: "production",
+      }),
+    ).toThrow(/FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION.*cannot be enabled in production\/release/);
+  });
+
+  it("is a no-op in a non-protected profile", () => {
+    expect(() =>
+      assertFridayTestOnlyEnvSwitchAllowed("FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION", {}),
+    ).not.toThrow();
+  });
+});
+
+describe("ART-NONPROD-001 open-world test-only switch registry guard", () => {
+  it("registers exactly the known test-only switches", () => {
+    expect([...FRIDAY_TEST_ONLY_ENV_SWITCHES].sort()).toEqual(
+      [
+        "FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION",
+        "FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION",
+        "FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION",
+      ],
+    );
+  });
+
+  it("every FRIDAY_ALLOW_TEST_ONLY_* literal under src/ is registered (open-world)", () => {
+    const discovered = discoverTestOnlySwitchesUnderSrc();
+    // Sanity: the scan actually found the switches (guards against a broken walk).
+    expect(discovered.size).toBeGreaterThanOrEqual(FRIDAY_TEST_ONLY_ENV_SWITCHES.length);
+
+    const unregistered = [...discovered].filter((n) => !isRegisteredFridayTestOnlyEnvSwitch(n));
+    // If this fails, a new FRIDAY_ALLOW_TEST_ONLY_* switch was added under src/
+    // without registering + protected-profile-gating it. Register it in
+    // FRIDAY_TEST_ONLY_ENV_SWITCHES and gate it fail-closed.
+    expect(unregistered).toEqual([]);
+  });
+
+  it("every registered switch is refused in a protected profile and allowed in dev/test", () => {
+    for (const name of FRIDAY_TEST_ONLY_ENV_SWITCHES) {
+      expect(() => assertFridayTestOnlyEnvSwitchAllowed(name, { NODE_ENV: "production" })).toThrow();
+      expect(() => assertFridayTestOnlyEnvSwitchAllowed(name, { FRIDAY_RELEASE_TAG: "v1" })).toThrow();
+      expect(() => assertFridayTestOnlyEnvSwitchAllowed(name, {})).not.toThrow();
+    }
+  });
+
+  it("catches an un-registered / un-gated switch (open-world negative control)", () => {
+    const simulated = new Set<string>([
+      ...discoverTestOnlySwitchesUnderSrc(),
+      "FRIDAY_ALLOW_TEST_ONLY_FAKE_UNGATED_SWITCH",
+    ]);
+    const unregistered = [...simulated].filter((n) => !isRegisteredFridayTestOnlyEnvSwitch(n));
+    expect(unregistered).toEqual(["FRIDAY_ALLOW_TEST_ONLY_FAKE_UNGATED_SWITCH"]);
+  });
+});


### PR DESCRIPTION
## SEC/ART-NONPROD-001 — gate `FRIDAY_ALLOW_TEST_ONLY_*` switches behind a protected-release profile

**Requirement (ART-NONPROD-001, P0):** no mock/test-only activation switch may be activatable in the default/production (release) path.

**Concrete defect (found by a currentness reconcile of the next ranked P0 rows after DUR-OPERATION-JOURNAL-001 merged):** three ENV-sourced test-only switches were honored WITHOUT a protected-profile gate, so setting them in a production/tagged-release build activated a test/mock lane:
- `FRIDAY_ALLOW_TEST_ONLY_PLUGIN_EXECUTION` / `FRIDAY_ALLOW_TEST_ONLY_AUTONOMY_LIFECYCLE_EXECUTION` — `resolveTestOnlyFlagFromEnv` in `friday-hub-bootstrap.ts` → drove `pluginRuntimeMode="full"` + test-only plugin/autonomy execution.
- `FRIDAY_ALLOW_TEST_ONLY_MASTER_KEY_GENERATION` — `getMasterKey` in `friday-secret-crypto.ts` → the test-only master-key generation escape hatch (default is fail-closed; production must supply `FRIDAY_MASTER_KEY`).

**Fix (fail-closed, consolidated — mirrors the existing `resolveFridayCanonicalMutatingActionGate` throw precedent):** code-only, no migration.
- New leaf module `src/security/friday-protected-profile.ts`: single-source `isFridayProtectedReleaseProfile(env)` (`NODE_ENV=production` OR `FRIDAY_RELEASE_TAG` non-empty), a CLOSED registry of the test-only ENV switch names, and a fail-closed message naming the specific switch. Leaf module — imports nothing from the Friday tree, so both `#hub` and `#providers` consume it without an import cycle.
- `friday-hub-bootstrap.ts`: `resolveTestOnlyFlagFromEnv` now throws when a truthy value (env-sourced, and defense-in-depth an explicit config `true`) resolves in a protected profile; threaded through both call sites; `isFridayCanonicalGateProtectedProfile` delegates to the shared predicate (single source of truth).
- `friday-secret-crypto.ts`: `getMasterKey` refuses (FridayDomainError 503) when the test-only generation flag is set in a protected profile — scoped AFTER the real-`FRIDAY_MASTER_KEY` return, so a production deploy with a real key is unaffected; only the generation escape hatch is refused.

**Open-world guard:** `test/unit/security/friday-protected-profile.test.ts` enumerates every `FRIDAY_ALLOW_TEST_ONLY_*` literal referenced under `src/` and asserts each is registered AND refused in a protected profile — so a future un-gated test-only switch fails the guard rather than silently shipping an activatable mock lane. The real signed-artifact / release-manifest observation scan is release-gated and intentionally OUT OF SCOPE (code-only source-level guard; mirrors the deferred real-observation boundary in `tools/inventory/reconcile.mjs`).

**Red-first:** with the 2 gate files reverted to `51684b98` (keeping the new leaf module), the 8 throw-expecting cases FAIL (`expected [Function] to throw` — the switches activate) across both `NODE_ENV=production` and `FRIDAY_RELEASE_TAG` profiles and all 3 switches; green after the fix. Dev/test-profile cases stay green (dev/test lanes unaffected). Independently re-verified.

**No-regression:** no existing test relied on activating a test-only switch under a production profile (checked hub-bootstrap-integration, secsetup, closure-lib). New tests + existing hub-bootstrap-env + secret-crypto suites pass; broad `test/unit/hub/` + `test/unit/providers/security/` + `test/unit/security/` = 925 passed; integration + closure-lib 52 passed; tsc 0; eslint 0. Born-current on `51684b98`; 6-file diff, no migration.

**Governance:** R13 preserves R12 §34 U19: implementer ≠ fresh reviewer ≠ merge executor. Builder executes the returned protected `--match-head-commit` squash after exact-SHA PASS + unchanged-recheck. Product NO_GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
