### PR TITLE
⛔ QUARANTINED (3-strike) — DUR-OPERATION-JOURNAL-001 follow-up #4: legacy-NULL digest reconciliation

### DIFF
--- a/src/api/http/routes/friday-route-idempotency.ts
+++ b/src/api/http/routes/friday-route-idempotency.ts
@@ -73,3 +73,54 @@ export function throwIdempotencyConflict(
     { httpStatus: 409 },
   );
 }
+
+/** What a caller must do to the persisted store after {@link reconcileLegacyBackfillDigest}. */
+export type FridayLegacyDigestReconcileOutcome =
+  /** No pre-existing row — proceed with the normal INSERT (which stamps the digest). */
+  | "insert"
+  /** Pre-existing LEGACY row (NULL digest) whose identity matches — BACKFILL the digest onto it. */
+  | "backfill"
+  /** Pre-existing row whose digest already matches — idempotent no-op; do not re-stamp. */
+  | "match";
+
+/**
+ * The SINGLE cross-store rule for reconciling a digest-bearing write against a pre-existing row,
+ * INCLUDING legacy rows written before the v100 migration added the (nullable) `payload_digest`
+ * column. Every cross-store idempotency site (HTTP journal, Rust continuity projector, satellite
+ * outbox) routes through this one primitive so their legacy handling can never drift apart.
+ *
+ * A legacy row has no stored digest to compare against, so this must NEVER blindly stamp the
+ * incoming digest — that would LAUNDER a divergent write (same key reused for a DIFFERENT identity)
+ * into "the canonical digest". Instead the caller supplies a `contentIdentity` recomputed
+ * SYMMETRICALLY over the row's persisted columns and over the incoming write's values; equality
+ * proves the incoming write reproduces the bytes ALREADY PERSISTED. Decisions:
+ *   - no existing row              → `insert` (caller's INSERT stamps the digest).
+ *   - legacy NULL + identity MATCH → `backfill` (caller stamps the digest first-write-only).
+ *   - legacy NULL + identity DIFF  → throwIdempotencyConflict (genuine divergence; nothing stamped).
+ *   - non-null digest match        → `match` (idempotent no-op).
+ *   - non-null digest mismatch     → throwIdempotencyConflict.
+ * The throw is raised BEFORE any stamp so the caller's transaction rolls back divergence
+ * data-loss-free (the existing row is preserved).
+ */
+export function reconcileLegacyBackfillDigest(params: {
+  existing: { payloadDigest: string | null; contentIdentity: string } | undefined;
+  incomingDigest: string;
+  incomingContentIdentity: string;
+  conflictKey: string;
+  conflictOperationId: string;
+}): FridayLegacyDigestReconcileOutcome {
+  const { existing } = params;
+  if (!existing) {
+    return "insert";
+  }
+  if (existing.payloadDigest === null) {
+    if (existing.contentIdentity !== params.incomingContentIdentity) {
+      throwIdempotencyConflict(params.conflictKey, params.conflictOperationId);
+    }
+    return "backfill";
+  }
+  if (existing.payloadDigest !== params.incomingDigest) {
+    throwIdempotencyConflict(params.conflictKey, params.conflictOperationId);
+  }
+  return "match";
+}

--- a/src/api/http/routes/friday-route-idempotency.ts
+++ b/src/api/http/routes/friday-route-idempotency.ts
@@ -84,16 +84,25 @@ export type FridayLegacyDigestReconcileOutcome =
   | "match";
 
 /**
- * The SINGLE cross-store rule for reconciling a digest-bearing write against a pre-existing row,
- * INCLUDING legacy rows written before the v100 migration added the (nullable) `payload_digest`
- * column. Every cross-store idempotency site (HTTP journal, Rust continuity projector, satellite
- * outbox) routes through this one primitive so their legacy handling can never drift apart.
+ * The reconcile rule for a digest-bearing write against a pre-existing row, INCLUDING a legacy row
+ * written before the v100 migration added the (nullable) `payload_digest` column, for sites whose
+ * digest inputs are ALL persisted columns (so a legacy row's identity is EXACTLY reconstructable).
+ * The satellite outbox uses this: its digest is over the stable routing identity
+ * {satelliteId, queueKey, messageType, keyId}, all persisted, so the incoming digest can be
+ * recomputed from the row's own stored columns and compared exactly.
+ *
+ * Sites whose identity CANNOT be exactly reconstructed from persisted columns (e.g. the Rust
+ * continuity projector — its digest is over the whole receipt, which is not stored, and some
+ * receipt fields are never persisted) MUST NOT use this to backfill; they fail closed instead
+ * (a legacy row → typed conflict), because a lossy content comparison would launder a divergent
+ * write whose divergence lives in an omitted/unpersisted field.
  *
  * A legacy row has no stored digest to compare against, so this must NEVER blindly stamp the
  * incoming digest — that would LAUNDER a divergent write (same key reused for a DIFFERENT identity)
  * into "the canonical digest". Instead the caller supplies a `contentIdentity` recomputed
- * SYMMETRICALLY over the row's persisted columns and over the incoming write's values; equality
- * proves the incoming write reproduces the bytes ALREADY PERSISTED. Decisions:
+ * SYMMETRICALLY over the row's persisted columns and over the incoming write's values; for these
+ * exactly-reconstructable sites equality proves the incoming write reproduces the bytes ALREADY
+ * PERSISTED. Decisions:
  *   - no existing row              → `insert` (caller's INSERT stamps the digest).
  *   - legacy NULL + identity MATCH → `backfill` (caller stamps the digest first-write-only).
  *   - legacy NULL + identity DIFF  → throwIdempotencyConflict (genuine divergence; nothing stamped).

--- a/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
@@ -3,7 +3,7 @@ import type Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 import {
   hashIdempotencyPayload,
-  reconcileLegacyBackfillDigest,
+  throwIdempotencyConflict,
 } from "../http/routes/friday-route-idempotency.js";
 
 /**
@@ -218,203 +218,6 @@ function bodyRefFromReceipt(receipt: FridayRustHubRunReceipt): string {
   return `rust-run-body-ref:sha256=${receipt.finalMessageSha256};len=${receipt.finalMessageLen}`;
 }
 
-/**
- * Content-identity of a projected `friday_agent_runs` row: a digest over exactly the deterministic
- * columns the projection writes (the constant columns attempt/max_attempts/duration_ms/task are
- * omitted — they never vary between projections). It exists ONLY to decide, when a re-projection
- * lands on a LEGACY row whose `payload_digest` is NULL (pre-v100, so no receipt digest is stored
- * to compare against), whether the incoming projection reproduces the bytes ALREADY PERSISTED. The
- * SAME function is applied to the existing row's stored columns and to the values the incoming
- * projection would write, so equality proves identity symmetrically. This is a transient
- * comparison value, never persisted (the persisted digest is the receipt digest `payloadDigest`).
- */
-function projectedAgentRunContentIdentity(fields: {
-  status: string;
-  sessionKey: string | null;
-  providerId: string | null;
-  model: string | null;
-  completedAt: string | null;
-  usageInput: number | null;
-  usageOutput: number | null;
-  errorCode: string | null;
-  responseText: string | null;
-  summary: string | null;
-  metadataJson: string | null;
-}): string {
-  return hashIdempotencyPayload({
-    status: fields.status,
-    sessionKey: fields.sessionKey,
-    providerId: fields.providerId,
-    model: fields.model,
-    completedAt: fields.completedAt,
-    usageInput: fields.usageInput,
-    usageOutput: fields.usageOutput,
-    errorCode: fields.errorCode,
-    responseText: fields.responseText,
-    summary: fields.summary,
-    metadataJson: fields.metadataJson,
-  });
-}
-
-/**
- * Content-identity of a projected `llm_usage_records` row (companion to
- * {@link projectedAgentRunContentIdentity}); the constant columns provider_kind, provider_api,
- * route_strategy, task_complexity, cache_read/cache_write tokens, cost_usd and currency are omitted.
- * Same legacy-row backfill decision, same never-persisted transient role.
- */
-function projectedUsageContentIdentity(fields: {
-  occurredAt: string | null;
-  usageDay: string | null;
-  usageMonth: string | null;
-  providerId: string | null;
-  model: string | null;
-  inputTokens: number | null;
-  outputTokens: number | null;
-  totalTokens: number | null;
-  metadataJson: string | null;
-  createdAt: string | null;
-}): string {
-  return hashIdempotencyPayload({
-    occurredAt: fields.occurredAt,
-    usageDay: fields.usageDay,
-    usageMonth: fields.usageMonth,
-    providerId: fields.providerId,
-    model: fields.model,
-    inputTokens: fields.inputTokens,
-    outputTokens: fields.outputTokens,
-    totalTokens: fields.totalTokens,
-    metadataJson: fields.metadataJson,
-    createdAt: fields.createdAt,
-  });
-}
-
-/**
- * Reconcile the projected `friday_agent_runs` row's digest against any pre-existing row (including a
- * LEGACY NULL-digest row), via the single {@link reconcileLegacyBackfillDigest} primitive: a legacy
- * row is stamped (backfilled) first-write-only ONLY when its persisted content-identity matches the
- * incoming projection, otherwise a divergence throws the typed 409 before any stamp. Runs inside the
- * caller's write transaction, so a throw rolls back data-loss-free.
- */
-function reconcileProjectedAgentRunDigest(
-  db: Database.Database,
-  runId: string,
-  payloadDigest: string,
-  incoming: Parameters<typeof projectedAgentRunContentIdentity>[0],
-): void {
-  const existing = db
-    .prepare(
-      `SELECT status, session_key, provider_id, model, completed_at,
-              usage_input, usage_output, error_code, response_text, summary,
-              metadata_json, payload_digest
-         FROM friday_agent_runs WHERE id = ?`,
-    )
-    .get(runId) as
-    | {
-        status: string;
-        session_key: string | null;
-        provider_id: string | null;
-        model: string | null;
-        completed_at: string | null;
-        usage_input: number | null;
-        usage_output: number | null;
-        error_code: string | null;
-        response_text: string | null;
-        summary: string | null;
-        metadata_json: string | null;
-        payload_digest: string | null;
-      }
-    | undefined;
-  const outcome = reconcileLegacyBackfillDigest({
-    existing: existing && {
-      payloadDigest: existing.payload_digest,
-      contentIdentity: projectedAgentRunContentIdentity({
-        status: existing.status,
-        sessionKey: existing.session_key,
-        providerId: existing.provider_id,
-        model: existing.model,
-        completedAt: existing.completed_at,
-        usageInput: existing.usage_input,
-        usageOutput: existing.usage_output,
-        errorCode: existing.error_code,
-        responseText: existing.response_text,
-        summary: existing.summary,
-        metadataJson: existing.metadata_json,
-      }),
-    },
-    incomingDigest: payloadDigest,
-    incomingContentIdentity: projectedAgentRunContentIdentity(incoming),
-    conflictKey: runId,
-    conflictOperationId: "mission_spine.rust_continuity_projection",
-  });
-  if (outcome === "backfill") {
-    db
-      .prepare("UPDATE friday_agent_runs SET payload_digest = ? WHERE id = ? AND payload_digest IS NULL")
-      .run(payloadDigest, runId);
-  }
-}
-
-/**
- * Companion to {@link reconcileProjectedAgentRunDigest} for the `llm_usage_records` row — the SOLE
- * divergence check when the terminal agent_run row was reaped but the longer-retained usage ledger
- * row survives. Same single-primitive backfill/conflict rule.
- */
-function reconcileProjectedUsageDigest(
-  db: Database.Database,
-  runId: string,
-  usageLedgerId: string,
-  payloadDigest: string,
-  incoming: Parameters<typeof projectedUsageContentIdentity>[0],
-): void {
-  const existing = db
-    .prepare(
-      `SELECT occurred_at, usage_day, usage_month, provider_id, model,
-              input_tokens, output_tokens, total_tokens, metadata_json,
-              created_at, payload_digest
-         FROM llm_usage_records WHERE id = ?`,
-    )
-    .get(usageLedgerId) as
-    | {
-        occurred_at: string | null;
-        usage_day: string | null;
-        usage_month: string | null;
-        provider_id: string | null;
-        model: string | null;
-        input_tokens: number | null;
-        output_tokens: number | null;
-        total_tokens: number | null;
-        metadata_json: string | null;
-        created_at: string | null;
-        payload_digest: string | null;
-      }
-    | undefined;
-  const outcome = reconcileLegacyBackfillDigest({
-    existing: existing && {
-      payloadDigest: existing.payload_digest,
-      contentIdentity: projectedUsageContentIdentity({
-        occurredAt: existing.occurred_at,
-        usageDay: existing.usage_day,
-        usageMonth: existing.usage_month,
-        providerId: existing.provider_id,
-        model: existing.model,
-        inputTokens: existing.input_tokens,
-        outputTokens: existing.output_tokens,
-        totalTokens: existing.total_tokens,
-        metadataJson: existing.metadata_json,
-        createdAt: existing.created_at,
-      }),
-    },
-    incomingDigest: payloadDigest,
-    incomingContentIdentity: projectedUsageContentIdentity(incoming),
-    conflictKey: runId,
-    conflictOperationId: "mission_spine.rust_continuity_projection",
-  });
-  if (outcome === "backfill") {
-    db
-      .prepare("UPDATE llm_usage_records SET payload_digest = ? WHERE id = ? AND payload_digest IS NULL")
-      .run(payloadDigest, usageLedgerId);
-  }
-}
-
 export function createFridayRustHubRunContinuityProjectorService(): FridayRustHubRunContinuityProjectorService {
   return {
     project(db, receipt) {
@@ -489,25 +292,21 @@ export function createFridayRustHubRunContinuityProjectorService(): FridayRustHu
       // no-op (no dup, no throw). `create()` in the agent-run repo is a plain INSERT hardcoded
       // to 'pending', so it cannot be reused for an idempotent terminal projected row.
       //
-      // Digest guard: a pre-existing row whose stored digest DIFFERS is a genuine cross-store
-      // idempotency conflict (the same run_id projected from a divergent receipt), NOT a
-      // replay. INSERT OR IGNORE alone would silently drop the divergent projection; instead
-      // surface the SAME typed 409 the HTTP idempotency layer raises.
-      // Reconcile the agent_run digest (legacy backfill / cross-store conflict) via the single
-      // primitive — see `reconcileProjectedAgentRunDigest`.
-      reconcileProjectedAgentRunDigest(db, runId, payloadDigest, {
-        status,
-        sessionKey,
-        providerId: receipt.providerId,
-        model: receipt.model,
-        completedAt: completedAtIso,
-        usageInput: receipt.usagePromptTokens,
-        usageOutput: receipt.usageCompletionTokens,
-        errorCode,
-        responseText: responseTextRef,
-        summary,
-        metadataJson,
-      });
+      // Digest guard — FAIL-CLOSED on any pre-existing row that is not an EXACT digest match,
+      // INCLUDING a LEGACY (NULL-digest) pre-v100 row. A projected row's digest is over the WHOLE
+      // refs-only receipt, and the raw receipt is NOT persisted (nor are unpersisted receipt fields
+      // like modelSize/backendKind, nor several inserted columns), so the ORIGINAL receipt identity
+      // of a legacy row CANNOT be reconstructed — we therefore must NOT stamp/backfill a digest we
+      // cannot validate (that would launder a divergent re-projection). `null !== payloadDigest` is
+      // always true, so any digest-bearing projection landing on a legacy row raises the SAME typed
+      // 409 the non-null-divergent case raises, rather than being silently swallowed by INSERT OR
+      // IGNORE. A non-null EXACT match falls through to the idempotent INSERT OR IGNORE no-op.
+      const existingAgentRunDigest = db
+        .prepare("SELECT payload_digest FROM friday_agent_runs WHERE id = ?")
+        .get(runId) as { payload_digest: string | null } | undefined;
+      if (existingAgentRunDigest && existingAgentRunDigest.payload_digest !== payloadDigest) {
+        throwIdempotencyConflict(runId, "mission_spine.rust_continuity_projection");
+      }
 
       const agentRunInsert = db
         .prepare(
@@ -557,23 +356,17 @@ export function createFridayRustHubRunContinuityProjectorService(): FridayRustHu
         // wiring is deferred), so pricing is unresolved by definition.
         pricingResolved: false,
       });
-      // Digest guard (companion to the agent_run guard): a pre-existing usage row for this
-      // run whose stored digest DIFFERS is the same divergent-receipt conflict — surface the
-      // typed 409 rather than silently dropping via INSERT OR IGNORE.
-      // Companion reconcile for the usage row, through the SAME primitive — see
-      // `reconcileProjectedUsageDigest`.
-      reconcileProjectedUsageDigest(db, runId, usageLedgerId, payloadDigest, {
-        occurredAt: completedAtIso,
-        usageDay,
-        usageMonth,
-        providerId: receipt.providerId,
-        model: receipt.model,
-        inputTokens: receipt.usagePromptTokens,
-        outputTokens: receipt.usageCompletionTokens,
-        totalTokens: receipt.usageTotalTokens,
-        metadataJson: usageMetadataJson,
-        createdAt: completedAtIso,
-      });
+      // Digest guard (FAIL-CLOSED companion to the agent_run guard) — the SOLE divergence check
+      // when the terminal agent_run row was reaped but the longer-retained usage ledger row
+      // survives. Same rule: a legacy (NULL-digest) usage row's original receipt identity cannot be
+      // reconstructed, so any digest-bearing projection onto it (or a non-null divergent one) raises
+      // the typed 409 rather than stamping an unvalidatable digest; a non-null EXACT match no-ops.
+      const existingUsageDigest = db
+        .prepare("SELECT payload_digest FROM llm_usage_records WHERE id = ?")
+        .get(usageLedgerId) as { payload_digest: string | null } | undefined;
+      if (existingUsageDigest && existingUsageDigest.payload_digest !== payloadDigest) {
+        throwIdempotencyConflict(runId, "mission_spine.rust_continuity_projection");
+      }
 
       const usageInsert = db
         .prepare(

--- a/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
@@ -299,12 +299,23 @@ export function createFridayRustHubRunContinuityProjectorService(): FridayRustHu
       const existingAgentRunDigest = db
         .prepare("SELECT payload_digest FROM friday_agent_runs WHERE id = ?")
         .get(runId) as { payload_digest: string | null } | undefined;
-      if (
-        existingAgentRunDigest
-        && existingAgentRunDigest.payload_digest !== null
-        && existingAgentRunDigest.payload_digest !== payloadDigest
-      ) {
-        throwIdempotencyConflict(runId, "mission_spine.rust_continuity_projection");
+      if (existingAgentRunDigest) {
+        if (existingAgentRunDigest.payload_digest === null) {
+          // Legacy pre-v100 row (its `payload_digest` predates the digest column, so it is NULL):
+          // BACKFILL the canonical digest onto the row on the FIRST digest-bearing projection so a
+          // SUBSEQUENT projection of the same run_id with a DIFFERENT digest then hits the non-null
+          // typed-409 branch below. Without this the null short-circuits the guard, so a divergent
+          // re-projection is neither recorded nor flagged — it is silently dropped by INSERT OR
+          // IGNORE (the row already exists). Scoped to `payload_digest IS NULL` so it stamps a
+          // legacy row exactly once and never overwrites an already-stamped digest; atomic with the
+          // conflict decision inside the caller's write transaction (composeRustReadOnlyAgentRun
+          // runs project() in withWriteTransaction). Does NOT touch row content or the insert path.
+          db
+            .prepare("UPDATE friday_agent_runs SET payload_digest = ? WHERE id = ? AND payload_digest IS NULL")
+            .run(payloadDigest, runId);
+        } else if (existingAgentRunDigest.payload_digest !== payloadDigest) {
+          throwIdempotencyConflict(runId, "mission_spine.rust_continuity_projection");
+        }
       }
 
       const agentRunInsert = db
@@ -361,12 +372,19 @@ export function createFridayRustHubRunContinuityProjectorService(): FridayRustHu
       const existingUsageDigest = db
         .prepare("SELECT payload_digest FROM llm_usage_records WHERE id = ?")
         .get(usageLedgerId) as { payload_digest: string | null } | undefined;
-      if (
-        existingUsageDigest
-        && existingUsageDigest.payload_digest !== null
-        && existingUsageDigest.payload_digest !== payloadDigest
-      ) {
-        throwIdempotencyConflict(runId, "mission_spine.rust_continuity_projection");
+      if (existingUsageDigest) {
+        if (existingUsageDigest.payload_digest === null) {
+          // Legacy pre-v100 usage row (NULL digest): BACKFILL the canonical digest so a later
+          // divergent projection conflicts (via the non-null branch below) instead of being
+          // silently dropped by INSERT OR IGNORE. Companion to the agent_run backfill above;
+          // `payload_digest IS NULL` keeps it a first-write-only stamp, atomic with the conflict
+          // decision in the caller's transaction. Does NOT touch row content or the insert path.
+          db
+            .prepare("UPDATE llm_usage_records SET payload_digest = ? WHERE id = ? AND payload_digest IS NULL")
+            .run(payloadDigest, usageLedgerId);
+        } else if (existingUsageDigest.payload_digest !== payloadDigest) {
+          throwIdempotencyConflict(runId, "mission_spine.rust_continuity_projection");
+        }
       }
 
       const usageInsert = db

--- a/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
+++ b/src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.ts
@@ -3,7 +3,7 @@ import type Database from "better-sqlite3";
 import { FridayDomainError } from "#errors";
 import {
   hashIdempotencyPayload,
-  throwIdempotencyConflict,
+  reconcileLegacyBackfillDigest,
 } from "../http/routes/friday-route-idempotency.js";
 
 /**
@@ -218,6 +218,203 @@ function bodyRefFromReceipt(receipt: FridayRustHubRunReceipt): string {
   return `rust-run-body-ref:sha256=${receipt.finalMessageSha256};len=${receipt.finalMessageLen}`;
 }
 
+/**
+ * Content-identity of a projected `friday_agent_runs` row: a digest over exactly the deterministic
+ * columns the projection writes (the constant columns attempt/max_attempts/duration_ms/task are
+ * omitted — they never vary between projections). It exists ONLY to decide, when a re-projection
+ * lands on a LEGACY row whose `payload_digest` is NULL (pre-v100, so no receipt digest is stored
+ * to compare against), whether the incoming projection reproduces the bytes ALREADY PERSISTED. The
+ * SAME function is applied to the existing row's stored columns and to the values the incoming
+ * projection would write, so equality proves identity symmetrically. This is a transient
+ * comparison value, never persisted (the persisted digest is the receipt digest `payloadDigest`).
+ */
+function projectedAgentRunContentIdentity(fields: {
+  status: string;
+  sessionKey: string | null;
+  providerId: string | null;
+  model: string | null;
+  completedAt: string | null;
+  usageInput: number | null;
+  usageOutput: number | null;
+  errorCode: string | null;
+  responseText: string | null;
+  summary: string | null;
+  metadataJson: string | null;
+}): string {
+  return hashIdempotencyPayload({
+    status: fields.status,
+    sessionKey: fields.sessionKey,
+    providerId: fields.providerId,
+    model: fields.model,
+    completedAt: fields.completedAt,
+    usageInput: fields.usageInput,
+    usageOutput: fields.usageOutput,
+    errorCode: fields.errorCode,
+    responseText: fields.responseText,
+    summary: fields.summary,
+    metadataJson: fields.metadataJson,
+  });
+}
+
+/**
+ * Content-identity of a projected `llm_usage_records` row (companion to
+ * {@link projectedAgentRunContentIdentity}); the constant columns provider_kind, provider_api,
+ * route_strategy, task_complexity, cache_read/cache_write tokens, cost_usd and currency are omitted.
+ * Same legacy-row backfill decision, same never-persisted transient role.
+ */
+function projectedUsageContentIdentity(fields: {
+  occurredAt: string | null;
+  usageDay: string | null;
+  usageMonth: string | null;
+  providerId: string | null;
+  model: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  totalTokens: number | null;
+  metadataJson: string | null;
+  createdAt: string | null;
+}): string {
+  return hashIdempotencyPayload({
+    occurredAt: fields.occurredAt,
+    usageDay: fields.usageDay,
+    usageMonth: fields.usageMonth,
+    providerId: fields.providerId,
+    model: fields.model,
+    inputTokens: fields.inputTokens,
+    outputTokens: fields.outputTokens,
+    totalTokens: fields.totalTokens,
+    metadataJson: fields.metadataJson,
+    createdAt: fields.createdAt,
+  });
+}
+
+/**
+ * Reconcile the projected `friday_agent_runs` row's digest against any pre-existing row (including a
+ * LEGACY NULL-digest row), via the single {@link reconcileLegacyBackfillDigest} primitive: a legacy
+ * row is stamped (backfilled) first-write-only ONLY when its persisted content-identity matches the
+ * incoming projection, otherwise a divergence throws the typed 409 before any stamp. Runs inside the
+ * caller's write transaction, so a throw rolls back data-loss-free.
+ */
+function reconcileProjectedAgentRunDigest(
+  db: Database.Database,
+  runId: string,
+  payloadDigest: string,
+  incoming: Parameters<typeof projectedAgentRunContentIdentity>[0],
+): void {
+  const existing = db
+    .prepare(
+      `SELECT status, session_key, provider_id, model, completed_at,
+              usage_input, usage_output, error_code, response_text, summary,
+              metadata_json, payload_digest
+         FROM friday_agent_runs WHERE id = ?`,
+    )
+    .get(runId) as
+    | {
+        status: string;
+        session_key: string | null;
+        provider_id: string | null;
+        model: string | null;
+        completed_at: string | null;
+        usage_input: number | null;
+        usage_output: number | null;
+        error_code: string | null;
+        response_text: string | null;
+        summary: string | null;
+        metadata_json: string | null;
+        payload_digest: string | null;
+      }
+    | undefined;
+  const outcome = reconcileLegacyBackfillDigest({
+    existing: existing && {
+      payloadDigest: existing.payload_digest,
+      contentIdentity: projectedAgentRunContentIdentity({
+        status: existing.status,
+        sessionKey: existing.session_key,
+        providerId: existing.provider_id,
+        model: existing.model,
+        completedAt: existing.completed_at,
+        usageInput: existing.usage_input,
+        usageOutput: existing.usage_output,
+        errorCode: existing.error_code,
+        responseText: existing.response_text,
+        summary: existing.summary,
+        metadataJson: existing.metadata_json,
+      }),
+    },
+    incomingDigest: payloadDigest,
+    incomingContentIdentity: projectedAgentRunContentIdentity(incoming),
+    conflictKey: runId,
+    conflictOperationId: "mission_spine.rust_continuity_projection",
+  });
+  if (outcome === "backfill") {
+    db
+      .prepare("UPDATE friday_agent_runs SET payload_digest = ? WHERE id = ? AND payload_digest IS NULL")
+      .run(payloadDigest, runId);
+  }
+}
+
+/**
+ * Companion to {@link reconcileProjectedAgentRunDigest} for the `llm_usage_records` row — the SOLE
+ * divergence check when the terminal agent_run row was reaped but the longer-retained usage ledger
+ * row survives. Same single-primitive backfill/conflict rule.
+ */
+function reconcileProjectedUsageDigest(
+  db: Database.Database,
+  runId: string,
+  usageLedgerId: string,
+  payloadDigest: string,
+  incoming: Parameters<typeof projectedUsageContentIdentity>[0],
+): void {
+  const existing = db
+    .prepare(
+      `SELECT occurred_at, usage_day, usage_month, provider_id, model,
+              input_tokens, output_tokens, total_tokens, metadata_json,
+              created_at, payload_digest
+         FROM llm_usage_records WHERE id = ?`,
+    )
+    .get(usageLedgerId) as
+    | {
+        occurred_at: string | null;
+        usage_day: string | null;
+        usage_month: string | null;
+        provider_id: string | null;
+        model: string | null;
+        input_tokens: number | null;
+        output_tokens: number | null;
+        total_tokens: number | null;
+        metadata_json: string | null;
+        created_at: string | null;
+        payload_digest: string | null;
+      }
+    | undefined;
+  const outcome = reconcileLegacyBackfillDigest({
+    existing: existing && {
+      payloadDigest: existing.payload_digest,
+      contentIdentity: projectedUsageContentIdentity({
+        occurredAt: existing.occurred_at,
+        usageDay: existing.usage_day,
+        usageMonth: existing.usage_month,
+        providerId: existing.provider_id,
+        model: existing.model,
+        inputTokens: existing.input_tokens,
+        outputTokens: existing.output_tokens,
+        totalTokens: existing.total_tokens,
+        metadataJson: existing.metadata_json,
+        createdAt: existing.created_at,
+      }),
+    },
+    incomingDigest: payloadDigest,
+    incomingContentIdentity: projectedUsageContentIdentity(incoming),
+    conflictKey: runId,
+    conflictOperationId: "mission_spine.rust_continuity_projection",
+  });
+  if (outcome === "backfill") {
+    db
+      .prepare("UPDATE llm_usage_records SET payload_digest = ? WHERE id = ? AND payload_digest IS NULL")
+      .run(payloadDigest, usageLedgerId);
+  }
+}
+
 export function createFridayRustHubRunContinuityProjectorService(): FridayRustHubRunContinuityProjectorService {
   return {
     project(db, receipt) {
@@ -296,27 +493,21 @@ export function createFridayRustHubRunContinuityProjectorService(): FridayRustHu
       // idempotency conflict (the same run_id projected from a divergent receipt), NOT a
       // replay. INSERT OR IGNORE alone would silently drop the divergent projection; instead
       // surface the SAME typed 409 the HTTP idempotency layer raises.
-      const existingAgentRunDigest = db
-        .prepare("SELECT payload_digest FROM friday_agent_runs WHERE id = ?")
-        .get(runId) as { payload_digest: string | null } | undefined;
-      if (existingAgentRunDigest) {
-        if (existingAgentRunDigest.payload_digest === null) {
-          // Legacy pre-v100 row (its `payload_digest` predates the digest column, so it is NULL):
-          // BACKFILL the canonical digest onto the row on the FIRST digest-bearing projection so a
-          // SUBSEQUENT projection of the same run_id with a DIFFERENT digest then hits the non-null
-          // typed-409 branch below. Without this the null short-circuits the guard, so a divergent
-          // re-projection is neither recorded nor flagged — it is silently dropped by INSERT OR
-          // IGNORE (the row already exists). Scoped to `payload_digest IS NULL` so it stamps a
-          // legacy row exactly once and never overwrites an already-stamped digest; atomic with the
-          // conflict decision inside the caller's write transaction (composeRustReadOnlyAgentRun
-          // runs project() in withWriteTransaction). Does NOT touch row content or the insert path.
-          db
-            .prepare("UPDATE friday_agent_runs SET payload_digest = ? WHERE id = ? AND payload_digest IS NULL")
-            .run(payloadDigest, runId);
-        } else if (existingAgentRunDigest.payload_digest !== payloadDigest) {
-          throwIdempotencyConflict(runId, "mission_spine.rust_continuity_projection");
-        }
-      }
+      // Reconcile the agent_run digest (legacy backfill / cross-store conflict) via the single
+      // primitive — see `reconcileProjectedAgentRunDigest`.
+      reconcileProjectedAgentRunDigest(db, runId, payloadDigest, {
+        status,
+        sessionKey,
+        providerId: receipt.providerId,
+        model: receipt.model,
+        completedAt: completedAtIso,
+        usageInput: receipt.usagePromptTokens,
+        usageOutput: receipt.usageCompletionTokens,
+        errorCode,
+        responseText: responseTextRef,
+        summary,
+        metadataJson,
+      });
 
       const agentRunInsert = db
         .prepare(
@@ -369,23 +560,20 @@ export function createFridayRustHubRunContinuityProjectorService(): FridayRustHu
       // Digest guard (companion to the agent_run guard): a pre-existing usage row for this
       // run whose stored digest DIFFERS is the same divergent-receipt conflict — surface the
       // typed 409 rather than silently dropping via INSERT OR IGNORE.
-      const existingUsageDigest = db
-        .prepare("SELECT payload_digest FROM llm_usage_records WHERE id = ?")
-        .get(usageLedgerId) as { payload_digest: string | null } | undefined;
-      if (existingUsageDigest) {
-        if (existingUsageDigest.payload_digest === null) {
-          // Legacy pre-v100 usage row (NULL digest): BACKFILL the canonical digest so a later
-          // divergent projection conflicts (via the non-null branch below) instead of being
-          // silently dropped by INSERT OR IGNORE. Companion to the agent_run backfill above;
-          // `payload_digest IS NULL` keeps it a first-write-only stamp, atomic with the conflict
-          // decision in the caller's transaction. Does NOT touch row content or the insert path.
-          db
-            .prepare("UPDATE llm_usage_records SET payload_digest = ? WHERE id = ? AND payload_digest IS NULL")
-            .run(payloadDigest, usageLedgerId);
-        } else if (existingUsageDigest.payload_digest !== payloadDigest) {
-          throwIdempotencyConflict(runId, "mission_spine.rust_continuity_projection");
-        }
-      }
+      // Companion reconcile for the usage row, through the SAME primitive — see
+      // `reconcileProjectedUsageDigest`.
+      reconcileProjectedUsageDigest(db, runId, usageLedgerId, payloadDigest, {
+        occurredAt: completedAtIso,
+        usageDay,
+        usageMonth,
+        providerId: receipt.providerId,
+        model: receipt.model,
+        inputTokens: receipt.usagePromptTokens,
+        outputTokens: receipt.usageCompletionTokens,
+        totalTokens: receipt.usageTotalTokens,
+        metadataJson: usageMetadataJson,
+        createdAt: completedAtIso,
+      });
 
       const usageInsert = db
         .prepare(

--- a/src/satellites/services/friday-outbox-queue-service.ts
+++ b/src/satellites/services/friday-outbox-queue-service.ts
@@ -2,7 +2,7 @@ import { FridayDomainError } from "#errors";
 import type { FridaySqliteLayer } from "#state";
 import {
   hashIdempotencyPayload,
-  throwIdempotencyConflict,
+  reconcileLegacyBackfillDigest,
 } from "../../api/http/routes/friday-route-idempotency.js";
 import type {
   FridayOutboxEnqueueInput,
@@ -54,6 +54,28 @@ export interface CreateOutboxQueueServiceDeps {
 /** Base retry backoff: 5 seconds, doubled per attempt. */
 const BASE_RETRY_MS = 5_000;
 
+/**
+ * Canonical digest over the STABLE outbox message identity (routing fields only — never the
+ * per-dispatch transport ciphertext/nonce/timestamp, so a legitimate same-key re-dispatch stays an
+ * idempotent no-op). A SINGLE definition consumed by BOTH the incoming-write digest and the
+ * recompute over a legacy row's stored columns, so the two can never drift apart. All four fields
+ * are persisted columns (`satellite_id, queue_key, message_type, key_id`), which is what makes a
+ * legacy (NULL-digest) row's identity provable from the bytes already persisted.
+ */
+function outboxRoutingIdentityDigest(fields: {
+  satelliteId: string;
+  queueKey: string;
+  messageType: string;
+  keyId: string;
+}): string {
+  return hashIdempotencyPayload({
+    satelliteId: fields.satelliteId,
+    queueKey: fields.queueKey,
+    messageType: fields.messageType,
+    keyId: fields.keyId,
+  });
+}
+
 export function createFridayOutboxQueueService(
   deps: CreateOutboxQueueServiceDeps,
 ): FridayOutboxQueueService {
@@ -61,12 +83,12 @@ export function createFridayOutboxQueueService(
     enqueue(input) {
       const id = deps.idGenerator();
       const nowIso = deps.nowIso();
-      // Digest over the STABLE message identity only. The transport ciphertext/nonce carry a
-      // per-dispatch timestamp (see the workflow satellite dispatch payload's `requestedAt`),
-      // so digesting them would false-positive on a legitimate same-key re-dispatch — which
-      // MUST stay an idempotent no-op (no-degrade). Divergence in the routing identity, on the
-      // other hand, is a genuine reuse-of-key-for-a-different-message conflict.
-      const payloadDigest = hashIdempotencyPayload({
+      // Digest over the STABLE message identity only (see `outboxRoutingIdentityDigest`): the
+      // transport ciphertext/nonce carry a per-dispatch timestamp, so digesting them would
+      // false-positive on a legitimate same-key re-dispatch — which MUST stay an idempotent no-op
+      // (no-degrade). Divergence in the routing identity, on the other hand, is a genuine
+      // reuse-of-key-for-a-different-message conflict.
+      const payloadDigest = outboxRoutingIdentityDigest({
         satelliteId: input.satelliteId,
         queueKey: input.queueKey,
         messageType: input.messageType,
@@ -78,30 +100,50 @@ export function createFridayOutboxQueueService(
         // conflict rather than silently resolving to the existing id.
         const existing = db
           .prepare(
-            "SELECT id, payload_digest FROM outbox_messages WHERE satellite_id = ? AND idempotency_key = ?",
+            `SELECT id, satellite_id, queue_key, message_type, key_id, payload_digest
+               FROM outbox_messages WHERE satellite_id = ? AND idempotency_key = ?`,
           )
           .get(input.satelliteId, input.idempotencyKey) as
-          | { id: string; payload_digest: string | null }
+          | {
+              id: string;
+              satellite_id: string;
+              queue_key: string;
+              message_type: string;
+              key_id: string;
+              payload_digest: string | null;
+            }
           | undefined;
         if (existing) {
-          if (existing.payload_digest === null) {
-            // Legacy pre-v100 row (NULL digest): BACKFILL the canonical digest onto the row on the
-            // FIRST digest-bearing enqueue so a SUBSEQUENT enqueue that reuses this
-            // (satellite_id, idempotency_key) with a DIFFERENT message identity then hits the typed
-            // 409 branch below. Without this the null short-circuits the guard, so a divergent
-            // re-enqueue is silently resolved to the existing id instead of being flagged. Scoped to
-            // `payload_digest IS NULL` so it stamps a legacy row exactly once and never overwrites an
-            // already-stamped digest; atomic with the conflict decision inside this
-            // withWriteTransaction. Does NOT insert a row or alter the idempotent-replay path.
+          // Reconcile through the SINGLE cross-store primitive. For a LEGACY (NULL-digest) row the
+          // row's identity is PROVED from the bytes already persisted — the canonical routing-identity
+          // digest recomputed from its OWN stored routing columns (all four inputs are persisted),
+          // via the SAME `outboxRoutingIdentityDigest` used for the incoming digest, so the incoming
+          // routing identity IS `payloadDigest`. A `backfill` outcome means "same identity" ⇒ stamp
+          // the legacy row first-write-only; a divergence throws inside the primitive before any
+          // stamp, never laundering a divergent re-enqueue's digest onto the row.
+          const reconcile = reconcileLegacyBackfillDigest({
+            existing: {
+              payloadDigest: existing.payload_digest,
+              contentIdentity: outboxRoutingIdentityDigest({
+                satelliteId: existing.satellite_id,
+                queueKey: existing.queue_key,
+                messageType: existing.message_type,
+                keyId: existing.key_id,
+              }),
+            },
+            incomingDigest: payloadDigest,
+            incomingContentIdentity: payloadDigest,
+            conflictKey: input.idempotencyKey,
+            conflictOperationId: "outbox.enqueue",
+          });
+          if (reconcile === "backfill") {
             db
               .prepare(
                 "UPDATE outbox_messages SET payload_digest = ? WHERE satellite_id = ? AND idempotency_key = ? AND payload_digest IS NULL",
               )
               .run(payloadDigest, input.satelliteId, input.idempotencyKey);
-          } else if (existing.payload_digest !== payloadDigest) {
-            throwIdempotencyConflict(input.idempotencyKey, "outbox.enqueue");
           }
-          // Same identity (idempotent retry) → resolve to the existing id, unchanged behavior.
+          // Same identity (idempotent retry, or just-backfilled legacy) → resolve to the existing id.
           return { id: existing.id };
         }
 

--- a/src/satellites/services/friday-outbox-queue-service.ts
+++ b/src/satellites/services/friday-outbox-queue-service.ts
@@ -84,7 +84,21 @@ export function createFridayOutboxQueueService(
           | { id: string; payload_digest: string | null }
           | undefined;
         if (existing) {
-          if (existing.payload_digest !== null && existing.payload_digest !== payloadDigest) {
+          if (existing.payload_digest === null) {
+            // Legacy pre-v100 row (NULL digest): BACKFILL the canonical digest onto the row on the
+            // FIRST digest-bearing enqueue so a SUBSEQUENT enqueue that reuses this
+            // (satellite_id, idempotency_key) with a DIFFERENT message identity then hits the typed
+            // 409 branch below. Without this the null short-circuits the guard, so a divergent
+            // re-enqueue is silently resolved to the existing id instead of being flagged. Scoped to
+            // `payload_digest IS NULL` so it stamps a legacy row exactly once and never overwrites an
+            // already-stamped digest; atomic with the conflict decision inside this
+            // withWriteTransaction. Does NOT insert a row or alter the idempotent-replay path.
+            db
+              .prepare(
+                "UPDATE outbox_messages SET payload_digest = ? WHERE satellite_id = ? AND idempotency_key = ? AND payload_digest IS NULL",
+              )
+              .run(payloadDigest, input.satelliteId, input.idempotencyKey);
+          } else if (existing.payload_digest !== payloadDigest) {
             throwIdempotencyConflict(input.idempotencyKey, "outbox.enqueue");
           }
           // Same identity (idempotent retry) → resolve to the existing id, unchanged behavior.

--- a/test/integration/idempotency/friday-cross-store-legacy-null-digest-backfill.test.ts
+++ b/test/integration/idempotency/friday-cross-store-legacy-null-digest-backfill.test.ts
@@ -1,27 +1,33 @@
 /**
  * DUR-OPERATION-JOURNAL-001 — follow-up defect #4: legacy-NULL digest backfill (integration).
  *
- * The cross-store digest-conflict guards added by the merged PR (#1623) short-circuit
- * when the EXISTING row's `payload_digest` is NULL — the state of every row written
- * BEFORE the v100 migration added the (nullable) `payload_digest` column. Because the
- * guard only fires on a NON-NULL divergent digest, a divergent re-projection / re-enqueue
- * that targets a legacy row is neither recorded nor flagged: it is silently swallowed by
- * `INSERT OR IGNORE` (projector / outbox insert is a no-op — the row already exists) or
- * silently resolved to the existing id (outbox). The genuine payload divergence vanishes.
+ * The cross-store digest-conflict guards added by the merged PR (#1623) short-circuit when the
+ * EXISTING row's `payload_digest` is NULL — the state of every row written BEFORE the v100
+ * migration added the (nullable) `payload_digest` column. Because the guard only fires on a
+ * NON-NULL divergent digest, a divergent re-projection / re-enqueue that targets a legacy row is
+ * neither recorded nor flagged: it is silently swallowed by `INSERT OR IGNORE` (projector / outbox
+ * insert is a no-op — the row already exists) or silently resolved to the existing id (outbox).
  *
- * The fix BACKFILLS the canonical digest onto a legacy (NULL-digest) row on the FIRST
- * digest-bearing write (`UPDATE <table> SET payload_digest = ? WHERE <key> AND
- * payload_digest IS NULL`), so:
- *   - the first legitimate re-projection/re-enqueue is NOT rejected (no over-fail); it
- *     stamps the legacy row with its digest, and
- *   - a SUBSEQUENT write with a DIFFERENT digest then hits the now-non-null digest and
- *     raises the SAME typed 409 SECURITY_IDEMPOTENCY_KEY_CONFLICT the non-null path raises.
+ * The fix does NOT blindly stamp the incoming digest onto a legacy row — that would LAUNDER a
+ * divergent write (same key reused for a DIFFERENT identity) into "the canonical digest". Instead,
+ * on a legacy (NULL-digest) row it PROVES the incoming write reproduces the bytes ALREADY
+ * PERSISTED before stamping:
+ *   - outbox: recompute the canonical routing-identity digest from the row's OWN persisted columns
+ *     (`satellite_id, queue_key, message_type, key_id`) and compare;
+ *   - projector: recompute a content-identity over the row's persisted content columns and compare.
+ * Then:
+ *   - MATCH  ⇒ same identity → BACKFILL the canonical digest (first-write-only via
+ *     `payload_digest IS NULL`) so a LATER divergent write hits the now-non-null typed-409 branch;
+ *   - MISMATCH ⇒ genuine divergence → the SAME typed 409 (SECURITY_IDEMPOTENCY_KEY_CONFLICT) the
+ *     non-null path raises, BEFORE any stamp (data-loss-free: the row is preserved, nothing
+ *     laundered).
  *
- * RED-FIRST: on the pre-fix code the legacy-NULL divergent SECOND write is a silent no-op
- * (no conflict) — the `toThrow`/conflict assertions FAIL. After the backfill they pass. The
- * happy paths (non-null matching = no-op, non-null different = conflict, fresh insert sets
- * its digest, idempotent replay resolves to the existing id) are UNCHANGED and are covered
- * here and in `friday-cross-store-digest-conflict.test.ts`.
+ * RED-FIRST: on the pre-fix (blind-stamp) code, a DIVERGENT write against a legacy row on FIRST
+ * contact is silently accepted (stamped / resolved, no throw) — the `toThrow`/409 negative-control
+ * assertions FAIL. After the prove-then-stamp fix they pass, and the same-identity backfill +
+ * happy paths (non-null matching = no-op, non-null different = conflict, fresh insert stamps its
+ * digest, idempotent replay resolves to the existing id) remain UNCHANGED (covered here and in
+ * `friday-cross-store-digest-conflict.test.ts`).
  */
 
 import { describe, expect, it } from "vitest";
@@ -74,6 +80,16 @@ function isConflict(err: unknown): err is FridayDomainError {
   );
 }
 
+/** Run `fn`, returning whatever it threw (or `undefined` if it did not throw). */
+function capture(fn: () => void): unknown {
+  try {
+    fn();
+    return undefined;
+  } catch (err) {
+    return err;
+  }
+}
+
 /**
  * Drive the REAL projector exactly as production does: inside a write transaction
  * (`composeRustReadOnlyAgentRun` runs `project()` in `withWriteTransaction`), so a thrown
@@ -107,53 +123,41 @@ function makeLegacy(layer: FridaySqliteLayer, runId: string): void {
 }
 
 describe("legacy-NULL digest backfill — Rust run-continuity projector (friday_agent_runs, site 1)", () => {
-  it("backfills the legacy row's digest on the first divergent projection, then conflicts on the second", () => {
+  it("REJECTS a DIVERGENT projection against a legacy row on first contact — never launders its digest", () => {
     const layer = createTestDb();
     try {
       const runId = BASE_RECEIPT.runId;
       const usageId = usageLedgerIdForRun(runId);
 
-      // Seed a pre-v100 legacy row (digest column NULL).
+      // Seed a pre-v100 legacy row (digest column NULL) from BASE_RECEIPT's content.
       project(layer, BASE_RECEIPT);
       makeLegacy(layer, runId);
       expect(agentRunDigest(layer, runId)).toBe(null); // precondition: legacy NULL
       expect(usageDigest(layer, usageId)).toBe(null);
 
-      // First divergent write with digest D1 → must NOT throw; must BACKFILL D1 onto the legacy
-      // row (both the agent_run row AND its companion usage row), not silently drop it.
-      const divergent1: FridayRustHubRunReceipt = {
+      // A DIVERGENT receipt (different usage content) is the same run_id reused for a DIFFERENT
+      // projection. On the FIRST digest-bearing contact the guard has no stored digest to compare,
+      // so it must PROVE identity against the persisted content — which differs — and raise the
+      // typed 409 rather than stamping the divergent digest. (RED on the blind-stamp code: it
+      // stamps + no-ops with no throw.)
+      const divergent: FridayRustHubRunReceipt = {
         ...BASE_RECEIPT,
         usagePromptTokens: 9999,
         usageTotalTokens: 10_419,
       };
-      const d1 = hashIdempotencyPayload(divergent1);
-      expect(() => project(layer, divergent1)).not.toThrow();
-      expect(agentRunDigest(layer, runId)).toBe(d1); // backfilled, not NULL, not dropped
-      expect(usageDigest(layer, usageId)).toBe(d1); // site-2 backfill in the same write
-
-      // Second write with a DIFFERENT digest D2 → the legacy gap is now closed: typed 409.
-      const divergent2: FridayRustHubRunReceipt = {
-        ...BASE_RECEIPT,
-        usagePromptTokens: 5555,
-        usageTotalTokens: 6000,
-      };
-      let caught: unknown;
-      try {
-        project(layer, divergent2);
-      } catch (err) {
-        caught = err;
-      }
+      const caught = capture(() => project(layer, divergent));
       expect(isConflict(caught)).toBe(true);
       expect((caught as FridayDomainError).httpStatus).toBe(409);
 
-      // The backfilled digest is unchanged by the rejected divergent write (guard threw first).
-      expect(agentRunDigest(layer, runId)).toBe(d1);
+      // The rejected write laundered nothing: the legacy digest is still NULL (throw rolled back
+      // before any UPDATE), so the divergent receipt's digest was NOT adopted as canonical.
+      expect(agentRunDigest(layer, runId)).toBe(null);
     } finally {
       layer.close();
     }
   });
 
-  it("stays an idempotent no-op when the legacy row is re-projected with the SAME receipt (no over-fail)", () => {
+  it("backfills a legacy row on a SAME-identity re-projection, then conflicts when a later projection diverges", () => {
     const layer = createTestDb();
     try {
       const runId = BASE_RECEIPT.runId;
@@ -162,8 +166,10 @@ describe("legacy-NULL digest backfill — Rust run-continuity projector (friday_
 
       project(layer, BASE_RECEIPT);
       makeLegacy(layer, runId);
+      expect(agentRunDigest(layer, runId)).toBe(null);
 
-      // Same receipt re-projected onto the legacy row: backfills to the SAME digest, never throws.
+      // Same run re-projected onto the legacy row: content matches → BACKFILL the canonical digest
+      // (both the agent_run row AND its companion usage row), never throwing (no over-fail).
       expect(() => project(layer, BASE_RECEIPT)).not.toThrow();
       expect(agentRunDigest(layer, runId)).toBe(dSame);
       expect(usageDigest(layer, usageId)).toBe(dSame);
@@ -173,6 +179,18 @@ describe("legacy-NULL digest backfill — Rust run-continuity projector (friday_
         .prepare("SELECT COUNT(*) AS n FROM friday_agent_runs WHERE id = ?")
         .get(runId) as { n: number };
       expect(count.n).toBe(1);
+
+      // The legacy gap is now closed: a LATER divergent projection hits the non-null typed 409.
+      const divergent: FridayRustHubRunReceipt = {
+        ...BASE_RECEIPT,
+        usagePromptTokens: 5555,
+        usageTotalTokens: 6000,
+      };
+      const caught = capture(() => project(layer, divergent));
+      expect(isConflict(caught)).toBe(true);
+      expect((caught as FridayDomainError).httpStatus).toBe(409);
+      // The backfilled digest is unchanged by the rejected divergent write (guard threw first).
+      expect(agentRunDigest(layer, runId)).toBe(dSame);
     } finally {
       layer.close();
     }
@@ -187,12 +205,11 @@ describe("legacy-NULL digest backfill — Rust run-continuity projector (llm_usa
   // agent_runs) while the longer-retained usage/cost ledger row survives — a re-projection then
   // re-inserts the agent_run fresh (no conflict) and the usage guard is the sole divergence check.
   // We drive the REAL projector against exactly that partial-legacy shape.
-  it("backfills a legacy usage row (agent_run reaped) then conflicts on a subsequent divergent projection", () => {
+  it("REJECTS a divergent usage projection (agent_run reaped) on first contact — never launders its digest", () => {
     const layer = createTestDb();
     try {
       const runId = BASE_RECEIPT.runId;
       const usageId = usageLedgerIdForRun(runId);
-      const dBase = hashIdempotencyPayload(BASE_RECEIPT);
 
       // Seed both rows, mark the usage row legacy (NULL), and simulate the agent_run reaper having
       // deleted the terminal agent_run row — leaving only the surviving legacy usage ledger row.
@@ -201,8 +218,38 @@ describe("legacy-NULL digest backfill — Rust run-continuity projector (llm_usa
       layer.writer.prepare("DELETE FROM friday_agent_runs WHERE id = ?").run(runId);
       expect(usageDigest(layer, usageId)).toBe(null); // precondition: legacy NULL usage row
 
+      // Divergent re-projection: agent_run absent → re-inserted fresh (no throw at site 1); the
+      // legacy usage row's content differs from the divergent projection → site 2 must raise the
+      // typed 409 rather than stamp. (RED on the blind-stamp code.)
+      const divergent: FridayRustHubRunReceipt = {
+        ...BASE_RECEIPT,
+        usagePromptTokens: 1,
+        usageTotalTokens: 2,
+      };
+      const caught = capture(() => project(layer, divergent));
+      expect(isConflict(caught)).toBe(true);
+      expect((caught as FridayDomainError).httpStatus).toBe(409);
+      // Nothing laundered: the usage row's digest is still NULL (throw rolled back the projection).
+      expect(usageDigest(layer, usageId)).toBe(null);
+    } finally {
+      layer.close();
+    }
+  });
+
+  it("backfills a legacy usage row (agent_run reaped) on a SAME-identity re-projection, then conflicts on divergence", () => {
+    const layer = createTestDb();
+    try {
+      const runId = BASE_RECEIPT.runId;
+      const usageId = usageLedgerIdForRun(runId);
+      const dBase = hashIdempotencyPayload(BASE_RECEIPT);
+
+      project(layer, BASE_RECEIPT);
+      layer.writer.prepare("UPDATE llm_usage_records SET payload_digest = NULL WHERE id = ?").run(usageId);
+      layer.writer.prepare("DELETE FROM friday_agent_runs WHERE id = ?").run(runId);
+      expect(usageDigest(layer, usageId)).toBe(null);
+
       // First re-projection (same receipt): agent_run absent → re-inserted fresh (no throw at
-      // site 1); legacy usage row → BACKFILLED to the canonical digest at site 2.
+      // site 1); legacy usage row content matches → BACKFILLED to the canonical digest at site 2.
       expect(() => project(layer, BASE_RECEIPT)).not.toThrow();
       expect(usageDigest(layer, usageId)).toBe(dBase);
 
@@ -216,12 +263,7 @@ describe("legacy-NULL digest backfill — Rust run-continuity projector (llm_usa
         usagePromptTokens: 1,
         usageTotalTokens: 2,
       };
-      let caught: unknown;
-      try {
-        project(layer, divergent);
-      } catch (err) {
-        caught = err;
-      }
+      const caught = capture(() => project(layer, divergent));
       expect(isConflict(caught)).toBe(true);
       expect((caught as FridayDomainError).httpStatus).toBe(409);
       // The usage row's backfilled digest survives the rejected write (guard threw before its insert).
@@ -282,6 +324,14 @@ describe("legacy-NULL digest backfill — satellite outbox enqueue (site 3)", ()
     return row ? row.payload_digest : null;
   }
 
+  function rowCount(layer: FridaySqliteLayer, satelliteId: string, idempotencyKey: string): number {
+    return (
+      layer.writer
+        .prepare("SELECT COUNT(*) AS n FROM outbox_messages WHERE satellite_id = ? AND idempotency_key = ?")
+        .get(satelliteId, idempotencyKey) as { n: number }
+    ).n;
+  }
+
   function makeLegacyRow(layer: FridaySqliteLayer, satelliteId: string, idempotencyKey: string): void {
     layer.writer
       .prepare(
@@ -290,7 +340,7 @@ describe("legacy-NULL digest backfill — satellite outbox enqueue (site 3)", ()
       .run(satelliteId, idempotencyKey);
   }
 
-  it("backfills the legacy row's digest on the first divergent enqueue, then conflicts on the second", () => {
+  it("REJECTS a DIVERGENT enqueue against a legacy row on first contact — never launders its digest", () => {
     const layer = createTestDb();
     try {
       insertSatellite(layer, SAT);
@@ -302,30 +352,47 @@ describe("legacy-NULL digest backfill — satellite outbox enqueue (site 3)", ()
       makeLegacyRow(layer, SAT, base.idempotencyKey);
       expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(null); // precondition: legacy NULL
 
-      // First divergent enqueue (same key, DIFFERENT message identity): must NOT throw, must
-      // resolve to the existing id (no-degrade), and must BACKFILL the row's digest to D1.
-      const divergent1: FridayOutboxEnqueueInput = { ...base, messageType: "skill.execute" };
-      const d1 = digestOf(divergent1);
-      const retry = service.enqueue(divergent1);
-      expect(retry.id).toBe(first.id);
-      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(d1); // backfilled, not NULL
-
-      // Second enqueue with ANOTHER different identity (D2 != D1) → legacy gap closed: typed 409.
-      let caught: unknown;
-      try {
-        service.enqueue({ ...base, messageType: "channel.deliver" });
-      } catch (err) {
-        caught = err;
-      }
+      // A DIVERGENT enqueue (same key, DIFFERENT message identity) on FIRST contact must PROVE
+      // identity against the persisted routing columns — which differ — and raise the typed 409
+      // rather than stamp the divergent digest and resolve to the existing id. (RED on the
+      // blind-stamp code: it stamps + resolves with no throw.)
+      const divergent: FridayOutboxEnqueueInput = { ...base, messageType: "skill.execute" };
+      const caught = capture(() => service.enqueue(divergent));
       expect(isConflict(caught)).toBe(true);
       expect((caught as FridayDomainError).httpStatus).toBe(409);
 
-      // Still exactly one row; digest unchanged by the rejected write.
-      const count = layer.writer
-        .prepare("SELECT COUNT(*) AS n FROM outbox_messages WHERE satellite_id = ? AND idempotency_key = ?")
-        .get(SAT, base.idempotencyKey) as { n: number };
-      expect(count.n).toBe(1);
-      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(d1);
+      // Nothing laundered: still one row, digest still NULL (the divergent digest was NOT adopted).
+      expect(rowCount(layer, SAT, base.idempotencyKey)).toBe(1);
+      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(null);
+    } finally {
+      layer.close();
+    }
+  });
+
+  it("backfills a legacy row on a SAME-identity re-enqueue, then conflicts when a later enqueue diverges", () => {
+    const layer = createTestDb();
+    try {
+      insertSatellite(layer, SAT);
+      const service = makeService(layer);
+      const dSame = digestOf(base);
+
+      const first = service.enqueue(base);
+      makeLegacyRow(layer, SAT, base.idempotencyKey);
+      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(null);
+
+      // Same routing identity + key, re-encoded transport body (fresh nonce/ciphertext): identity
+      // matches → resolves to the original id (no-degrade) and BACKFILLS the canonical digest.
+      const retry = service.enqueue({ ...base, payloadCiphertext: "cipher-A-reencoded", nonce: "nonce-A2" });
+      expect(retry.id).toBe(first.id);
+      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(dSame); // backfilled, not NULL
+      expect(rowCount(layer, SAT, base.idempotencyKey)).toBe(1);
+
+      // The legacy gap is now closed: a LATER enqueue with a different identity → typed 409.
+      const caught = capture(() => service.enqueue({ ...base, messageType: "channel.deliver" }));
+      expect(isConflict(caught)).toBe(true);
+      expect((caught as FridayDomainError).httpStatus).toBe(409);
+      // Digest unchanged by the rejected write.
+      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(dSame);
     } finally {
       layer.close();
     }
@@ -341,20 +408,10 @@ describe("legacy-NULL digest backfill — satellite outbox enqueue (site 3)", ()
       const first = service.enqueue(base);
       makeLegacyRow(layer, SAT, base.idempotencyKey);
 
-      // Same routing identity + key, re-encoded transport body (fresh nonce/ciphertext): MUST
-      // remain an idempotent no-op resolving to the original id, and backfill the SAME digest.
-      const retry = service.enqueue({
-        ...base,
-        payloadCiphertext: "cipher-A-reencoded",
-        nonce: "nonce-A2",
-      });
+      const retry = service.enqueue({ ...base, payloadCiphertext: "cipher-A-reencoded", nonce: "nonce-A2" });
       expect(retry.id).toBe(first.id);
       expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(dSame);
-
-      const count = layer.writer
-        .prepare("SELECT COUNT(*) AS n FROM outbox_messages WHERE satellite_id = ? AND idempotency_key = ?")
-        .get(SAT, base.idempotencyKey) as { n: number };
-      expect(count.n).toBe(1);
+      expect(rowCount(layer, SAT, base.idempotencyKey)).toBe(1);
     } finally {
       layer.close();
     }

--- a/test/integration/idempotency/friday-cross-store-legacy-null-digest-backfill.test.ts
+++ b/test/integration/idempotency/friday-cross-store-legacy-null-digest-backfill.test.ts
@@ -1,0 +1,377 @@
+/**
+ * DUR-OPERATION-JOURNAL-001 — follow-up defect #4: legacy-NULL digest backfill (integration).
+ *
+ * The cross-store digest-conflict guards added by the merged PR (#1623) short-circuit
+ * when the EXISTING row's `payload_digest` is NULL — the state of every row written
+ * BEFORE the v100 migration added the (nullable) `payload_digest` column. Because the
+ * guard only fires on a NON-NULL divergent digest, a divergent re-projection / re-enqueue
+ * that targets a legacy row is neither recorded nor flagged: it is silently swallowed by
+ * `INSERT OR IGNORE` (projector / outbox insert is a no-op — the row already exists) or
+ * silently resolved to the existing id (outbox). The genuine payload divergence vanishes.
+ *
+ * The fix BACKFILLS the canonical digest onto a legacy (NULL-digest) row on the FIRST
+ * digest-bearing write (`UPDATE <table> SET payload_digest = ? WHERE <key> AND
+ * payload_digest IS NULL`), so:
+ *   - the first legitimate re-projection/re-enqueue is NOT rejected (no over-fail); it
+ *     stamps the legacy row with its digest, and
+ *   - a SUBSEQUENT write with a DIFFERENT digest then hits the now-non-null digest and
+ *     raises the SAME typed 409 SECURITY_IDEMPOTENCY_KEY_CONFLICT the non-null path raises.
+ *
+ * RED-FIRST: on the pre-fix code the legacy-NULL divergent SECOND write is a silent no-op
+ * (no conflict) — the `toThrow`/conflict assertions FAIL. After the backfill they pass. The
+ * happy paths (non-null matching = no-op, non-null different = conflict, fresh insert sets
+ * its digest, idempotent replay resolves to the existing id) are UNCHANGED and are covered
+ * here and in `friday-cross-store-digest-conflict.test.ts`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { FridayDomainError } from "#errors";
+import type { FridaySqliteLayer } from "#state";
+import {
+  createFridayOutboxMessageRepository,
+  createFridayOutboxQueueService,
+  type FridayOutboxEnqueueInput,
+} from "#satellites";
+import { hashIdempotencyPayload } from "../../../src/api/http/routes/friday-route-idempotency.js";
+import { createTestDb, createTestIdGenerator } from "../../unit/satellites/_helpers/create-test-db.helper.js";
+import {
+  createFridayRustHubRunContinuityProjectorService,
+  usageLedgerIdForRun,
+  type FridayRustHubRunReceipt,
+} from "../../../src/api/mission-spine/friday-rust-hub-run-continuity-projector-service.js";
+
+const NOW = "2026-07-12T10:00:00.000Z";
+
+const BASE_RECEIPT: FridayRustHubRunReceipt = {
+  truthLabel: "rust_wired_dev",
+  proofOnly: true,
+  ok: true,
+  runId: "hub_run_task_dev_legacy_1720000000000000000",
+  routeId: "deepseek:deepseek-v4-flash",
+  providerId: "deepseek",
+  model: "deepseek-v4-flash",
+  modelSize: "Flash",
+  backendKind: "Http",
+  loopStatus: "Finished",
+  errorCategory: null,
+  turns: 3,
+  executedTools: 2,
+  finalMessageSha256: "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", // pragma: allowlist secret
+  finalMessageLen: 128,
+  auditChainVerified: true,
+  usagePromptTokens: 1500,
+  usageCompletionTokens: 420,
+  usageTotalTokens: 1920,
+  completedAtIso: NOW,
+};
+
+function isConflict(err: unknown): err is FridayDomainError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === "SECURITY_IDEMPOTENCY_KEY_CONFLICT"
+  );
+}
+
+/**
+ * Drive the REAL projector exactly as production does: inside a write transaction
+ * (`composeRustReadOnlyAgentRun` runs `project()` in `withWriteTransaction`), so a thrown
+ * conflict rolls back any partial insert — faithful atomicity, not a bare handle.
+ */
+function project(layer: FridaySqliteLayer, receipt: FridayRustHubRunReceipt) {
+  const projector = createFridayRustHubRunContinuityProjectorService();
+  return layer.withWriteTransaction((db) => projector.project(db, receipt));
+}
+
+function agentRunDigest(layer: FridaySqliteLayer, runId: string): string | null {
+  const row = layer.writer
+    .prepare("SELECT payload_digest FROM friday_agent_runs WHERE id = ?")
+    .get(runId) as { payload_digest: string | null } | undefined;
+  return row ? row.payload_digest : null;
+}
+
+function usageDigest(layer: FridaySqliteLayer, usageId: string): string | null {
+  const row = layer.writer
+    .prepare("SELECT payload_digest FROM llm_usage_records WHERE id = ?")
+    .get(usageId) as { payload_digest: string | null } | undefined;
+  return row ? row.payload_digest : null;
+}
+
+/** Simulate the pre-v100 state: NULL out the digest columns the migration added as nullable. */
+function makeLegacy(layer: FridaySqliteLayer, runId: string): void {
+  layer.writer.prepare("UPDATE friday_agent_runs SET payload_digest = NULL WHERE id = ?").run(runId);
+  layer.writer
+    .prepare("UPDATE llm_usage_records SET payload_digest = NULL WHERE id = ?")
+    .run(usageLedgerIdForRun(runId));
+}
+
+describe("legacy-NULL digest backfill — Rust run-continuity projector (friday_agent_runs, site 1)", () => {
+  it("backfills the legacy row's digest on the first divergent projection, then conflicts on the second", () => {
+    const layer = createTestDb();
+    try {
+      const runId = BASE_RECEIPT.runId;
+      const usageId = usageLedgerIdForRun(runId);
+
+      // Seed a pre-v100 legacy row (digest column NULL).
+      project(layer, BASE_RECEIPT);
+      makeLegacy(layer, runId);
+      expect(agentRunDigest(layer, runId)).toBe(null); // precondition: legacy NULL
+      expect(usageDigest(layer, usageId)).toBe(null);
+
+      // First divergent write with digest D1 → must NOT throw; must BACKFILL D1 onto the legacy
+      // row (both the agent_run row AND its companion usage row), not silently drop it.
+      const divergent1: FridayRustHubRunReceipt = {
+        ...BASE_RECEIPT,
+        usagePromptTokens: 9999,
+        usageTotalTokens: 10_419,
+      };
+      const d1 = hashIdempotencyPayload(divergent1);
+      expect(() => project(layer, divergent1)).not.toThrow();
+      expect(agentRunDigest(layer, runId)).toBe(d1); // backfilled, not NULL, not dropped
+      expect(usageDigest(layer, usageId)).toBe(d1); // site-2 backfill in the same write
+
+      // Second write with a DIFFERENT digest D2 → the legacy gap is now closed: typed 409.
+      const divergent2: FridayRustHubRunReceipt = {
+        ...BASE_RECEIPT,
+        usagePromptTokens: 5555,
+        usageTotalTokens: 6000,
+      };
+      let caught: unknown;
+      try {
+        project(layer, divergent2);
+      } catch (err) {
+        caught = err;
+      }
+      expect(isConflict(caught)).toBe(true);
+      expect((caught as FridayDomainError).httpStatus).toBe(409);
+
+      // The backfilled digest is unchanged by the rejected divergent write (guard threw first).
+      expect(agentRunDigest(layer, runId)).toBe(d1);
+    } finally {
+      layer.close();
+    }
+  });
+
+  it("stays an idempotent no-op when the legacy row is re-projected with the SAME receipt (no over-fail)", () => {
+    const layer = createTestDb();
+    try {
+      const runId = BASE_RECEIPT.runId;
+      const usageId = usageLedgerIdForRun(runId);
+      const dSame = hashIdempotencyPayload(BASE_RECEIPT);
+
+      project(layer, BASE_RECEIPT);
+      makeLegacy(layer, runId);
+
+      // Same receipt re-projected onto the legacy row: backfills to the SAME digest, never throws.
+      expect(() => project(layer, BASE_RECEIPT)).not.toThrow();
+      expect(agentRunDigest(layer, runId)).toBe(dSame);
+      expect(usageDigest(layer, usageId)).toBe(dSame);
+
+      // Still exactly one row (backfill never inserts).
+      const count = layer.writer
+        .prepare("SELECT COUNT(*) AS n FROM friday_agent_runs WHERE id = ?")
+        .get(runId) as { n: number };
+      expect(count.n).toBe(1);
+    } finally {
+      layer.close();
+    }
+  });
+});
+
+describe("legacy-NULL digest backfill — Rust run-continuity projector (llm_usage_records, site 2)", () => {
+  // The usage-records guard is defense-in-depth BEHIND the agent_run guard: both derive from the
+  // SAME per-receipt digest and the agent_run guard is checked first, so a plain divergent
+  // re-projection conflicts at site 1 before site 2 is reached. Its guard genuinely matters when
+  // the agent_run row was REAPED (the terminal-run retention reaper deletes completed/failed
+  // agent_runs) while the longer-retained usage/cost ledger row survives — a re-projection then
+  // re-inserts the agent_run fresh (no conflict) and the usage guard is the sole divergence check.
+  // We drive the REAL projector against exactly that partial-legacy shape.
+  it("backfills a legacy usage row (agent_run reaped) then conflicts on a subsequent divergent projection", () => {
+    const layer = createTestDb();
+    try {
+      const runId = BASE_RECEIPT.runId;
+      const usageId = usageLedgerIdForRun(runId);
+      const dBase = hashIdempotencyPayload(BASE_RECEIPT);
+
+      // Seed both rows, mark the usage row legacy (NULL), and simulate the agent_run reaper having
+      // deleted the terminal agent_run row — leaving only the surviving legacy usage ledger row.
+      project(layer, BASE_RECEIPT);
+      layer.writer.prepare("UPDATE llm_usage_records SET payload_digest = NULL WHERE id = ?").run(usageId);
+      layer.writer.prepare("DELETE FROM friday_agent_runs WHERE id = ?").run(runId);
+      expect(usageDigest(layer, usageId)).toBe(null); // precondition: legacy NULL usage row
+
+      // First re-projection (same receipt): agent_run absent → re-inserted fresh (no throw at
+      // site 1); legacy usage row → BACKFILLED to the canonical digest at site 2.
+      expect(() => project(layer, BASE_RECEIPT)).not.toThrow();
+      expect(usageDigest(layer, usageId)).toBe(dBase);
+
+      // Reap the agent_run again so the NEXT divergent write passes site 1 and reaches site 2.
+      layer.writer.prepare("DELETE FROM friday_agent_runs WHERE id = ?").run(runId);
+
+      // Divergent re-projection: agent_run re-inserts fresh (no conflict) but the usage row's
+      // now-non-null digest diverges → the usage guard raises the typed 409.
+      const divergent: FridayRustHubRunReceipt = {
+        ...BASE_RECEIPT,
+        usagePromptTokens: 1,
+        usageTotalTokens: 2,
+      };
+      let caught: unknown;
+      try {
+        project(layer, divergent);
+      } catch (err) {
+        caught = err;
+      }
+      expect(isConflict(caught)).toBe(true);
+      expect((caught as FridayDomainError).httpStatus).toBe(409);
+      // The usage row's backfilled digest survives the rejected write (guard threw before its insert).
+      expect(usageDigest(layer, usageId)).toBe(dBase);
+    } finally {
+      layer.close();
+    }
+  });
+});
+
+describe("legacy-NULL digest backfill — satellite outbox enqueue (site 3)", () => {
+  const SAT = "sat-outbox-legacy-1";
+
+  function insertSatellite(layer: FridaySqliteLayer, id: string): void {
+    layer.writer
+      .prepare(
+        `INSERT INTO satellites (id, type, display_name, pairing_status, trust_level, public_key,
+         token_version, transport, platform, arch, app_version, node_version, tags_json, created_at, updated_at)
+         VALUES (?, 'phone', 'Test', 'online', 'restricted', 'pk', 1, 'ws', 'linux', 'arm64', '1.0', '22.0', '[]', ?, ?)`,
+      )
+      .run(id, NOW, NOW);
+  }
+
+  function makeService(layer: FridaySqliteLayer) {
+    return createFridayOutboxQueueService({
+      db: layer,
+      outboxRepo: createFridayOutboxMessageRepository(),
+      idGenerator: createTestIdGenerator(),
+      nowIso: () => NOW,
+    });
+  }
+
+  const base: FridayOutboxEnqueueInput = {
+    satelliteId: SAT,
+    queueKey: "workflow:run-1",
+    messageType: "workflow.node.execute",
+    payloadCiphertext: "cipher-A",
+    nonce: "nonce-A",
+    keyId: "inline-transport:v1",
+    idempotencyKey: "idem-legacy-1",
+  };
+
+  function digestOf(input: FridayOutboxEnqueueInput): string {
+    return hashIdempotencyPayload({
+      satelliteId: input.satelliteId,
+      queueKey: input.queueKey,
+      messageType: input.messageType,
+      keyId: input.keyId,
+    });
+  }
+
+  function rowDigest(layer: FridaySqliteLayer, satelliteId: string, idempotencyKey: string): string | null {
+    const row = layer.writer
+      .prepare(
+        "SELECT payload_digest FROM outbox_messages WHERE satellite_id = ? AND idempotency_key = ?",
+      )
+      .get(satelliteId, idempotencyKey) as { payload_digest: string | null } | undefined;
+    return row ? row.payload_digest : null;
+  }
+
+  function makeLegacyRow(layer: FridaySqliteLayer, satelliteId: string, idempotencyKey: string): void {
+    layer.writer
+      .prepare(
+        "UPDATE outbox_messages SET payload_digest = NULL WHERE satellite_id = ? AND idempotency_key = ?",
+      )
+      .run(satelliteId, idempotencyKey);
+  }
+
+  it("backfills the legacy row's digest on the first divergent enqueue, then conflicts on the second", () => {
+    const layer = createTestDb();
+    try {
+      insertSatellite(layer, SAT);
+      const service = makeService(layer);
+
+      // Seed a pre-v100 legacy row (digest column NULL).
+      const first = service.enqueue(base);
+      expect(first.id).toBeTruthy();
+      makeLegacyRow(layer, SAT, base.idempotencyKey);
+      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(null); // precondition: legacy NULL
+
+      // First divergent enqueue (same key, DIFFERENT message identity): must NOT throw, must
+      // resolve to the existing id (no-degrade), and must BACKFILL the row's digest to D1.
+      const divergent1: FridayOutboxEnqueueInput = { ...base, messageType: "skill.execute" };
+      const d1 = digestOf(divergent1);
+      const retry = service.enqueue(divergent1);
+      expect(retry.id).toBe(first.id);
+      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(d1); // backfilled, not NULL
+
+      // Second enqueue with ANOTHER different identity (D2 != D1) → legacy gap closed: typed 409.
+      let caught: unknown;
+      try {
+        service.enqueue({ ...base, messageType: "channel.deliver" });
+      } catch (err) {
+        caught = err;
+      }
+      expect(isConflict(caught)).toBe(true);
+      expect((caught as FridayDomainError).httpStatus).toBe(409);
+
+      // Still exactly one row; digest unchanged by the rejected write.
+      const count = layer.writer
+        .prepare("SELECT COUNT(*) AS n FROM outbox_messages WHERE satellite_id = ? AND idempotency_key = ?")
+        .get(SAT, base.idempotencyKey) as { n: number };
+      expect(count.n).toBe(1);
+      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(d1);
+    } finally {
+      layer.close();
+    }
+  });
+
+  it("stays an idempotent no-op when the legacy row is re-enqueued with the SAME identity (no over-fail)", () => {
+    const layer = createTestDb();
+    try {
+      insertSatellite(layer, SAT);
+      const service = makeService(layer);
+      const dSame = digestOf(base);
+
+      const first = service.enqueue(base);
+      makeLegacyRow(layer, SAT, base.idempotencyKey);
+
+      // Same routing identity + key, re-encoded transport body (fresh nonce/ciphertext): MUST
+      // remain an idempotent no-op resolving to the original id, and backfill the SAME digest.
+      const retry = service.enqueue({
+        ...base,
+        payloadCiphertext: "cipher-A-reencoded",
+        nonce: "nonce-A2",
+      });
+      expect(retry.id).toBe(first.id);
+      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(dSame);
+
+      const count = layer.writer
+        .prepare("SELECT COUNT(*) AS n FROM outbox_messages WHERE satellite_id = ? AND idempotency_key = ?")
+        .get(SAT, base.idempotencyKey) as { n: number };
+      expect(count.n).toBe(1);
+    } finally {
+      layer.close();
+    }
+  });
+
+  it("a fresh enqueue (no existing row) inserts and stamps its digest (happy path unchanged)", () => {
+    const layer = createTestDb();
+    try {
+      insertSatellite(layer, SAT);
+      const service = makeService(layer);
+
+      const res = service.enqueue(base);
+      expect(res.id).toBeTruthy();
+      // Fresh insert records the digest (non-null) — the exactly-once/insert path is unchanged.
+      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(digestOf(base));
+    } finally {
+      layer.close();
+    }
+  });
+});

--- a/test/integration/idempotency/friday-cross-store-legacy-null-digest-backfill.test.ts
+++ b/test/integration/idempotency/friday-cross-store-legacy-null-digest-backfill.test.ts
@@ -1,33 +1,34 @@
 /**
- * DUR-OPERATION-JOURNAL-001 — follow-up defect #4: legacy-NULL digest backfill (integration).
+ * DUR-OPERATION-JOURNAL-001 — follow-up defect #4: legacy-NULL digest reconciliation (integration).
  *
  * The cross-store digest-conflict guards added by the merged PR (#1623) short-circuit when the
  * EXISTING row's `payload_digest` is NULL — the state of every row written BEFORE the v100
- * migration added the (nullable) `payload_digest` column. Because the guard only fires on a
- * NON-NULL divergent digest, a divergent re-projection / re-enqueue that targets a legacy row is
- * neither recorded nor flagged: it is silently swallowed by `INSERT OR IGNORE` (projector / outbox
- * insert is a no-op — the row already exists) or silently resolved to the existing id (outbox).
+ * migration added the (nullable) `payload_digest` column. Because the guard only fired on a
+ * NON-NULL divergent digest, a divergent re-projection / re-enqueue that targets a legacy row was
+ * neither recorded nor flagged: silently swallowed by `INSERT OR IGNORE` / resolved to the existing
+ * id. The fix closes that gap — but a legacy row must NEVER be stamped with a digest we cannot
+ * validate, or a divergent first-write gets laundered into "the canonical digest".
  *
- * The fix does NOT blindly stamp the incoming digest onto a legacy row — that would LAUNDER a
- * divergent write (same key reused for a DIFFERENT identity) into "the canonical digest". Instead,
- * on a legacy (NULL-digest) row it PROVES the incoming write reproduces the bytes ALREADY
- * PERSISTED before stamping:
- *   - outbox: recompute the canonical routing-identity digest from the row's OWN persisted columns
- *     (`satellite_id, queue_key, message_type, key_id`) and compare;
- *   - projector: recompute a content-identity over the row's persisted content columns and compare.
- * Then:
- *   - MATCH  ⇒ same identity → BACKFILL the canonical digest (first-write-only via
- *     `payload_digest IS NULL`) so a LATER divergent write hits the now-non-null typed-409 branch;
- *   - MISMATCH ⇒ genuine divergence → the SAME typed 409 (SECURITY_IDEMPOTENCY_KEY_CONFLICT) the
- *     non-null path raises, BEFORE any stamp (data-loss-free: the row is preserved, nothing
- *     laundered).
+ * Two site classes, per whether the row's ORIGINAL identity is exactly reconstructable:
  *
- * RED-FIRST: on the pre-fix (blind-stamp) code, a DIVERGENT write against a legacy row on FIRST
- * contact is silently accepted (stamped / resolved, no throw) — the `toThrow`/409 negative-control
- * assertions FAIL. After the prove-then-stamp fix they pass, and the same-identity backfill +
- * happy paths (non-null matching = no-op, non-null different = conflict, fresh insert stamps its
- * digest, idempotent replay resolves to the existing id) remain UNCHANGED (covered here and in
- * `friday-cross-store-digest-conflict.test.ts`).
+ *  • PROJECTOR (friday_agent_runs + llm_usage_records): the digest is over the WHOLE receipt, which
+ *    is NOT persisted, and several inserted columns / unpersisted receipt fields (task,
+ *    provider_kind, modelSize, backendKind, …) cannot be recovered. The original identity CANNOT be
+ *    reconstructed, so the projector FAILS CLOSED: any digest-bearing projection onto a legacy
+ *    (NULL-digest) row raises the typed 409 (SECURITY_IDEMPOTENCY_KEY_CONFLICT) and stamps NOTHING.
+ *    (`null !== incomingDigest` is always true.) This still closes the silent-swallow — divergence
+ *    now surfaces loudly. A non-null EXACT digest match is the idempotent no-op (unchanged).
+ *
+ *  • OUTBOX (outbox_messages): the digest is over the stable routing identity
+ *    {satelliteId, queueKey, messageType, keyId}, ALL persisted columns, so a legacy row's identity
+ *    IS exactly reconstructable. The outbox recomputes the canonical digest from the row's own
+ *    stored columns and BACKFILLS on an exact match (no over-fail for a legitimate same-identity
+ *    re-enqueue), or raises the typed 409 on a mismatch — never laundering a divergent write.
+ *
+ * RED-FIRST (vs the prior head 4c4859f5, which compared only SELECTED projector columns): a legacy
+ * projector row whose divergence lives in an OMITTED column (task / provider_kind) or an UNPERSISTED
+ * receipt field (modelSize) was ACCEPTED and stamped there; here each such case must 409 and leave
+ * payload_digest NULL. The outbox exact-recompute cases are unchanged.
  */
 
 import { describe, expect, it } from "vitest";
@@ -90,6 +91,11 @@ function capture(fn: () => void): unknown {
   }
 }
 
+function expectConflict(caught: unknown): void {
+  expect(isConflict(caught)).toBe(true);
+  expect((caught as FridayDomainError).httpStatus).toBe(409);
+}
+
 /**
  * Drive the REAL projector exactly as production does: inside a write transaction
  * (`composeRustReadOnlyAgentRun` runs `project()` in `withWriteTransaction`), so a thrown
@@ -122,159 +128,144 @@ function makeLegacy(layer: FridaySqliteLayer, runId: string): void {
     .run(usageLedgerIdForRun(runId));
 }
 
-describe("legacy-NULL digest backfill — Rust run-continuity projector (friday_agent_runs, site 1)", () => {
-  it("REJECTS a DIVERGENT projection against a legacy row on first contact — never launders its digest", () => {
+describe("legacy-NULL digest FAIL-CLOSED — Rust projector (friday_agent_runs, site 1)", () => {
+  it("a digest-bearing projection onto a legacy NULL-digest row raises the typed 409 and stamps nothing", () => {
     const layer = createTestDb();
     try {
       const runId = BASE_RECEIPT.runId;
-      const usageId = usageLedgerIdForRun(runId);
-
-      // Seed a pre-v100 legacy row (digest column NULL) from BASE_RECEIPT's content.
       project(layer, BASE_RECEIPT);
       makeLegacy(layer, runId);
       expect(agentRunDigest(layer, runId)).toBe(null); // precondition: legacy NULL
-      expect(usageDigest(layer, usageId)).toBe(null);
 
-      // A DIVERGENT receipt (different usage content) is the same run_id reused for a DIFFERENT
-      // projection. On the FIRST digest-bearing contact the guard has no stored digest to compare,
-      // so it must PROVE identity against the persisted content — which differs — and raise the
-      // typed 409 rather than stamping the divergent digest. (RED on the blind-stamp code: it
-      // stamps + no-ops with no throw.)
-      const divergent: FridayRustHubRunReceipt = {
-        ...BASE_RECEIPT,
-        usagePromptTokens: 9999,
-        usageTotalTokens: 10_419,
-      };
-      const caught = capture(() => project(layer, divergent));
-      expect(isConflict(caught)).toBe(true);
-      expect((caught as FridayDomainError).httpStatus).toBe(409);
+      // Even the SAME receipt cannot prove the legacy row's original identity (the raw receipt is
+      // not stored), so it fails closed rather than stamping an unvalidatable digest. This is the
+      // intended fail-closed over-fail; in practice the pre-v100 projected-row population is empty
+      // (the projector post-dates v100 and is gated DEFAULT-OFF).
+      expectConflict(capture(() => project(layer, BASE_RECEIPT)));
+      expect(agentRunDigest(layer, runId)).toBe(null); // nothing stamped; throw rolled back
+    } finally {
+      layer.close();
+    }
+  });
 
-      // The rejected write laundered nothing: the legacy digest is still NULL (throw rolled back
-      // before any UPDATE), so the divergent receipt's digest was NOT adopted as canonical.
+  it("a legacy row whose OMITTED column (task) diverges is NOT laundered — 409, digest stays null", () => {
+    const layer = createTestDb();
+    try {
+      const runId = BASE_RECEIPT.runId;
+      project(layer, BASE_RECEIPT);
+      // A legacy row whose `task` differs from what the projection would write. `task` was omitted
+      // from the prior head's content-identity, so it MATCHED there and got backfilled (laundered).
+      layer.writer
+        .prepare("UPDATE friday_agent_runs SET task = 'a genuinely different task', payload_digest = NULL WHERE id = ?")
+        .run(runId);
+      expect(agentRunDigest(layer, runId)).toBe(null);
+
+      expectConflict(capture(() => project(layer, BASE_RECEIPT)));
       expect(agentRunDigest(layer, runId)).toBe(null);
     } finally {
       layer.close();
     }
   });
 
-  it("backfills a legacy row on a SAME-identity re-projection, then conflicts when a later projection diverges", () => {
+  it("a receipt differing only in the UNPERSISTED modelSize is NOT laundered — 409, digest stays null", () => {
     const layer = createTestDb();
     try {
       const runId = BASE_RECEIPT.runId;
-      const usageId = usageLedgerIdForRun(runId);
-      const dSame = hashIdempotencyPayload(BASE_RECEIPT);
-
       project(layer, BASE_RECEIPT);
       makeLegacy(layer, runId);
       expect(agentRunDigest(layer, runId)).toBe(null);
 
-      // Same run re-projected onto the legacy row: content matches → BACKFILL the canonical digest
-      // (both the agent_run row AND its companion usage row), never throwing (no over-fail).
-      expect(() => project(layer, BASE_RECEIPT)).not.toThrow();
-      expect(agentRunDigest(layer, runId)).toBe(dSame);
-      expect(usageDigest(layer, usageId)).toBe(dSame);
+      // modelSize/backendKind are never persisted to any column, so the prior head's content-identity
+      // could not see this divergence and stamped the incoming whole-receipt digest. Fail-closed 409.
+      const modelSizeVariant: FridayRustHubRunReceipt = { ...BASE_RECEIPT, modelSize: "Pro" };
+      expect(hashIdempotencyPayload(modelSizeVariant)).not.toBe(hashIdempotencyPayload(BASE_RECEIPT)); // whole-receipt digest DID diverge
+      expectConflict(capture(() => project(layer, modelSizeVariant)));
+      expect(agentRunDigest(layer, runId)).toBe(null);
+    } finally {
+      layer.close();
+    }
+  });
 
-      // Still exactly one row (backfill never inserts).
+  it("a non-null EXACT digest match stays an idempotent no-op (happy path unchanged)", () => {
+    const layer = createTestDb();
+    try {
+      const runId = BASE_RECEIPT.runId;
+      const dBase = hashIdempotencyPayload(BASE_RECEIPT);
+      project(layer, BASE_RECEIPT);
+      expect(agentRunDigest(layer, runId)).toBe(dBase); // fresh insert stamped the digest
+
+      // Re-project the same receipt (digest NON-null): exact match → no throw, no dup.
+      expect(() => project(layer, BASE_RECEIPT)).not.toThrow();
+      expect(agentRunDigest(layer, runId)).toBe(dBase);
       const count = layer.writer
         .prepare("SELECT COUNT(*) AS n FROM friday_agent_runs WHERE id = ?")
         .get(runId) as { n: number };
       expect(count.n).toBe(1);
+    } finally {
+      layer.close();
+    }
+  });
 
-      // The legacy gap is now closed: a LATER divergent projection hits the non-null typed 409.
-      const divergent: FridayRustHubRunReceipt = {
-        ...BASE_RECEIPT,
-        usagePromptTokens: 5555,
-        usageTotalTokens: 6000,
-      };
-      const caught = capture(() => project(layer, divergent));
-      expect(isConflict(caught)).toBe(true);
-      expect((caught as FridayDomainError).httpStatus).toBe(409);
-      // The backfilled digest is unchanged by the rejected divergent write (guard threw first).
-      expect(agentRunDigest(layer, runId)).toBe(dSame);
+  it("a non-null DIFFERENT digest raises the typed 409 (unchanged #1623 behavior)", () => {
+    const layer = createTestDb();
+    try {
+      project(layer, BASE_RECEIPT);
+      // Digest is now non-null; a divergent receipt for the same run_id → typed 409.
+      const divergent: FridayRustHubRunReceipt = { ...BASE_RECEIPT, usagePromptTokens: 9999, usageTotalTokens: 10_419 };
+      expectConflict(capture(() => project(layer, divergent)));
     } finally {
       layer.close();
     }
   });
 });
 
-describe("legacy-NULL digest backfill — Rust run-continuity projector (llm_usage_records, site 2)", () => {
-  // The usage-records guard is defense-in-depth BEHIND the agent_run guard: both derive from the
-  // SAME per-receipt digest and the agent_run guard is checked first, so a plain divergent
-  // re-projection conflicts at site 1 before site 2 is reached. Its guard genuinely matters when
-  // the agent_run row was REAPED (the terminal-run retention reaper deletes completed/failed
-  // agent_runs) while the longer-retained usage/cost ledger row survives — a re-projection then
-  // re-inserts the agent_run fresh (no conflict) and the usage guard is the sole divergence check.
-  // We drive the REAL projector against exactly that partial-legacy shape.
-  it("REJECTS a divergent usage projection (agent_run reaped) on first contact — never launders its digest", () => {
+describe("legacy-NULL digest FAIL-CLOSED — Rust projector (llm_usage_records, site 2)", () => {
+  // Site 2 is the SOLE divergence check when the terminal agent_run row was reaped (the retention
+  // reaper deletes completed/failed agent_runs) while the longer-retained usage/cost ledger row
+  // survives: the re-projection re-inserts the agent_run fresh (no conflict at site 1) and the usage
+  // guard is reached. We drive the REAL projector against exactly that partial-legacy shape.
+  it("a legacy usage row (agent_run reaped) whose OMITTED column (provider_kind) diverges is NOT laundered — 409, digest stays null", () => {
     const layer = createTestDb();
     try {
       const runId = BASE_RECEIPT.runId;
       const usageId = usageLedgerIdForRun(runId);
 
-      // Seed both rows, mark the usage row legacy (NULL), and simulate the agent_run reaper having
-      // deleted the terminal agent_run row — leaving only the surviving legacy usage ledger row.
       project(layer, BASE_RECEIPT);
-      layer.writer.prepare("UPDATE llm_usage_records SET payload_digest = NULL WHERE id = ?").run(usageId);
-      layer.writer.prepare("DELETE FROM friday_agent_runs WHERE id = ?").run(runId);
-      expect(usageDigest(layer, usageId)).toBe(null); // precondition: legacy NULL usage row
+      // A legacy usage row whose `provider_kind` differs from the projection's constant ('unknown').
+      // provider_kind was omitted from the prior head's usage content-identity → matched → laundered.
+      layer.writer
+        .prepare("UPDATE llm_usage_records SET provider_kind = 'deepseek', payload_digest = NULL WHERE id = ?")
+        .run(usageId);
+      layer.writer.prepare("DELETE FROM friday_agent_runs WHERE id = ?").run(runId); // reap → reach site 2
+      expect(usageDigest(layer, usageId)).toBe(null);
 
-      // Divergent re-projection: agent_run absent → re-inserted fresh (no throw at site 1); the
-      // legacy usage row's content differs from the divergent projection → site 2 must raise the
-      // typed 409 rather than stamp. (RED on the blind-stamp code.)
-      const divergent: FridayRustHubRunReceipt = {
-        ...BASE_RECEIPT,
-        usagePromptTokens: 1,
-        usageTotalTokens: 2,
-      };
-      const caught = capture(() => project(layer, divergent));
-      expect(isConflict(caught)).toBe(true);
-      expect((caught as FridayDomainError).httpStatus).toBe(409);
-      // Nothing laundered: the usage row's digest is still NULL (throw rolled back the projection).
+      expectConflict(capture(() => project(layer, BASE_RECEIPT)));
       expect(usageDigest(layer, usageId)).toBe(null);
     } finally {
       layer.close();
     }
   });
 
-  it("backfills a legacy usage row (agent_run reaped) on a SAME-identity re-projection, then conflicts on divergence", () => {
+  it("a plain legacy usage row (agent_run reaped) fails closed on any digest-bearing projection — 409, digest stays null", () => {
     const layer = createTestDb();
     try {
       const runId = BASE_RECEIPT.runId;
       const usageId = usageLedgerIdForRun(runId);
-      const dBase = hashIdempotencyPayload(BASE_RECEIPT);
 
       project(layer, BASE_RECEIPT);
       layer.writer.prepare("UPDATE llm_usage_records SET payload_digest = NULL WHERE id = ?").run(usageId);
       layer.writer.prepare("DELETE FROM friday_agent_runs WHERE id = ?").run(runId);
       expect(usageDigest(layer, usageId)).toBe(null);
 
-      // First re-projection (same receipt): agent_run absent → re-inserted fresh (no throw at
-      // site 1); legacy usage row content matches → BACKFILLED to the canonical digest at site 2.
-      expect(() => project(layer, BASE_RECEIPT)).not.toThrow();
-      expect(usageDigest(layer, usageId)).toBe(dBase);
-
-      // Reap the agent_run again so the NEXT divergent write passes site 1 and reaches site 2.
-      layer.writer.prepare("DELETE FROM friday_agent_runs WHERE id = ?").run(runId);
-
-      // Divergent re-projection: agent_run re-inserts fresh (no conflict) but the usage row's
-      // now-non-null digest diverges → the usage guard raises the typed 409.
-      const divergent: FridayRustHubRunReceipt = {
-        ...BASE_RECEIPT,
-        usagePromptTokens: 1,
-        usageTotalTokens: 2,
-      };
-      const caught = capture(() => project(layer, divergent));
-      expect(isConflict(caught)).toBe(true);
-      expect((caught as FridayDomainError).httpStatus).toBe(409);
-      // The usage row's backfilled digest survives the rejected write (guard threw before its insert).
-      expect(usageDigest(layer, usageId)).toBe(dBase);
+      expectConflict(capture(() => project(layer, BASE_RECEIPT)));
+      expect(usageDigest(layer, usageId)).toBe(null);
     } finally {
       layer.close();
     }
   });
 });
 
-describe("legacy-NULL digest backfill — satellite outbox enqueue (site 3)", () => {
+describe("legacy-NULL digest EXACT-RECOMPUTE backfill — satellite outbox enqueue (site 3)", () => {
   const SAT = "sat-outbox-legacy-1";
 
   function insertSatellite(layer: FridaySqliteLayer, id: string): void {
@@ -346,22 +337,16 @@ describe("legacy-NULL digest backfill — satellite outbox enqueue (site 3)", ()
       insertSatellite(layer, SAT);
       const service = makeService(layer);
 
-      // Seed a pre-v100 legacy row (digest column NULL).
       const first = service.enqueue(base);
       expect(first.id).toBeTruthy();
       makeLegacyRow(layer, SAT, base.idempotencyKey);
       expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(null); // precondition: legacy NULL
 
-      // A DIVERGENT enqueue (same key, DIFFERENT message identity) on FIRST contact must PROVE
-      // identity against the persisted routing columns — which differ — and raise the typed 409
-      // rather than stamp the divergent digest and resolve to the existing id. (RED on the
-      // blind-stamp code: it stamps + resolves with no throw.)
+      // Different routing identity (DIFFERENT message_type) — the recompute over the row's stored
+      // routing columns will not match → typed 409 (not a stamp/resolve). All four digest inputs are
+      // persisted columns, so this comparison is exact.
       const divergent: FridayOutboxEnqueueInput = { ...base, messageType: "skill.execute" };
-      const caught = capture(() => service.enqueue(divergent));
-      expect(isConflict(caught)).toBe(true);
-      expect((caught as FridayDomainError).httpStatus).toBe(409);
-
-      // Nothing laundered: still one row, digest still NULL (the divergent digest was NOT adopted).
+      expectConflict(capture(() => service.enqueue(divergent)));
       expect(rowCount(layer, SAT, base.idempotencyKey)).toBe(1);
       expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(null);
     } finally {
@@ -369,7 +354,7 @@ describe("legacy-NULL digest backfill — satellite outbox enqueue (site 3)", ()
     }
   });
 
-  it("backfills a legacy row on a SAME-identity re-enqueue, then conflicts when a later enqueue diverges", () => {
+  it("BACKFILLS a legacy row on a SAME-identity re-enqueue (no over-fail), then conflicts when a later enqueue diverges", () => {
     const layer = createTestDb();
     try {
       insertSatellite(layer, SAT);
@@ -380,38 +365,17 @@ describe("legacy-NULL digest backfill — satellite outbox enqueue (site 3)", ()
       makeLegacyRow(layer, SAT, base.idempotencyKey);
       expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(null);
 
-      // Same routing identity + key, re-encoded transport body (fresh nonce/ciphertext): identity
-      // matches → resolves to the original id (no-degrade) and BACKFILLS the canonical digest.
-      const retry = service.enqueue({ ...base, payloadCiphertext: "cipher-A-reencoded", nonce: "nonce-A2" });
-      expect(retry.id).toBe(first.id);
-      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(dSame); // backfilled, not NULL
-      expect(rowCount(layer, SAT, base.idempotencyKey)).toBe(1);
-
-      // The legacy gap is now closed: a LATER enqueue with a different identity → typed 409.
-      const caught = capture(() => service.enqueue({ ...base, messageType: "channel.deliver" }));
-      expect(isConflict(caught)).toBe(true);
-      expect((caught as FridayDomainError).httpStatus).toBe(409);
-      // Digest unchanged by the rejected write.
-      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(dSame);
-    } finally {
-      layer.close();
-    }
-  });
-
-  it("stays an idempotent no-op when the legacy row is re-enqueued with the SAME identity (no over-fail)", () => {
-    const layer = createTestDb();
-    try {
-      insertSatellite(layer, SAT);
-      const service = makeService(layer);
-      const dSame = digestOf(base);
-
-      const first = service.enqueue(base);
-      makeLegacyRow(layer, SAT, base.idempotencyKey);
-
+      // Same routing identity + key, re-encoded transport body (fresh nonce/ciphertext): the routing
+      // digest recomputed from stored columns matches → resolves to the original id (no-degrade) and
+      // backfills the canonical digest. Exact reconstruction ⇒ safe to stamp.
       const retry = service.enqueue({ ...base, payloadCiphertext: "cipher-A-reencoded", nonce: "nonce-A2" });
       expect(retry.id).toBe(first.id);
       expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(dSame);
       expect(rowCount(layer, SAT, base.idempotencyKey)).toBe(1);
+
+      // Legacy gap now closed: a LATER enqueue with a different identity → typed 409.
+      expectConflict(capture(() => service.enqueue({ ...base, messageType: "channel.deliver" })));
+      expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(dSame);
     } finally {
       layer.close();
     }
@@ -425,7 +389,6 @@ describe("legacy-NULL digest backfill — satellite outbox enqueue (site 3)", ()
 
       const res = service.enqueue(base);
       expect(res.id).toBeTruthy();
-      // Fresh insert records the digest (non-null) — the exactly-once/insert path is unchanged.
       expect(rowDigest(layer, SAT, base.idempotencyKey)).toBe(digestOf(base));
     } finally {
       layer.close();


### PR DESCRIPTION
# ⛔ QUARANTINED — DO NOT MERGE (DUR-OPERATION-JOURNAL-001 follow-up #4)

**Status: 3-strike quarantine.** Three consecutive Codex-Advisor exact-SHA NEEDS_CHANGES on the same root class → parked for a deliberate root-cause remediation, not another point patch. This PR is a **Draft** and must not be merged in its current shape.

## What this PR was trying to do
Close the residual from the merged DUR keystone (#1623, `51684b98`): the cross-store digest-conflict guards short-circuited on a legacy pre-v100 `payload_digest IS NULL` row, so a divergent re-projection / re-enqueue against a legacy row was silently swallowed instead of raising the typed 409. Three stores: Rust continuity projector (`friday_agent_runs`, `llm_usage_records`) + satellite outbox (`outbox_messages`).

## Root-cause matrix (3 Advisor rounds, one root class)
The root class is: **a legacy-NULL-digest backfill can only be safe if the row's ORIGINAL logical identity is exactly reconstructable from persisted state; every attempt used a LOSSY identity proxy, which launders a divergence hiding in the un-covered part.**

| Round | Head | Approach | Advisor HIGH |
|---|---|---|---|
| 1 | `ce0dbf70` | Blind stamp the incoming digest onto a legacy NULL row on first write | Launders a divergent first-write (accepts + stamps a different payload's digest) |
| 2 | `4c4859f5` | Prove-then-stamp via a content-identity over *selected* persisted columns | Content-identity omits inserted columns (`task`, `provider_kind`, timestamps, …) and cannot cover UNPERSISTED receipt fields (`modelSize`/`backendKind`); divergent-in-omitted-field rows match + get stamped |
| 3 | `d5dd906a` | Projector → **fail closed** (identity unreconstructable); outbox → keep exact routing-digest recompute | Outbox routing digest excludes `payloadCiphertext`, so a same-key/same-routing enqueue with a **different logical payload** is not distinguished from a legit re-encoding → backfilled + resolved (laundered). Also: the no-degrade rationale falsely claimed the projector post-dates v100 |

## Corrections to prior claims (Advisor r3 MEDIUM/LOW)
- **The projector PREDATES the v100 migration by more than a month.** The earlier claim that it post-dates v100 (and therefore has no possible legacy NULL-digest rows, making the projector fail-closed over-fail "inert") is **false and withdrawn**. `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` being default-off does not prove the projector was never enabled or that no NULL-digest projected rows exist — so the projector fail-closed path can genuinely 409 a legitimate re-projection of a pre-v100 row (a real, not theoretical, over-fail).
- Prior revisions of this description described blind first-write backfill at all three sites; the last reviewed head (`d5dd906a`) actually **fails closed** at the two projector sites and keeps exact routing-recompute backfill at the outbox. This body now reflects the real behavior.

## Why quarantine (not round 4)
The authoritative closure now requires a **design decision + likely a schema change**, which is out of scope for another same-session point patch:
1. **Outbox**: bind idempotency to a STABLE logical-payload digest computed BEFORE volatile encryption/timestamp encoding, and persist enough provenance to compare the original operation payload — OR fail closed when a legacy row's semantic payload identity cannot be reconstructed. This changes the **merged #1623 outbox idempotency contract** (which deliberately digests routing-only so a re-dispatch with a fresh nonce stays idempotent) and likely needs a migration to persist a plaintext-payload digest. That is an authority/contract decision, not a mechanical fix.
2. **Projector**: the fail-closed approach is defensible but has a real over-fail cost on any surviving pre-v100 projected rows; a durable fix may also want a reconstructable identity rather than blanket 409.
3. Both point at the same missing primitive: a **persisted, encryption-independent logical-payload identity** for cross-store idempotency on rows that predate the digest column.

## Follow-up (deliberate, NOT this session's whack-a-mole)
Reopen as a scoped design change (pre-encryption payload-digest column + backfill/migration semantics, or a uniform fail-closed-with-reconstruction policy) with operator/Advisor sign-off on the outbox idempotency-contract change. Branch + history preserved for that work.

_The merged DUR keystone (#1623) is unaffected and remains shipped._
