### PR TITLE
CORE-A (CR-0/1/2/3) — R14 CORE-RUNNABLE-001: owner bootstrap + provider handshake + session/agent Rust path (default-off, honest)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,7 +205,7 @@
         "filename": "src/api/http/routes/friday-provider-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 283
+        "line_number": 289
       }
     ],
     "src/api/http/routes/friday-setup-routes.ts": [
@@ -778,14 +778,14 @@
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 140
       },
       {
         "type": "Secret Keyword",
         "filename": "test/unit/hub/friday-hub-bootstrap-env.test.ts",
         "hashed_secret": "8a8281cec699f5e51330e21dd7fab3531af6ef0c",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 141
       }
     ],
     "test/unit/media-understanding/friday-openai-vision-provider.test.ts": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-17T12:33:19Z"
+  "generated_at": "2026-07-20T04:31:58Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -196,7 +196,7 @@
         "filename": "src/api/http/routes/friday-auth-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 317
+        "line_number": 355
       }
     ],
     "src/api/http/routes/friday-provider-routes.ts": [
@@ -205,7 +205,7 @@
         "filename": "src/api/http/routes/friday-provider-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 289
+        "line_number": 294
       }
     ],
     "src/api/http/routes/friday-setup-routes.ts": [
@@ -611,7 +611,7 @@
         "filename": "test/unit/api/http/routes/friday-auth-routes.test.ts",
         "hashed_secret": "3b5910f25dbc879c344ca806b582efb0da6ffa6f",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 34
       }
     ],
     "test/unit/api/http/routes/friday-multi-tenant-security-routes.test.ts": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-20T04:31:58Z"
+  "generated_at": "2026-07-20T11:47:26Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,7 +205,7 @@
         "filename": "src/api/http/routes/friday-provider-routes.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 294
+        "line_number": 296
       }
     ],
     "src/api/http/routes/friday-setup-routes.ts": [
@@ -990,5 +990,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-20T11:47:26Z"
+  "generated_at": "2026-07-20T17:30:58Z"
 }

--- a/context/MEMORY.md
+++ b/context/MEMORY.md
@@ -18,4 +18,4 @@
 - Tool call summary (`src/agent/services/friday-tool-call-summary.ts`) captures privacy-safe tool execution metadata (arg keys only, no values) for observability and world model training data.
 - Warn-once pattern is used across 7+ modules (hub-bootstrap, auth, memory, system, http-server, workspace-context, unix-socket-bridge) to deduplicate runtime warnings without losing critical signals.
 - OpenAI Responses API (`openai-responses`) streaming is now supported alongside `openai-completions` in the agent LLM client.
-- Database migration count: 107 (latest: v107-setup-bootstrap-login-challenge).
+- Database migration count: 108 (latest: v108-provider-mutation-approval-consumption).

--- a/context/MEMORY.md
+++ b/context/MEMORY.md
@@ -18,4 +18,4 @@
 - Tool call summary (`src/agent/services/friday-tool-call-summary.ts`) captures privacy-safe tool execution metadata (arg keys only, no values) for observability and world model training data.
 - Warn-once pattern is used across 7+ modules (hub-bootstrap, auth, memory, system, http-server, workspace-context, unix-socket-bridge) to deduplicate runtime warnings without losing critical signals.
 - OpenAI Responses API (`openai-responses`) streaming is now supported alongside `openai-completions` in the agent LLM client.
-- Database migration count: 106 (latest: v106-realtime-events-owner).
+- Database migration count: 107 (latest: v107-setup-bootstrap-login-challenge).

--- a/docs/ops/ts-runtime-retirement-manifest.json
+++ b/docs/ops/ts-runtime-retirement-manifest.json
@@ -5035,7 +5035,7 @@
         "CANONICAL_APPROVAL_REQUIRED",
         "expect(mockService.createProvider).not.toHaveBeenCalled",
         "providers.create accepts canonical approval in gate-required profile and strips control fields",
-        "expect(mockService.createProvider).toHaveBeenCalledWith(providerBody)"
+        "expect(mockService.createProvider).toHaveBeenCalledWith(providerBody, undefined)"
       ],
       "proof": "src/api/http/routes/friday-provider-routes.ts providers.create strips canonical control fields before providerService.createProvider and maybeRequireProviderMutationTicket gates the route in gate-required profiles. The behavior test proves missing approval blocks before service mutation and valid canonical approval strips control fields before delegation.",
       "next_action": "Keep provider profile creation as a governed adapter until the provider configuration owner moves to a Rust projection/mutation entrypoint."

--- a/rust-core/crates/friday-ffi/src/lib.rs
+++ b/rust-core/crates/friday-ffi/src/lib.rs
@@ -2026,6 +2026,13 @@ fn message_kind_name(m: &friday_protocol::Message) -> &'static str {
         // stays exhaustive.
         M::MemoryDecisionRequest { .. } => "MemoryDecisionRequest",
         M::MemoryDecisionResult { .. } => "MemoryDecisionResult",
+        // (CORE-A CR-3) Session create/append lifecycle. DARK on the FFI surface (nothing here
+        // constructs or dispatches them — they ride the FLAGLESS sealed-WS agent-run server arms);
+        // NAMED so unsupported envelopes keep the real kind and this match stays exhaustive.
+        M::SessionCreateRequest { .. } => "SessionCreateRequest",
+        M::SessionCreateResult { .. } => "SessionCreateResult",
+        M::SessionMessageAppendRequest { .. } => "SessionMessageAppendRequest",
+        M::SessionMessageAppendResult { .. } => "SessionMessageAppendResult",
         // A1 run-outcome learning terminal decision arm. DARK on the FFI surface (the owner-authed
         // decision rides the sealed-WS agent-run server arm gated by
         // FRIDAY_RUN_OUTCOME_LEARNING_CONFIRM); NAMED so unsupported envelopes keep the real kind.

--- a/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
+++ b/rust-core/crates/friday-hub/src/bin/hub_agent_run_server.rs
@@ -2282,6 +2282,58 @@ fn serve_sealed_session<S: Read + Write, T: Transport>(
                 ws_send_envelope(ws, session_key, &result, SESSION_AAD)?;
                 processed += 1;
             }
+            // (CORE-A CR-3) SESSION-CREATE dispatch — FLAGLESS (always-on). An inbound
+            // `SessionCreateRequest` ensures ONE `agent_session` row via the EXISTING
+            // `friday_hub::hub_server::session_create_result_for_db` — owner bound to the Rust-derived
+            // AUTHENTICATED owner (`runtime.policy().principal_id()` == the configured `--owner`),
+            // FIX-Q3b fail-closed on a disagreeing body owner — and replies with a refs-only
+            // `SessionCreateResult` (or an `Error`). PURE `&Db` mutation: NO provider/model call, ZERO
+            // `token_ledger` rows; the sealed session IS the channel auth (single-peer/single-owner
+            // SERVER invariant). **UNLIKE the DARK-first sibling arms above (mission-intake /
+            // memory-confirm) this arm is intentionally NOT flag-gated:** R14 requires a FLAGLESS
+            // production-default Rust session path, and `SessionCreateRequest` is a BRAND-NEW wire kind
+            // that no existing client constructs — so handling it always-on is BYTE-IDENTICAL for ALL
+            // existing traffic (the deploy-safety concern the sibling flags addressed for DARK-first
+            // wire-before-handler splits does not apply when wire + handler ship together).
+            Message::SessionCreateRequest { request } => {
+                let now_ms = now_ms();
+                let result = friday_hub::hub_server::session_create_result_for_db(
+                    runtime.db(),
+                    &env.msg_id,
+                    request,
+                    runtime.policy().principal_id(),
+                    now_ms,
+                );
+                eprintln!(
+                    "hub_agent_run_server_dispatch: msg_id={} leg=session_create (flagless)",
+                    env.msg_id
+                );
+                ws_send_envelope(ws, session_key, &result, SESSION_AAD)?;
+                processed += 1;
+            }
+            // (CORE-A CR-3) SESSION-MESSAGE-APPEND dispatch — FLAGLESS (always-on; same rationale as
+            // the session-create arm). An inbound `SessionMessageAppendRequest` appends ONE message
+            // via the EXISTING owner-gated `friday_hub::hub_server::session_message_append_result_for_db`
+            // — OWNER-GATED fail-closed against the Rust-derived AUTHENTICATED owner (a message for a
+            // session the authenticated principal does not own writes ZERO rows) — and replies with a
+            // refs-only `SessionMessageAppendResult` (or an `Error`). PURE `&Db` mutation: NO
+            // provider/model call, ZERO `token_ledger` rows.
+            Message::SessionMessageAppendRequest { request } => {
+                let now_ms = now_ms();
+                let result = friday_hub::hub_server::session_message_append_result_for_db(
+                    runtime.db(),
+                    &env.msg_id,
+                    request,
+                    runtime.policy().principal_id(),
+                    now_ms,
+                );
+                eprintln!(
+                    "hub_agent_run_server_dispatch: msg_id={} leg=session_message_append (flagless)",
+                    env.msg_id
+                );
+                ws_send_envelope(ws, session_key, &result, SESSION_AAD)?;
+                processed += 1;
+            }
             Message::ContextPassportTransferRequest { request }
                 if context_passport_transfer_enabled =>
             {

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -1609,10 +1609,18 @@ pub fn session_create_result_for_db(
 ) -> Envelope {
     let owner = authenticated_owner.unwrap_or("").trim();
     if owner.is_empty() {
-        return session_error(msg_id, now_ms, "session create requires an authenticated owner");
+        return session_error(
+            msg_id,
+            now_ms,
+            "session create requires an authenticated owner",
+        );
     }
     if request.session_id.trim().is_empty() {
-        return session_error(msg_id, now_ms, "session create requires a non-empty session id");
+        return session_error(
+            msg_id,
+            now_ms,
+            "session create requires a non-empty session id",
+        );
     }
     // FIX-Q3b: a body-asserted owner that DISAGREES with the authenticated owner is fail-closed.
     // Absent/blank/matching ⇒ bind the authenticated owner (single-owner v1: the forwarded
@@ -1686,11 +1694,19 @@ pub fn session_message_append_result_for_db(
 ) -> Envelope {
     let owner = authenticated_owner.unwrap_or("").trim();
     if owner.is_empty() {
-        return session_error(msg_id, now_ms, "session append requires an authenticated owner");
+        return session_error(
+            msg_id,
+            now_ms,
+            "session append requires an authenticated owner",
+        );
     }
     let session_id = request.session_id.trim();
     if session_id.is_empty() {
-        return session_error(msg_id, now_ms, "session append requires a non-empty session id");
+        return session_error(
+            msg_id,
+            now_ms,
+            "session append requires a non-empty session id",
+        );
     }
     if request.role.trim().is_empty() {
         return session_error(msg_id, now_ms, "session append requires a non-empty role");
@@ -1723,7 +1739,10 @@ pub fn session_message_append_result_for_db(
     // session `updated_at` to the SAME `now_ms` — so `seq` is parsed from the id suffix and the
     // timestamps are `now_ms` (authoritative, not invented). Defensive parse: an unexpected id shape
     // fails closed rather than reporting a wrong ordinal.
-    let seq = match message_id.rsplit_once(":m").and_then(|(_, s)| s.parse::<i64>().ok()) {
+    let seq = match message_id
+        .rsplit_once(":m")
+        .and_then(|(_, s)| s.parse::<i64>().ok())
+    {
         Some(seq) => seq,
         None => return session_error(msg_id, now_ms, "session append produced an unparseable id"),
     };
@@ -4047,7 +4066,10 @@ mod tests {
             }
             other => panic!("expected SessionMessageAppendResult, got {other:?}"),
         }
-        assert_eq!(friday_storage::session_message_count(db.conn(), sid).unwrap(), 1);
+        assert_eq!(
+            friday_storage::session_message_count(db.conn(), sid).unwrap(),
+            1
+        );
 
         // APPEND as a DIFFERENT owner "bob" → REFUSED fail-closed (Error), NO row written.
         let denied = session_message_append_result_for_db(
@@ -4178,8 +4200,14 @@ mod tests {
         );
         match r2.message {
             Message::SessionCreateResult { result } => {
-                assert_eq!(result.created_at, first, "created_at must be preserved on re-ensure");
-                assert_eq!(result.updated_at, later, "updated_at must bump on re-ensure");
+                assert_eq!(
+                    result.created_at, first,
+                    "created_at must be preserved on re-ensure"
+                );
+                assert_eq!(
+                    result.updated_at, later,
+                    "updated_at must bump on re-ensure"
+                );
             }
             other => panic!("expected SessionCreateResult, got {other:?}"),
         }

--- a/rust-core/crates/friday-hub/src/hub_server.rs
+++ b/rust-core/crates/friday-hub/src/hub_server.rs
@@ -33,12 +33,14 @@ use friday_protocol::{
     ProviderWorkspaceActionResultWire, RouteDecisionControlRequestWire,
     RouteDecisionControlResultWire, RouteDecisionProjectionWire,
     RunOutcomeLearningDecisionRequestWire, RunOutcomeLearningDecisionResultWire,
-    WorkItemStatusRequestWire, WorkItemStatusResultWire, SUPPORTED,
+    SessionCreateRequestWire, SessionCreateResultWire, SessionMessageAppendRequestWire,
+    SessionMessageAppendResultWire, WorkItemStatusRequestWire, WorkItemStatusResultWire, SUPPORTED,
 };
 use friday_providers::unified::{FallbackStatus, PlatformProvider, ProviderSession, SessionStatus};
 use friday_storage::{
     get_run_answer_for_principal, get_run_result, get_run_result_ref, load_session_owner,
-    AnswerDenyReason, Db, MissionBodySnapshot, RunAnswerAccess, RunResultRef,
+    AnswerDenyReason, Db, MissionBodySnapshot, RunAnswerAccess, RunResultRef, SessionMessage,
+    SessionOwner,
 };
 use friday_transport::{ws_recv_envelope, ws_send_envelope, TransportError, WireWebSocket};
 use serde_json::json;
@@ -1576,6 +1578,182 @@ pub fn memory_decision_result_for_db(
                 blocker: None,
                 recallable,
             },
+        },
+    )
+    .with_correlation(msg_id.to_string())
+}
+
+/// (CORE-A CR-3) CREATE/ensure ONE agent-session row from a sealed [`Message::SessionCreateRequest`]
+/// — the Rust-owned `sessions.create`. PURE Hub `&Db` mutation: NO provider/model call, ZERO
+/// `token_ledger` rows. Reuses the EXISTING [`friday_storage::ensure_session_with_owner`] storage
+/// primitive (no new storage).
+///
+/// **OWNER binding (FIX-Q3b + INV-5/INV-7):** the session's owner axis (`agent_session.user_id`) is
+/// bound to the Rust-derived AUTHENTICATED owner (`authenticated_owner`, the configured
+/// `--owner`/`principal_id`), NEVER a raw client field — exactly as `run_session_task_pinned` binds
+/// it. A body `user_id` that is present AND disagrees with the authenticated owner is fail-closed (an
+/// `Error`, writing ZERO rows); an absent/blank/matching body `user_id` binds the authenticated
+/// owner. An empty authenticated owner is refused (no anonymous session). The descriptive axes
+/// (channel/chat_id/account_id/chat_kind) ride from the request; `metadata_json` is refs-only and NOT
+/// persisted by the minimal store.
+///
+/// Reply: a REFS-ONLY [`Message::SessionCreateResult`] (id + stored timestamps, read back so an
+/// idempotent re-ensure reports the row's ORIGINAL `created_at`). Any storage failure surfaces as a
+/// typed `Error` (fail-closed) — never a fake receipt.
+pub fn session_create_result_for_db(
+    db: &Db,
+    msg_id: &str,
+    request: SessionCreateRequestWire,
+    authenticated_owner: Option<&str>,
+    now_ms: i64,
+) -> Envelope {
+    let owner = authenticated_owner.unwrap_or("").trim();
+    if owner.is_empty() {
+        return session_error(msg_id, now_ms, "session create requires an authenticated owner");
+    }
+    if request.session_id.trim().is_empty() {
+        return session_error(msg_id, now_ms, "session create requires a non-empty session id");
+    }
+    // FIX-Q3b: a body-asserted owner that DISAGREES with the authenticated owner is fail-closed.
+    // Absent/blank/matching ⇒ bind the authenticated owner (single-owner v1: the forwarded
+    // principal equals the configured owner, so the live path is unchanged).
+    if let Some(body_owner) = request.user_id.as_deref() {
+        let body_owner = body_owner.trim();
+        if !body_owner.is_empty() && body_owner != owner {
+            return session_error(
+                msg_id,
+                now_ms,
+                "session create owner mismatch (body user_id disagrees with authenticated owner)",
+            );
+        }
+    }
+
+    let session_id = request.session_id.trim();
+    let session_owner = SessionOwner {
+        // OWNER SCOPE axis = the authenticated principal (NEVER the raw body field).
+        user_id: Some(owner.to_string()),
+        channel: request.channel.clone(),
+        chat_id: request.chat_id.clone(),
+        account_id: request.account_id.clone(),
+        chat_kind: request.chat_kind.clone(),
+        ..SessionOwner::default()
+    };
+    if friday_storage::ensure_session_with_owner(db.conn(), session_id, &session_owner, now_ms)
+        .is_err()
+    {
+        return session_error(msg_id, now_ms, "session create storage write failed");
+    }
+    // Read back the AUTHORITATIVE timestamps (an idempotent re-ensure keeps `created_at`).
+    let (created_at, updated_at) = match friday_storage::session_timestamps(db.conn(), session_id) {
+        Ok(Some(ts)) => ts,
+        _ => return session_error(msg_id, now_ms, "session create readback failed"),
+    };
+
+    Envelope::new(
+        format!("{msg_id}-session-create"),
+        now_ms,
+        Message::SessionCreateResult {
+            result: SessionCreateResultWire {
+                session_id: session_id.to_string(),
+                created_at,
+                updated_at,
+            },
+        },
+    )
+    .with_correlation(msg_id.to_string())
+}
+
+/// (CORE-A CR-3) APPEND ONE conversation message from a sealed
+/// [`Message::SessionMessageAppendRequest`] — the Rust-owned `sessions.messages.create`. PURE Hub
+/// `&Db` mutation: NO provider/model call, ZERO `token_ledger` rows. Reuses the EXISTING owner-gated
+/// [`friday_storage::append_session_message`] (seq auto-increment, `updated_at` bump) — no new
+/// storage.
+///
+/// **OWNER-GATED fail-closed (INV-5/INV-7):** the append is REFUSED (a typed `Error`, ZERO rows)
+/// unless the target session is owned by the AUTHENTICATED principal
+/// ([`friday_storage::session_owner_matches`] on the SAME `agent_session.user_id` axis as the C2-4
+/// read API). A guessed `session_id`, an owner-less session, or a DIFFERENT owner cannot append. An
+/// empty authenticated owner is refused.
+///
+/// Reply: a REFS-ONLY [`Message::SessionMessageAppendResult`] (message id + store-assigned `seq` +
+/// timestamps; NEVER the appended body).
+pub fn session_message_append_result_for_db(
+    db: &Db,
+    msg_id: &str,
+    request: SessionMessageAppendRequestWire,
+    authenticated_owner: Option<&str>,
+    now_ms: i64,
+) -> Envelope {
+    let owner = authenticated_owner.unwrap_or("").trim();
+    if owner.is_empty() {
+        return session_error(msg_id, now_ms, "session append requires an authenticated owner");
+    }
+    let session_id = request.session_id.trim();
+    if session_id.is_empty() {
+        return session_error(msg_id, now_ms, "session append requires a non-empty session id");
+    }
+    if request.role.trim().is_empty() {
+        return session_error(msg_id, now_ms, "session append requires a non-empty role");
+    }
+    // OWNER GATE FIRST: refuse before ANY write when the authenticated principal does not own the
+    // session (a non-owner, an owner-less session, or an absent id all fail-closed here).
+    match friday_storage::session_owner_matches(db.conn(), owner, session_id) {
+        Ok(true) => {}
+        Ok(false) => {
+            return session_error(
+                msg_id,
+                now_ms,
+                "session append refused: authenticated owner does not own this session",
+            );
+        }
+        Err(_) => return session_error(msg_id, now_ms, "session append owner check failed"),
+    }
+
+    let message = SessionMessage {
+        role: request.role.clone(),
+        content: request.content.clone(),
+        refs: request.refs.clone(),
+    };
+    let message_id =
+        match friday_storage::append_session_message(db.conn(), session_id, &message, now_ms) {
+            Ok(id) => id,
+            Err(_) => return session_error(msg_id, now_ms, "session append storage write failed"),
+        };
+    // The store assigns `message_id = "<session>:m<seq>"` and writes the message `created_at` AND the
+    // session `updated_at` to the SAME `now_ms` — so `seq` is parsed from the id suffix and the
+    // timestamps are `now_ms` (authoritative, not invented). Defensive parse: an unexpected id shape
+    // fails closed rather than reporting a wrong ordinal.
+    let seq = match message_id.rsplit_once(":m").and_then(|(_, s)| s.parse::<i64>().ok()) {
+        Some(seq) => seq,
+        None => return session_error(msg_id, now_ms, "session append produced an unparseable id"),
+    };
+
+    Envelope::new(
+        format!("{msg_id}-session-append"),
+        now_ms,
+        Message::SessionMessageAppendResult {
+            result: SessionMessageAppendResultWire {
+                message_id,
+                seq,
+                created_at: now_ms,
+                updated_at: now_ms,
+            },
+        },
+    )
+    .with_correlation(msg_id.to_string())
+}
+
+/// (CORE-A CR-3) Fail-closed session-lifecycle refusal/error envelope: a typed [`Message::Error`]
+/// correlated to the inbound request. Used for owner refusals, empty-owner, invalid input, and
+/// storage failures — a WRITE op that does not succeed surfaces an `Error` (the TS sealed client
+/// fails closed → 503), NEVER a fabricated refs receipt.
+fn session_error(msg_id: &str, now_ms: i64, message: &str) -> Envelope {
+    Envelope::new(
+        format!("{msg_id}-session-error"),
+        now_ms,
+        Message::Error {
+            code: ErrorCode::Internal,
+            message: message.to_string(),
         },
     )
     .with_correlation(msg_id.to_string())
@@ -3804,6 +3982,207 @@ mod tests {
             ))
             .to_string_lossy()
             .into_owned()
+    }
+
+    // ─── (CORE-A CR-3) session create/append handler KATs ───
+
+    #[test]
+    fn session_create_binds_authenticated_owner_and_append_is_owner_gated() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let now = 1_700_000_000_000;
+        let sid = "discord:default:cr3-chat";
+
+        // CREATE as owner "alice": ensures the row + binds the OWNER axis to the authenticated owner.
+        let create = session_create_result_for_db(
+            &db,
+            "m-create",
+            SessionCreateRequestWire {
+                session_id: sid.into(),
+                channel: Some("discord".into()),
+                chat_id: Some("cr3-chat".into()),
+                user_id: Some("alice".into()),
+                account_id: Some("default".into()),
+                chat_kind: Some("dm".into()),
+                metadata_json: Some("{\"src\":\"cr3\"}".into()),
+            },
+            Some("alice"),
+            now,
+        );
+        match create.message {
+            Message::SessionCreateResult { result } => {
+                assert_eq!(result.session_id, sid);
+                assert_eq!(result.created_at, now);
+                assert_eq!(result.updated_at, now);
+            }
+            other => panic!("expected SessionCreateResult, got {other:?}"),
+        }
+        // The stored owner axis is the AUTHENTICATED owner.
+        assert_eq!(
+            friday_storage::load_session_owner(db.conn(), sid)
+                .unwrap()
+                .unwrap()
+                .user_id
+                .as_deref(),
+            Some("alice")
+        );
+
+        // APPEND as the OWNER "alice" → accepted, refs-only receipt, row written.
+        let ok = session_message_append_result_for_db(
+            &db,
+            "m-append-ok",
+            SessionMessageAppendRequestWire {
+                session_id: sid.into(),
+                role: "user".into(),
+                content: "remember teal".into(),
+                refs: Some("run-1".into()),
+            },
+            Some("alice"),
+            now + 1,
+        );
+        match ok.message {
+            Message::SessionMessageAppendResult { result } => {
+                assert_eq!(result.message_id, format!("{sid}:m0"));
+                assert_eq!(result.seq, 0);
+                assert_eq!(result.created_at, now + 1);
+            }
+            other => panic!("expected SessionMessageAppendResult, got {other:?}"),
+        }
+        assert_eq!(friday_storage::session_message_count(db.conn(), sid).unwrap(), 1);
+
+        // APPEND as a DIFFERENT owner "bob" → REFUSED fail-closed (Error), NO row written.
+        let denied = session_message_append_result_for_db(
+            &db,
+            "m-append-bob",
+            SessionMessageAppendRequestWire {
+                session_id: sid.into(),
+                role: "user".into(),
+                content: "sneaky".into(),
+                refs: None,
+            },
+            Some("bob"),
+            now + 2,
+        );
+        assert!(
+            matches!(denied.message, Message::Error { .. }),
+            "a non-owner append must fail closed with an Error, got {:?}",
+            denied.message
+        );
+        assert_eq!(
+            friday_storage::session_message_count(db.conn(), sid).unwrap(),
+            1,
+            "a refused append must write ZERO rows"
+        );
+    }
+
+    #[test]
+    fn session_create_refuses_empty_and_mismatched_owner_and_append_unknown_session() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let now = 1_700_000_100_000;
+
+        // Empty authenticated owner → refused (no anonymous session).
+        let anon = session_create_result_for_db(
+            &db,
+            "m-anon",
+            SessionCreateRequestWire {
+                session_id: "s:default:x".into(),
+                channel: None,
+                chat_id: None,
+                user_id: None,
+                account_id: None,
+                chat_kind: None,
+                metadata_json: None,
+            },
+            Some("   "),
+            now,
+        );
+        assert!(matches!(anon.message, Message::Error { .. }));
+        assert!(!friday_storage::session_exists(db.conn(), "s:default:x").unwrap());
+
+        // FIX-Q3b: a body user_id that disagrees with the authenticated owner → fail-closed, no row.
+        let mismatch = session_create_result_for_db(
+            &db,
+            "m-mismatch",
+            SessionCreateRequestWire {
+                session_id: "s:default:y".into(),
+                channel: None,
+                chat_id: None,
+                user_id: Some("mallory".into()),
+                account_id: None,
+                chat_kind: None,
+                metadata_json: None,
+            },
+            Some("alice"),
+            now,
+        );
+        assert!(matches!(mismatch.message, Message::Error { .. }));
+        assert!(!friday_storage::session_exists(db.conn(), "s:default:y").unwrap());
+
+        // Append to a session that does not exist → owner check fails closed (Error), no row.
+        let ghost = session_message_append_result_for_db(
+            &db,
+            "m-ghost",
+            SessionMessageAppendRequestWire {
+                session_id: "s:default:ghost".into(),
+                role: "user".into(),
+                content: "hi".into(),
+                refs: None,
+            },
+            Some("alice"),
+            now,
+        );
+        assert!(matches!(ghost.message, Message::Error { .. }));
+    }
+
+    #[test]
+    fn session_create_is_idempotent_and_preserves_created_at() {
+        let db = Db::open_hub(&tmp_db()).unwrap();
+        let sid = "discord:default:idem";
+        let first = 1_700_000_200_000;
+        let r1 = session_create_result_for_db(
+            &db,
+            "m1",
+            SessionCreateRequestWire {
+                session_id: sid.into(),
+                channel: Some("discord".into()),
+                chat_id: Some("idem".into()),
+                user_id: Some("alice".into()),
+                account_id: None,
+                chat_kind: None,
+                metadata_json: None,
+            },
+            Some("alice"),
+            first,
+        );
+        let created_at = match r1.message {
+            Message::SessionCreateResult { result } => result.created_at,
+            other => panic!("expected SessionCreateResult, got {other:?}"),
+        };
+        assert_eq!(created_at, first);
+
+        // Re-ensure later: created_at is PRESERVED (original), updated_at BUMPED.
+        let later = first + 5_000;
+        let r2 = session_create_result_for_db(
+            &db,
+            "m2",
+            SessionCreateRequestWire {
+                session_id: sid.into(),
+                channel: Some("discord".into()),
+                chat_id: Some("idem".into()),
+                user_id: Some("alice".into()),
+                account_id: None,
+                chat_kind: None,
+                metadata_json: None,
+            },
+            Some("alice"),
+            later,
+        );
+        match r2.message {
+            Message::SessionCreateResult { result } => {
+                assert_eq!(result.created_at, first, "created_at must be preserved on re-ensure");
+                assert_eq!(result.updated_at, later, "updated_at must bump on re-ensure");
+            }
+            other => panic!("expected SessionCreateResult, got {other:?}"),
+        }
     }
 
     #[test]

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -1637,9 +1637,13 @@ pub enum Message {
     /// (CORE-A CR-3) client->hub: append ONE conversation message to an existing session (the
     /// Rust-owned `sessions.messages.create`). PURE Hub `&Db` mutation. OWNER-GATED fail-closed: a
     /// message for a session the authenticated principal does not own is refused (no row written).
-    SessionMessageAppendRequest { request: SessionMessageAppendRequestWire },
+    SessionMessageAppendRequest {
+        request: SessionMessageAppendRequestWire,
+    },
     /// (CORE-A CR-3) hub->client: refs-only append receipt (message id + seq + timestamps; no body).
-    SessionMessageAppendResult { result: SessionMessageAppendResultWire },
+    SessionMessageAppendResult {
+        result: SessionMessageAppendResultWire,
+    },
     /// client->hub: mint one ContextPassport for an existing Mission through the Hub gate.
     /// Never a provider/model call; never direct client DB writes.
     ContextPassportTransferRequest {

--- a/rust-core/crates/friday-protocol/src/lib.rs
+++ b/rust-core/crates/friday-protocol/src/lib.rs
@@ -431,6 +431,87 @@ pub struct MemoryDecisionResultWire {
     pub recallable: bool,
 }
 
+/// (CORE-A CR-3) Client request to CREATE/ensure ONE agent-session row over the sealed single-peer
+/// session — the Rust-owned counterpart of the retired TS `sessions.create`. This is a PURE Hub
+/// `&Db` mutation (NO provider/model call). The session's OWNER is the server-AUTHENTICATED principal
+/// (the single-peer session IS the channel auth), NEVER a raw client field: the dispatch arm binds
+/// `agent_session.user_id` to the Rust-derived owner exactly as `run_session_task_pinned` does, and
+/// applies the FIX-Q3b cross-check (a body `user_id` that disagrees with the authenticated owner is
+/// fail-closed). `session_id` is the canonical session key the client already derives; the remaining
+/// axes are DESCRIPTIVE surface metadata. Matches the internally-tagged `{ request }` wrapper the
+/// sibling `MemoryDecisionRequest` uses.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionCreateRequestWire {
+    /// The canonical session key (`agent_session_id`) to ensure. Non-empty (the store rejects blank).
+    pub session_id: String,
+    /// Descriptive surface channel (e.g. `discord`). Additive + optional; absent ⇒ omitted on the wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    /// Descriptive surface chat id. Additive + optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_id: Option<String>,
+    /// The OWNER principal the client forwards. **NOT the authority** — the dispatch arm binds the
+    /// session owner to the server-AUTHENTICATED principal and FIX-Q3b-refuses a value that
+    /// disagrees. Additive + optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    /// Descriptive account/tenant id. Additive + optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<String>,
+    /// Descriptive chat kind (e.g. `dm` / `channel`). Additive + optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_kind: Option<String>,
+    /// Opaque client metadata as a JSON STRING (refs-only; the minimal session store does not persist
+    /// it — it is echoed client-side). Additive + optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata_json: Option<String>,
+}
+
+/// (CORE-A CR-3) Hub receipt for a session create/ensure. REFS-ONLY: the ensured session id + its
+/// stored timestamps — NEVER any message body or descriptive echo (the client already holds the
+/// surface fields it sent). `created_at` is the row's ORIGINAL creation time (an idempotent re-ensure
+/// of an existing session keeps its `created_at` and only bumps `updated_at`), read back from the
+/// store so the receipt is authoritative, not a `now_ms` guess.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionCreateResultWire {
+    pub session_id: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// (CORE-A CR-3) Client request to APPEND ONE conversation message to an existing session over the
+/// sealed single-peer session — the Rust-owned counterpart of the retired TS
+/// `sessions.messages.create`. PURE Hub `&Db` mutation (NO provider/model call). OWNER-GATED: the
+/// dispatch arm refuses fail-closed unless the target session is owned by the server-AUTHENTICATED
+/// principal (a guessed `session_id` cannot append to another owner's session). `content` is a BODY
+/// kept Hub-side (the SAME discipline as the session store) — it rides the SEALED session, never a
+/// refs field.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionMessageAppendRequestWire {
+    /// The target session key (`agent_session_id`) — the message is refused unless the authenticated
+    /// principal owns it.
+    pub session_id: String,
+    /// The speaker role (e.g. `user` / `assistant`). Non-empty (the store rejects a blank role).
+    pub role: String,
+    /// The message body kept Hub-side. Sealed on the wire; never echoed in the refs-only receipt.
+    pub content: String,
+    /// Optional soft-link ref (e.g. the producing run id). Additive + optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refs: Option<String>,
+}
+
+/// (CORE-A CR-3) Hub receipt for a session message append. REFS-ONLY: the assigned message id + its
+/// per-session ordinal + timestamps — NEVER the appended body. `seq` is the store-assigned monotonic
+/// ordinal (0 for the first message); `created_at`/`updated_at` are the append time (the store writes
+/// both to the same `now_ms`).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionMessageAppendResultWire {
+    pub message_id: String,
+    pub seq: i64,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
 /// One refs-only context-passport item proposed by a trusted client. Labels are operator/user
 /// reviewed summaries or refs; sensitive raw material must not ride this wire. The Hub runs the
 /// canonical context-passport gate before persisting any row.
@@ -1547,6 +1628,18 @@ pub enum Message {
     /// the resulting lifecycle state, a coarse status, and whether it is now
     /// recallable. NEVER the candidate's content (the content stays Hub-side).
     MemoryDecisionResult { result: MemoryDecisionResultWire },
+    /// (CORE-A CR-3) client->hub: create/ensure ONE agent-session row (the Rust-owned
+    /// `sessions.create`). PURE Hub `&Db` mutation; NO provider/model call. Owner is the
+    /// server-AUTHENTICATED principal (single-peer session = channel auth), never a raw client field.
+    SessionCreateRequest { request: SessionCreateRequestWire },
+    /// (CORE-A CR-3) hub->client: refs-only session create receipt (id + timestamps; no body).
+    SessionCreateResult { result: SessionCreateResultWire },
+    /// (CORE-A CR-3) client->hub: append ONE conversation message to an existing session (the
+    /// Rust-owned `sessions.messages.create`). PURE Hub `&Db` mutation. OWNER-GATED fail-closed: a
+    /// message for a session the authenticated principal does not own is refused (no row written).
+    SessionMessageAppendRequest { request: SessionMessageAppendRequestWire },
+    /// (CORE-A CR-3) hub->client: refs-only append receipt (message id + seq + timestamps; no body).
+    SessionMessageAppendResult { result: SessionMessageAppendResultWire },
     /// client->hub: mint one ContextPassport for an existing Mission through the Hub gate.
     /// Never a provider/model call; never direct client DB writes.
     ContextPassportTransferRequest {
@@ -2631,6 +2724,101 @@ mod tests {
         assert!(json.contains("\"result\":{"));
         assert!(json.contains("\"recallable\":false"));
         assert!(json.contains("\"blocker\":\"owner_scope_mismatch\""));
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+    }
+
+    #[test]
+    fn session_lifecycle_wire_round_trips_and_uses_the_request_result_wrapper() {
+        // (CORE-A CR-3) The session create/append wire rides the SAME internally-tagged
+        // `{ request }` / `{ result }` wrapper as MemoryDecision/MissionIntake (enum `tag="kind"`
+        // + a single named field). This pins the byte-exact `{kind,request}` nesting so a flat-shape
+        // regression (which 503s server-side on `Envelope::decode`) is caught at the protocol layer.
+        let create_req = Message::SessionCreateRequest {
+            request: SessionCreateRequestWire {
+                session_id: "discord:default:chat-1".into(),
+                channel: Some("discord".into()),
+                chat_id: Some("chat-1".into()),
+                user_id: Some("owner-1".into()),
+                account_id: Some("default".into()),
+                chat_kind: Some("dm".into()),
+                metadata_json: Some("{\"source\":\"cr3\"}".into()),
+            },
+        };
+        let env = Envelope::new("sess-create-req", 1000, create_req.clone()).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"SessionCreateRequest\""));
+        assert!(json.contains("\"request\":{"));
+        assert!(json.contains("\"session_id\":\"discord:default:chat-1\""));
+        assert!(json.contains("\"chat_kind\":\"dm\""));
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+
+        // Absent optional axes are OMITTED (byte-clean) and round-trip to `None`.
+        let create_req_min = Message::SessionCreateRequest {
+            request: SessionCreateRequestWire {
+                session_id: "system:default:heartbeat".into(),
+                channel: None,
+                chat_id: None,
+                user_id: None,
+                account_id: None,
+                chat_kind: None,
+                metadata_json: None,
+            },
+        };
+        let env_min = Envelope::new("sess-create-min", 1000, create_req_min.clone());
+        let json_min = env_min.encode().unwrap();
+        assert!(!json_min.contains("channel"));
+        assert!(!json_min.contains("metadata_json"));
+        assert_eq!(Envelope::decode(&json_min).unwrap(), env_min);
+
+        let create_res = Message::SessionCreateResult {
+            result: SessionCreateResultWire {
+                session_id: "discord:default:chat-1".into(),
+                created_at: 900,
+                updated_at: 1000,
+            },
+        };
+        let env = Envelope::new("sess-create-res", 1001, create_res).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"SessionCreateResult\""));
+        assert!(json.contains("\"result\":{"));
+        assert!(json.contains("\"created_at\":900"));
+        assert!(json.contains("\"updated_at\":1000"));
+        // REFS-ONLY: no descriptive echo / no body on the receipt.
+        assert!(!json.contains("chat_kind"));
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+
+        let append_req = Message::SessionMessageAppendRequest {
+            request: SessionMessageAppendRequestWire {
+                session_id: "discord:default:chat-1".into(),
+                role: "user".into(),
+                content: "remember teal".into(),
+                refs: Some("run-7".into()),
+            },
+        };
+        let env = Envelope::new("sess-append-req", 1002, append_req.clone()).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"SessionMessageAppendRequest\""));
+        assert!(json.contains("\"request\":{"));
+        assert!(json.contains("\"role\":\"user\""));
+        assert!(json.contains("\"refs\":\"run-7\""));
+        assert_eq!(Envelope::decode(&json).unwrap(), env);
+
+        let append_res = Message::SessionMessageAppendResult {
+            result: SessionMessageAppendResultWire {
+                message_id: "discord:default:chat-1:m0".into(),
+                seq: 0,
+                created_at: 1002,
+                updated_at: 1002,
+            },
+        };
+        let env = Envelope::new("sess-append-res", 1003, append_res).with_correlation("c1");
+        let json = env.encode().unwrap();
+        assert!(json.contains("\"kind\":\"SessionMessageAppendResult\""));
+        assert!(json.contains("\"result\":{"));
+        assert!(json.contains("\"message_id\":\"discord:default:chat-1:m0\""));
+        assert!(json.contains("\"seq\":0"));
+        // REFS-ONLY: the appended body never rides the receipt.
+        assert!(!json.contains("remember teal"));
         assert_eq!(Envelope::decode(&json).unwrap(), env);
     }
 

--- a/rust-core/crates/friday-storage/src/agent_session.rs
+++ b/rust-core/crates/friday-storage/src/agent_session.rs
@@ -259,6 +259,38 @@ pub fn session_exists(conn: &Connection, agent_session_id: &str) -> Result<bool>
     Ok(exists)
 }
 
+/// (CORE-A CR-3) A session's `(created_at, updated_at)` timestamps, or `None` when the session row
+/// is absent. Pure refs read (no body). The create receipt reads this back so it can report the
+/// row's ORIGINAL `created_at` (an idempotent re-ensure keeps `created_at` and only bumps
+/// `updated_at`) rather than guessing `now_ms`. `.optional()` maps ONLY the no-row case to `None`
+/// and propagates any real storage error.
+pub fn session_timestamps(
+    conn: &Connection,
+    agent_session_id: &str,
+) -> Result<Option<(i64, i64)>> {
+    let row = conn
+        .query_row(
+            "SELECT created_at, updated_at FROM agent_session WHERE agent_session_id = ?1",
+            [agent_session_id],
+            |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)),
+        )
+        .optional()?;
+    Ok(row)
+}
+
+/// (CORE-A CR-3) PUBLIC fail-closed owner check: whether the session exists AND is owned by exactly
+/// `user_id` (the `agent_session.user_id` axis bound to the authenticated caller). Thin wrapper over
+/// the private [`owner_matches`] so the Hub session-append dispatch arm can OWNER-GATE without
+/// duplicating the check: a blank `user_id`, an absent session, an owner-less (NULL `user_id`)
+/// session, or a DIFFERENT owner all return `false`.
+pub fn session_owner_matches(
+    conn: &Connection,
+    user_id: &str,
+    agent_session_id: &str,
+) -> Result<bool> {
+    owner_matches(conn, user_id, agent_session_id)
+}
+
 /// Append one conversation message to a session, returning the assigned
 /// `message_id`. The `seq` is assigned as `max(seq) + 1` for the session (0 for the
 /// first message), computed and inserted in ONE transaction so concurrent appends

--- a/rust-core/crates/friday-storage/src/agent_session.rs
+++ b/rust-core/crates/friday-storage/src/agent_session.rs
@@ -264,10 +264,7 @@ pub fn session_exists(conn: &Connection, agent_session_id: &str) -> Result<bool>
 /// row's ORIGINAL `created_at` (an idempotent re-ensure keeps `created_at` and only bumps
 /// `updated_at`) rather than guessing `now_ms`. `.optional()` maps ONLY the no-row case to `None`
 /// and propagates any real storage error.
-pub fn session_timestamps(
-    conn: &Connection,
-    agent_session_id: &str,
-) -> Result<Option<(i64, i64)>> {
+pub fn session_timestamps(conn: &Connection, agent_session_id: &str) -> Result<Option<(i64, i64)>> {
     let row = conn
         .query_row(
             "SELECT created_at, updated_at FROM agent_session WHERE agent_session_id = ?1",

--- a/rust-core/crates/friday-storage/src/lib.rs
+++ b/rust-core/crates/friday-storage/src/lib.rs
@@ -45,8 +45,8 @@ pub use agent_session::{
     append_session_message, archive_session_for_owner, ensure_session, ensure_session_with_owner,
     fork_session_for_owner, list_sessions_for_owner, load_session_messages, load_session_owner,
     open_session_for_owner, session_exists, session_forked_from, session_message_count,
-    session_message_count_for_owner, ArchiveOutcome, ForkOutcome, SessionListItem, SessionMessage,
-    SessionOwner, StoredSessionMessage,
+    session_message_count_for_owner, session_owner_matches, session_timestamps, ArchiveOutcome,
+    ForkOutcome, SessionListItem, SessionMessage, SessionOwner, StoredSessionMessage,
 };
 pub use authorize::authorize_mutating_action;
 pub use authorize_ed25519::{

--- a/scripts/ci/install-smoke.mjs
+++ b/scripts/ci/install-smoke.mjs
@@ -17,6 +17,7 @@
  */
 
 import { execFileSync, spawn } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
 import {
   existsSync,
   mkdtempSync,
@@ -25,11 +26,11 @@ import {
   rmSync,
   readdirSync,
 } from "node:fs";
-import { createServer } from "node:net";
+import { connect, createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const ROOT = fileURLToPath(new URL("../../", import.meta.url)).replace(/\/$/, "");
 const TIMEOUT_MS = 30_000;
@@ -44,6 +45,19 @@ let tmpDir;
 let serverProc;
 let packSourceBackupDir;
 let packedTarball;
+// CORE-A round-3 Lane C (finding #4): the packaged Rust agent-run WS server proof.
+let rustServerProc;
+let rustProofTmpDir;
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+function isTrue(value) {
+  return TRUE_VALUES.has(String(value ?? "").trim().toLowerCase());
+}
+// The SecureStore domain-separation tag for the WS X25519 client secret — byte-identical to
+// `WS_X25519_SECRET_PURPOSE` in friday-rust-hub-agent-run-ws-client-x25519-secret.ts. The client
+// secret is sha256(purpose || masterKey); the Rust enroll bin derives the matching pubkey from the
+// SAME master key, so driving the sealed client with this secret is a REAL ECDH handshake.
+const RUST_WS_X25519_SECRET_PURPOSE = "friday.rust.agent_run.ws.x25519_secret.v1"; // pragma: allowlist secret
 
 function withPackIsolatedReleaseArtifacts(fn) {
   const releaseSourceDir = join(ROOT, "dist", "releases", "source");
@@ -126,6 +140,17 @@ function cleanup() {
       serverProc.kill("SIGINT");
     } catch {}
   }
+  if (rustServerProc && !rustServerProc.killed) {
+    try {
+      rustServerProc.kill("SIGKILL");
+    } catch {}
+  }
+  if (rustProofTmpDir) {
+    try {
+      rmSync(rustProofTmpDir, { recursive: true, force: true });
+    } catch {}
+    rustProofTmpDir = undefined;
+  }
   if (tmpDir) {
     try {
       rmSync(tmpDir, { recursive: true, force: true });
@@ -191,6 +216,204 @@ async function loginWithLocalPassphrase(baseUrl) {
     fail(`Local passphrase login failed: status=${loginRes.status} body=${JSON.stringify(loginBody)}`);
   }
   return loginBody.data.accessToken;
+}
+
+async function pollTcpOpen(port, host, deadlineMs) {
+  while (Date.now() < deadlineMs) {
+    const opened = await new Promise((resolve) => {
+      const socket = connect(port, host);
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.once("error", () => resolve(false));
+    });
+    if (opened) {
+      return true;
+    }
+    await sleep(200);
+  }
+  return false;
+}
+
+/**
+ * CORE-A round-3 Lane C (finding #4): prove the PACKAGED Rust agent-run WS server actually
+ * SERVES session create + append — the exact leg a clean install used to 503 on because the
+ * server was never packaged/launched. This launches the release-built `hub_agent_run_server`,
+ * enrolls THIS host's peer pubkey, and drives session create → append over the REAL compiled
+ * sealed ECDH client with NO route flag, NO mock/test seam, and NO TS fallback (a 503 or a
+ * failed handshake throws → the smoke fails). It makes NO paid provider call (session create +
+ * append are pure Hub `&Db` mutations). The final SIGNED clean-install and a paid LIVE provider
+ * turn stay EXTERNAL LEAVES (EXT-MAC-*, EXT-TEXT-PROVIDER-LIVE-EVIDENCE-001).
+ *
+ * Runs when release bins are prebuilt (rust-core/target/release) OR when
+ * FRIDAY_INSTALL_SMOKE_BUILD_RUST=1 (then it cargo-builds them). Otherwise it SKIPS loudly so an
+ * env without a Rust toolchain is not silently degraded; set FRIDAY_INSTALL_SMOKE_REQUIRE_RUST=1
+ * to make an unavailable server a hard failure.
+ */
+async function runRustAgentRunSessionProof() {
+  console.log("9. Proving the packaged Rust agent-run WS server serves session create + append…");
+  const rustCoreDir = join(ROOT, "rust-core");
+  const releaseDir = join(rustCoreDir, "target", "release");
+  const serverBin = join(releaseDir, "hub_agent_run_server");
+  const enrollBin = join(releaseDir, "hub_agent_run_enroll");
+
+  const skip = (reason) => {
+    if (isTrue(process.env.FRIDAY_INSTALL_SMOKE_REQUIRE_RUST)) {
+      fail(`Rust agent-run proof required but ${reason}`);
+    }
+    console.log(
+      `   → SKIP: ${reason}. Set FRIDAY_INSTALL_SMOKE_BUILD_RUST=1 to build the bins here, ` +
+      `or FRIDAY_INSTALL_SMOKE_REQUIRE_RUST=1 to make this a hard failure.`,
+    );
+  };
+
+  let haveBins = existsSync(serverBin) && existsSync(enrollBin);
+  if (!haveBins) {
+    if (!existsSync(rustCoreDir)) {
+      return skip("rust-core/ is absent in this checkout");
+    }
+    if (!isTrue(process.env.FRIDAY_INSTALL_SMOKE_BUILD_RUST)) {
+      return skip("prebuilt Rust bins are absent");
+    }
+    console.log("   building hub_agent_run_server + hub_agent_run_enroll (cargo --release)…");
+    try {
+      execFileSync(
+        "cargo",
+        ["build", "--release", "--bin", "hub_agent_run_server", "--bin", "hub_agent_run_enroll"],
+        { cwd: rustCoreDir, stdio: ["pipe", "pipe", "pipe"] },
+      );
+    } catch (err) {
+      fail(`cargo build of the Rust agent-run bins failed: ${err.message}`);
+    }
+    haveBins = existsSync(serverBin) && existsSync(enrollBin);
+    if (!haveBins) {
+      fail("cargo build did not produce the expected Rust agent-run bins");
+    }
+  }
+
+  rustProofTmpDir = mkdtempSync(join(tmpdir(), "friday-rust-proof-"));
+  const storeDir = join(rustProofTmpDir, "store");
+  const wsRoot = join(rustProofTmpDir, "ws");
+  const dbPath = join(rustProofTmpDir, "hub.sqlite");
+  mkdirSync(storeDir, { recursive: true });
+  mkdirSync(wsRoot, { recursive: true });
+
+  const masterKeyHex = randomBytes(32).toString("hex");
+  const owner = "owner:install-smoke";
+  const port = await chooseInstallSmokePort();
+
+  // The Rust bins read the SAME master key the client secret derives from; a dummy DeepSeek key
+  // satisfies HubRuntime::live's construction (session create/append make NO provider call, so it
+  // is never used). EXPLICITLY strip any route/test flags so the proof is flagless by construction.
+  const rustEnv = {
+    ...process.env,
+    FRIDAY_MASTER_KEY: masterKeyHex,
+    FRIDAY_DEEPSEEK_API_KEY: "sk-install-smoke-not-real", // pragma: allowlist secret
+  };
+  delete rustEnv.FRIDAY_ROUTE_AGENT_RUN_VIA_RUST;
+  delete rustEnv.FRIDAY_ROUTE_SESSIONS_VIA_RUST;
+  delete rustEnv.FRIDAY_HUB_AGENT_RUN_WS_X25519_SECRET_PRESENT;
+
+  // Enroll THIS host's client pubkey into the store the server pins (derived from the master key).
+  try {
+    execFileSync(enrollBin, ["--store-dir", storeDir], { env: rustEnv, stdio: ["pipe", "pipe", "pipe"] });
+  } catch (err) {
+    fail(`hub_agent_run_enroll failed: ${err.message}`);
+  }
+  console.log("   → peer pubkey enrolled into the server's SecureStore ✓");
+
+  // Launch the packaged server on the chosen loopback port.
+  rustServerProc = spawn(
+    serverBin,
+    ["--workspace", wsRoot, "--db", dbPath, "--port", String(port), "--owner", owner, "--store-dir", storeDir],
+    { env: rustEnv, stdio: ["pipe", "pipe", "pipe"] },
+  );
+  let rustStderr = "";
+  rustServerProc.stdout.on("data", () => {});
+  rustServerProc.stderr.on("data", (d) => { rustStderr += d.toString(); });
+  rustServerProc.on("error", (err) => fail(`Rust server process error: ${err.message}`));
+
+  const ready = await pollTcpOpen(port, "127.0.0.1", Date.now() + 15_000);
+  if (!ready || rustServerProc.exitCode !== null) {
+    fail(
+      `Packaged Rust agent-run WS server did not listen on 127.0.0.1:${port} ` +
+      `(exit ${rustServerProc?.exitCode}).\nstderr: ${rustStderr}`,
+    );
+  }
+  console.log(`   → packaged hub_agent_run_server listening on 127.0.0.1:${port} ✓`);
+
+  // Derive the client X25519 secret exactly as resolveRustAgentRunWsClientX25519Secret does; drive
+  // the REAL compiled sealed client (no injected resolver, no fixture) — a genuine ECDH handshake.
+  const clientSecret = new Uint8Array(
+    createHash("sha256")
+      .update(RUST_WS_X25519_SECRET_PURPOSE)
+      .update(Buffer.from(masterKeyHex, "hex"))
+      .digest(),
+  );
+  const clientModuleUrl = pathToFileURL(
+    join(ROOT, "dist", "api", "mission-spine", "friday-rust-hub-agent-run-ws-sealed-client.js"),
+  ).href;
+  let mod;
+  try {
+    mod = await import(clientModuleUrl);
+  } catch (err) {
+    fail(`Could not import the compiled sealed client (build dist first): ${err.message}`);
+  }
+  if (typeof mod.createFridayRustHubAgentRunSealedClient !== "function") {
+    fail("Compiled sealed client is missing createFridayRustHubAgentRunSealedClient (stale dist?)");
+  }
+  const client = mod.createFridayRustHubAgentRunSealedClient({
+    host: "127.0.0.1",
+    port,
+    clientSecret,
+    timeoutMs: 10_000,
+  });
+  if (typeof client.createSession !== "function" || typeof client.appendSessionMessage !== "function") {
+    fail("Compiled sealed client is missing createSession/appendSessionMessage — rebuild dist (npm run build).");
+  }
+
+  const sessionId = "channel:smoke|account:default|chat:install-smoke-1";
+  let created;
+  try {
+    created = await client.createSession({ sessionId, userId: owner, channel: "smoke", chatId: "install-smoke-1" });
+  } catch (err) {
+    fail(`Session CREATE was not served by Rust (a 503 / TS fallback is a failure): ${err?.code ?? ""} ${err?.message ?? err}`);
+  }
+  if (created?.truthLabel !== "rust_wired" || created?.sessionId !== sessionId) {
+    fail(`Session CREATE returned an unexpected receipt: ${JSON.stringify(created)}`);
+  }
+
+  let appended;
+  try {
+    appended = await client.appendSessionMessage({ sessionId, role: "user", content: "install-smoke session append proof" });
+  } catch (err) {
+    fail(`Session APPEND was not served by Rust (a 503 / TS fallback is a failure): ${err?.code ?? ""} ${err?.message ?? err}`);
+  }
+  if (
+    appended?.truthLabel !== "rust_wired" ||
+    typeof appended?.messageId !== "string" || appended.messageId.length === 0 ||
+    typeof appended?.seq !== "number"
+  ) {
+    fail(`Session APPEND returned an unexpected receipt: ${JSON.stringify(appended)}`);
+  }
+
+  console.log(`   → CREATE receipt (Rust-served): ${JSON.stringify(created)}`);
+  console.log(`   → APPEND receipt (Rust-served): ${JSON.stringify(appended)}`);
+  console.log("   → session create + append served by the packaged Rust server (no flags, no mock, no TS fallback) ✓");
+
+  // Teardown the Rust server + temp state.
+  try { rustServerProc.kill("SIGINT"); } catch {}
+  const rustShutdownDeadline = Date.now() + 5_000;
+  while (rustServerProc.exitCode === null && Date.now() < rustShutdownDeadline) {
+    await sleep(100);
+  }
+  if (rustServerProc.exitCode === null) {
+    try { rustServerProc.kill("SIGKILL"); } catch {}
+  }
+  rustServerProc = null;
+  rmSync(rustProofTmpDir, { recursive: true, force: true });
+  rustProofTmpDir = null;
 }
 
 async function run() {
@@ -381,6 +604,9 @@ async function run() {
   // Clean up tarball
   try { rmSync(tarball); } catch {}
   packedTarball = undefined;
+
+  // ── Step 9: packaged Rust agent-run WS server serves session create + append ──
+  await runRustAgentRunSessionProof();
 
   console.log("\n✅ Install smoke test passed\n");
 }

--- a/scripts/ops/build-friday-companion-dmg.sh
+++ b/scripts/ops/build-friday-companion-dmg.sh
@@ -115,6 +115,18 @@ mkdir -p "${OUTPUT_DIR}"
 cp -R "${APP_DIR}" "${STAGING_DIR}/FridayCompanion.app"
 ln -s /Applications "${STAGING_DIR}/Applications"
 
+# CORE-A round-3 Lane C (finding #4): stage the Rust agent-run WS server payload —
+# both bins (hub_agent_run_server + hub_agent_run_enroll), the launchd plist TEMPLATE,
+# the fill/enroll/launch cutover tool, and a payload-manifest.json — into the DMG (a
+# top-level rust-agent-run/ folder; kept OUT of the signed .app bundle so it does not
+# invalidate the app signature). The release runtime routes a qualifying agent-run /
+# session create+append to this loopback sealed-WS server; TS startRun is retired to a
+# fail-closed 503 with NO silent fallback. Before this, the DMG carried ZERO Rust
+# server, so a clean install hit 503 on every run. install-friday-launchagent.sh
+# consumes the staged payload to install + enroll + launch the 4th launch agent.
+bash "${REPO_DIR}/scripts/ops/launchd/stage-rust-agent-run-ws-server-payload.sh" \
+  --repo-dir "${REPO_DIR}" --dest-dir "${STAGING_DIR}" >/dev/null
+
 /usr/bin/ditto -c -k --sequesterRsrc --keepParent "${APP_DIR}" "${ZIP_PATH}"
 /usr/bin/hdiutil create \
   -quiet \

--- a/scripts/ops/build-friday-source-distribution.sh
+++ b/scripts/ops/build-friday-source-distribution.sh
@@ -37,6 +37,19 @@ trap cleanup EXIT
 PACKAGE_TGZ="$("${NPM_BIN}" pack --ignore-scripts --silent --pack-destination "${PACK_TEMP_DIR}" "${REPO_DIR}" | tail -n 1 | tr -d '\r')"
 mv "${PACK_TEMP_DIR}/${PACKAGE_TGZ}" "${OUTPUT_DIR}/${PACKAGE_TGZ}"
 
+# CORE-A round-3 Lane C (finding #4): the cross-platform npm tarball cannot embed the
+# arch-specific Rust agent-run WS server, so stage the server payload — both bins
+# (hub_agent_run_server + hub_agent_run_enroll), the launchd plist TEMPLATE, the
+# fill/enroll/launch cutover tool, and a payload-manifest.json — as a SIBLING release
+# artifact (dist/releases/source/rust-agent-run/) next to the tgz. The release runtime
+# routes a qualifying agent-run / session create+append to this loopback sealed-WS
+# server; TS startRun is retired to a fail-closed 503 with NO silent fallback. Before
+# this, the source distribution shipped ZERO Rust server, so a clean install hit 503 on
+# every run. install-friday-launchagent.sh consumes the staged payload to install +
+# enroll + launch the server.
+bash "${REPO_DIR}/scripts/ops/launchd/stage-rust-agent-run-ws-server-payload.sh" \
+  --repo-dir "${REPO_DIR}" --dest-dir "${OUTPUT_DIR}" >/dev/null
+
 ARTIFACT_PATH="${OUTPUT_DIR}/${PACKAGE_TGZ}"
 DOWNLOAD_BASE_URL="${FRIDAY_RELEASE_DOWNLOAD_BASE_URL:-https://github.com/thesongzhu/Friday/releases/download/v${VERSION}}"
 

--- a/scripts/ops/check-friday-desktop-release-pipeline.mjs
+++ b/scripts/ops/check-friday-desktop-release-pipeline.mjs
@@ -337,6 +337,84 @@ function runDesktopGuiSmokeContractCheck(repoRoot) {
   };
 }
 
+/**
+ * CORE-A round-3 Lane C (finding #4): static contract that the release artifacts PACKAGE the Rust
+ * agent-run WS server (both bins + the launchd plist template) and that the installer LAUNCHES +
+ * ENROLLS it. Before this, the DMG / source-dist / installer had ZERO hub_agent_run refs, so a clean
+ * install shipped no Rust server and every agent-run / session create+append hit a fail-closed 503.
+ */
+function rustAgentRunPackagingContractChecks(repoRoot) {
+  const readText = (rel) => {
+    const abs = path.join(repoRoot, rel);
+    return fs.existsSync(abs) ? fs.readFileSync(abs, "utf8") : null;
+  };
+  const check = (label, target, ok, detail) => ({
+    kind: "rust-agent-run-packaging-contract",
+    label,
+    target,
+    status: ok ? "passed" : "failed",
+    ...(ok ? {} : { stderr: detail ?? "contract assertion failed" }),
+  });
+  const containsAll = (text, tokens) => text != null && tokens.every((t) => text.includes(t));
+
+  const stagingHelperRel = "scripts/ops/launchd/stage-rust-agent-run-ws-server-payload.sh";
+  const plistRel = "scripts/ops/launchd/com.friday.rust-agent-run-ws-server.plist";
+  const dmgRel = "scripts/ops/build-friday-companion-dmg.sh";
+  const srcDistRel = "scripts/ops/build-friday-source-distribution.sh";
+  const installerRel = "scripts/ops/install-friday-launchagent.sh";
+
+  const stagingHelper = readText(stagingHelperRel);
+  const plist = readText(plistRel);
+  const dmg = readText(dmgRel);
+  const srcDist = readText(srcDistRel);
+  const installer = readText(installerRel);
+
+  return [
+    check(
+      "Rust agent-run plist template pins the server args",
+      plistRel,
+      containsAll(plist, ["__RUST_SERVER_BIN__", "--workspace", "--db", "--port", "--owner", "--store-dir"]),
+      "the launchd plist template must pin --workspace/--db/--port/--owner/--store-dir",
+    ),
+    check(
+      "Staging helper builds both bins + stages the plist + writes a manifest",
+      stagingHelperRel,
+      containsAll(stagingHelper, [
+        "cargo build --release --bin",
+        "hub_agent_run_server",
+        "hub_agent_run_enroll",
+        "PLIST_TEMPLATE",
+        "payload-manifest.json",
+      ]),
+      "the staging helper must cargo-build both bins, stage the plist template, and write payload-manifest.json",
+    ),
+    check(
+      "DMG build stages the Rust agent-run payload",
+      dmgRel,
+      containsAll(dmg, ["stage-rust-agent-run-ws-server-payload.sh"]),
+      "build-friday-companion-dmg.sh must invoke the Rust agent-run staging helper",
+    ),
+    check(
+      "Source distribution stages the Rust agent-run payload",
+      srcDistRel,
+      containsAll(srcDist, ["stage-rust-agent-run-ws-server-payload.sh"]),
+      "build-friday-source-distribution.sh must invoke the Rust agent-run staging helper",
+    ),
+    check(
+      "Installer launches + enrolls the Rust agent-run WS server",
+      installerRel,
+      containsAll(installer, [
+        "com.friday.rust-agent-run-ws-server",
+        "hub_agent_run_enroll",
+        "launchctl bootstrap",
+        "plutil -lint",
+        "master.key",
+      ]),
+      "install-friday-launchagent.sh must fill+lint the plist, enroll the peer, and launchctl bootstrap the WS server label",
+    ),
+  ];
+}
+
 const repoRoot = resolveRepoRoot();
 const pkg = readPackageJson(repoRoot);
 
@@ -375,6 +453,10 @@ const checks = [
     ["apps/friday-android/build-emu.sh", "Android emulator build script"],
     ["scripts/ops/check-friday-companion-release-env.sh", "Companion release env check"],
     ["scripts/ops/build-friday-companion-dmg.sh", "DMG build script"],
+    ["scripts/ops/build-friday-source-distribution.sh", "Source distribution build script"],
+    ["scripts/ops/launchd/stage-rust-agent-run-ws-server-payload.sh", "Rust agent-run WS server packaging staging helper"],
+    ["scripts/ops/launchd/com.friday.rust-agent-run-ws-server.plist", "Rust agent-run WS server launchd plist template"],
+    ["scripts/ops/launchd/build-and-install-rust-agent-run-ws-server.sh", "Rust agent-run WS server cutover tool"],
     ["scripts/ops/build-friday-sparkle-appcast.sh", "Sparkle appcast build script"],
     ["scripts/ops/publish-friday-homebrew-cask.sh", "Homebrew publication script"],
     ["scripts/ops/write-friday-release-manifest.mjs", "Release manifest generator"],
@@ -418,6 +500,7 @@ const checks = [
   runNativeActionClosureCheck(repoRoot),
   runIosDesignDestinationCaptureContractCheck(repoRoot),
   runDesktopGuiSmokeContractCheck(repoRoot),
+  ...rustAgentRunPackagingContractChecks(repoRoot),
   ...artifactFreshnessChecks(repoRoot),
 ];
 

--- a/scripts/ops/install-friday-launchagent.sh
+++ b/scripts/ops/install-friday-launchagent.sh
@@ -97,6 +97,79 @@ HUB_PLIST_PATH="${AGENT_DIR}/${HUB_LABEL}.plist"
 COMPANION_PLIST_PATH="${AGENT_DIR}/${COMPANION_LABEL}.plist"
 UI_PLIST_PATH="${AGENT_DIR}/${UI_LABEL}.plist"
 
+# =============================================================================
+# CORE-A round-3 Lane C (finding #4): resolve whether to install + launch the Rust
+# agent-run WS server (com.friday.rust-agent-run-ws-server) as a 4th launch agent.
+# =============================================================================
+# The release runtime routes a qualifying agent-run / session create+append to this
+# loopback sealed-WS server; TS startRun is retired to a fail-closed 503 with NO
+# silent fallback. Before this, the packaged install shipped/launched NO Rust server,
+# so a clean install hit 503 on every run. This promotes the DARK cutover (fill plist,
+# plutil -lint, port check, provision ~/.friday/master.key, hub_agent_run_enroll,
+# launchctl bootstrap) into the installer so it happens WITHOUT a human.
+#
+# It stays a no-op (byte-identical to the pre-Lane-C 3-agent install) UNLESS a staged
+# Rust payload is found — i.e. only in a packaged release install (the DMG's / source
+# distribution's rust-agent-run/ folder), or when explicitly opted in for a dev tree.
+RUST_LABEL="com.friday.rust-agent-run-ws-server"
+RUST_PLIST_PATH="${AGENT_DIR}/${RUST_LABEL}.plist"
+RUST_AGENT_ENABLED="false"
+RUST_PAYLOAD_DIR=""
+RUST_SERVER_BIN=""
+RUST_ENROLL_BIN=""
+RUST_PLIST_TEMPLATE=""
+
+rust_truthy() { case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in 1|true|yes|on) return 0 ;; *) return 1 ;; esac; }
+
+# Locate a staged payload (both bins + the plist template). Search order:
+#   1) FRIDAY_RUST_AGENT_RUN_PAYLOAD_DIR (explicit)
+#   2) <repo>/rust-agent-run  (packaged: extracted / DMG-copied next to the app or repo)
+#   3) with FRIDAY_INSTALL_RUST_AGENT_RUN truthy: <repo>/rust-core/target/release (dev)
+resolve_rust_payload() {
+  local candidates=()
+  [[ -n "${FRIDAY_RUST_AGENT_RUN_PAYLOAD_DIR:-}" ]] && candidates+=("${FRIDAY_RUST_AGENT_RUN_PAYLOAD_DIR}")
+  candidates+=("${REPO_DIR}/rust-agent-run")
+  if rust_truthy "${FRIDAY_INSTALL_RUST_AGENT_RUN:-}"; then
+    candidates+=("${REPO_DIR}/rust-core/target/release")
+  fi
+  local dir server enroll template
+  for dir in "${candidates[@]}"; do
+    server="${dir}/hub_agent_run_server"
+    enroll="${dir}/hub_agent_run_enroll"
+    [[ -x "${server}" && -x "${enroll}" ]] || continue
+    # The plist template travels with the staged payload; fall back to the repo path.
+    if [[ -f "${dir}/${RUST_LABEL}.plist" ]]; then
+      template="${dir}/${RUST_LABEL}.plist"
+    elif [[ -f "${REPO_DIR}/scripts/ops/launchd/${RUST_LABEL}.plist" ]]; then
+      template="${REPO_DIR}/scripts/ops/launchd/${RUST_LABEL}.plist"
+    else
+      continue
+    fi
+    RUST_PAYLOAD_DIR="${dir}"; RUST_SERVER_BIN="${server}"
+    RUST_ENROLL_BIN="${enroll}"; RUST_PLIST_TEMPLATE="${template}"
+    return 0
+  done
+  return 1
+}
+
+if resolve_rust_payload; then
+  RUST_AGENT_ENABLED="true"
+  RUST_STORE_DIR="${FRIDAY_HUB_AGENT_RUN_STORE_DIR:-${HOME}/.friday/agent-run-securestore}"
+  RUST_WORKSPACE_ROOT="${FRIDAY_HUB_AGENT_RUN_WORKSPACE:-${HOME}/.friday/agent-run/workspace}"
+  RUST_HUB_DB_PATH="${FRIDAY_HUB_AGENT_RUN_DB_PATH:-${HOME}/.friday/agent-run/hub.sqlite}"
+  # The OWNER allowlist entry MUST equal the TS hub's authenticated principal or every
+  # dispatch is refused (fail-closed). It is deploy-specific, so it is an operator input;
+  # a wrong/placeholder value never fakes success — it 503s. Documented default flagged below.
+  RUST_OWNER_PRINCIPAL="${FRIDAY_HUB_AGENT_RUN_OWNER_PRINCIPAL:-owner:local}"
+  # Pick a stable, free loopback port distinct from the hub port (default 3141) unless pinned.
+  if [[ -n "${FRIDAY_HUB_AGENT_RUN_WS_PORT:-}" ]]; then
+    RUST_WS_PORT="${FRIDAY_HUB_AGENT_RUN_WS_PORT}"
+  else
+    RUST_WS_PORT="$("${NODE_BIN}" -e "const net=require('node:net');const s=net.createServer();s.listen(0,'127.0.0.1',()=>{const p=s.address().port;s.close(()=>console.log(p));});" 2>/dev/null || echo "")"
+    [[ "${RUST_WS_PORT}" =~ ^[0-9]+$ ]] || RUST_WS_PORT="61789"
+  fi
+fi
+
 write_common_env() {
   cat <<EOF
     <key>FRIDAY_NODE_BIN</key>
@@ -112,6 +185,26 @@ EOF
     <string>${STATE_DIR}</string>
 EOF
   fi
+}
+
+# CORE-A Lane C (finding #4): when the Rust agent-run WS server is installed, the TS hub
+# must know the loopback PORT to dial + the Hub DB the owner-gated answer readback reads
+# from. These are pure transport-wiring (NOT the route flag — the release profile default
+# from CR-3 needs no flag; an explicit FRIDAY_ROUTE_*_VIA_RUST=0 remains the kill switch).
+# No secret goes here (the WS X25519 secret is SecureStore-derived on the TS side; the
+# server reads its own master key). Empty when the Rust agent is not installed.
+write_hub_agent_run_env() {
+  if [[ "${RUST_AGENT_ENABLED}" != "true" ]]; then
+    return 0
+  fi
+  cat <<EOF
+    <key>FRIDAY_HUB_AGENT_RUN_WS_HOST</key>
+    <string>127.0.0.1</string>
+    <key>FRIDAY_HUB_AGENT_RUN_WS_PORT</key>
+    <string>${RUST_WS_PORT}</string>
+    <key>FRIDAY_HUB_AGENT_RUN_DB_PATH</key>
+    <string>${RUST_HUB_DB_PATH}</string>
+EOF
 }
 
 cat > "${HUB_PLIST_PATH}" <<EOF
@@ -138,6 +231,7 @@ cat > "${HUB_PLIST_PATH}" <<EOF
   <key>EnvironmentVariables</key>
   <dict>
 $(write_common_env)
+$(write_hub_agent_run_env)
     <key>FRIDAY_AUTO_OPEN_UI</key>
     <string>false</string>
     <key>FRIDAY_CHANNEL_WAKE_UI</key>
@@ -258,9 +352,130 @@ else
   echo "[install] launch agents written; kickstart skipped."
 fi
 
+# =============================================================================
+# CORE-A round-3 Lane C (finding #4): install + enroll + launch the Rust agent-run
+# WS server (the promoted DARK cutover). Best-effort + fail-CLOSED: any problem here
+# is surfaced but never rolls back the base 3 agents (no degrade of prior behavior).
+# =============================================================================
+# escape a value for a sed replacement (\, &, / delimiter) — mirrors the DARK tool.
+rust_sed_escape() { printf '%s' "$1" | sed -e 's/[\\&/]/\\&/g'; }
+
+install_rust_agent_run_ws_server() {
+  # Stable install locations (survive DMG unmount / tarball dir removal).
+  local bin_dir="${HOME}/.friday/agent-run/bin"
+  local server_bin="${bin_dir}/hub_agent_run_server"
+  local enroll_bin="${bin_dir}/hub_agent_run_enroll"
+  local master_key_file="${HOME}/.friday/master.key"
+
+  mkdir -p "${bin_dir}" "${RUST_STORE_DIR}" "${RUST_WORKSPACE_ROOT}" \
+           "$(dirname "${RUST_HUB_DB_PATH}")" || { echo "[install] rust: mkdir failed" >&2; return 1; }
+  install -m 0755 "${RUST_SERVER_BIN}" "${server_bin}" || { echo "[install] rust: staging server bin failed" >&2; return 1; }
+  install -m 0755 "${RUST_ENROLL_BIN}" "${enroll_bin}" || { echo "[install] rust: staging enroll bin failed" >&2; return 1; }
+
+  # (provision master key) The server reads FRIDAY_MASTER_KEY or ~/.friday/master.key
+  # (never auto-generated on the Rust side). On a clean install provision the FILE so the
+  # server is bootable; the TS hub adopts the same file key when no keychain key pre-exists.
+  if [[ -z "${FRIDAY_MASTER_KEY:-}" && ! -f "${master_key_file}" ]]; then
+    mkdir -p "$(dirname "${master_key_file}")"
+    "${NODE_BIN}" -e "process.stdout.write(require('node:crypto').randomBytes(32).toString('hex'))" > "${master_key_file}" \
+      || { echo "[install] rust: master key provisioning failed" >&2; return 1; }
+    chmod 600 "${master_key_file}"
+    echo "[install] rust: provisioned master key file ${master_key_file} (0600)."
+  fi
+  if [[ -z "${FRIDAY_MASTER_KEY:-}" && ! -r "${master_key_file}" ]]; then
+    echo "[install] rust: no master key (FRIDAY_MASTER_KEY unset AND ${master_key_file} absent) — skipping (server would fail closed)." >&2
+    return 1
+  fi
+
+  # (port check) The supervised server is the SINGLE owner of the loopback port. Bootout any
+  # prior instance FIRST so a re-install frees its own port, then require the port be free +
+  # distinct from the TS hub port (3141 when the hub plist sets no FRIDAY_PORT).
+  launchctl bootout "gui/${UID}" "${RUST_PLIST_PATH}" >/dev/null 2>&1 || true
+  if (( RUST_WS_PORT == 3141 )); then
+    echo "[install] rust: chosen WS port ${RUST_WS_PORT} collides with the TS hub default (3141) — skipping." >&2
+    return 1
+  fi
+  if command -v lsof >/dev/null 2>&1; then
+    if lsof -nP -iTCP:"${RUST_WS_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+      echo "[install] rust: WS port ${RUST_WS_PORT} is already in use — skipping (set FRIDAY_HUB_AGENT_RUN_WS_PORT to a free port)." >&2
+      return 1
+    fi
+  fi
+
+  # (fill plist) from the payload's template into the live LaunchAgents dir.
+  sed \
+    -e "s/__RUST_SERVER_BIN__/$(rust_sed_escape "${server_bin}")/g" \
+    -e "s/__WORKSPACE_ROOT__/$(rust_sed_escape "${RUST_WORKSPACE_ROOT}")/g" \
+    -e "s/__HUB_DB_PATH__/$(rust_sed_escape "${RUST_HUB_DB_PATH}")/g" \
+    -e "s/__WS_PORT__/$(rust_sed_escape "${RUST_WS_PORT}")/g" \
+    -e "s/__OWNER_PRINCIPAL__/$(rust_sed_escape "${RUST_OWNER_PRINCIPAL}")/g" \
+    -e "s/__STORE_DIR__/$(rust_sed_escape "${RUST_STORE_DIR}")/g" \
+    -e "s/__LOG_DIR__/$(rust_sed_escape "${LOG_DIR}")/g" \
+    -e "s/__REPO_DIR__/$(rust_sed_escape "${REPO_DIR}")/g" \
+    "${RUST_PLIST_TEMPLATE}" > "${RUST_PLIST_PATH}" \
+    || { echo "[install] rust: filling plist failed" >&2; return 1; }
+  if grep -q '__[A-Z_]*__' "${RUST_PLIST_PATH}"; then
+    echo "[install] rust: filled plist still has placeholders:" >&2
+    grep -o '__[A-Z_]*__' "${RUST_PLIST_PATH}" | sort -u >&2
+    rm -f "${RUST_PLIST_PATH}"
+    return 1
+  fi
+
+  # (plutil -lint)
+  if command -v plutil >/dev/null 2>&1; then
+    if ! plutil -lint "${RUST_PLIST_PATH}" >/dev/null; then
+      plutil -lint "${RUST_PLIST_PATH}" >&2 || true
+      rm -f "${RUST_PLIST_PATH}"
+      echo "[install] rust: plutil -lint failed on filled plist" >&2
+      return 1
+    fi
+  fi
+
+  # (enroll) THIS host's client pubkey into the SAME store-dir the plist pins. Reads the
+  # master key (env/file); idempotent (re-enroll REPLACES, never appends).
+  if ! "${enroll_bin}" --store-dir "${RUST_STORE_DIR}" >/dev/null; then
+    echo "[install] rust: hub_agent_run_enroll failed (store-dir ${RUST_STORE_DIR}) — skipping bootstrap." >&2
+    return 1
+  fi
+
+  # (launchctl bootstrap)
+  if [[ "${KICKSTART}" == "true" ]]; then
+    launchctl enable "gui/${UID}/${RUST_LABEL}" >/dev/null 2>&1 || true
+    if ! launchctl bootstrap "gui/${UID}" "${RUST_PLIST_PATH}"; then
+      echo "[install] rust: launchctl bootstrap failed" >&2
+      return 1
+    fi
+    launchctl kickstart -k "gui/${UID}/${RUST_LABEL}" >/dev/null 2>&1 || true
+  fi
+
+  echo "[install] rust: installed ${RUST_LABEL}"
+  echo "[install] rust:   plist    ${RUST_PLIST_PATH}"
+  echo "[install] rust:   server   ${server_bin}  (loopback 127.0.0.1:${RUST_WS_PORT})"
+  echo "[install] rust:   store    ${RUST_STORE_DIR}   (enrolled)"
+  echo "[install] rust:   hub DB   ${RUST_HUB_DB_PATH}"
+  echo "[install] rust:   owner    ${RUST_OWNER_PRINCIPAL}   (MUST equal the TS hub's authenticated principal, or dispatch is refused fail-closed)"
+  echo "[install] rust: NOTE end-to-end serving also requires the TS hub + this server to share the SAME master key (clean install: ${master_key_file}); a keychain-held hub key must be aligned to it."
+  return 0
+}
+
+if [[ "${RUST_AGENT_ENABLED}" == "true" ]]; then
+  if install_rust_agent_run_ws_server; then
+    echo "[install] Rust agent-run WS server installed (4th launch agent)."
+  else
+    echo "[install] WARNING: Rust agent-run WS server NOT installed (see above); the base agents are unaffected." >&2
+  fi
+else
+  echo "[install] Rust agent-run WS server payload not found — skipped (packaged release installs stage it under rust-agent-run/; set FRIDAY_INSTALL_RUST_AGENT_RUN=1 for a built dev tree)."
+fi
+
 echo "[install] installed launch agents:"
 echo "[install]   ${HUB_PLIST_PATH}"
 echo "[install]   ${COMPANION_PLIST_PATH}"
 echo "[install]   ${UI_PLIST_PATH}"
-echo "[install] labels: ${HUB_LABEL}, ${COMPANION_LABEL}, ${UI_LABEL}"
+if [[ "${RUST_AGENT_ENABLED}" == "true" && -f "${RUST_PLIST_PATH}" ]]; then
+  echo "[install]   ${RUST_PLIST_PATH}"
+  echo "[install] labels: ${HUB_LABEL}, ${COMPANION_LABEL}, ${UI_LABEL}, ${RUST_LABEL}"
+else
+  echo "[install] labels: ${HUB_LABEL}, ${COMPANION_LABEL}, ${UI_LABEL}"
+fi
 echo "[install] logs: ${LOG_DIR}"

--- a/scripts/ops/launchd/stage-rust-agent-run-ws-server-payload.sh
+++ b/scripts/ops/launchd/stage-rust-agent-run-ws-server-payload.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# stage-rust-agent-run-ws-server-payload.sh
+# =============================================================================
+# CORE-A round-3 Lane C (finding #4) — the SHARED packaging step that puts the
+# Rust agent-run WS server INTO the release artifacts.
+# =============================================================================
+#
+# WHY THIS EXISTS
+#   The release runtime routes a qualifying agent-run / session create+append to
+#   the loopback Rust sealed-WS server (`hub_agent_run_server`); TS `startRun` is
+#   retired to a fail-closed 503 (no silent TS fallback). BEFORE this step the
+#   server + its enroll CLI were packaged/launched ONLY by the DARK operator tool
+#   `build-and-install-rust-agent-run-ws-server.sh` — there were ZERO
+#   `hub_agent_run` / `cargo` / `rust-core` refs in the DMG or source-dist build
+#   scripts, so a clean install shipped NO Rust server and every run hit 503.
+#
+#   This helper is the ONE place that release-BUILDS the two bins and STAGES the
+#   packaged payload (both bins + the launchd plist template + the fill/enroll/
+#   launch cutover tool + a manifest) into a caller-supplied destination. Both
+#   `build-friday-companion-dmg.sh` and `build-friday-source-distribution.sh`
+#   call it so the two channels stay byte-consistent; `install-friday-launchagent.sh`
+#   consumes the staged payload to install + enroll + launch the 4th launch agent.
+#
+# WHAT IT STAGES (into <DEST_DIR>/rust-agent-run/)
+#   * hub_agent_run_server   — the loopback sealed-WS server bin (--workspace --db
+#                              --port --owner --store-dir; reads ~/.friday/master.key)
+#   * hub_agent_run_enroll   — enrolls THIS host's client pubkey into --store-dir
+#   * com.friday.rust-agent-run-ws-server.plist — the launchd plist TEMPLATE (the
+#                              installer fills its placeholders)
+#   * build-and-install-rust-agent-run-ws-server.sh — the fill/lint/port-check/
+#                              stage cutover tool the installer reuses
+#   * payload-manifest.json  — the machine-readable manifest listing the above
+#                              (the release-pipeline contract asserts this shape)
+#
+# USAGE
+#   stage-rust-agent-run-ws-server-payload.sh --repo-dir <abs> --dest-dir <abs> [--skip-build]
+#   stage-rust-agent-run-ws-server-payload.sh <repo-dir> <dest-dir> [--skip-build]
+#
+# EXIT CODES
+#   0 ok · 2 bad args · 70 build failure / missing bin · 78 missing prerequisite
+# =============================================================================
+
+set -Eeuo pipefail
+
+REPO_DIR="${REPO_DIR:-}"
+DEST_DIR="${DEST_DIR:-}"
+SKIP_BUILD="false"
+
+log() { printf '[stage-rust-agent-run] %s\n' "$*" >&2; }
+die() { printf '[stage-rust-agent-run] ERROR: %s\n' "$*" >&2; exit "${2:-1}"; }
+
+# The payload files (single source of truth for the packaging contract). The two
+# bin BASENAMES + the plist template + cutover tool are what every consumer keys on.
+SERVER_BIN_NAME="hub_agent_run_server"
+ENROLL_BIN_NAME="hub_agent_run_enroll"
+PLIST_TEMPLATE_REL="scripts/ops/launchd/com.friday.rust-agent-run-ws-server.plist"
+CUTOVER_TOOL_REL="scripts/ops/launchd/build-and-install-rust-agent-run-ws-server.sh"
+PAYLOAD_SUBDIR="rust-agent-run"
+
+# --- parse args (flags win over positionals) ---------------------------------
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-dir)  REPO_DIR="${2:?missing value for --repo-dir}"; shift 2 ;;
+    --dest-dir)  DEST_DIR="${2:?missing value for --dest-dir}"; shift 2 ;;
+    --skip-build) SKIP_BUILD="true"; shift ;;
+    -h|--help)
+      grep -E '^#( |$)' "${BASH_SOURCE[0]}" | sed -E 's/^# ?//'
+      exit 0 ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+if [[ -z "${REPO_DIR}" && ${#POSITIONAL[@]} -ge 1 ]]; then REPO_DIR="${POSITIONAL[0]}"; fi
+if [[ -z "${DEST_DIR}" && ${#POSITIONAL[@]} -ge 2 ]]; then DEST_DIR="${POSITIONAL[1]}"; fi
+
+[[ -n "${REPO_DIR}" ]] || die "REPO_DIR is required (--repo-dir or positional)." 2
+[[ -d "${REPO_DIR}" ]] || die "REPO_DIR is not a directory: ${REPO_DIR}" 2
+REPO_DIR="$(cd "${REPO_DIR}" && pwd)"
+[[ -n "${DEST_DIR}" ]] || die "DEST_DIR is required (--dest-dir or positional)." 2
+
+RUST_CORE_DIR="${REPO_DIR}/rust-core"
+[[ -d "${RUST_CORE_DIR}" ]] || die "rust-core/ not found under REPO_DIR: ${RUST_CORE_DIR}" 78
+PLIST_TEMPLATE="${REPO_DIR}/${PLIST_TEMPLATE_REL}"
+[[ -f "${PLIST_TEMPLATE}" ]] || die "plist template not found: ${PLIST_TEMPLATE}" 78
+CUTOVER_TOOL="${REPO_DIR}/${CUTOVER_TOOL_REL}"
+[[ -f "${CUTOVER_TOOL}" ]] || die "cutover tool not found: ${CUTOVER_TOOL}" 78
+
+RELEASE_DIR="${RUST_CORE_DIR}/target/release"
+SERVER_BIN="${RELEASE_DIR}/${SERVER_BIN_NAME}"
+ENROLL_BIN="${RELEASE_DIR}/${ENROLL_BIN_NAME}"
+
+# --- release-build the two bins (same invocation as the cutover tool) --------
+if [[ "${SKIP_BUILD}" == "true" ]]; then
+  log "skip-build: using existing release bins."
+else
+  command -v cargo >/dev/null 2>&1 || die "cargo not found in PATH; install the Rust toolchain." 70
+  log "release-building ${SERVER_BIN_NAME} + ${ENROLL_BIN_NAME} (cargo --release) ..."
+  ( cd "${RUST_CORE_DIR}" \
+      && cargo build --release --bin "${SERVER_BIN_NAME}" --bin "${ENROLL_BIN_NAME}" ) \
+    || die "cargo build --release failed." 70
+fi
+[[ -x "${SERVER_BIN}" ]] || die "server bin missing/not executable: ${SERVER_BIN} (build first)." 70
+[[ -x "${ENROLL_BIN}" ]] || die "enroll bin missing/not executable: ${ENROLL_BIN} (build first)." 70
+
+# --- stage the payload -------------------------------------------------------
+PAYLOAD_DIR="${DEST_DIR%/}/${PAYLOAD_SUBDIR}"
+mkdir -p "${PAYLOAD_DIR}"
+install -m 0755 "${SERVER_BIN}" "${PAYLOAD_DIR}/${SERVER_BIN_NAME}"
+install -m 0755 "${ENROLL_BIN}" "${PAYLOAD_DIR}/${ENROLL_BIN_NAME}"
+install -m 0644 "${PLIST_TEMPLATE}" "${PAYLOAD_DIR}/$(basename "${PLIST_TEMPLATE_REL}")"
+install -m 0755 "${CUTOVER_TOOL}" "${PAYLOAD_DIR}/$(basename "${CUTOVER_TOOL_REL}")"
+
+ARCH="$(uname -m)"
+OS="$(uname -s)"
+sha_of() { if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}'; else echo "unavailable"; fi; }
+
+# The manifest is the machine-readable packaging contract the release-pipeline
+# check asserts on. It names BOTH bins + the plist template (+ the cutover tool)
+# and the installer that consumes them.
+cat > "${PAYLOAD_DIR}/payload-manifest.json" <<EOF
+{
+  "schema": "friday.rust-agent-run.payload.manifest.v1",
+  "label": "com.friday.rust-agent-run-ws-server",
+  "os": "${OS}",
+  "arch": "${ARCH}",
+  "bins": [
+    { "name": "${SERVER_BIN_NAME}", "role": "server", "sha256": "$(sha_of "${PAYLOAD_DIR}/${SERVER_BIN_NAME}")" },
+    { "name": "${ENROLL_BIN_NAME}", "role": "enroll", "sha256": "$(sha_of "${PAYLOAD_DIR}/${ENROLL_BIN_NAME}")" }
+  ],
+  "plistTemplate": "$(basename "${PLIST_TEMPLATE_REL}")",
+  "cutoverTool": "$(basename "${CUTOVER_TOOL_REL}")",
+  "installer": "scripts/ops/install-friday-launchagent.sh",
+  "serverArgs": ["--workspace", "--db", "--port", "--owner", "--store-dir"],
+  "installerSteps": ["fill-plist", "plutil-lint", "port-check", "provision-master-key", "hub_agent_run_enroll", "launchctl-bootstrap"]
+}
+EOF
+
+log "staged Rust agent-run WS server payload → ${PAYLOAD_DIR}"
+log "  ${SERVER_BIN_NAME}, ${ENROLL_BIN_NAME}, $(basename "${PLIST_TEMPLATE_REL}"), $(basename "${CUTOVER_TOOL_REL}"), payload-manifest.json"
+printf '%s\n' "${PAYLOAD_DIR}"

--- a/src/api/auth/device-attest/friday-provider-approval-transcript.ts
+++ b/src/api/auth/device-attest/friday-provider-approval-transcript.ts
@@ -1,0 +1,234 @@
+// ─── SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 ───
+//
+// Canonical device-authored provider-approval transcript encoding + P-256
+// proof-of-possession verifier.
+//
+// The encoding is a DETERMINISTIC, length-prefixed binary framing with a fixed
+// field order and a domain-separation prefix (distinct from the owner-claim
+// domain, so a signature over one transcript kind can never be replayed as the
+// other). All EC math is delegated to Node's `crypto.verify` — there is no
+// hand-rolled curve arithmetic; the low-level parsing/hashing/curve-check
+// primitives are REUSED from the owner-claim module.
+//
+// This module verifies signature + possession + transcript-field binding ONLY.
+// It NEVER asserts key protection, NEVER grants owner authority, NEVER mutates
+// state, and NEVER binds the transcript to the request/owner — the mutating-action
+// gate + confirm route do that with the returned verified fields.
+
+import { createHash, verify as cryptoVerify, type KeyObject } from "node:crypto";
+
+import {
+  canonicalDevicePublicKeyHash,
+  decodeFlexibleBase64,
+  importPresentedPublicKey,
+  isLowS,
+  isP256PublicKey,
+  parseCanonicalP1363Signature,
+} from "./friday-owner-claim-transcript.js";
+import type {
+  FridayProviderApprovalPoPVerifier,
+  ProviderApprovalPoPFailure,
+  ProviderApprovalPoPResult,
+  ProviderApprovalSignatureAlgorithm,
+  ProviderApprovalTranscript,
+  ProviderApprovalTranscriptVersion,
+  VerifyProviderApprovalPossessionInput,
+} from "./friday-provider-approval-transcript.types.js";
+
+// ─── Allowlists (value constants) ───
+
+export const PROVIDER_APPROVAL_TRANSCRIPT_VERSION: ProviderApprovalTranscriptVersion =
+  "friday-provider-approval-v1";
+
+export const PROVIDER_APPROVAL_ALGORITHM: ProviderApprovalSignatureAlgorithm =
+  "ECDSA_P256_SHA256";
+
+export const PROVIDER_APPROVAL_ALLOWED_TRANSCRIPT_VERSIONS: ReadonlySet<string> =
+  new Set([PROVIDER_APPROVAL_TRANSCRIPT_VERSION]);
+
+export const PROVIDER_APPROVAL_ALLOWED_ALGORITHMS: ReadonlySet<string> = new Set([
+  PROVIDER_APPROVAL_ALGORITHM,
+]);
+
+/** Fixed claim-kind discriminator that MUST appear in every transcript. */
+export const PROVIDER_APPROVAL_KIND = "provider_mutation_approval" as const;
+
+// ─── Domain separation (distinct from the owner-claim domain) ───
+
+const TRANSCRIPT_DOMAIN = "friday.provider-approval.transcript";
+
+// ─── Canonical encoding ───
+
+function lengthPrefixed(value: string): Buffer {
+  const body = Buffer.from(value, "utf8");
+  const prefix = Buffer.alloc(4);
+  prefix.writeUInt32BE(body.byteLength, 0);
+  return Buffer.concat([prefix, body]);
+}
+
+/**
+ * Deterministically encode a transcript to its canonical bytes:
+ * `LP(domain) ‖ LP(field_0) ‖ … ‖ LP(field_n)` where LP(x) = u32be(len) ‖ utf8(x).
+ *
+ * The field order below is part of the wire contract and MUST NOT be reordered
+ * without bumping the transcript version. Fields are listed EXPLICITLY (no dynamic
+ * property access) so the exact signed layout is auditable at a glance. The UI
+ * device-key encoder mirrors this byte-for-byte (asserted by a cross-encoder test).
+ */
+export function encodeProviderApprovalTranscript(
+  transcript: ProviderApprovalTranscript,
+): Buffer {
+  return Buffer.concat([
+    lengthPrefixed(TRANSCRIPT_DOMAIN),
+    lengthPrefixed(transcript.transcriptVersion),
+    lengthPrefixed(transcript.algorithm),
+    lengthPrefixed(transcript.kind),
+    lengthPrefixed(transcript.approvalId),
+    lengthPrefixed(transcript.actionDigest),
+    lengthPrefixed(transcript.decidedByPrincipalId),
+    lengthPrefixed(transcript.expiresAt),
+    lengthPrefixed(transcript.devicePublicKeyHash),
+  ]);
+}
+
+/** SHA-256 hex digest of the canonical transcript bytes. */
+export function providerApprovalTranscriptDigestHex(
+  transcript: ProviderApprovalTranscript,
+): string {
+  return createHash("sha256")
+    .update(encodeProviderApprovalTranscript(transcript))
+    .digest("hex");
+}
+
+// ─── Verification pipeline ───
+
+function reject(
+  reason: ProviderApprovalPoPFailure["reason"],
+  detail?: string,
+): ProviderApprovalPoPFailure {
+  return detail === undefined ? { ok: false, reason } : { ok: false, reason, detail };
+}
+
+function isNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Return the name of the first required transcript field that is missing/empty,
+ * or null when all are present. Checked EXPLICITLY (no dynamic indexing).
+ */
+function firstMissingField(transcript: ProviderApprovalTranscript): string | null {
+  if (!isNonEmptyString(transcript.approvalId)) return "approvalId";
+  if (!isNonEmptyString(transcript.actionDigest)) return "actionDigest";
+  if (!isNonEmptyString(transcript.decidedByPrincipalId)) return "decidedByPrincipalId";
+  if (!isNonEmptyString(transcript.expiresAt)) return "expiresAt";
+  if (!isNonEmptyString(transcript.devicePublicKeyHash)) return "devicePublicKeyHash";
+  return null;
+}
+
+function verifyPossession(
+  input: VerifyProviderApprovalPossessionInput,
+): ProviderApprovalPoPResult {
+  const { transcript, devicePublicKey, signature, nowMs } = input;
+
+  // 1. Transcript-version allowlist.
+  if (!PROVIDER_APPROVAL_ALLOWED_TRANSCRIPT_VERSIONS.has(transcript.transcriptVersion)) {
+    return reject("unsupported_transcript_version", String(transcript.transcriptVersion));
+  }
+
+  // 2. Algorithm allowlist (bound INTO the transcript, so substitution changes bytes).
+  if (!PROVIDER_APPROVAL_ALLOWED_ALGORITHMS.has(transcript.algorithm)) {
+    return reject("unsupported_algorithm", String(transcript.algorithm));
+  }
+
+  // 3. Kind discriminator + required non-empty fields.
+  if (transcript.kind !== PROVIDER_APPROVAL_KIND) {
+    return reject("malformed_transcript", "kind");
+  }
+  const missing = firstMissingField(transcript);
+  if (missing) {
+    return reject("malformed_transcript", missing);
+  }
+
+  // 4. Freshness / expiry (bound in the transcript).
+  const expiryMs = Date.parse(transcript.expiresAt);
+  if (Number.isNaN(expiryMs)) {
+    return reject("malformed_transcript", "expiresAt");
+  }
+  if (!Number.isFinite(nowMs)) {
+    return reject("expired", "invalid-clock");
+  }
+  if (nowMs >= expiryMs) {
+    return reject("expired");
+  }
+
+  // 5. Import + curve-check the presented public key.
+  let key: KeyObject;
+  try {
+    key = importPresentedPublicKey(devicePublicKey);
+  } catch (err) {
+    return reject("invalid_public_key", err instanceof Error ? err.name : "import-failed");
+  }
+  if (!isP256PublicKey(key)) {
+    return reject("unsupported_key", "expected-prime256v1");
+  }
+
+  // 6. Bind the transcript's public-key hash to the ACTUAL presented key.
+  const actualKeyHash = canonicalDevicePublicKeyHash(key);
+  if (actualKeyHash !== transcript.devicePublicKeyHash) {
+    return reject("public_key_hash_mismatch");
+  }
+
+  // 7. Decode + structurally validate the signature (canonical raw P-1363 only).
+  let sigBytes: Buffer;
+  try {
+    sigBytes = decodeFlexibleBase64(signature.value);
+  } catch {
+    return reject("malformed_signature", "undecodable");
+  }
+  const parsed = parseCanonicalP1363Signature(sigBytes);
+  if (!parsed) {
+    return reject("malformed_signature", "expected-64-byte-raw-in-range");
+  }
+
+  // 8. Malleability: enforce low-S canonical form (reject high-S twin).
+  if (!isLowS(parsed.s)) {
+    return reject("non_canonical_signature", "high-s");
+  }
+
+  // 9. Cryptographic ECDSA verification over the canonical transcript bytes.
+  const canonicalBytes = encodeProviderApprovalTranscript(transcript);
+  let cryptoValid: boolean;
+  try {
+    cryptoValid = cryptoVerify(
+      "sha256",
+      canonicalBytes,
+      { key, dsaEncoding: "ieee-p1363" },
+      parsed.raw,
+    );
+  } catch (err) {
+    return reject("signature_mismatch", err instanceof Error ? err.name : "verify-error");
+  }
+  if (!cryptoValid) {
+    return reject("signature_mismatch");
+  }
+
+  // Possession proven. The caller binds actionDigest/owner/device to the request.
+  return {
+    ok: true,
+    algorithm: PROVIDER_APPROVAL_ALGORITHM,
+    transcriptVersion: transcript.transcriptVersion,
+    transcriptDigestHex: providerApprovalTranscriptDigestHex(transcript),
+    devicePublicKeyHash: actualKeyHash,
+    approvalId: transcript.approvalId,
+    actionDigest: transcript.actionDigest,
+    decidedByPrincipalId: transcript.decidedByPrincipalId,
+    expiresAt: transcript.expiresAt,
+  };
+}
+
+// ─── Factory (stable seam) ───
+
+export function createFridayProviderApprovalPoPVerifier(): FridayProviderApprovalPoPVerifier {
+  return { verifyPossession };
+}

--- a/src/api/auth/device-attest/friday-provider-approval-transcript.types.ts
+++ b/src/api/auth/device-attest/friday-provider-approval-transcript.types.ts
@@ -1,0 +1,160 @@
+// ─── SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 ───
+//
+// Server-side proof-of-possession (PoP) verifier types for the DEVICE-AUTHORED
+// provider-mutation approval transcript.
+//
+// SCOPE (binding): this module verifies a CANONICAL provider-approval transcript
+// + a P-256 ECDSA signature over it. It proves the signer holds the private key
+// for the presented public key and that the signed transcript binds every
+// approval field (approvalId / actionDigest / decidedByPrincipalId / expiry /
+// public-key-hash). It does NOT — and MUST NOT — assert key protection, grant
+// owner authority, mutate any store, or bind the transcript to the request/owner:
+// the CALLER (the mutating-action gate + the confirm route) performs the
+// action-digest / owner-device binding after this pure PoP check succeeds.
+//
+// The Hub holds NO signing key on this path. The approval is authored (signed) by
+// the owner's protected device key; the Hub can ONLY verify it with the presented
+// PUBLIC key. This is the SEC-APPROVAL-AUTHORITY-001 verify-only Hub contract —
+// the symmetric-HMAC "Hub self-sign" minter is removed from the confirm path.
+
+/** The single canonical transcript encoding version accepted by this verifier. */
+export type ProviderApprovalTranscriptVersion = "friday-provider-approval-v1";
+
+/**
+ * The single canonical signature algorithm: ECDSA over NIST P-256 with SHA-256,
+ * IEEE P-1363 fixed-width raw (r‖s) encoding, low-S (canonical) enforced.
+ */
+export type ProviderApprovalSignatureAlgorithm = "ECDSA_P256_SHA256";
+
+// ─── Canonical transcript fields ───
+
+/**
+ * The full set of fields bound by the canonical provider-approval transcript. The
+ * signature is computed over the deterministic encoding of ALL of these; a change
+ * to ANY field changes the signed bytes and therefore fails verification.
+ */
+export interface ProviderApprovalTranscript {
+  /** Explicit, allow-listed transcript-encoding version. */
+  transcriptVersion: ProviderApprovalTranscriptVersion;
+  /** Explicit, allow-listed signature algorithm (bound INTO the transcript). */
+  algorithm: ProviderApprovalSignatureAlgorithm;
+  /** Fixed claim-kind discriminator. */
+  kind: "provider_mutation_approval";
+  /** Unique id the owner device assigns to this single approval. */
+  approvalId: string;
+  /**
+   * The EXACT mutating-action digest being approved. The gate recomputes this
+   * server-side from the request that actually arrives; a drift changes the
+   * digest and the signature no longer covers it (fail closed).
+   */
+  actionDigest: string;
+  /**
+   * The owner principal that authored the approval. MUST equal the authenticated
+   * owner AND (via the device-owner principal id) the hash of the signing key.
+   */
+  decidedByPrincipalId: string;
+  /** Absolute expiry (ISO-8601) after which the approval is stale. */
+  expiresAt: string;
+  /**
+   * SHA-256 hex digest of the canonical SPKI DER of the device public key. The
+   * verifier recomputes this from the presented key and rejects on mismatch, so
+   * the signed transcript is cryptographically bound to a specific public key.
+   */
+  devicePublicKeyHash: string;
+}
+
+// ─── Presented public key + signature ───
+
+/**
+ * The device public key presented alongside the transcript + signature. SPKI DER
+ * (base64/base64url) or SPKI PEM. Normalized to canonical SPKI DER before hashing
+ * + verifying; a non-P-256 key is rejected.
+ */
+export type ProviderApprovalPresentedPublicKey =
+  | { encoding: "spki-der-base64"; value: string }
+  | { encoding: "spki-pem"; value: string };
+
+/**
+ * The canonical signature encoding: IEEE P-1363 fixed-width raw (r‖s), exactly 64
+ * bytes, base64/base64url. DER / alternate encodings are rejected as malformed.
+ */
+export interface ProviderApprovalPresentedSignature {
+  encoding: "ieee-p1363-base64";
+  value: string;
+}
+
+/**
+ * The self-describing device proof: the signed transcript + the public key that
+ * signed it + the raw P-1363 signature. This is what the client sends and what
+ * the Hub verifies with the PUBLIC key only.
+ */
+export interface ProviderApprovalDeviceProof {
+  transcript: ProviderApprovalTranscript;
+  devicePublicKey: ProviderApprovalPresentedPublicKey;
+  signature: ProviderApprovalPresentedSignature;
+}
+
+// ─── Verifier input ───
+
+export interface VerifyProviderApprovalPossessionInput {
+  transcript: ProviderApprovalTranscript;
+  devicePublicKey: ProviderApprovalPresentedPublicKey;
+  signature: ProviderApprovalPresentedSignature;
+  /** Wall-clock epoch milliseconds used for the freshness (expiry) gate. */
+  nowMs: number;
+}
+
+// ─── Typed failure reasons (discriminated, never thrown strings) ───
+
+export type ProviderApprovalPoPRejectReason =
+  | "unsupported_transcript_version"
+  | "unsupported_algorithm"
+  | "malformed_transcript"
+  | "expired"
+  | "invalid_public_key"
+  | "unsupported_key"
+  | "public_key_hash_mismatch"
+  | "malformed_signature"
+  | "non_canonical_signature"
+  | "signature_mismatch";
+
+// ─── Verifier result (discriminated union) ───
+
+export interface ProviderApprovalPoPSuccess {
+  ok: true;
+  algorithm: ProviderApprovalSignatureAlgorithm;
+  transcriptVersion: ProviderApprovalTranscriptVersion;
+  /** SHA-256 hex of the canonical transcript bytes that were verified. */
+  transcriptDigestHex: string;
+  /** SHA-256 hex of the canonical SPKI DER of the verified public key. */
+  devicePublicKeyHash: string;
+  /** The verified approval fields (trusted ONLY after crypto verification). */
+  approvalId: string;
+  actionDigest: string;
+  decidedByPrincipalId: string;
+  expiresAt: string;
+}
+
+export interface ProviderApprovalPoPFailure {
+  ok: false;
+  reason: ProviderApprovalPoPRejectReason;
+  /** Non-sensitive diagnostic detail. NEVER contains key material or a signature. */
+  detail?: string;
+}
+
+export type ProviderApprovalPoPResult =
+  | ProviderApprovalPoPSuccess
+  | ProviderApprovalPoPFailure;
+
+// ─── Stable verifier seam ───
+
+export interface FridayProviderApprovalPoPVerifier {
+  /**
+   * Stateless verification of transcript-field binding + P-256 ECDSA
+   * proof-of-possession. Pure: no side effects, grants NO authority, performs NO
+   * request/owner binding (the caller does that with the returned fields).
+   */
+  verifyPossession(
+    input: VerifyProviderApprovalPossessionInput,
+  ): ProviderApprovalPoPResult;
+}

--- a/src/api/auth/device-attest/index.ts
+++ b/src/api/auth/device-attest/index.ts
@@ -50,3 +50,31 @@ export {
   ownerClaimTranscriptDigestHex,
   parseCanonicalP1363Signature,
 } from "./friday-owner-claim-transcript.js";
+
+// ─── SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 — device-authored provider approval ───
+
+export type {
+  FridayProviderApprovalPoPVerifier,
+  ProviderApprovalDeviceProof,
+  ProviderApprovalPoPFailure,
+  ProviderApprovalPoPRejectReason,
+  ProviderApprovalPoPResult,
+  ProviderApprovalPoPSuccess,
+  ProviderApprovalPresentedPublicKey,
+  ProviderApprovalPresentedSignature,
+  ProviderApprovalSignatureAlgorithm,
+  ProviderApprovalTranscript,
+  ProviderApprovalTranscriptVersion,
+  VerifyProviderApprovalPossessionInput,
+} from "./friday-provider-approval-transcript.types.js";
+
+export {
+  PROVIDER_APPROVAL_ALGORITHM,
+  PROVIDER_APPROVAL_ALLOWED_ALGORITHMS,
+  PROVIDER_APPROVAL_ALLOWED_TRANSCRIPT_VERSIONS,
+  PROVIDER_APPROVAL_KIND,
+  PROVIDER_APPROVAL_TRANSCRIPT_VERSION,
+  createFridayProviderApprovalPoPVerifier,
+  encodeProviderApprovalTranscript,
+  providerApprovalTranscriptDigestHex,
+} from "./friday-provider-approval-transcript.js";

--- a/src/api/auth/friday-auth-service.ts
+++ b/src/api/auth/friday-auth-service.ts
@@ -1,5 +1,7 @@
 import * as crypto from "node:crypto";
 
+import type Database from "better-sqlite3";
+
 import { FridayDomainError } from "#errors";
 
 import type {
@@ -14,6 +16,8 @@ import type {
   FridayAuthDeviceClaimResponse,
   FridayAuthDeviceReadbackRequest,
   FridayAuthDeviceReadbackResponse,
+  FridayAuthLoginChallengeRequest,
+  FridayAuthLoginChallengeResponse,
   FridayAuthMeResponse,
   FridayAuthMigrateChallengeRequest,
   FridayAuthMigrateChallengeResponse,
@@ -216,10 +220,16 @@ const READBACK_MAX_TRANSCRIPT_TTL_MS = 5 * 60 * 1000;
  * The PoP verifier enforces the transcript's own `expiresAt` but imposes NO upper
  * bound, so a client could otherwise mint a far-future login transcript once and
  * replay it indefinitely. Clamp the accepted window so a login proof is
- * short-lived by construction. NOTE: the AUTHORITATIVE anti-spoof / anti-replay
- * control that GATES minting is the native-IPC caller-identity precondition
- * (`isDeviceOwnerAuthorityEnabled`); a server-issued single-use login-challenge
- * nonce would be a defence-in-depth hardening follow-up.
+ * short-lived by construction.
+ *
+ * ANTI-REPLAY CONTROL HIERARCHY (corrected — Advisor #1628 finding #2): the PRIMARY
+ * anti-replay control is the server-issued single-use `device_login_challenge`
+ * nonce, CAS-consumed inside the SAME transaction that mints the session (a
+ * replayed login finds it consumed → mints NOTHING). This TTL clamp and the native
+ * `isDeviceOwnerAuthorityEnabled` gate are DEFENCE-IN-DEPTH on top of it — the
+ * native gate additionally decides whether a device may carry owner authority AT
+ * ALL (hard-wired off today), and the clamp bounds a proof's freshness window; but
+ * neither is what makes a proof single-use. The single-use nonce is.
  */
 const LOGIN_MAX_TRANSCRIPT_TTL_MS = 5 * 60 * 1000;
 
@@ -643,7 +653,16 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
    * device-key login is not a weaker session, it is the SAME session anchored on a
    * different possession proof.
    */
-  function mintSession(
+  /**
+   * Perform the session-mint WRITES against an ALREADY-OPEN write transaction
+   * (session row + rotating refresh token + registered access token + last_login
+   * stamp) and return the login response. Extracted from `mintSession` so a caller
+   * that must mint ATOMICALLY with another write (e.g. the device-key login's
+   * single-use login-challenge CAS-consume) can run both in ONE transaction — a
+   * rollback then unwinds BOTH the consume and the mint together.
+   */
+  function mintSessionWrites(
+    db: Database.Database,
     user: FridayUserRow,
     ip?: string,
     userAgent?: string,
@@ -656,30 +675,28 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
       new Date(now).getTime() + deps.refreshTokenTtlSec * 1000,
     ).toISOString();
 
-    deps.db.withWriteTransaction((db) => {
-      sessionRepo.create(db, {
-        id: sessionId,
-        userId: user.id,
-        refreshTokenHash: refreshHash,
-        expiresAt,
-        ipAddress: ip,
-        userAgent,
-        now,
-      });
-      deps.registerIssuedAccessToken?.(db, {
-        tokenId: accessTokenClaims.tokenId,
-        sessionId,
-        userId: user.id,
-        expiresAtEpoch: accessTokenClaims.exp,
-        now,
-      });
-
-      db.prepare("UPDATE users SET last_login_at = ?, updated_at = ? WHERE id = ?").run(
-        now,
-        now,
-        user.id,
-      );
+    sessionRepo.create(db, {
+      id: sessionId,
+      userId: user.id,
+      refreshTokenHash: refreshHash,
+      expiresAt,
+      ipAddress: ip,
+      userAgent,
+      now,
     });
+    deps.registerIssuedAccessToken?.(db, {
+      tokenId: accessTokenClaims.tokenId,
+      sessionId,
+      userId: user.id,
+      expiresAtEpoch: accessTokenClaims.exp,
+      now,
+    });
+
+    db.prepare("UPDATE users SET last_login_at = ?, updated_at = ? WHERE id = ?").run(
+      now,
+      now,
+      user.id,
+    );
 
     return {
       accessToken,
@@ -692,6 +709,14 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         role: user.role as FridayRole,
       },
     };
+  }
+
+  function mintSession(
+    user: FridayUserRow,
+    ip?: string,
+    userAgent?: string,
+  ): FridayLoginResponse {
+    return deps.db.withWriteTransaction((db) => mintSessionWrites(db, user, ip, userAgent));
   }
 
   /**
@@ -802,6 +827,22 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         "Proof-of-possession transcript was not minted for device-key login.",
       );
     }
+    // ── Require a SERVER-ISSUED single-use login-challenge nonce (Advisor #1628
+    // finding #2) ── The signed transcript MUST carry the nonce from a fresh
+    // `device_login_challenge` (issued by issueLoginChallenge). A blank/absent nonce
+    // is refused up-front; the AUTHORITATIVE single-use gate is the CAS-consume in
+    // the mint transaction below (a value that does not match a LIVE challenge for
+    // THIS device/origin yields changes=0 there). This is the PRIMARY anti-replay
+    // control — a captured owner-login transcript can never be replayed to mint a
+    // second session.
+    const loginNonce = proof.transcript.nonce.trim();
+    if (!loginNonce) {
+      recordFailure(lockoutKey, ip);
+      throw new FridayAuthError(
+        "INVALID_CREDENTIALS",
+        "Device-key login requires a server-issued single-use challenge nonce.",
+      );
+    }
     const pop = ownerClaimPoPVerifier.verifyPossession({
       transcript: proof.transcript,
       devicePublicKey: { encoding: "spki-der-base64", value: devicePublicKey },
@@ -840,8 +881,51 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
       );
     }
 
+    // ── PRIMARY anti-replay: single-use login-challenge CAS-consume ⊗ session mint,
+    // ATOMICALLY in ONE write transaction ──
+    // The login-challenge nonce is CAS-consumed BEFORE the session is minted, in the
+    // SAME transaction. On the FIRST valid login the consume flips exactly one row
+    // (changes=1) and the mint runs. On a REPLAY (same signed transcript submitted
+    // again) the challenge is already consumed → changes=0 → we throw, the whole unit
+    // ROLLS BACK, and NO second token pair / session / last_login write survives
+    // (ZERO state change). The gate also binds origin + deviceId + devicePublicKeyHash,
+    // so a nonce minted for a different device/origin/key never consumes here. This is
+    // reached ONLY past the honesty gate above, so an attestation-disabled build never
+    // burns the nonce (it fails closed earlier with the nonce still live).
+    const now = deps.nowIso();
+    const loginNonceHash = sha256Hex(loginNonce);
+    let response: FridayLoginResponse;
+    try {
+      response = deps.db.withWriteTransaction((db) => {
+        const consumed = bootstrapNonceRepo.consumeLoginChallengeNonce(db, {
+          nonceHash: loginNonceHash,
+          origin,
+          nowIso: now,
+          deviceId,
+          // Equals sha256Hex(devicePublicKey); already asserted == the sentinel-bound
+          // owner key hash above, so a login for a non-owner key never reaches here.
+          devicePublicKeyHash: boundKeyHash,
+        });
+        if (consumed !== 1) {
+          throw new FridayAuthError(
+            "INVALID_CREDENTIALS",
+            "Login challenge is invalid, expired, cross-origin, bound to a different device, or already used.",
+          );
+        }
+        return mintSessionWrites(db, localUser, ip, userAgent);
+      });
+    } catch (err) {
+      // A consumed/replayed/expired challenge is a rejected login → record the
+      // failure (rate-limit a replay attacker) and re-throw. The mint writes never
+      // throw INVALID_CREDENTIALS, so this only fires for the CAS refusal.
+      if (err instanceof FridayAuthError && err.code === "INVALID_CREDENTIALS") {
+        recordFailure(lockoutKey, ip);
+      }
+      throw err;
+    }
+
     resetFailures(lockoutKey, ip);
-    return mintSession(localUser, ip, userAgent);
+    return response;
   }
 
   return {
@@ -986,6 +1070,80 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         osUser,
         origin,
         action,
+        createdAt: now,
+        expiresAt,
+      };
+    },
+
+    issueLoginChallenge(
+      request: FridayAuthLoginChallengeRequest,
+      ip?: string,
+    ): FridayAuthLoginChallengeResponse {
+      // Loopback-only, mirroring the bootstrap-challenge ingress boundary.
+      if (!isLocalhostAddress(ip)) {
+        throw new FridayDomainError(
+          "AUTH_LOGIN_CHALLENGE_NOT_ALLOWED",
+          "Login challenge is only allowed from localhost.",
+          { httpStatus: 403 },
+        );
+      }
+
+      const installId = (request.installId ?? "").trim();
+      const osUser = (request.osUser ?? "").trim();
+      const origin = (request.origin ?? "").trim();
+      const deviceId = (request.deviceId ?? "").trim();
+      const devicePublicKey = (request.devicePublicKey ?? "").trim();
+      const action =
+        (request.action ?? LOGIN_TRANSCRIPT_ACTION).trim() || LOGIN_TRANSCRIPT_ACTION;
+      if (!installId || !osUser || !origin || !deviceId || !devicePublicKey) {
+        throw new FridayDomainError(
+          "VALIDATION_ERROR",
+          "installId, osUser, origin, deviceId and devicePublicKey are required to issue a login challenge",
+          { httpStatus: 400 },
+        );
+      }
+
+      const now = deps.nowIso();
+      const expiresAt = new Date(
+        new Date(now).getTime() + bootstrapNonceTtlSec * 1000,
+      ).toISOString();
+      const challengeId = deps.idGenerator();
+      // Raw nonce is returned ONCE; only its hash is persisted. The device binding
+      // (deviceId + key hash) is stamped at ISSUE so the consume CAS gates on it —
+      // a challenge minted for device A can never be consumed by a login presenting
+      // device B or a different key, even if the raw nonce leaked.
+      const nonce = generateBootstrapNonce();
+      const nonceHash = sha256Hex(nonce);
+      const devicePublicKeyHash = sha256Hex(devicePublicKey);
+
+      deps.db.withWriteTransaction((db) => {
+        bootstrapNonceRepo.insertLoginChallengeNonce(db, {
+          id: challengeId,
+          nonceHash,
+          hubId: bootstrapHubId,
+          installId,
+          osUser,
+          origin,
+          action,
+          deviceId,
+          devicePublicKey,
+          devicePublicKeyHash,
+          createdAt: now,
+          expiresAt,
+        });
+      });
+
+      return {
+        challengeId,
+        nonce,
+        kind: "device_login_challenge",
+        hubId: bootstrapHubId,
+        installId,
+        osUser,
+        origin,
+        action,
+        deviceId,
+        devicePublicKeyHash,
         createdAt: now,
         expiresAt,
       };

--- a/src/api/auth/friday-auth-service.ts
+++ b/src/api/auth/friday-auth-service.ts
@@ -628,6 +628,31 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
     return deps.db.withReadConnection((db) => userRepo.findLocalUser(db));
   }
 
+  /**
+   * SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 (Option B*): resolve the durable
+   * owner↔device binding SERVER-SIDE for an authenticated user, WITHOUT changing
+   * token minting (`principalId` stays `user.id`). Reads the user's
+   * `users.password_hash`; if it is the device-owner sentinel
+   * (`device-owner$v1$<sha256Hex(SPKI-DER base64 string)>`) it returns the bound
+   * device's sentinel hash (the `<hash>` portion), else `null` (no device binding —
+   * e.g. a passphrase owner or a first-boot NULL slot). The provider-approval seam
+   * consumes this to bind a device-authored approval to the authenticated owner's
+   * REGISTERED device using the SAME hashing convention `deviceKeyLogin` already
+   * trusts (`sha256Hex(devicePublicKey)`), so no NEW hash is introduced. This never
+   * mints, never grants, and never touches the SEC-SETUP claim/login/nonce hashing.
+   */
+  function resolveBoundDeviceOwnerSentinelHash(userId: string): string | null {
+    const trimmed = userId.trim();
+    if (!trimmed) return null;
+    const user = findUserById(trimmed);
+    const storedHash = user?.password_hash;
+    if (!storedHash || !storedHash.startsWith(DEVICE_OWNER_HASH_PREFIX)) {
+      return null;
+    }
+    const boundKeyHash = storedHash.slice(DEVICE_OWNER_HASH_PREFIX.length).trim();
+    return boundKeyHash.length > 0 ? boundKeyHash : null;
+  }
+
   function resolveTenantId(user: FridayUserRow): string {
     const role = user.role as FridayRole;
     return normalizeTenantId(
@@ -1029,6 +1054,7 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
   }
 
   return {
+    resolveBoundDeviceOwnerSentinelHash,
     getBootstrapStatus(): FridayAuthBootstrapStatusResponse {
       const localUser = findLocalUser();
       const bootstrapRequired = Boolean(

--- a/src/api/auth/friday-auth-service.ts
+++ b/src/api/auth/friday-auth-service.ts
@@ -57,8 +57,16 @@ import type {
 } from "./device-attest/index.js";
 import {
   deriveDeviceKeyProtection,
-  isDeviceOwnerAuthorityEnabled,
+  type FridayDeviceKeyProtection,
+  isReleaseTrustedKeyProtection,
 } from "../../security/friday-device-owner-authority-precondition.js";
+import {
+  consumeVerifiedNativeOwnerClaimContext,
+  createAbsentNativeOwnerClaimResolver,
+  deriveNativeOwnerExchangeConnectionId,
+  type NativeOwnerClaimBinding,
+  type NativeOwnerClaimContextResolver,
+} from "../../security/attestation/friday-verified-native-owner-claim-context.js";
 
 // ─── Helpers ───
 
@@ -222,16 +230,70 @@ const READBACK_MAX_TRANSCRIPT_TTL_MS = 5 * 60 * 1000;
  * replay it indefinitely. Clamp the accepted window so a login proof is
  * short-lived by construction.
  *
- * ANTI-REPLAY CONTROL HIERARCHY (corrected — Advisor #1628 finding #2): the PRIMARY
- * anti-replay control is the server-issued single-use `device_login_challenge`
- * nonce, CAS-consumed inside the SAME transaction that mints the session (a
- * replayed login finds it consumed → mints NOTHING). This TTL clamp and the native
- * `isDeviceOwnerAuthorityEnabled` gate are DEFENCE-IN-DEPTH on top of it — the
- * native gate additionally decides whether a device may carry owner authority AT
- * ALL (hard-wired off today), and the clamp bounds a proof's freshness window; but
- * neither is what makes a proof single-use. The single-use nonce is.
+ * ANTI-REPLAY CONTROL HIERARCHY (Option C): the PRIMARY anti-replay control is the
+ * server-issued single-use `device_login_challenge` nonce, CAS-consumed inside the
+ * SAME transaction that mints the session (a replayed login finds it consumed →
+ * mints NOTHING). This TTL clamp and the per-claim `VerifiedNativeOwnerClaimContext`
+ * consume are DEFENCE-IN-DEPTH on top of it — the capability additionally decides
+ * whether THIS request carries owner authority AT ALL (absent on this tree), and the
+ * clamp bounds a proof's freshness window; but neither is what makes a proof
+ * single-use. The single-use nonce is.
  */
 const LOGIN_MAX_TRANSCRIPT_TTL_MS = 5 * 60 * 1000;
+
+// ─── CR-1 Option C — opaque per-claim native-owner capability binding ───
+
+/**
+ * The pinned artifact role the attested owner-device app binary must fill. Bound
+ * into every capability; the pinned code-sign policy refuses a validly-signed peer
+ * filling a DIFFERENT role (helper vs. main app).
+ */
+const OWNER_DEVICE_ARTIFACT_ROLE = "friday.owner-device.app" as const;
+
+/**
+ * The fixed presentation channel for the native install-IPC device claim/login
+ * exchange. Bound into the capability so a capability minted for the native IPC
+ * channel can never be consumed for a different channel.
+ */
+const NATIVE_OWNER_CLAIM_CHANNEL = "install-ipc" as const;
+
+/**
+ * Freshness window (epoch-ms) for a minted per-claim capability, aligned with the
+ * 300s bootstrap/login nonce TTL. The capability is dead past this instant even if
+ * every bound field still matches — expiry ⇒ refusal ⇒ zero state change.
+ */
+const NATIVE_OWNER_CAPABILITY_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Build the request-derived binding an opaque `VerifiedNativeOwnerClaimContext`
+ * must be bound to. Every field comes from THIS request's authoritative context —
+ * never from the capability's own self-assertion.
+ */
+function buildNativeOwnerClaimBinding(input: {
+  hubId: string;
+  installId: string;
+  osUser: string;
+  origin: string;
+  action: string;
+  nonce: string;
+  nowMs: number;
+  deviceId: string;
+  devicePublicKeyHash: string;
+}): NativeOwnerClaimBinding {
+  return {
+    hubId: input.hubId,
+    installId: input.installId,
+    osUser: input.osUser,
+    origin: input.origin,
+    channel: NATIVE_OWNER_CLAIM_CHANNEL,
+    action: input.action,
+    nonce: input.nonce,
+    expiresAtMs: input.nowMs + NATIVE_OWNER_CAPABILITY_TTL_MS,
+    deviceId: input.deviceId,
+    devicePublicKeyHash: input.devicePublicKeyHash,
+    artifactRole: OWNER_DEVICE_ARTIFACT_ROLE,
+  };
+}
 
 function isLocalhostAddress(addr?: string): boolean {
   return isFridayLoopbackAddress(addr);
@@ -418,13 +480,26 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
   const warn = deps.warn ?? console.warn;
   const warnOnce = createWarnOnce(warn);
   const rateLimiter = deps.rateLimiter;
-  // SEC-SETUP-BOOTSTRAP-001 (CR-1): the SOLE device-owner authority predicate.
-  // Defaults to the real, server-derived, fail-closed precondition (hard-wired
-  // false today — native-IPC attestation is absent). Injectable ONLY for tests
-  // that exercise the enabled branch without flipping the compile-time constant;
-  // production never overrides it, so the native gate is never faked here.
-  const deviceOwnerAuthorityEnabled =
-    deps.deviceOwnerAuthorityEnabled ?? (() => isDeviceOwnerAuthorityEnabled());
+  // CR-1 Option C: the SOLE device-owner authority is now an OPAQUE, per-claim
+  // `VerifiedNativeOwnerClaimContext` resolved from the native IPC accept boundary
+  // — NOT a global boolean. The default resolver is honestly ABSENT on this
+  // dev/CI tree (returns null → every device claim/login fails closed with ZERO
+  // state change). Production wires a resolver backed by the Companion Unix-socket
+  // peercred+codesign accept boundary; tests inject a resolver that runs the REAL
+  // mint over injected native-evidence doubles (the brand makes a forged literal
+  // impossible, so no request/env/test seam can fabricate authority).
+  const resolveNativeOwnerClaimContext: NativeOwnerClaimContextResolver =
+    deps.resolveNativeOwnerClaimContext ?? createAbsentNativeOwnerClaimResolver();
+  // Presence signal for getBootstrapStatus ONLY — reports whether the native claim
+  // surface currently exists, WITHOUT minting or authorizing any request. Defaults
+  // to false (no native surface on this tree).
+  const nativeOwnerClaimSurfaceAvailable =
+    deps.nativeOwnerClaimSurfaceAvailable ?? (() => false);
+  // CR-1 Option C (finding #6): on a fresh RELEASE profile, passphrase bootstrap is
+  // NOT offered (device-native only). Gates ONLY the creation of a fresh passphrase
+  // owner — legacy passphrase LOGIN + migration/recovery stay available. Defaults
+  // to false (dev/CI: passphrase bootstrap allowed).
+  const releaseProfileNativeOnly = deps.releaseProfileNativeOnly ?? (() => false);
   const warnSinkMeta = warn as unknown as { mock?: unknown };
   const suppressExpectedTestWarnings = isFridayTestSecurityWarningSuppressed()
     && warn === console.warn
@@ -734,12 +809,14 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
    *   - This path REQUIRES the sentinel prefix, so a scrypt/legacy passphrase owner
    *     (or a first-boot NULL slot) can never be logged in via the device path.
    *
-   * Honesty gate: possession of a SOFTWARE device key is insufficient to carry
-   * release-profile owner authority. Minting is gated on `deviceOwnerAuthorityEnabled()`
-   * — the server-derived native-IPC attestation precondition, hard-wired false on
-   * this build. So today this ALWAYS fails closed (the caller falls back to the
-   * passphrase gate); it starts minting the moment attestation lands, WITHOUT this
-   * code faking it.
+   * Honesty gate (Option C): possession of a SOFTWARE device key is insufficient
+   * to mint a session. Minting requires an OPAQUE per-claim
+   * `VerifiedNativeOwnerClaimContext` bound to THIS request, resolved from the
+   * native IPC accept boundary and CONSUMED atomically with the login-challenge CAS
+   * + session mint. On this dev/CI tree the boundary is honestly absent → the
+   * resolver returns null → the consume fails closed (DEVICE_AUTHORITY_DISABLED)
+   * with the challenge STILL LIVE. Nothing global authorizes; it starts minting the
+   * moment a real native accept boundary is wired, WITHOUT this code faking it.
    */
   function deviceKeyLogin(
     request: FridayLoginRequest,
@@ -868,35 +945,58 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
       );
     }
 
-    // ── HONEST NATIVE-IPC GATE (fail-closed, checked AFTER full validation) ──
-    // Even a cryptographically VALID software-key PoP does NOT mint a session
-    // unless device-owner authority is enabled. Today that is hard-wired false
-    // (native-IPC attestation absent), so this ALWAYS fails closed and the caller
-    // falls back to the passphrase path. Not a credential failure → no lockout
-    // increment (the PoP was valid; the capability is simply disabled).
-    if (!deviceOwnerAuthorityEnabled()) {
-      throw new FridayAuthError(
-        "DEVICE_AUTHORITY_DISABLED",
-        "Device-bound owner authority is disabled on this build (native-IPC attestation unavailable).",
-      );
-    }
+    // ── OPAQUE PER-CLAIM NATIVE-OWNER CAPABILITY GATE (Option C) ──
+    // A cryptographically VALID software-key PoP is NOT sufficient to mint a
+    // session: the login must ALSO present a `VerifiedNativeOwnerClaimContext`
+    // bound to THIS exact request (hub/install/os-user/origin/channel/action/nonce/
+    // device/key/role + accepted native connection), minted ONLY inside the native
+    // IPC accept boundary from real peercred + code-sign attestation + release-
+    // trusted key custody. Nothing global authorizes. On this dev/CI tree the
+    // boundary is honestly absent → the resolver returns null → the consume below
+    // fails closed (DEVICE_AUTHORITY_DISABLED) with the login challenge STILL LIVE.
+    const loginBinding = buildNativeOwnerClaimBinding({
+      hubId: bootstrapHubId,
+      installId: proof.transcript.installId.trim(),
+      osUser: proof.transcript.osUser.trim(),
+      origin,
+      action: LOGIN_TRANSCRIPT_ACTION,
+      nonce: loginNonce,
+      nowMs,
+      deviceId,
+      devicePublicKeyHash: boundKeyHash,
+    });
+    const loginCapability = resolveNativeOwnerClaimContext(loginBinding);
 
-    // ── PRIMARY anti-replay: single-use login-challenge CAS-consume ⊗ session mint,
-    // ATOMICALLY in ONE write transaction ──
-    // The login-challenge nonce is CAS-consumed BEFORE the session is minted, in the
-    // SAME transaction. On the FIRST valid login the consume flips exactly one row
-    // (changes=1) and the mint runs. On a REPLAY (same signed transcript submitted
-    // again) the challenge is already consumed → changes=0 → we throw, the whole unit
-    // ROLLS BACK, and NO second token pair / session / last_login write survives
-    // (ZERO state change). The gate also binds origin + deviceId + devicePublicKeyHash,
-    // so a nonce minted for a different device/origin/key never consumes here. This is
-    // reached ONLY past the honesty gate above, so an attestation-disabled build never
-    // burns the nonce (it fails closed earlier with the nonce still live).
+    // ── PRIMARY anti-replay: capability consume ⊗ single-use login-challenge
+    // CAS-consume ⊗ session mint, ATOMICALLY in ONE write transaction ──
+    // The capability is consumed FIRST; a refusal throws BEFORE the nonce CAS, so
+    // the whole unit ROLLS BACK with the challenge STILL LIVE (an attestation-
+    // disabled build never burns the nonce). Past it, the login-challenge nonce is
+    // CAS-consumed BEFORE the session is minted, in the SAME transaction: the first
+    // valid login flips exactly one row (changes=1) and mints; a REPLAY finds the
+    // challenge consumed → changes=0 → throw → the whole unit rolls back with NO
+    // second token pair / session / last_login write (ZERO state change). The nonce
+    // gate binds origin + deviceId + devicePublicKeyHash, so a nonce minted for a
+    // different device/origin/key never consumes here.
     const now = deps.nowIso();
     const loginNonceHash = sha256Hex(loginNonce);
     let response: FridayLoginResponse;
     try {
       response = deps.db.withWriteTransaction((db) => {
+        const cap = consumeVerifiedNativeOwnerClaimContext(loginCapability, {
+          binding: loginBinding,
+          expectedConnectionId: deriveNativeOwnerExchangeConnectionId(loginBinding),
+          nowMs: Date.parse(now),
+        });
+        if (!cap.ok) {
+          // No valid per-claim capability for THIS request → fail closed. Not a
+          // credential failure (the PoP was valid) → no lockout increment. The
+          // throw precedes the nonce CAS, so the challenge stays live.
+          throw new FridayAuthError(
+            "DEVICE_AUTHORITY_DISABLED",
+            "Device-key login requires a verified native-owner capability for this request (native-IPC attestation unavailable or unverified).",
+          );
+        }
         const consumed = bootstrapNonceRepo.consumeLoginChallengeNonce(db, {
           nonceHash: loginNonceHash,
           origin,
@@ -937,10 +1037,13 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
       );
       return {
         bootstrapRequired,
-        // CR-1: device-claim is the authoritative first-run path ONLY when
-        // device-owner authority is enabled (server-derived, fail-closed). False
-        // on the current build → the UI honestly keeps the passphrase gate.
-        deviceClaimAvailable: deviceOwnerAuthorityEnabled(),
+        // CR-1 Option C: report ONLY whether the native device-claim SURFACE is
+        // present for the current native surface — this is a presence signal, it
+        // does NOT authorize any later request (authorization is the per-claim
+        // capability, resolved+consumed at claim/login time). False on this tree →
+        // the UI honestly keeps the passphrase gate. NEVER derived from a global
+        // authority boolean.
+        deviceClaimAvailable: nativeOwnerClaimSurfaceAvailable(),
       };
     },
 
@@ -952,6 +1055,18 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         throw new FridayDomainError(
           "AUTH_BOOTSTRAP_NOT_ALLOWED",
           "Bootstrap is only allowed from localhost.",
+          { httpStatus: 403 },
+        );
+      }
+
+      // Option C (finding #6): a fresh RELEASE is device-native only — passphrase
+      // bootstrap is NOT offered and there is NO silent fallback. Legacy passphrase
+      // LOGIN and migration/recovery remain available; only CREATING a fresh
+      // passphrase owner is retired here. Dev/CI (non-release) is unaffected.
+      if (releaseProfileNativeOnly()) {
+        throw new FridayDomainError(
+          "AUTH_BOOTSTRAP_PASSPHRASE_RETIRED",
+          "A fresh release is device-native only; passphrase bootstrap is not offered. Use device-owner claim, or recover an existing passphrase owner.",
           { httpStatus: 403 },
         );
       }
@@ -1237,10 +1352,6 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
           { httpStatus: 401 },
         );
       }
-      // Server-derived key-protection posture (never self-reported). Today the
-      // only reachable value is "unverified" → fail closed for release authority.
-      const keyProtection = deriveDeviceKeyProtection();
-
       const localUser = findLocalUser();
       if (!localUser) {
         throw new FridayDomainError(
@@ -1260,19 +1371,61 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
       }
 
       const now = deps.nowIso();
+      const nowMs = Date.parse(now);
       const nonceHash = sha256Hex(nonce);
       const devicePublicKeyHash = sha256Hex(devicePublicKey);
       const ownerSentinel = deviceOwnerSentinel(devicePublicKeyHash);
 
-      // Atomic, crash-safe claim: BOTH writes run in ONE write transaction, so a
-      // crash / thrown error mid-claim rolls back the whole unit — the nonce stays
-      // unconsumed AND the owner slot stays NULL (never a partial owner).
+      // ── OPAQUE PER-CLAIM NATIVE-OWNER CAPABILITY (Option C — LIVE-DEFECT FIX) ──
+      // Writing the durable device-owner sentinel is an AUTHORITY-bearing act: it
+      // seizes the single owner slot for a device key. It therefore REQUIRES a
+      // `VerifiedNativeOwnerClaimContext` bound to THIS request (minted only inside
+      // the native IPC accept boundary from real peercred + code-sign + release-
+      // trusted custody). WITHOUT a capability the claim is REFUSED with ZERO state
+      // change — no nonce consumed, no owner written. This closes the head defect
+      // where a valid software-key PoP wrote `device-owner$v1$…` + consumed the
+      // nonce with no native authority. Resolved OUTSIDE the txn (the native
+      // exchange must not hold the write lock); CONSUMED INSIDE it, atomically with
+      // the nonce CAS + owner CAS.
+      const claimBinding = buildNativeOwnerClaimBinding({
+        hubId: bootstrapHubId,
+        installId: (request.installId ?? "").trim(),
+        osUser: (request.osUser ?? "").trim(),
+        origin,
+        action: CLAIM_TRANSCRIPT_ACTION,
+        nonce,
+        nowMs,
+        deviceId,
+        devicePublicKeyHash,
+      });
+      const claimCapability = resolveNativeOwnerClaimContext(claimBinding);
+
+      // Atomic, crash-safe claim: capability consume + BOTH writes run in ONE write
+      // transaction, so a crash / thrown error mid-claim rolls back the whole unit —
+      // the nonce stays unconsumed AND the owner slot stays NULL (never a partial
+      // owner, never an authority-less write).
+      //   0. CONSUME the per-claim capability. Absent/drift/expired/replayed =>
+      //      refuse, ZERO state change (thrown BEFORE the nonce CAS).
       //   1. CAS-consume the nonce (origin/expiry/single-use gate). changes=0 =>
       //      replay / expired / cross-origin => reject, ZERO state change.
       //   2. CAS-claim the owner slot (password_hash IS NULL). changes=0 =>
       //      already claimed => 409, ZERO state change (nonce consume rolls back).
+      let grantedKeyProtection: FridayDeviceKeyProtection;
       try {
-        deps.db.withWriteTransaction((db) => {
+        grantedKeyProtection = deps.db.withWriteTransaction((db) => {
+          const cap = consumeVerifiedNativeOwnerClaimContext(claimCapability, {
+            binding: claimBinding,
+            expectedConnectionId: deriveNativeOwnerExchangeConnectionId(claimBinding),
+            nowMs,
+          });
+          if (!cap.ok) {
+            throw new FridayDomainError(
+              "AUTH_BOOTSTRAP_DEVICE_AUTHORITY_UNVERIFIED",
+              "Device owner-claim requires a verified native-owner capability for this request; refused with no state change (no owner written, no nonce consumed).",
+              { httpStatus: 401 },
+            );
+          }
+
           const consumed = bootstrapNonceRepo.consumeOwnerClaimNonce(db, {
             nonceHash,
             kind: "install_owner_claim",
@@ -1303,6 +1456,7 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
               { httpStatus: 409 },
             );
           }
+          return cap.keyProtection;
         });
       } catch (error) {
         // Defence-in-depth: the partial UNIQUE(kind) WHERE consumed_at IS NOT NULL
@@ -1324,11 +1478,11 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         userId: localUser.id,
         deviceId,
         devicePublicKeyHash,
-        // Authoritative readback: server-derived posture + the truth that this
-        // device binding carries NO owner authority in release/default (the
-        // device principal stays DISABLED until native-IPC precondition (b)).
-        keyProtection,
-        deviceAuthorityEnabled: deviceOwnerAuthorityEnabled(),
+        // Authoritative readback: the key-protection posture the consumed capability
+        // carried (release-trusted native custody), and — since a capability was
+        // consumed — this device binding now carries owner authority for THIS build.
+        keyProtection: grantedKeyProtection,
+        deviceAuthorityEnabled: isReleaseTrustedKeyProtection(grantedKeyProtection),
       };
     },
 
@@ -1614,7 +1768,11 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         keyProtection,
         // ALWAYS false in release/default — the provisional device binding
         // carries ZERO authority until native-IPC precondition (b) lands.
-        deviceAuthorityEnabled: deviceOwnerAuthorityEnabled(),
+        // Option C: this path grants ZERO owner authority (a provisional migration
+        // binding / an activated dual-read binding / a read-only posture never
+        // seizes owner login). Authority is ONLY the per-claim native capability
+        // consumed at claim/login — never a global boolean. Always false here.
+        deviceAuthorityEnabled: false,
       };
     },
 
@@ -1810,7 +1968,11 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         passphraseStillActive: true,
         // ALWAYS false in release/default — activation grants ZERO authority until
         // native-IPC precondition (b) lands.
-        deviceAuthorityEnabled: deviceOwnerAuthorityEnabled(),
+        // Option C: this path grants ZERO owner authority (a provisional migration
+        // binding / an activated dual-read binding / a read-only posture never
+        // seizes owner login). Authority is ONLY the per-claim native capability
+        // consumed at claim/login — never a global boolean. Always false here.
+        deviceAuthorityEnabled: false,
       };
     },
 
@@ -1855,7 +2017,11 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         activatedAt: row?.activated_at ?? null,
         revokedAt: row?.revoked_at ?? null,
         passphraseStillActive: true,
-        deviceAuthorityEnabled: deviceOwnerAuthorityEnabled(),
+        // Option C: this path grants ZERO owner authority (a provisional migration
+        // binding / an activated dual-read binding / a read-only posture never
+        // seizes owner login). Authority is ONLY the per-claim native capability
+        // consumed at claim/login — never a global boolean. Always false here.
+        deviceAuthorityEnabled: false,
       };
     },
 

--- a/src/api/auth/friday-auth-service.ts
+++ b/src/api/auth/friday-auth-service.ts
@@ -193,6 +193,15 @@ const CLAIM_TRANSCRIPT_ACTION = "owner-claim";
 const MIGRATE_TRANSCRIPT_ACTION = "owner-migrate";
 
 /**
+ * SEC-SETUP-BOOTSTRAP-001 (CR-1): the canonical transcript `action` a device-key
+ * LOGIN proof MUST be minted for. Because `action` is bound INTO the signed
+ * transcript bytes, a proof minted for owner-claim / owner-migrate / owner-readback
+ * can NEVER be replayed into the login leg — and a login proof can never be
+ * replayed into those legs. This is the domain separator for the login intent.
+ */
+const LOGIN_TRANSCRIPT_ACTION = "owner-login";
+
+/**
  * Server-side maximum accepted transcript TTL for a device readback (aligned with
  * the 300s bootstrap-nonce TTL). The transcript's own `expiresAt` is the freshness
  * signal, but the PoP verifier imposes NO upper bound — so a client could mint a
@@ -200,6 +209,19 @@ const MIGRATE_TRANSCRIPT_ACTION = "owner-migrate";
  * so a readback proof is short-lived by construction.
  */
 const READBACK_MAX_TRANSCRIPT_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * SEC-SETUP-BOOTSTRAP-001 (CR-1): server-side maximum accepted transcript TTL for
+ * a device-key LOGIN (aligned with the readback / bootstrap-nonce 300s window).
+ * The PoP verifier enforces the transcript's own `expiresAt` but imposes NO upper
+ * bound, so a client could otherwise mint a far-future login transcript once and
+ * replay it indefinitely. Clamp the accepted window so a login proof is
+ * short-lived by construction. NOTE: the AUTHORITATIVE anti-spoof / anti-replay
+ * control that GATES minting is the native-IPC caller-identity precondition
+ * (`isDeviceOwnerAuthorityEnabled`); a server-issued single-use login-challenge
+ * nonce would be a defence-in-depth hardening follow-up.
+ */
+const LOGIN_MAX_TRANSCRIPT_TTL_MS = 5 * 60 * 1000;
 
 function isLocalhostAddress(addr?: string): boolean {
   return isFridayLoopbackAddress(addr);
@@ -386,6 +408,13 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
   const warn = deps.warn ?? console.warn;
   const warnOnce = createWarnOnce(warn);
   const rateLimiter = deps.rateLimiter;
+  // SEC-SETUP-BOOTSTRAP-001 (CR-1): the SOLE device-owner authority predicate.
+  // Defaults to the real, server-derived, fail-closed precondition (hard-wired
+  // false today — native-IPC attestation is absent). Injectable ONLY for tests
+  // that exercise the enabled branch without flipping the compile-time constant;
+  // production never overrides it, so the native gate is never faked here.
+  const deviceOwnerAuthorityEnabled =
+    deps.deviceOwnerAuthorityEnabled ?? (() => isDeviceOwnerAuthorityEnabled());
   const warnSinkMeta = warn as unknown as { mock?: unknown };
   const suppressExpectedTestWarnings = isFridayTestSecurityWarningSuppressed()
     && warn === console.warn
@@ -607,6 +636,214 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
     }
   }
 
+  /**
+   * Mint a real session for an authenticated user (session row + rotating refresh
+   * token + registered access token + last_login stamp). Shared by the passphrase/
+   * email login path and the device-key login path so BOTH mint identically — a
+   * device-key login is not a weaker session, it is the SAME session anchored on a
+   * different possession proof.
+   */
+  function mintSession(
+    user: FridayUserRow,
+    ip?: string,
+    userAgent?: string,
+  ): FridayLoginResponse {
+    const now = deps.nowIso();
+    const sessionId = deps.idGenerator();
+    const { accessToken, refreshToken, accessTokenClaims } = generateTokenPair(user, sessionId);
+    const refreshHash = hashToken(refreshToken);
+    const expiresAt = new Date(
+      new Date(now).getTime() + deps.refreshTokenTtlSec * 1000,
+    ).toISOString();
+
+    deps.db.withWriteTransaction((db) => {
+      sessionRepo.create(db, {
+        id: sessionId,
+        userId: user.id,
+        refreshTokenHash: refreshHash,
+        expiresAt,
+        ipAddress: ip,
+        userAgent,
+        now,
+      });
+      deps.registerIssuedAccessToken?.(db, {
+        tokenId: accessTokenClaims.tokenId,
+        sessionId,
+        userId: user.id,
+        expiresAtEpoch: accessTokenClaims.exp,
+        now,
+      });
+
+      db.prepare("UPDATE users SET last_login_at = ?, updated_at = ? WHERE id = ?").run(
+        now,
+        now,
+        user.id,
+      );
+    });
+
+    return {
+      accessToken,
+      refreshToken,
+      expiresInSec: deps.accessTokenTtlSec,
+      user: {
+        id: user.id,
+        email: user.email ?? undefined,
+        displayName: user.display_name,
+        role: user.role as FridayRole,
+      },
+    };
+  }
+
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 (CR-1): device-key login mint. A machine whose owner
+   * slot was claimed by a device (users.password_hash = the non-scrypt device
+   * sentinel `device-owner$v1$<sha256Hex(devicePublicKey)>`) authenticates by
+   * proving possession of the BOUND private key — signing a fresh canonical
+   * transcript minted for action `owner-login`. On success it mints a real session
+   * mirroring the passphrase path.
+   *
+   * Cross-path safety (both directions):
+   *   - The device sentinel is NOT a valid scrypt/legacy hash, so the passphrase
+   *     path (`verifyPassword`) rejects it — a device owner can never be logged in
+   *     with a passphrase.
+   *   - This path REQUIRES the sentinel prefix, so a scrypt/legacy passphrase owner
+   *     (or a first-boot NULL slot) can never be logged in via the device path.
+   *
+   * Honesty gate: possession of a SOFTWARE device key is insufficient to carry
+   * release-profile owner authority. Minting is gated on `deviceOwnerAuthorityEnabled()`
+   * — the server-derived native-IPC attestation precondition, hard-wired false on
+   * this build. So today this ALWAYS fails closed (the caller falls back to the
+   * passphrase gate); it starts minting the moment attestation lands, WITHOUT this
+   * code faking it.
+   */
+  function deviceKeyLogin(
+    request: FridayLoginRequest,
+    ip?: string,
+    userAgent?: string,
+  ): FridayLoginResponse {
+    // Loopback-only, consistent with the device-claim family.
+    if (!isLocalhostAddress(ip)) {
+      throw new FridayAuthError(
+        "INVALID_CREDENTIALS",
+        "Device-key login is only allowed from localhost.",
+      );
+    }
+
+    const localUser = findLocalUser();
+    if (!localUser) {
+      throw new FridayAuthError("USER_NOT_FOUND", "No local user configured");
+    }
+    const lockoutKey = `device:${localUser.id}`;
+    checkLockout(lockoutKey, ip);
+
+    // ── Cross-path guard: ONLY a device-claimed owner may device-login ──
+    // The AUTHORITATIVE, durable owner<->device binding is users.password_hash =
+    // the device sentinel (the consumed install-nonce row is reaped on a retention
+    // horizon and is NOT relied upon here). A scrypt/legacy passphrase owner or a
+    // first-boot NULL slot is refused, so this path can never authenticate a
+    // passphrase owner.
+    const storedHash = localUser.password_hash;
+    if (!storedHash || !storedHash.startsWith(DEVICE_OWNER_HASH_PREFIX)) {
+      recordFailure(lockoutKey, ip);
+      throw new FridayAuthError(
+        "INVALID_CREDENTIALS",
+        "No device-bound owner is configured for this machine.",
+      );
+    }
+    const boundKeyHash = storedHash.slice(DEVICE_OWNER_HASH_PREFIX.length);
+
+    const devicePublicKey = (request.devicePublicKey ?? "").trim();
+    const deviceId = (request.deviceId ?? "").trim();
+    const origin = (request.origin ?? "").trim();
+    if (!devicePublicKey || !deviceId || !origin) {
+      recordFailure(lockoutKey, ip);
+      throw new FridayAuthError(
+        "INVALID_CREDENTIALS",
+        "devicePublicKey, deviceId and origin are required for device-key login.",
+      );
+    }
+
+    // ── Bind the presented key to the durable owner<->device binding ──
+    // The presented key MUST hash to the sentinel-bound value (the SAME sha256Hex
+    // the claim path wrote), so a possession-proof for a DIFFERENT key cannot log
+    // in this owner.
+    if (sha256Hex(devicePublicKey) !== boundKeyHash) {
+      recordFailure(lockoutKey, ip);
+      throw new FridayAuthError(
+        "INVALID_CREDENTIALS",
+        "Presented device key is not the bound owner device key.",
+      );
+    }
+
+    // ── Proof-of-possession over a FRESH owner-login transcript ──
+    const proof = coerceDeviceClaimProof(request.deviceLoginProof);
+    if (!proof) {
+      recordFailure(lockoutKey, ip);
+      throw new FridayAuthError(
+        "INVALID_CREDENTIALS",
+        "Device-key login requires a proof-of-possession (signed transcript + signature).",
+      );
+    }
+    // Bind the signed transcript to THIS login request.
+    if (proof.transcript.origin !== origin || proof.transcript.deviceId !== deviceId) {
+      recordFailure(lockoutKey, ip);
+      throw new FridayAuthError(
+        "INVALID_CREDENTIALS",
+        "Proof-of-possession transcript does not match the login request.",
+      );
+    }
+    // Domain-separate the login intent: the transcript MUST be minted FOR
+    // owner-login. Because `action` is bound into the signed bytes, a proof minted
+    // for owner-claim / owner-migrate / owner-readback can NEVER be replayed here.
+    if (proof.transcript.action !== LOGIN_TRANSCRIPT_ACTION) {
+      recordFailure(lockoutKey, ip);
+      throw new FridayAuthError(
+        "INVALID_CREDENTIALS",
+        "Proof-of-possession transcript was not minted for device-key login.",
+      );
+    }
+    const pop = ownerClaimPoPVerifier.verifyPossession({
+      transcript: proof.transcript,
+      devicePublicKey: { encoding: "spki-der-base64", value: devicePublicKey },
+      signature: proof.signature,
+      nowMs: Date.parse(deps.nowIso()),
+    });
+    if (!pop.ok) {
+      recordFailure(lockoutKey, ip);
+      throw new FridayAuthError(
+        "INVALID_CREDENTIALS",
+        `Device proof-of-possession failed: ${pop.reason}.`,
+      );
+    }
+
+    // ── Server-side max-TTL clamp (login freshness) ──
+    const nowMs = Date.parse(deps.nowIso());
+    const expiryMs = Date.parse(proof.transcript.expiresAt);
+    if (!Number.isFinite(expiryMs) || expiryMs - nowMs > LOGIN_MAX_TRANSCRIPT_TTL_MS) {
+      recordFailure(lockoutKey, ip);
+      throw new FridayAuthError(
+        "INVALID_CREDENTIALS",
+        "Proof-of-possession transcript expiry exceeds the maximum allowed TTL.",
+      );
+    }
+
+    // ── HONEST NATIVE-IPC GATE (fail-closed, checked AFTER full validation) ──
+    // Even a cryptographically VALID software-key PoP does NOT mint a session
+    // unless device-owner authority is enabled. Today that is hard-wired false
+    // (native-IPC attestation absent), so this ALWAYS fails closed and the caller
+    // falls back to the passphrase path. Not a credential failure → no lockout
+    // increment (the PoP was valid; the capability is simply disabled).
+    if (!deviceOwnerAuthorityEnabled()) {
+      throw new FridayAuthError(
+        "DEVICE_AUTHORITY_DISABLED",
+        "Device-bound owner authority is disabled on this build (native-IPC attestation unavailable).",
+      );
+    }
+
+    resetFailures(lockoutKey, ip);
+    return mintSession(localUser, ip, userAgent);
+  }
+
   return {
     getBootstrapStatus(): FridayAuthBootstrapStatusResponse {
       const localUser = findLocalUser();
@@ -616,6 +853,10 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
       );
       return {
         bootstrapRequired,
+        // CR-1: device-claim is the authoritative first-run path ONLY when
+        // device-owner authority is enabled (server-derived, fail-closed). False
+        // on the current build → the UI honestly keeps the passphrase gate.
+        deviceClaimAvailable: deviceOwnerAuthorityEnabled(),
       };
     },
 
@@ -929,7 +1170,7 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         // device binding carries NO owner authority in release/default (the
         // device principal stays DISABLED until native-IPC precondition (b)).
         keyProtection,
-        deviceAuthorityEnabled: isDeviceOwnerAuthorityEnabled(),
+        deviceAuthorityEnabled: deviceOwnerAuthorityEnabled(),
       };
     },
 
@@ -1215,7 +1456,7 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         keyProtection,
         // ALWAYS false in release/default — the provisional device binding
         // carries ZERO authority until native-IPC precondition (b) lands.
-        deviceAuthorityEnabled: isDeviceOwnerAuthorityEnabled(),
+        deviceAuthorityEnabled: deviceOwnerAuthorityEnabled(),
       };
     },
 
@@ -1411,7 +1652,7 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         passphraseStillActive: true,
         // ALWAYS false in release/default — activation grants ZERO authority until
         // native-IPC precondition (b) lands.
-        deviceAuthorityEnabled: isDeviceOwnerAuthorityEnabled(),
+        deviceAuthorityEnabled: deviceOwnerAuthorityEnabled(),
       };
     },
 
@@ -1456,11 +1697,20 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
         activatedAt: row?.activated_at ?? null,
         revokedAt: row?.revoked_at ?? null,
         passphraseStillActive: true,
-        deviceAuthorityEnabled: isDeviceOwnerAuthorityEnabled(),
+        deviceAuthorityEnabled: deviceOwnerAuthorityEnabled(),
       };
     },
 
     login(request, ip, userAgent) {
+      // SEC-SETUP-BOOTSTRAP-001 (CR-1): a genuine (non-null) device-login proof
+      // selects the device-key login path (proof-of-possession of the bound
+      // device key), which mints a session ONLY when device-owner authority is
+      // enabled. Requiring non-null means a stray null proof cannot hijack a
+      // passphrase/email request; the device path never touches that logic below.
+      if (request.deviceLoginProof !== undefined && request.deviceLoginProof !== null) {
+        return deviceKeyLogin(request, ip, userAgent);
+      }
+
       let user: FridayUserRow | null = null;
 
       // Resolve the principal early for lockout key derivation.
@@ -1528,50 +1778,7 @@ export function createFridayAuthService(deps: CreateFridayAuthServiceDeps): Frid
       // Auth succeeded — reset lockout state
       resetFailures(lockoutKey, ip);
 
-      const now = deps.nowIso();
-      const sessionId = deps.idGenerator();
-      const { accessToken, refreshToken, accessTokenClaims } = generateTokenPair(user, sessionId);
-      const refreshHash = hashToken(refreshToken);
-      const expiresAt = new Date(
-        new Date(now).getTime() + deps.refreshTokenTtlSec * 1000,
-      ).toISOString();
-
-      deps.db.withWriteTransaction((db) => {
-        sessionRepo.create(db, {
-          id: sessionId,
-          userId: user.id,
-          refreshTokenHash: refreshHash,
-          expiresAt,
-          ipAddress: ip,
-          userAgent,
-          now,
-        });
-        deps.registerIssuedAccessToken?.(db, {
-          tokenId: accessTokenClaims.tokenId,
-          sessionId,
-          userId: user.id,
-          expiresAtEpoch: accessTokenClaims.exp,
-          now,
-        });
-
-        db.prepare("UPDATE users SET last_login_at = ?, updated_at = ? WHERE id = ?").run(
-          now,
-          now,
-          user.id,
-        );
-      });
-
-      return {
-        accessToken,
-        refreshToken,
-        expiresInSec: deps.accessTokenTtlSec,
-        user: {
-          id: user.id,
-          email: user.email ?? undefined,
-          displayName: user.display_name,
-          role: user.role as FridayRole,
-        },
-      };
+      return mintSession(user, ip, userAgent);
     },
 
     refresh(request) {

--- a/src/api/auth/friday-auth-service.types.ts
+++ b/src/api/auth/friday-auth-service.types.ts
@@ -11,6 +11,8 @@ import type {
   FridayAuthDeviceClaimResponse,
   FridayAuthDeviceReadbackRequest,
   FridayAuthDeviceReadbackResponse,
+  FridayAuthLoginChallengeRequest,
+  FridayAuthLoginChallengeResponse,
   FridayAuthMeResponse,
   FridayAuthMigrateChallengeRequest,
   FridayAuthMigrateChallengeResponse,
@@ -46,6 +48,18 @@ export interface FridayAuthService {
     request: FridayAuthBootstrapChallengeRequest,
     ip?: string,
   ): FridayAuthBootstrapChallengeResponse;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 (CR-1 · Advisor #1628 finding #2): mint a single-use
+   * `device_login_challenge` nonce bound to the device (deviceId +
+   * devicePublicKeyHash) + origin + action for a device-key LOGIN. Returns the raw
+   * nonce ONCE; only its hash is persisted. deviceKeyLogin CAS-consumes it inside
+   * the same transaction that mints the session, so the login proof-of-possession
+   * is NOT replayable. Loopback-only.
+   */
+  issueLoginChallenge(
+    request: FridayAuthLoginChallengeRequest,
+    ip?: string,
+  ): FridayAuthLoginChallengeResponse;
   /**
    * SEC-SETUP-BOOTSTRAP-001: atomically claim the local owner slot by consuming
    * a single-use install nonce and binding a device public key. Replay-protected,

--- a/src/api/auth/friday-auth-service.types.ts
+++ b/src/api/auth/friday-auth-service.types.ts
@@ -31,6 +31,14 @@ import type { FridayRateLimitService } from "./friday-rate-limit-service.types.j
 import type { NativeOwnerClaimContextResolver } from "../../security/attestation/friday-verified-native-owner-claim-context.js";
 
 export interface FridayAuthService {
+  /**
+   * SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 (Option B*): resolve the authenticated
+   * user's durable owner↔device binding SERVER-SIDE. Returns the bound device's
+   * sentinel hash (the `<hash>` in `users.password_hash = device-owner$v1$<hash>`)
+   * when the user is a device-claimed owner, else `null` (passphrase / unclaimed).
+   * Pure read; mints nothing and never changes token minting (`principalId=user.id`).
+   */
+  resolveBoundDeviceOwnerSentinelHash(userId: string): string | null;
   login(request: FridayLoginRequest, ip?: string, userAgent?: string): FridayLoginResponse;
   refresh(request: FridayRefreshRequest): FridayRefreshResponse;
   logout(request: FridayLogoutRequest, principal: FridayAuthPrincipal): FridayLogoutResponse;

--- a/src/api/auth/friday-auth-service.types.ts
+++ b/src/api/auth/friday-auth-service.types.ts
@@ -28,6 +28,7 @@ import type {
   FridayRole,
 } from "../model/friday-api-auth.types.js";
 import type { FridayRateLimitService } from "./friday-rate-limit-service.types.js";
+import type { NativeOwnerClaimContextResolver } from "../../security/attestation/friday-verified-native-owner-claim-context.js";
 
 export interface FridayAuthService {
   login(request: FridayLoginRequest, ip?: string, userAgent?: string): FridayLoginResponse;
@@ -167,17 +168,35 @@ export interface CreateFridayAuthServiceDeps {
   /** Optional rate limit service for auth lockout. */
   rateLimiter?: FridayRateLimitService;
   /**
-   * SEC-SETUP-BOOTSTRAP-001 (CR-1): server-derived predicate for whether a
-   * device-bound owner principal may carry release-profile owner authority. This
-   * is the SOLE gate that lets a device-key login mint a session and that flags
-   * `deviceClaimAvailable` in the bootstrap status. It defaults to the real
-   * `isDeviceOwnerAuthorityEnabled()` (hard-wired `false` today because the
-   * native-IPC attestation precondition is absent). It is injectable ONLY so a
-   * test can exercise the enabled branch WITHOUT flipping the compile-time
-   * attestation constant — production wiring never overrides it, so the honest
-   * native gate is never faked.
+   * CR-1 Option C: the SOLE device-owner authority is an OPAQUE, per-claim
+   * `VerifiedNativeOwnerClaimContext` resolved from the native IPC accept boundary
+   * for THIS request — NOT a global boolean. It is CONSUMED atomically with the
+   * bootstrap/login nonce CAS + owner/session write; a refusal (absent, drift,
+   * expiry, replay, connection substitution, kill-switch) produces ZERO state
+   * change. Defaults to {@link createAbsentNativeOwnerClaimResolver} — honestly
+   * absent on this unsigned dev/CI tree (returns null → every device claim/login
+   * fails closed). Production wires a resolver backed by the Companion Unix-socket
+   * peercred+codesign accept boundary; tests inject a resolver that runs the REAL
+   * mint over injected native-evidence doubles. The capability brand makes a
+   * forged request/env/test literal impossible, so no seam can fabricate authority.
    */
-  deviceOwnerAuthorityEnabled?: () => boolean;
+  resolveNativeOwnerClaimContext?: NativeOwnerClaimContextResolver;
+  /**
+   * CR-1 Option C: presence signal for `getBootstrapStatus().deviceClaimAvailable`
+   * ONLY. Reports whether the native device-claim SURFACE currently exists, WITHOUT
+   * minting or authorizing any later request. Defaults to `() => false` (no native
+   * surface on this tree). It must never be used to authorize a claim/login.
+   */
+  nativeOwnerClaimSurfaceAvailable?: () => boolean;
+  /**
+   * CR-1 Option C (finding #6): when `true` (a fresh RELEASE profile —
+   * `isFridayCanonicalGateProtectedProfile(env)`), passphrase bootstrap is NOT
+   * offered and there is NO silent fallback (device-native only). It gates ONLY
+   * the creation of a fresh passphrase owner; legacy passphrase LOGIN and
+   * migration/recovery stay available so legacy data remains usable for bounded
+   * recovery. Defaults to `() => false` (dev/CI: passphrase bootstrap allowed).
+   */
+  releaseProfileNativeOnly?: () => boolean;
   /** Optional audit hook for failed auth and lockout decisions. */
   auditAuthEvent?: (event: {
     type: "auth.login.failed" | "auth.login.locked_out";

--- a/src/api/auth/friday-auth-service.types.ts
+++ b/src/api/auth/friday-auth-service.types.ts
@@ -152,6 +152,18 @@ export interface CreateFridayAuthServiceDeps {
   ) => void;
   /** Optional rate limit service for auth lockout. */
   rateLimiter?: FridayRateLimitService;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 (CR-1): server-derived predicate for whether a
+   * device-bound owner principal may carry release-profile owner authority. This
+   * is the SOLE gate that lets a device-key login mint a session and that flags
+   * `deviceClaimAvailable` in the bootstrap status. It defaults to the real
+   * `isDeviceOwnerAuthorityEnabled()` (hard-wired `false` today because the
+   * native-IPC attestation precondition is absent). It is injectable ONLY so a
+   * test can exercise the enabled branch WITHOUT flipping the compile-time
+   * attestation constant — production wiring never overrides it, so the honest
+   * native gate is never faked.
+   */
+  deviceOwnerAuthorityEnabled?: () => boolean;
   /** Optional audit hook for failed auth and lockout decisions. */
   auditAuthEvent?: (event: {
     type: "auth.login.failed" | "auth.login.locked_out";

--- a/src/api/http/persistence/friday-provider-approval-consumption-repository.ts
+++ b/src/api/http/persistence/friday-provider-approval-consumption-repository.ts
@@ -1,0 +1,270 @@
+/**
+ * SEC-APPROVAL-AUTHORITY-001 · CORE-A round-3 Lane B (Advisor round-2 finding #3) —
+ * durable single-use ledger for canonical mutating-action approvals.
+ *
+ * The mutating-action gate used to track single-use in a process-local in-memory
+ * `Set<string>` (`consumedCanonicalApprovalKeys`). On restart the Set was gone, so a
+ * fresh process re-admitted the SAME device-authored approval (its `deviceProof` is
+ * re-verified asymmetrically), letting a captured confirmed approval be replayed to
+ * drive a SECOND provider mutation.
+ *
+ * This module defines a store interface that the gate consumes plus two implementations
+ * (mirroring {@link FridayHttpIdempotencyStore}):
+ *
+ *  - {@link FridayInMemoryApprovalConsumptionStore}: byte-for-byte the previous Set
+ *    behaviour. Default when no db-backed store is injected (keeps db-less gate/route
+ *    unit tests unchanged).
+ *  - {@link FridaySqliteApprovalConsumptionStore}: durable, backed by
+ *    `provider_mutation_approval_consumption` (migration v108). Survives restarts, and
+ *    both `reserveConsumed` and `reserveInFlight` are a single atomic INSERT so a
+ *    cross-process race cannot double-reserve — exactly one wins the PRIMARY KEY.
+ *
+ * Two consumption shapes:
+ *  - INLINE (`reserveConsumed`): the whole single-use is one atomic INSERT with
+ *    status='consumed', committed in the store's OWN write transaction. Used by every
+ *    gate caller whose mutation is not restructured for same-transaction atomicity.
+ *  - TWO-PHASE (`reserveInFlight` → `completeConsumptionInTransaction`): the reserve is
+ *    an atomic INSERT with status='in_flight' (single-use is already enforced here — a
+ *    replay collides on the PK). The paired provider mutation then flips the row to
+ *    'consumed' via `completeConsumptionInTransaction` INSIDE THE SAME
+ *    `withWriteTransaction` as the mutation write, so a rollback unwinds BOTH the
+ *    completion and the mutation (no effect without a durable consumption; a crash
+ *    between reserve and completion leaves an in_flight orphan that boot reconcile marks
+ *    indeterminate — fail-closed). A clean pre-commit failure calls `releaseReservation`
+ *    so the owner can retry the same confirmed approval (no effect ran).
+ */
+
+import type Database from "better-sqlite3";
+
+import type { FridaySqliteLayer } from "#state";
+
+/** A single canonical-approval single-use reservation. */
+export interface FridayApprovalConsumptionReservation {
+  /**
+   * The canonical approval USE KEY (`createCanonicalApprovalUseKey`):
+   * approvalId:actionDigest:issuer:hmac:deviceSignature. The PRIMARY KEY — a replay of
+   * the identical signed approval reproduces it exactly and so collides.
+   */
+  readonly useKey: string;
+  readonly actionDigest: string;
+  readonly idempotencyKey?: string;
+  /** The mutating action consumed for (e.g. 'providers.create') — provenance only. */
+  readonly mutationOperationId: string;
+}
+
+export type FridayApprovalConsumptionReserveOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: "canonical_approval_already_used" };
+
+export interface FridayApprovalConsumptionStore {
+  /**
+   * INLINE single-use: atomically record consumption (status='consumed') in the store's
+   * OWN write transaction. Returns `{ ok: false }` when the use key was already
+   * reserved/consumed (PK conflict) so the gate denies `canonical_approval_already_used`.
+   */
+  reserveConsumed(
+    reservation: FridayApprovalConsumptionReservation,
+  ): FridayApprovalConsumptionReserveOutcome;
+
+  /**
+   * TWO-PHASE single-use phase 1: atomically reserve (status='in_flight') in the store's
+   * OWN write transaction, returning `{ ok: false }` on a PK conflict. Single-use is
+   * already enforced here. The caller MUST then either
+   * {@link completeConsumptionInTransaction} (in the SAME txn as the mutation) or, on a
+   * clean pre-commit failure, {@link releaseReservation}.
+   */
+  reserveInFlight(
+    reservation: FridayApprovalConsumptionReservation,
+  ): FridayApprovalConsumptionReserveOutcome;
+
+  /**
+   * TWO-PHASE single-use phase 2 (ATOMIC): flip the in_flight reservation to 'consumed'
+   * on the PROVIDED db handle, so the consume commits in the SAME write transaction as
+   * the provider mutation. A rollback of that transaction unwinds BOTH.
+   */
+  completeConsumptionInTransaction(db: Database.Database, useKey: string): void;
+
+  /**
+   * Release an in_flight reservation after a clean pre-commit failure (no side effect
+   * ran), so the owner can retry the same confirmed approval. Scoped to status='in_flight'
+   * so a completed/indeterminate row is never removed.
+   */
+  releaseReservation(useKey: string): void;
+
+  /** True iff a consumption row (any status) exists for the use key. */
+  hasConsumption(useKey: string): boolean;
+
+  /**
+   * Boot-time reconcile: any `in_flight` row in a freshly-booted process is a crash
+   * orphan (no mutation is live yet). Mark them `indeterminate` (fail-closed) so a replay
+   * is refused rather than admitted. Run once before the server accepts requests.
+   */
+  reconcileOrphanedReservations(): void;
+}
+
+type ConsumptionStatus = "in_flight" | "consumed" | "indeterminate";
+
+// ─── In-memory implementation (default; equivalent to the previous Set behaviour) ───
+
+export class FridayInMemoryApprovalConsumptionStore implements FridayApprovalConsumptionStore {
+  private readonly entries = new Map<string, ConsumptionStatus>();
+
+  reserveConsumed(
+    reservation: FridayApprovalConsumptionReservation,
+  ): FridayApprovalConsumptionReserveOutcome {
+    if (this.entries.has(reservation.useKey)) {
+      return { ok: false, reason: "canonical_approval_already_used" };
+    }
+    this.entries.set(reservation.useKey, "consumed");
+    return { ok: true };
+  }
+
+  reserveInFlight(
+    reservation: FridayApprovalConsumptionReservation,
+  ): FridayApprovalConsumptionReserveOutcome {
+    if (this.entries.has(reservation.useKey)) {
+      return { ok: false, reason: "canonical_approval_already_used" };
+    }
+    this.entries.set(reservation.useKey, "in_flight");
+    return { ok: true };
+  }
+
+  completeConsumptionInTransaction(_db: Database.Database, useKey: string): void {
+    // In-memory: mirror the durable UPDATE (scoped to an existing in_flight reservation).
+    if (this.entries.get(useKey) === "in_flight") {
+      this.entries.set(useKey, "consumed");
+    }
+  }
+
+  releaseReservation(useKey: string): void {
+    if (this.entries.get(useKey) === "in_flight") {
+      this.entries.delete(useKey);
+    }
+  }
+
+  hasConsumption(useKey: string): boolean {
+    return this.entries.has(useKey);
+  }
+
+  reconcileOrphanedReservations(): void {
+    // A volatile in-memory store starts empty on every boot, so there is nothing durable
+    // to reconcile. Still flip any residual in_flight rows for parity with the durable store.
+    for (const [key, status] of this.entries.entries()) {
+      if (status === "in_flight") {
+        this.entries.set(key, "indeterminate");
+      }
+    }
+  }
+}
+
+// ─── Durable SQLite implementation ───
+
+function isPrimaryKeyConflict(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null)?.code;
+  return (
+    code === "SQLITE_CONSTRAINT_PRIMARYKEY" ||
+    code === "SQLITE_CONSTRAINT_UNIQUE" ||
+    code === "SQLITE_CONSTRAINT"
+  );
+}
+
+export class FridaySqliteApprovalConsumptionStore implements FridayApprovalConsumptionStore {
+  constructor(private readonly sqlite: FridaySqliteLayer) {}
+
+  private insert(reservation: FridayApprovalConsumptionReservation, status: ConsumptionStatus): void {
+    const nowMs = Date.now();
+    this.sqlite.withWriteTransaction((db) => {
+      insertConsumptionRow(db, reservation, status, nowMs);
+    });
+  }
+
+  private reserve(
+    reservation: FridayApprovalConsumptionReservation,
+    status: ConsumptionStatus,
+  ): FridayApprovalConsumptionReserveOutcome {
+    try {
+      // Single atomic INSERT: a concurrent process (or a restart replay) holding the same
+      // use key makes this throw a PRIMARY KEY conflict rather than silently overwriting.
+      this.insert(reservation, status);
+      return { ok: true };
+    } catch (err) {
+      if (isPrimaryKeyConflict(err)) {
+        return { ok: false, reason: "canonical_approval_already_used" };
+      }
+      throw err;
+    }
+  }
+
+  reserveConsumed(
+    reservation: FridayApprovalConsumptionReservation,
+  ): FridayApprovalConsumptionReserveOutcome {
+    return this.reserve(reservation, "consumed");
+  }
+
+  reserveInFlight(
+    reservation: FridayApprovalConsumptionReservation,
+  ): FridayApprovalConsumptionReserveOutcome {
+    return this.reserve(reservation, "in_flight");
+  }
+
+  completeConsumptionInTransaction(db: Database.Database, useKey: string): void {
+    // Runs on the CALLER's db handle so it commits/rolls back with the provider mutation.
+    // Scoped to status='in_flight' so a concurrently-reconciled indeterminate row is never
+    // silently revived to consumed.
+    db.prepare(
+      `UPDATE provider_mutation_approval_consumption
+          SET status = 'consumed', consumed_at_ms = ?
+        WHERE use_key = ? AND status = 'in_flight'`,
+    ).run(Date.now(), useKey);
+  }
+
+  releaseReservation(useKey: string): void {
+    this.sqlite.withWriteTransaction((db) => {
+      db.prepare(
+        `DELETE FROM provider_mutation_approval_consumption
+           WHERE use_key = ? AND status = 'in_flight'`,
+      ).run(useKey);
+    });
+  }
+
+  hasConsumption(useKey: string): boolean {
+    const row = this.sqlite.withReadConnection((db) =>
+      db
+        .prepare("SELECT 1 AS present FROM provider_mutation_approval_consumption WHERE use_key = ?")
+        .get(useKey),
+    );
+    return row !== undefined;
+  }
+
+  reconcileOrphanedReservations(): void {
+    this.sqlite.withWriteTransaction((db) => {
+      db.prepare(
+        `UPDATE provider_mutation_approval_consumption
+            SET status = 'indeterminate'
+          WHERE status = 'in_flight'`,
+      ).run();
+    });
+  }
+}
+
+function insertConsumptionRow(
+  db: Database.Database,
+  reservation: FridayApprovalConsumptionReservation,
+  status: ConsumptionStatus,
+  nowMs: number,
+): void {
+  db.prepare(
+    `INSERT INTO provider_mutation_approval_consumption (
+       use_key, action_digest, idempotency_key, mutation_operation_id,
+       status, consumed_at_ms, created_at_ms
+     ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    reservation.useKey,
+    reservation.actionDigest,
+    reservation.idempotencyKey ?? null,
+    reservation.mutationOperationId,
+    status,
+    status === "consumed" ? nowMs : null,
+    nowMs,
+  );
+}

--- a/src/api/http/routes/friday-auth-routes.ts
+++ b/src/api/http/routes/friday-auth-routes.ts
@@ -317,6 +317,15 @@ export function createFridayAuthRoutes(
           password: typeof body.password === "string" ? body.password : undefined,
           localPassphrase: typeof body.localPassphrase === "string" ? body.localPassphrase : undefined,
           rememberMe: typeof body.rememberMe === "boolean" ? body.rememberMe : undefined,
+          // SEC-SETUP-BOOTSTRAP-001 (CR-1): device-key login fields. The presence
+          // of deviceLoginProof selects the device path in authService.login; the
+          // auth SERVICE defensively validates the untrusted proof envelope and
+          // fails closed on anything malformed (and requires device-owner authority
+          // to be enabled before minting a session).
+          devicePublicKey: typeof body.devicePublicKey === "string" ? body.devicePublicKey : undefined,
+          deviceId: typeof body.deviceId === "string" ? body.deviceId : undefined,
+          origin: typeof body.origin === "string" ? body.origin : undefined,
+          deviceLoginProof: body.deviceLoginProof as FridayLoginRequest["deviceLoginProof"],
         };
         return deps.authService.login(request, ctx.ip, ctx.userAgent);
       },

--- a/src/api/http/routes/friday-auth-routes.ts
+++ b/src/api/http/routes/friday-auth-routes.ts
@@ -10,6 +10,8 @@ import type {
   FridayAuthDeviceClaimResponse,
   FridayAuthDeviceReadbackRequest,
   FridayAuthDeviceReadbackResponse,
+  FridayAuthLoginChallengeRequest,
+  FridayAuthLoginChallengeResponse,
   FridayAuthMeResponse,
   FridayAuthMigrateChallengeRequest,
   FridayAuthMigrateChallengeResponse,
@@ -113,6 +115,42 @@ export function createFridayAuthRoutes(
           action: typeof body.action === "string" ? body.action : undefined,
         };
         return deps.authService.issueBootstrapChallenge(request, ctx.ip);
+      },
+    },
+    {
+      operationId: "auth.login.challenge",
+      method: "POST",
+      path: "/v1/auth/login/challenge",
+      // SEC-SETUP-BOOTSTRAP-001 (CR-1 · Advisor #1628 finding #2): device-key LOGIN
+      // challenge leg. Mints a single-use `device_login_challenge` nonce bound to the
+      // device (deviceId + devicePublicKeyHash) + origin so the login proof-of-
+      // possession is NOT replayable. authService.issueLoginChallenge enforces (a)
+      // loopback-only ingress and (b) required-field presence before any side effect;
+      // it does NOT gate on ownership (like auth.bootstrap.challenge). Only the nonce
+      // HASH is persisted; the raw nonce is returned once. Expired/unconsumed nonces
+      // are reaped by the bounded retention sweep, so this route cannot grow the
+      // ledger unbounded. Same public-first-run posture + rate-limit as the bootstrap
+      // challenge; the AUTHORITATIVE single-use gate is the CAS-consume at login.
+      auth: { public: true, allowUnauthenticatedMutation: true },
+      rateLimitPolicyId: "auth.login",
+      async handler(ctx): Promise<FridayAuthLoginChallengeResponse> {
+        const body = ctx.body as Record<string, unknown> | null;
+        if (!body || typeof body !== "object") {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "Request body is required",
+            { httpStatus: 400 },
+          );
+        }
+        const request: FridayAuthLoginChallengeRequest = {
+          installId: typeof body.installId === "string" ? body.installId : "",
+          osUser: typeof body.osUser === "string" ? body.osUser : "",
+          origin: typeof body.origin === "string" ? body.origin : "",
+          deviceId: typeof body.deviceId === "string" ? body.deviceId : "",
+          devicePublicKey: typeof body.devicePublicKey === "string" ? body.devicePublicKey : "",
+          action: typeof body.action === "string" ? body.action : undefined,
+        };
+        return deps.authService.issueLoginChallenge(request, ctx.ip);
       },
     },
     {

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -75,7 +75,12 @@ import {
   type FridayMutatingActionRequest,
   type FridayMutatingActionTicket,
 } from "../../../security/friday-mutating-action-gate.js";
+import { deviceOwnerPrincipalId } from "../../../security/friday-device-owner-authority-precondition.js";
 import { isUnauthenticatedPublicPrincipal } from "../../../security/friday-owner-session-channel-capability.js";
+import type {
+  FridayProviderApprovalPoPVerifier,
+  ProviderApprovalDeviceProof,
+} from "../../auth/device-attest/index.js";
 
 // ─── Validation helpers ───
 
@@ -462,30 +467,30 @@ export interface FridayProviderRoutesDeps {
    */
   nowIso?: () => string;
   /**
-   * Owner-confirm approval MINTER (CORE-RUNNABLE-001 / CORE-A CR-2).
+   * Owner-confirm DEVICE-APPROVAL VERIFIER (SEC-APPROVAL-AUTHORITY-001 / CORE-A CR-2).
    *
-   * Injected by the runtime with the SAME `signCanonicalApprovalForRequest` seam the
-   * plugin / provider-profile-upgrade lifecycles use: it derives the action digest
-   * itself with {@link createFridayMutatingActionDigest}, stamps a ~10-minute expiry
-   * and HMAC-signs with the hub token secret.
-   *
-   * It is consulted from EXACTLY ONE place — `providers.plan.confirm` — and only after
-   * an explicit, owner-authenticated confirmation of a plan digest the server itself
-   * produced. When absent, the confirm route fails closed (503); it never falls back
-   * to an unsigned or self-minted approval.
+   * The Hub holds NO signing key on the approval path. `providers.plan.confirm` no
+   * longer MINTS an HMAC approval — it VERIFIES the owner device's P-256
+   * proof-of-possession over the reviewed action digest with this asymmetric
+   * verifier and, on success, returns the DEVICE-AUTHORED canonical approval. The
+   * runtime injects `createFridayProviderApprovalPoPVerifier()`. When absent, the
+   * confirm route fails closed (503); it never self-mints an approval.
    */
-  signCanonicalApproval?: (
-    request: FridayMutatingActionRequest,
-    input: { approvalIdPrefix: string; childOfLifecycleTicketId?: string },
-  ) => FridayCanonicalApprovalResolution;
+  providerApprovalVerifier?: FridayProviderApprovalPoPVerifier;
 }
 
 // ─── Provider mutation plan / owner-confirm protocol (CORE-RUNNABLE-001) ───
 
-/** Plan lifetime. Deliberately <= the signed approval's ~10 minute expiry. */
+/** Plan lifetime. Deliberately <= the device approval's ~10 minute expiry. */
 const PROVIDER_MUTATION_PLAN_TTL_MS = 10 * 60 * 1000;
 /** Hard cap so an authenticated client cannot grow the plan store without bound. */
 const PROVIDER_MUTATION_PLAN_MAX_ENTRIES = 256;
+/**
+ * Max lifetime the Hub will honour on a DEVICE-AUTHORED approval. The owner device
+ * chooses the expiry; the Hub refuses one further out than this so a device cannot
+ * mint a long-lived standing approval. Matches the plan TTL.
+ */
+const PROVIDER_MUTATION_APPROVAL_MAX_LIFETIME_MS = 10 * 60 * 1000;
 
 const PROVIDER_PLANNABLE_ACTIONS = new Set<string>([
   "providers.create",
@@ -1087,6 +1092,18 @@ export function createFridayProviderRoutes(
         { httpStatus: 403, details: { action, resourceId } },
       );
     }
+    // SEC-APPROVAL-AUTHORITY-001 negative control (Hub self-sign / shared-HMAC leak):
+    // a provider mutation admits ONLY on a DEVICE-AUTHORED approval. Any Hub-minted
+    // symmetric-HMAC approval (`friday_canonical_gate`) — or an issuer-less one — is
+    // refused at the seam BEFORE the gate, so the Hub can never verify its own
+    // signature on the provider path.
+    if (controls.canonicalApproval && controls.canonicalApproval.issuer !== "friday_device_owner") {
+      throw new FridayDomainError(
+        "PROVIDER_MUTATION_APPROVAL_NOT_DEVICE_AUTHORED",
+        "Provider mutations require a device-authored owner approval; a Hub-signed or unsigned approval is refused.",
+        { httpStatus: 403, details: { action, resourceId } },
+      );
+    }
     // The digest of record is recomputed HERE, server-side, from the sanitized
     // parameters this request actually carries. The client-supplied `planDigest` is
     // only an input to that computation — it is never trusted as the truth, and any
@@ -1487,13 +1504,17 @@ export function createFridayProviderRoutes(
             { httpStatus: 400 },
           );
         }
-        if (!deps.signCanonicalApproval) {
+        // SEC-APPROVAL-AUTHORITY-001: the Hub holds NO signing key. It can only
+        // VERIFY the owner device's proof. A runtime without the asymmetric verifier
+        // fails closed — it NEVER self-mints an approval.
+        if (!deps.providerApprovalVerifier) {
           throw new FridayDomainError(
-            "PROVIDER_MUTATION_APPROVAL_SIGNER_UNAVAILABLE",
-            "This runtime cannot mint provider mutation approvals; the canonical approval signer is not wired.",
+            "PROVIDER_MUTATION_APPROVAL_VERIFIER_UNAVAILABLE",
+            "This runtime cannot verify device-authored provider approvals; the asymmetric approval verifier is not wired.",
             { httpStatus: 503 },
           );
         }
+        const deviceProof = readDeviceApprovalProof(body?.deviceApproval);
 
         pruneProviderMutationPlans();
         const record = providerMutationPlans.get(planDigest);
@@ -1519,28 +1540,78 @@ export function createFridayProviderRoutes(
           );
         }
 
+        // ─── ASYMMETRIC device proof-of-possession (verify-only; sync, no side effect) ───
         const confirmedAt = nowIso();
-        // Single-use at the plan layer too: the record is spent BEFORE the approval is
-        // minted, so a concurrent second confirm can never obtain a second signature.
-        record.confirmedAt = confirmedAt;
-
-        const canonicalApproval = deps.signCanonicalApproval(record.request, {
-          approvalIdPrefix: `provider-owner-confirm-${record.action}`,
+        const nowMs = Date.parse(confirmedAt);
+        const verified = deps.providerApprovalVerifier.verifyPossession({
+          transcript: deviceProof.transcript,
+          devicePublicKey: deviceProof.devicePublicKey,
+          signature: deviceProof.signature,
+          nowMs: Number.isFinite(nowMs) ? nowMs : Date.now(),
         });
-        if (canonicalApproval.actionDigest !== record.actionDigest) {
+        if (!verified.ok) {
+          throw new FridayDomainError(
+            "PROVIDER_MUTATION_APPROVAL_SIGNATURE_INVALID",
+            "The device-authored approval could not be verified; it was not signed by a valid owner device key over this action.",
+            { httpStatus: 403, details: { reason: verified.reason } },
+          );
+        }
+        // (1) The signed transcript must bind the EXACT reviewed action digest.
+        if (verified.actionDigest !== record.actionDigest) {
           throw new FridayDomainError(
             "PROVIDER_MUTATION_APPROVAL_DIGEST_MISMATCH",
-            "The minted approval did not bind to the reviewed plan's action digest; refusing to issue it.",
-            { httpStatus: 500 },
+            "The device-authored approval did not bind to the reviewed plan's action digest; refusing it.",
+            { httpStatus: 403 },
           );
         }
-        if (!canonicalApproval.expiresAt) {
+        // (2) The approving principal must be the authenticated owner, AND the signing
+        //     device public key must hash to that owner's bound device (the owner
+        //     principal id embeds the device key hash).
+        if (verified.decidedByPrincipalId !== ownerPrincipalId) {
           throw new FridayDomainError(
-            "PROVIDER_MUTATION_APPROVAL_EXPIRY_REQUIRED",
-            "The minted approval carried no expiry; refusing to issue it.",
-            { httpStatus: 500 },
+            "PROVIDER_MUTATION_APPROVAL_PRINCIPAL_MISMATCH",
+            "The device-authored approval was signed for a different owner principal than the confirming owner.",
+            { httpStatus: 403 },
           );
         }
+        if (deviceOwnerPrincipalId(verified.devicePublicKeyHash) !== ownerPrincipalId) {
+          throw new FridayDomainError(
+            "PROVIDER_MUTATION_APPROVAL_DEVICE_NOT_BOUND",
+            "The approval's signing device is not the owner's bound device.",
+            { httpStatus: 403 },
+          );
+        }
+        // (3) Bound expiry: present, in the future, and no longer than the max lifetime.
+        const expiresAtMs = Date.parse(verified.expiresAt);
+        if (
+          !Number.isFinite(expiresAtMs)
+          || !Number.isFinite(nowMs)
+          || expiresAtMs <= nowMs
+          || expiresAtMs - nowMs > PROVIDER_MUTATION_APPROVAL_MAX_LIFETIME_MS
+        ) {
+          throw new FridayDomainError(
+            "PROVIDER_MUTATION_APPROVAL_EXPIRY_INVALID",
+            "The device-authored approval's expiry is missing, in the past, or beyond the allowed lifetime.",
+            { httpStatus: 403 },
+          );
+        }
+
+        // Single-use at the plan layer: spend the record AFTER a successful verify
+        // (verifyPossession is synchronous, so the check-then-set below cannot
+        // interleave with a concurrent confirm of the same plan).
+        record.confirmedAt = confirmedAt;
+
+        // The Hub adds NO signature. It returns the DEVICE-AUTHORED approval, which the
+        // admission gate re-verifies asymmetrically against the same device proof.
+        const canonicalApproval: FridayCanonicalApprovalResolution = {
+          decision: "approved",
+          approvalId: verified.approvalId,
+          decidedByPrincipalId: ownerPrincipalId,
+          actionDigest: record.actionDigest,
+          expiresAt: verified.expiresAt,
+          issuer: "friday_device_owner",
+          deviceProof,
+        };
 
         return {
           approval: {
@@ -1550,7 +1621,7 @@ export function createFridayProviderRoutes(
             resourceId: record.resourceId,
             idempotencyKey: record.idempotencyKey,
             confirmedAt,
-            expiresAt: canonicalApproval.expiresAt,
+            expiresAt: verified.expiresAt,
             canonicalApproval,
           },
         };
@@ -2153,6 +2224,34 @@ function readCanonicalApproval(value: unknown): FridayCanonicalApprovalResolutio
     return value as FridayCanonicalApprovalResolution;
   }
   throw new FridayDomainError("VALIDATION_ERROR", "canonicalApproval must be an object", { httpStatus: 400 });
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Structurally validate the device-approval proof carried on the confirm body. This
+ * only checks SHAPE (the cryptographic verification is done by the asymmetric
+ * verifier); a malformed shape is a 400 so the verifier is never handed junk.
+ */
+function readDeviceApprovalProof(value: unknown): ProviderApprovalDeviceProof {
+  if (!isPlainObject(value)) {
+    throw new FridayDomainError(
+      "PROVIDER_MUTATION_APPROVAL_PROOF_REQUIRED",
+      "A device-authored approval proof (`deviceApproval`) is required to confirm a provider mutation plan.",
+      { httpStatus: 400 },
+    );
+  }
+  const { transcript, devicePublicKey, signature } = value;
+  if (!isPlainObject(transcript) || !isPlainObject(devicePublicKey) || !isPlainObject(signature)) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      "deviceApproval must carry a transcript, a devicePublicKey and a signature object.",
+      { httpStatus: 400 },
+    );
+  }
+  return value as unknown as ProviderApprovalDeviceProof;
 }
 
 function stripProviderMutationControlFields<T extends Record<string, unknown>>(body: T): T {

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -477,6 +477,16 @@ export interface FridayProviderRoutesDeps {
    * confirm route fails closed (503); it never self-mints an approval.
    */
   providerApprovalVerifier?: FridayProviderApprovalPoPVerifier;
+  /**
+   * SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 (Option B*): resolve the authenticated
+   * user's durable owner↔device binding SERVER-SIDE (`users.password_hash =
+   * device-owner$v1$<hash>` → `<hash>`, else `null`). The runtime injects
+   * `authService.resolveBoundDeviceOwnerSentinelHash`. Used to bind a device-authored
+   * provider approval to the authenticated owner's REGISTERED device WITHOUT changing
+   * token minting (`principalId=user.id`). When absent (test fixtures that never
+   * device-claim), a device-authored approval fails closed at the binding check.
+   */
+  resolveBoundDeviceOwnerSentinelHash?: (userId: string) => string | null;
 }
 
 // ─── Provider mutation plan / owner-confirm protocol (CORE-RUNNABLE-001) ───
@@ -1111,7 +1121,11 @@ export function createFridayProviderRoutes(
     // is refused below as `canonical_approval_digest_mismatch`.
     const request = createFridayProviderSetupMutatingActionRequest({
       action,
-      actor: createActorFromPrincipal(input.ctx.principal, `api:${input.ctx.requestId}`),
+      actor: createActorFromPrincipal(
+        input.ctx.principal,
+        `api:${input.ctx.requestId}`,
+        deps.resolveBoundDeviceOwnerSentinelHash,
+      ),
       surface,
       resourceId,
       parameters,
@@ -1423,7 +1437,11 @@ export function createFridayProviderRoutes(
         // recomputes when the mutation actually arrives.
         const request = createFridayProviderSetupMutatingActionRequest({
           action: descriptor.action,
-          actor: createActorFromPrincipal(ctx.principal, `api:${ctx.requestId}`),
+          actor: createActorFromPrincipal(
+            ctx.principal,
+            `api:${ctx.requestId}`,
+            deps.resolveBoundDeviceOwnerSentinelHash,
+          ),
           surface: descriptor.surface,
           resourceId: descriptor.resourceId,
           parameters: descriptor.parameters,
@@ -1564,20 +1582,36 @@ export function createFridayProviderRoutes(
             { httpStatus: 403 },
           );
         }
-        // (2) The approving principal must be the authenticated owner, AND the signing
-        //     device public key must hash to that owner's bound device (the owner
-        //     principal id embeds the device key hash).
-        if (verified.decidedByPrincipalId !== ownerPrincipalId) {
+        // (2) DURABLE owner-device binding (Option B*): the approval's signing device
+        //     MUST be the device registered to the AUTHENTICATED owner
+        //     (`users.password_hash = device-owner$v1$<hash>`), compared with the
+        //     sentinel's OWN convention `sha256Hex(devicePublicKey)` — the same one
+        //     `deviceKeyLogin` already trusts. The acting `principalId` stays `user.id`
+        //     (token minting is unchanged); a passphrase / unclaimed owner has NO
+        //     sentinel → refused. This resolves the authenticated owner's binding
+        //     SERVER-SIDE and never trusts a request-supplied principal.
+        const boundSentinelHash = deps.resolveBoundDeviceOwnerSentinelHash?.(
+          ctx.principal?.userId ?? ownerPrincipalId,
+        ) ?? null;
+        if (
+          boundSentinelHash === null
+          || createHash("sha256").update(deviceProof.devicePublicKey.value).digest("hex")
+            !== boundSentinelHash
+        ) {
           throw new FridayDomainError(
-            "PROVIDER_MUTATION_APPROVAL_PRINCIPAL_MISMATCH",
-            "The device-authored approval was signed for a different owner principal than the confirming owner.",
+            "PROVIDER_MUTATION_APPROVAL_DEVICE_NOT_BOUND",
+            "The device-authored approval was not signed by the authenticated owner's registered device.",
             { httpStatus: 403 },
           );
         }
-        if (deviceOwnerPrincipalId(verified.devicePublicKeyHash) !== ownerPrincipalId) {
+        // (2b) CANONICAL self-consistency (unchanged intent): the approval's declared
+        //      principal must match its signing device key hash
+        //      (`canonicalDevicePublicKeyHash`), so a valid proof cannot carry a
+        //      foreign owner principal.
+        if (deviceOwnerPrincipalId(verified.devicePublicKeyHash) !== verified.decidedByPrincipalId) {
           throw new FridayDomainError(
-            "PROVIDER_MUTATION_APPROVAL_DEVICE_NOT_BOUND",
-            "The approval's signing device is not the owner's bound device.",
+            "PROVIDER_MUTATION_APPROVAL_PRINCIPAL_MISMATCH",
+            "The device-authored approval's declared principal does not match its signing device key.",
             { httpStatus: 403 },
           );
         }
@@ -1603,10 +1637,16 @@ export function createFridayProviderRoutes(
 
         // The Hub adds NO signature. It returns the DEVICE-AUTHORED approval, which the
         // admission gate re-verifies asymmetrically against the same device proof.
+        // `decidedByPrincipalId` is the DEVICE principal from the verified transcript
+        // (`device-owner:<canonicalDevicePublicKeyHash>`), NOT the acting `user.id` —
+        // so the gate's canonical self-consistency (`deviceOwnerPrincipalId(verified
+        // .devicePublicKeyHash) === decidedByPrincipalId`) holds at mutate time. The
+        // durable owner↔device binding was enforced above (sentinel) and is re-enforced
+        // by the gate via the actor's server-resolved `boundDeviceOwnerSentinelHash`.
         const canonicalApproval: FridayCanonicalApprovalResolution = {
           decision: "approved",
           approvalId: verified.approvalId,
-          decidedByPrincipalId: ownerPrincipalId,
+          decidedByPrincipalId: verified.decidedByPrincipalId,
           actionDigest: record.actionDigest,
           expiresAt: verified.expiresAt,
           issuer: "friday_device_owner",
@@ -2201,6 +2241,7 @@ function readOAuthSelectionInput(body: Record<string, unknown> | null, defaultKi
 function createActorFromPrincipal(
   principal: FridayAuthPrincipal | null,
   fallbackId: string,
+  resolveBoundDeviceOwnerSentinelHash?: (userId: string) => string | null,
 ): FridayMutatingActionActor {
   if (!principal) {
     return {
@@ -2209,10 +2250,18 @@ function createActorFromPrincipal(
       principalId: fallbackId,
     };
   }
+  // Option B*: resolve the durable owner↔device binding SERVER-SIDE from the
+  // authenticated user id (NOT from the acting principalId, which stays `user.id`).
+  // `boundDeviceOwnerSentinelHash` binds a device-authored approval to the owner's
+  // registered device without perturbing the action digest (it is never hashed in).
+  const ownerUserId = principal.userId ?? principal.principalId;
+  const boundDeviceOwnerSentinelHash =
+    resolveBoundDeviceOwnerSentinelHash?.(ownerUserId) ?? undefined;
   return {
     kind: principal.principalType,
     id: principal.principalId,
     principalId: principal.principalId,
+    ...(boundDeviceOwnerSentinelHash ? { boundDeviceOwnerSentinelHash } : {}),
   };
 }
 

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -8,6 +8,7 @@ import type {
   FridayCompleteAnthropicOAuthCallbackRequest,
   FridayCompleteAnthropicOAuthCallbackResponse,
   FridayCompleteOpenAICodexDeviceOAuthResponse,
+  FridayConfirmProviderMutationResponse,
   FridayCreateProviderRequest,
   FridayCreateProviderResponse,
   FridayDeleteProviderResponse,
@@ -25,6 +26,9 @@ import type {
   FridayListProvidersResponse,
   FridayListProviderTemplatesResponse,
   FridayPinProviderRouteResponse,
+  FridayPlanProviderMutationResponse,
+  FridayProviderMutationPlan,
+  FridayProviderPlannableAction,
   FridayRunCapabilityDoctorRequest,
   FridayRunCapabilityDoctorResponse,
   FridaySetRoutingConfigRequest,
@@ -64,12 +68,14 @@ import {
 } from "../../../providers/services/friday-provider-oauth-selection.js";
 import { FRIDAY_ANTHROPIC_OAUTH_DISABLED_MESSAGE } from "../../../providers/oauth/friday-anthropic-oauth.js";
 import {
+  createFridayMutatingActionDigest,
   type FridayCanonicalApprovalResolution,
   type FridayMutatingActionActor,
   type FridayMutatingActionGate,
   type FridayMutatingActionRequest,
   type FridayMutatingActionTicket,
 } from "../../../security/friday-mutating-action-gate.js";
+import { isUnauthenticatedPublicPrincipal } from "../../../security/friday-owner-session-channel-capability.js";
 
 // ─── Validation helpers ───
 
@@ -450,6 +456,455 @@ export interface FridayProviderRoutesDeps {
    * When the flag is on but this is absent, those routes fail closed.
    */
   rustCapabilityDoctor?: FridayRustHubCapabilityDoctorService;
+  /**
+   * Clock for the provider mutation plan store (plan TTL / confirm expiry checks).
+   * Defaults to the wall clock; the runtime injects its canonical `nowIso`.
+   */
+  nowIso?: () => string;
+  /**
+   * Owner-confirm approval MINTER (CORE-RUNNABLE-001 / CORE-A CR-2).
+   *
+   * Injected by the runtime with the SAME `signCanonicalApprovalForRequest` seam the
+   * plugin / provider-profile-upgrade lifecycles use: it derives the action digest
+   * itself with {@link createFridayMutatingActionDigest}, stamps a ~10-minute expiry
+   * and HMAC-signs with the hub token secret.
+   *
+   * It is consulted from EXACTLY ONE place — `providers.plan.confirm` — and only after
+   * an explicit, owner-authenticated confirmation of a plan digest the server itself
+   * produced. When absent, the confirm route fails closed (503); it never falls back
+   * to an unsigned or self-minted approval.
+   */
+  signCanonicalApproval?: (
+    request: FridayMutatingActionRequest,
+    input: { approvalIdPrefix: string; childOfLifecycleTicketId?: string },
+  ) => FridayCanonicalApprovalResolution;
+}
+
+// ─── Provider mutation plan / owner-confirm protocol (CORE-RUNNABLE-001) ───
+
+/** Plan lifetime. Deliberately <= the signed approval's ~10 minute expiry. */
+const PROVIDER_MUTATION_PLAN_TTL_MS = 10 * 60 * 1000;
+/** Hard cap so an authenticated client cannot grow the plan store without bound. */
+const PROVIDER_MUTATION_PLAN_MAX_ENTRIES = 256;
+
+const PROVIDER_PLANNABLE_ACTIONS = new Set<string>([
+  "providers.create",
+  "providers.update",
+  "providers.delete",
+  "providers.validate",
+  "providers.routing.set",
+  "providers.routing.pin",
+  "providers.routing.penalty.clear",
+  "providers.auth.profiles.activate",
+  "providers.oauth.openai_codex.device.initiate",
+  "providers.oauth.openai_codex.device.complete",
+  "capabilities.doctor",
+]);
+
+/**
+ * The single canonical description of a gated provider mutation: the exact
+ * `{action, surface, resourceId, parameters}` tuple that feeds
+ * {@link createFridayProviderSetupMutatingActionRequest}.
+ *
+ * Both the plan endpoint AND every mutation route derive their gate inputs from this
+ * one builder, so a plan and the mutation it authorizes cannot drift apart.
+ */
+interface FridayProviderMutationDescriptor {
+  readonly action: FridayProviderPlannableAction;
+  readonly surface: string;
+  readonly resourceId?: string;
+  readonly parameters: Record<string, unknown>;
+  /** Secret-free review lines shown to the owner before they confirm. */
+  readonly humanReadableSummary: string[];
+}
+
+interface FridayProviderMutationPlanRecord {
+  readonly planDigest: string;
+  readonly actionDigest: string;
+  readonly request: FridayMutatingActionRequest;
+  readonly ownerPrincipalId: string;
+  readonly action: FridayProviderPlannableAction;
+  readonly surface: string;
+  readonly resourceId?: string;
+  readonly idempotencyKey?: string;
+  readonly humanReadableSummary: string[];
+  readonly createdAt: string;
+  readonly expiresAt: string;
+  confirmedAt?: string;
+}
+
+function asProviderMutationRecord(value: unknown): Record<string, unknown> | null {
+  if (value == null) {
+    return null;
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new FridayDomainError("VALIDATION_ERROR", "Request body must be an object", { httpStatus: 400 });
+  }
+  return { ...(value as Record<string, unknown>) };
+}
+
+function readOptionalTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function requireProviderMutationTargetId(value: string | undefined, field: string, action: string): string {
+  const trimmed = readOptionalTrimmedString(value);
+  if (!trimmed) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      `${field} is required to plan ${action}`,
+      { httpStatus: 400 },
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * DX-001 create-shape normalization (nested `config` → flat), extracted so the plan
+ * endpoint and the create route normalize byte-identically before hashing.
+ */
+function liftProviderCreateConfigFields(
+  rawInput: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  const raw = rawInput ? { ...rawInput } : rawInput;
+  if (raw && raw.config && typeof raw.config === "object" && !Array.isArray(raw.config)) {
+    const config = raw.config as Record<string, unknown>;
+    const liftFields = [
+      "api", "authMode", "supportedModels", "apiKey", "defaultModel", "headers",
+      "backendKind", "cliConfig", "runtimeCapabilities", "deploymentKind", "regionTag",
+    ] as const;
+    for (const field of liftFields) {
+      if (config[field] !== undefined && raw[field] === undefined) {
+        raw[field] = config[field];
+      }
+    }
+  }
+  return raw;
+}
+
+function assertProviderRoutingControlBody(
+  body: Record<string, unknown> | null,
+): asserts body is Record<string, unknown> {
+  if (!body || typeof body !== "object") {
+    throw new FridayDomainError("VALIDATION_ERROR", "Request body is required", { httpStatus: 400 });
+  }
+  if (typeof body.providerId !== "string" || typeof body.model !== "string") {
+    throw new FridayDomainError("VALIDATION_ERROR", "providerId and model are required", { httpStatus: 400 });
+  }
+  if (body.backendKind !== "http" && body.backendKind !== "cli" && body.backendKind !== "sdk") {
+    throw new FridayDomainError("VALIDATION_ERROR", "backendKind must be one of: http, cli, sdk", { httpStatus: 400 });
+  }
+}
+
+// ─── Secret-free plan summaries ───
+//
+// EVERY line below is built from an explicit allow-list of non-secret fields. An API
+// key / token / header value is NEVER echoed: credentials are reported only as a
+// presence boolean, and free-form header values only as a count.
+
+function describeProviderCredentialFields(body: Record<string, unknown>, summary: string[]): void {
+  if (body.apiKey !== undefined) {
+    summary.push(
+      typeof body.apiKey === "string" && body.apiKey.length > 0
+        ? "Credential: a new API key will be stored encrypted (the key itself is never shown or echoed back)."
+        : "Credential: the stored API key will be cleared.",
+    );
+  }
+  if (body.headers !== undefined && body.headers && typeof body.headers === "object" && !Array.isArray(body.headers)) {
+    const count = Object.keys(body.headers as Record<string, unknown>).length;
+    summary.push(`Custom headers: ${String(count)} header value(s) will be stored (values are not shown).`);
+  }
+}
+
+function describeProviderShapeFields(body: Record<string, unknown>, summary: string[]): void {
+  const labels: Array<[string, string]> = [
+    ["kind", "Provider kind"],
+    ["name", "Display name"],
+    ["backendKind", "Backend"],
+    ["baseUrl", "Endpoint"],
+    ["api", "API dialect"],
+    ["authMode", "Auth mode"],
+    ["deploymentKind", "Deployment"],
+    ["regionTag", "Region"],
+    ["defaultModel", "Default model"],
+  ];
+  for (const [field, label] of labels) {
+    if (typeof body[field] === "string" && (body[field] as string).length > 0) {
+      summary.push(`${label}: ${body[field] as string}`);
+    }
+  }
+  if (Array.isArray(body.supportedModels)) {
+    summary.push(`Models: ${(body.supportedModels as unknown[]).map((m) => String(m)).join(", ")}`);
+  }
+  if (typeof body.enabled === "boolean") {
+    summary.push(`Enabled: ${body.enabled ? "yes" : "no"}`);
+  }
+  if (typeof body.validateOnSave === "boolean") {
+    summary.push(`Test the connection on save: ${body.validateOnSave ? "yes" : "no"}`);
+  }
+}
+
+function summarizeProviderCreate(body: Record<string, unknown>): string[] {
+  const summary = ["Add a new model provider connection to this Friday hub."];
+  describeProviderShapeFields(body, summary);
+  describeProviderCredentialFields(body, summary);
+  return summary;
+}
+
+function summarizeProviderUpdate(providerId: string, body: Record<string, unknown>): string[] {
+  const changed = Object.keys(body).sort();
+  const summary = [
+    `Change the saved settings of provider "${providerId}".`,
+    changed.length > 0 ? `Fields changed: ${changed.join(", ")}` : "Fields changed: (none)",
+  ];
+  describeProviderShapeFields(body, summary);
+  describeProviderCredentialFields(body, summary);
+  return summary;
+}
+
+function summarizeProviderRoutingSet(body: Record<string, unknown>): string[] {
+  const summary = ["Change which provider Friday uses to answer by default."];
+  if (typeof body.defaultProviderId === "string") {
+    summary.push(`Default provider: ${body.defaultProviderId}`);
+  }
+  if (typeof body.defaultModel === "string") {
+    summary.push(`Default model: ${body.defaultModel}`);
+  }
+  if (Array.isArray(body.fallbackProviderIds)) {
+    const fallbacks = (body.fallbackProviderIds as unknown[]).map((id) => String(id));
+    summary.push(`Fallback providers: ${fallbacks.length > 0 ? fallbacks.join(", ") : "(none)"}`);
+  }
+  if (typeof body.costMode === "string") {
+    summary.push(`Cost mode: ${body.costMode}`);
+  }
+  if (typeof body.enforceRequestedModel === "boolean") {
+    summary.push(`Enforce requested model: ${body.enforceRequestedModel ? "yes" : "no"}`);
+  }
+  return summary;
+}
+
+/**
+ * Builds the canonical gate descriptor for one provider mutation.
+ *
+ * SECURITY: this is the ONLY place `{action, surface, resourceId, parameters}` is
+ * decided. The plan endpoint and the mutation routes both call it, so the digest the
+ * owner confirms and the digest the gate recomputes are produced by the same code on
+ * the same inputs. It performs the same validation the mutation performs, so an
+ * invalid plan is rejected up front instead of minting an unusable approval.
+ */
+function buildFridayProviderMutationDescriptor(input: {
+  action: string;
+  providerId?: string;
+  profileKey?: string;
+  /**
+   * Owner user id, required by the provider-OAuth actions whose gate parameters are
+   * owner-scoped. It is supplied by the SERVER from the authenticated principal at
+   * both plan and mutation time (never read from the request body), so a plan minted
+   * for one owner can never authorize another owner's OAuth mutation.
+   */
+  ownerUserId?: string;
+  body: unknown;
+}): FridayProviderMutationDescriptor {
+  const action = input.action;
+  if (!PROVIDER_PLANNABLE_ACTIONS.has(action)) {
+    throw new FridayDomainError(
+      "VALIDATION_ERROR",
+      `action must be one of: ${[...PROVIDER_PLANNABLE_ACTIONS].join(", ")}`,
+      { httpStatus: 400 },
+    );
+  }
+
+  switch (action as FridayProviderPlannableAction) {
+    case "providers.create": {
+      const raw = liftProviderCreateConfigFields(asProviderMutationRecord(input.body));
+      const body = raw ? stripProviderMutationControlFields(raw) : raw;
+      validateCreateBody(body);
+      const parameters = body as unknown as Record<string, unknown>;
+      return {
+        action: "providers.create",
+        surface: "api:/v1/providers/create",
+        parameters,
+        humanReadableSummary: summarizeProviderCreate(parameters),
+      };
+    }
+    case "providers.update": {
+      const providerId = requireProviderMutationTargetId(input.providerId, "providerId", action);
+      const raw = asProviderMutationRecord(input.body);
+      const body = raw ? stripProviderMutationControlFields(raw) : raw;
+      validateUpdateBody(body);
+      const patch = body as unknown as Record<string, unknown>;
+      return {
+        action: "providers.update",
+        surface: "api:/v1/providers/update",
+        resourceId: providerId,
+        parameters: { providerId, patch },
+        humanReadableSummary: summarizeProviderUpdate(providerId, patch),
+      };
+    }
+    case "providers.delete": {
+      const providerId = requireProviderMutationTargetId(input.providerId, "providerId", action);
+      return {
+        action: "providers.delete",
+        surface: "api:/v1/providers/delete",
+        resourceId: providerId,
+        parameters: { providerId },
+        humanReadableSummary: [
+          `Delete provider connection "${providerId}" from this hub.`,
+          "The stored credential for this provider is removed and any routing that points at it stops working.",
+        ],
+      };
+    }
+    case "providers.validate": {
+      const providerId = requireProviderMutationTargetId(input.providerId, "providerId", action);
+      return {
+        action: "providers.validate",
+        surface: "api:/v1/providers/validate",
+        resourceId: providerId,
+        parameters: { providerId },
+        humanReadableSummary: [
+          `Test the stored credential of provider "${providerId}" against its endpoint.`,
+          "This contacts the provider and records the validation result on the profile.",
+        ],
+      };
+    }
+    case "providers.routing.set": {
+      const raw = asProviderMutationRecord(input.body);
+      const body = raw ? stripProviderMutationControlFields(raw) : raw;
+      validateRoutingBody(body);
+      const parameters = body as unknown as Record<string, unknown>;
+      return {
+        action: "providers.routing.set",
+        surface: "api:/v1/model-routing/set",
+        resourceId: "model-routing",
+        parameters,
+        humanReadableSummary: summarizeProviderRoutingSet(parameters),
+      };
+    }
+    case "providers.routing.pin":
+    case "providers.routing.penalty.clear": {
+      const raw = asProviderMutationRecord(input.body);
+      const body = raw ? stripProviderMutationControlFields(raw) : raw;
+      assertProviderRoutingControlBody(body);
+      const resourceId = `${String(body.providerId)}:${String(body.model)}:${String(body.backendKind)}`;
+      const pinning = action === "providers.routing.pin";
+      return {
+        action: pinning ? "providers.routing.pin" : "providers.routing.penalty.clear",
+        surface: pinning ? "api:/v1/providers/routing/pin" : "api:/v1/providers/routing/penalties/clear",
+        resourceId,
+        parameters: body,
+        humanReadableSummary: [
+          pinning
+            ? `Pin routing to provider "${String(body.providerId)}" model "${String(body.model)}" (${String(body.backendKind)}).`
+            : `Clear the routing penalty on provider "${String(body.providerId)}" model "${String(body.model)}" (${String(body.backendKind)}).`,
+        ],
+      };
+    }
+    case "providers.auth.profiles.activate": {
+      const providerId = requireProviderMutationTargetId(input.providerId, "providerId", action);
+      const profileKey = requireProviderMutationTargetId(input.profileKey, "profileKey", action);
+      return {
+        action: "providers.auth.profiles.activate",
+        surface: "api:/v1/providers/auth-profiles/activate",
+        resourceId: `${providerId}:${profileKey}`,
+        parameters: { providerId, profileKey },
+        humanReadableSummary: [
+          `Switch provider "${providerId}" to auth profile "${profileKey}".`,
+          "Later requests to this provider will use that profile's stored credential.",
+        ],
+      };
+    }
+    case "providers.oauth.openai_codex.device.initiate":
+    case "providers.oauth.openai_codex.device.complete": {
+      const ownerUserId = requireProviderMutationTargetId(input.ownerUserId, "ownerUserId", action);
+      const raw = asProviderMutationRecord(input.body);
+      const body = raw ? stripProviderMutationControlFields(raw) : raw;
+      const completing = action === "providers.oauth.openai_codex.device.complete";
+      if (completing) {
+        // Same validation the mutation performs, so an unusable plan is refused up
+        // front. The device code VALUE never enters the descriptor (only its
+        // presence), so it can never reach a digest, a summary or a stored plan.
+        if (!body || typeof body.deviceCodeId !== "string" || body.deviceCodeId.trim() === "") {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "deviceCodeId is required and must be a non-empty string",
+            { httpStatus: 400 },
+          );
+        }
+      }
+      const selection = readOAuthSelectionInput(body, "openai-codex");
+      const resourceId = readOptionalTrimmedString(body?.providerId) ?? "openai-codex";
+      const summary = completing
+        ? [
+          `Finish signing in to OpenAI Codex and store the resulting login on provider "${resourceId}".`,
+          "The device code and the returned tokens are never shown here; they are stored encrypted.",
+        ]
+        : [
+          `Start an OpenAI Codex device sign-in for provider "${resourceId}".`,
+          "This asks OpenAI for a device code you will approve in your browser; no credential is stored yet.",
+        ];
+      if (selection.kind) {
+        summary.push(`Provider kind: ${selection.kind}`);
+      }
+      if (selection.name) {
+        summary.push(`Display name: ${selection.name}`);
+      }
+      if (selection.defaultModel) {
+        summary.push(`Default model: ${selection.defaultModel}`);
+      }
+      return {
+        action: completing
+          ? "providers.oauth.openai_codex.device.complete"
+          : "providers.oauth.openai_codex.device.initiate",
+        surface: completing
+          ? "api:/v1/auth/oauth/openai-codex/device/complete"
+          : "api:/v1/auth/oauth/openai-codex/device/initiate",
+        resourceId,
+        parameters: completing
+          ? { ownerUserId, selection, deviceCodeIdPresent: true }
+          : { ownerUserId, selection },
+        humanReadableSummary: summary,
+      };
+    }
+    case "capabilities.doctor": {
+      const providerIds = parseCapabilityDoctorProviderIds(input.body ?? undefined);
+      return {
+        action: "capabilities.doctor",
+        surface: "api:/v1/capabilities/doctor",
+        resourceId: providerIds ? providerIds.join(",") : "all-providers",
+        parameters: { providerIds: providerIds ?? "all-providers" },
+        humanReadableSummary: [
+          providerIds
+            ? `Run the capability doctor against provider(s): ${providerIds.join(", ")}.`
+            : "Run the capability doctor against every configured provider.",
+          "This contacts the providers and records capability proof results.",
+        ],
+      };
+    }
+  }
+}
+
+/**
+ * SERVER-SIDE plan digest. Derived only from the sanitized (secret-redacted)
+ * parameters plus the immutable identity of the mutation, never from anything the
+ * client asserts. Deterministic on purpose: re-planning the same change for the same
+ * owner yields the same digest, so a stale digest is detectable.
+ */
+function computeFridayProviderMutationPlanDigest(input: {
+  descriptor: FridayProviderMutationDescriptor;
+  ownerPrincipalId: string;
+  idempotencyKey?: string;
+}): string {
+  const sanitizedParameters = sanitizeProviderMutationParameters(input.descriptor.parameters);
+  return `fpmp_${hashStableJson({
+    version: 1,
+    kind: "friday.provider.mutation.plan",
+    action: input.descriptor.action,
+    surface: input.descriptor.surface,
+    resourceId: input.descriptor.resourceId,
+    ownerPrincipalId: input.ownerPrincipalId,
+    parameters: sanitizedParameters,
+    idempotencyKey: input.idempotencyKey,
+  })}`;
 }
 
 export function createFridayProviderSetupMutatingActionRequest(input: {
@@ -565,14 +1020,54 @@ export function createFridayProviderRoutes(
     };
   }
 
+  const nowIso = deps.nowIso ?? ((): string => new Date().toISOString());
+
+  /**
+   * Owner-confirm plan store. In-memory and process-local BY DESIGN: a plan is a
+   * short-lived, unprivileged review artifact — losing it on restart only forces a
+   * re-plan (fail-closed), while persisting it would create a durable record keyed to
+   * a mutation the owner may never confirm.
+   */
+  const providerMutationPlans = new Map<string, FridayProviderMutationPlanRecord>();
+
+  function pruneProviderMutationPlans(): void {
+    const nowMs = Date.parse(nowIso());
+    for (const [key, record] of providerMutationPlans) {
+      const expiresAtMs = Date.parse(record.expiresAt);
+      if (!Number.isFinite(expiresAtMs) || !Number.isFinite(nowMs) || expiresAtMs <= nowMs) {
+        providerMutationPlans.delete(key);
+      }
+    }
+    while (providerMutationPlans.size > PROVIDER_MUTATION_PLAN_MAX_ENTRIES) {
+      const oldest = providerMutationPlans.keys().next();
+      if (oldest.done) break;
+      providerMutationPlans.delete(oldest.value);
+    }
+  }
+
+  /**
+   * The plan + confirm endpoints require exactly the authority the mutation requires:
+   * a bound (non-synthetic) owner principal. The HTTP server already refuses the
+   * synthetic public principal on public POST routes; this is the in-handler
+   * restatement so the seam is fail-closed for every caller of the factory.
+   */
+  function requireProviderMutationOwnerPrincipalId(principal: FridayAuthPrincipal | null): string {
+    if (isUnauthenticatedPublicPrincipal(principal) || !principal?.principalId) {
+      throw new FridayDomainError(
+        "OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED",
+        "Provider setup planning and confirmation require a bound owner principal; the synthetic public principal cannot review or approve provider mutations.",
+        { httpStatus: 401 },
+      );
+    }
+    return principal.principalId;
+  }
+
   function maybeRequireProviderMutationTicket(input: {
-    action: string;
+    descriptor: FridayProviderMutationDescriptor;
     ctx: { requestId: string; principal: FridayAuthPrincipal | null };
     body?: Record<string, unknown> | null;
-    resourceId?: string;
-    parameters: Record<string, unknown>;
-    surface: string;
   }): FridayMutatingActionTicket | undefined {
+    const { action, surface, resourceId, parameters } = input.descriptor;
     if (!deps.providerMutationGateRequired) {
       return undefined;
     }
@@ -587,16 +1082,22 @@ export function createFridayProviderRoutes(
     if (!controls.planDigest) {
       throw new FridayDomainError(
         "PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED",
-        "Provider setup and routing mutations require an approved plan digest in this profile.",
-        { httpStatus: 403, details: { action: input.action, resourceId: input.resourceId } },
+        "Provider setup and routing mutations require an approved plan digest in this profile. "
+          + "Call POST /v1/providers/plan, review the returned summary, then POST /v1/providers/plan/confirm.",
+        { httpStatus: 403, details: { action, resourceId } },
       );
     }
+    // The digest of record is recomputed HERE, server-side, from the sanitized
+    // parameters this request actually carries. The client-supplied `planDigest` is
+    // only an input to that computation — it is never trusted as the truth, and any
+    // drift between what was confirmed and what arrived changes the action digest and
+    // is refused below as `canonical_approval_digest_mismatch`.
     const request = createFridayProviderSetupMutatingActionRequest({
-      action: input.action,
+      action,
       actor: createActorFromPrincipal(input.ctx.principal, `api:${input.ctx.requestId}`),
-      surface: input.surface,
-      resourceId: input.resourceId,
-      parameters: input.parameters,
+      surface,
+      resourceId,
+      parameters,
       planDigest: controls.planDigest,
       idempotencyKey: controls.idempotencyKey,
     });
@@ -868,6 +1369,194 @@ export function createFridayProviderRoutes(
       },
     },
 
+    // ─── Plan a provider mutation (step 1 of the owner-confirm protocol) ───
+    //
+    // READ-SHAPED: builds and records a review artifact. It performs NO provider
+    // mutation, mints NO approval and grants NO authority — the returned digests are
+    // useless until the same owner explicitly confirms them at
+    // POST /v1/providers/plan/confirm.
+    {
+      operationId: "providers.plan",
+      method: "POST",
+      path: "/v1/providers/plan",
+      auth: { public: true },
+      rateLimitPolicyId: "provider.write",
+      async handler(ctx): Promise<FridayPlanProviderMutationResponse> {
+        const ownerPrincipalId = requireProviderMutationOwnerPrincipalId(ctx.principal);
+        const body = asProviderMutationRecord(ctx.body);
+        const action = typeof body?.action === "string" ? body.action.trim() : "";
+        const idempotencyKey = readOptionalTrimmedString(body?.idempotencyKey);
+        const descriptor = buildFridayProviderMutationDescriptor({
+          action,
+          providerId: readOptionalTrimmedString(body?.providerId),
+          profileKey: readOptionalTrimmedString(body?.profileKey),
+          // SERVER-supplied, never client-supplied: the owner identity that the
+          // mutation route will itself derive from its own authenticated principal.
+          ownerUserId: readOptionalTrimmedString(ctx.principal?.userId),
+          body: body?.params ?? null,
+        });
+
+        const planDigest = computeFridayProviderMutationPlanDigest({
+          descriptor,
+          ownerPrincipalId,
+          idempotencyKey,
+        });
+        // Same builder + same digest function the mutation route will use, so the
+        // action digest the owner confirms is byte-identical to the one the gate
+        // recomputes when the mutation actually arrives.
+        const request = createFridayProviderSetupMutatingActionRequest({
+          action: descriptor.action,
+          actor: createActorFromPrincipal(ctx.principal, `api:${ctx.requestId}`),
+          surface: descriptor.surface,
+          resourceId: descriptor.resourceId,
+          parameters: descriptor.parameters,
+          planDigest,
+          idempotencyKey,
+        });
+        const actionDigest = createFridayMutatingActionDigest(request);
+
+        const createdAt = nowIso();
+        const createdAtMs = Date.parse(createdAt);
+        const expiresAt = new Date(
+          (Number.isFinite(createdAtMs) ? createdAtMs : Date.now()) + PROVIDER_MUTATION_PLAN_TTL_MS,
+        ).toISOString();
+
+        pruneProviderMutationPlans();
+        // A fresh plan always REPLACES any earlier record for the same digest, and is
+        // always unconfirmed: planning can never resurrect a spent confirmation.
+        providerMutationPlans.delete(planDigest);
+        providerMutationPlans.set(planDigest, {
+          planDigest,
+          actionDigest,
+          request,
+          ownerPrincipalId,
+          action: descriptor.action,
+          surface: descriptor.surface,
+          resourceId: descriptor.resourceId,
+          idempotencyKey,
+          humanReadableSummary: descriptor.humanReadableSummary,
+          createdAt,
+          expiresAt,
+        });
+
+        const plan: FridayProviderMutationPlan = {
+          planDigest,
+          actionDigest,
+          action: descriptor.action,
+          surface: descriptor.surface,
+          resourceId: descriptor.resourceId,
+          idempotencyKey,
+          humanReadableSummary: descriptor.humanReadableSummary,
+          approvalRequired: deps.providerMutationGateRequired === true,
+          createdAt,
+          expiresAt,
+        };
+        return { plan };
+      },
+    },
+
+    // ─── Confirm a provider mutation plan (step 2: the owner's explicit decision) ───
+    //
+    // This is the ONLY seam that mints a provider-setup canonical approval. It refuses
+    // unless: the caller is the SAME bound owner principal that created the plan; the
+    // plan digest names a plan THIS server produced; that plan has not expired; and it
+    // has not already been confirmed. There is no plan-and-approve shortcut anywhere —
+    // the mutation route never calls this, so an approval can only exist because a
+    // human owner asked for it against a summary they were shown.
+    {
+      operationId: "providers.plan.confirm",
+      method: "POST",
+      path: "/v1/providers/plan/confirm",
+      auth: { public: true },
+      rateLimitPolicyId: "provider.write",
+      async handler(ctx): Promise<FridayConfirmProviderMutationResponse> {
+        const ownerPrincipalId = requireProviderMutationOwnerPrincipalId(ctx.principal);
+        const body = asProviderMutationRecord(ctx.body);
+        const planDigest = readOptionalTrimmedString(body?.planDigest);
+        if (!planDigest) {
+          throw new FridayDomainError(
+            "VALIDATION_ERROR",
+            "planDigest is required to confirm a provider mutation plan",
+            { httpStatus: 400 },
+          );
+        }
+        if (body?.confirm !== true) {
+          throw new FridayDomainError(
+            "PROVIDER_MUTATION_CONFIRMATION_REQUIRED",
+            "Provider mutation approval requires an explicit owner confirmation (`confirm: true`) of the reviewed plan.",
+            { httpStatus: 400 },
+          );
+        }
+        if (!deps.signCanonicalApproval) {
+          throw new FridayDomainError(
+            "PROVIDER_MUTATION_APPROVAL_SIGNER_UNAVAILABLE",
+            "This runtime cannot mint provider mutation approvals; the canonical approval signer is not wired.",
+            { httpStatus: 503 },
+          );
+        }
+
+        pruneProviderMutationPlans();
+        const record = providerMutationPlans.get(planDigest);
+        if (!record) {
+          throw new FridayDomainError(
+            "PROVIDER_MUTATION_PLAN_NOT_FOUND",
+            "No live provider mutation plan matches that plan digest. Re-plan the change and review it again.",
+            { httpStatus: 404 },
+          );
+        }
+        if (record.ownerPrincipalId !== ownerPrincipalId) {
+          throw new FridayDomainError(
+            "PROVIDER_MUTATION_PLAN_OWNER_MISMATCH",
+            "A provider mutation plan can only be confirmed by the owner principal that created it.",
+            { httpStatus: 403 },
+          );
+        }
+        if (record.confirmedAt !== undefined) {
+          throw new FridayDomainError(
+            "PROVIDER_MUTATION_PLAN_ALREADY_CONFIRMED",
+            "That provider mutation plan has already been confirmed. Re-plan the change to confirm it again.",
+            { httpStatus: 409 },
+          );
+        }
+
+        const confirmedAt = nowIso();
+        // Single-use at the plan layer too: the record is spent BEFORE the approval is
+        // minted, so a concurrent second confirm can never obtain a second signature.
+        record.confirmedAt = confirmedAt;
+
+        const canonicalApproval = deps.signCanonicalApproval(record.request, {
+          approvalIdPrefix: `provider-owner-confirm-${record.action}`,
+        });
+        if (canonicalApproval.actionDigest !== record.actionDigest) {
+          throw new FridayDomainError(
+            "PROVIDER_MUTATION_APPROVAL_DIGEST_MISMATCH",
+            "The minted approval did not bind to the reviewed plan's action digest; refusing to issue it.",
+            { httpStatus: 500 },
+          );
+        }
+        if (!canonicalApproval.expiresAt) {
+          throw new FridayDomainError(
+            "PROVIDER_MUTATION_APPROVAL_EXPIRY_REQUIRED",
+            "The minted approval carried no expiry; refusing to issue it.",
+            { httpStatus: 500 },
+          );
+        }
+
+        return {
+          approval: {
+            planDigest: record.planDigest,
+            actionDigest: record.actionDigest,
+            action: record.action,
+            resourceId: record.resourceId,
+            idempotencyKey: record.idempotencyKey,
+            confirmedAt,
+            expiresAt: canonicalApproval.expiresAt,
+            canonicalApproval,
+          },
+        };
+      },
+    },
+
     {
       operationId: "providers.templates.get",
       method: "GET",
@@ -925,12 +1614,9 @@ export function createFridayProviderRoutes(
         const raw = ctx.body as Record<string, unknown> | null;
         const providerIds = parseCapabilityDoctorProviderIds(raw);
         const ticket = maybeRequireProviderMutationTicket({
-          action: "capabilities.doctor",
+          descriptor: buildFridayProviderMutationDescriptor({ action: "capabilities.doctor", body: raw }),
           ctx,
           body: raw,
-          resourceId: providerIds ? providerIds.join(",") : "all-providers",
-          parameters: { providerIds: providerIds ?? "all-providers" },
-          surface: "api:/v1/capabilities/doctor",
         });
         // DARK cut-over (DEFAULT-OFF): bridge to the Rust hub_capability_doctor bin
         // instead of fail-closing. The canonical mutation gate above still runs first
@@ -983,26 +1669,15 @@ export function createFridayProviderRoutes(
         // DX-001: Accept both flat and nested (config) formats.
         // If the body has a `config` object with provider fields, lift them to top level.
         const rawInput = ctx.body as Record<string, unknown> | null;
-        const raw = rawInput && typeof rawInput === "object" ? { ...rawInput } : rawInput;
-        if (raw && typeof raw === "object" && raw.config && typeof raw.config === "object") {
-          const config = raw.config as Record<string, unknown>;
-          const liftFields = ["api", "authMode", "supportedModels", "apiKey", "defaultModel", "headers", "backendKind", "cliConfig", "runtimeCapabilities", "deploymentKind", "regionTag"] as const;
-          for (const field of liftFields) {
-            if (config[field] !== undefined && raw[field] === undefined) {
-              raw[field] = config[field];
-            }
-          }
-        }
+        const raw = liftProviderCreateConfigFields(rawInput);
         const body = raw && typeof raw === "object"
           ? stripProviderMutationControlFields(raw)
           : raw;
         validateCreateBody(body);
         const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.create",
+          descriptor: buildFridayProviderMutationDescriptor({ action: "providers.create", body: rawInput }),
           ctx,
           body: raw && typeof raw === "object" ? raw : undefined,
-          parameters: body as unknown as Record<string, unknown>,
-          surface: "api:/v1/providers/create",
         });
         const provider = await deps.providerService.createProvider(body);
         return withCanonicalGate({
@@ -1027,12 +1702,9 @@ export function createFridayProviderRoutes(
           : raw;
         validateUpdateBody(body);
         const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.update",
+          descriptor: buildFridayProviderMutationDescriptor({ action: "providers.update", providerId, body: raw }),
           ctx,
           body: raw,
-          resourceId: providerId,
-          parameters: { providerId, patch: body as unknown as Record<string, unknown> },
-          surface: "api:/v1/providers/update",
         });
         const provider = await deps.providerService.updateProvider(
           providerId,
@@ -1056,12 +1728,9 @@ export function createFridayProviderRoutes(
         const { providerId } = ctx.params as { providerId: string };
         const body = (ctx.body ?? {}) as Record<string, unknown>;
         const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.delete",
+          descriptor: buildFridayProviderMutationDescriptor({ action: "providers.delete", providerId, body }),
           ctx,
           body,
-          resourceId: providerId,
-          parameters: { providerId },
-          surface: "api:/v1/providers/delete",
         });
         await deps.providerService.deleteProvider(providerId);
         return withCanonicalGate({ deleted: true as const }, ticket);
@@ -1079,12 +1748,9 @@ export function createFridayProviderRoutes(
         const { providerId } = ctx.params as { providerId: string };
         const body = (ctx.body ?? {}) as Record<string, unknown>;
         const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.validate",
+          descriptor: buildFridayProviderMutationDescriptor({ action: "providers.validate", providerId, body }),
           ctx,
           body,
-          resourceId: providerId,
-          parameters: { providerId },
-          surface: "api:/v1/providers/validate",
         });
         // DARK cut-over (DEFAULT-OFF): bridge to the Rust hub_capability_doctor bin
         // instead of fail-closing. The canonical mutation gate above still runs first.
@@ -1194,12 +1860,9 @@ export function createFridayProviderRoutes(
           throw new FridayDomainError("VALIDATION_ERROR", "backendKind must be one of: http, cli, sdk", { httpStatus: 400 });
         }
         const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.routing.pin",
+          descriptor: buildFridayProviderMutationDescriptor({ action: "providers.routing.pin", body: raw }),
           ctx,
           body: raw,
-          resourceId: `${body.providerId}:${body.model}:${body.backendKind}`,
-          parameters: body,
-          surface: "api:/v1/providers/routing/pin",
         });
         assertProviderRoutingControlsTestOracleAllowed(deps);
         await deps.providerService.pinRoute({
@@ -1239,12 +1902,9 @@ export function createFridayProviderRoutes(
           throw new FridayDomainError("VALIDATION_ERROR", "backendKind must be one of: http, cli, sdk", { httpStatus: 400 });
         }
         const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.routing.penalty.clear",
+          descriptor: buildFridayProviderMutationDescriptor({ action: "providers.routing.penalty.clear", body: raw }),
           ctx,
           body: raw,
-          resourceId: `${body.providerId}:${body.model}:${body.backendKind}`,
-          parameters: body,
-          surface: "api:/v1/providers/routing/penalties/clear",
         });
         assertProviderRoutingControlsTestOracleAllowed(deps);
         const cleared = await deps.providerService.clearRoutePenalty({
@@ -1280,12 +1940,14 @@ export function createFridayProviderRoutes(
         const { providerId, profileKey } = ctx.params as { providerId: string; profileKey: string };
         const body = (ctx.body ?? {}) as Record<string, unknown>;
         const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.auth.profiles.activate",
+          descriptor: buildFridayProviderMutationDescriptor({
+            action: "providers.auth.profiles.activate",
+            providerId,
+            profileKey,
+            body,
+          }),
           ctx,
           body,
-          resourceId: `${providerId}:${profileKey}`,
-          parameters: { providerId, profileKey },
-          surface: "api:/v1/providers/auth-profiles/activate",
         });
         const profile = await deps.providerService.activateAuthProfile(providerId, profileKey);
         return withCanonicalGate({ profile }, ticket);
@@ -1318,12 +1980,9 @@ export function createFridayProviderRoutes(
           : raw;
         validateRoutingBody(body);
         const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.routing.set",
+          descriptor: buildFridayProviderMutationDescriptor({ action: "providers.routing.set", body: raw }),
           ctx,
           body: raw,
-          resourceId: "model-routing",
-          parameters: body as unknown as Record<string, unknown>,
-          surface: "api:/v1/model-routing/set",
         });
         const routing = await deps.providerService.setRoutingConfig(body);
         return withCanonicalGate({ routing }, ticket);
@@ -1376,15 +2035,13 @@ export function createFridayProviderRoutes(
           ? stripProviderMutationControlFields(raw)
           : raw;
         const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.oauth.openai_codex.device.initiate",
+          descriptor: buildFridayProviderMutationDescriptor({
+            action: "providers.oauth.openai_codex.device.initiate",
+            ownerUserId,
+            body: raw,
+          }),
           ctx,
           body: raw,
-          resourceId: typeof body?.providerId === "string" ? body.providerId : "openai-codex",
-          parameters: {
-            ownerUserId,
-            selection: readOAuthSelectionInput(body, "openai-codex"),
-          },
-          surface: "api:/v1/auth/oauth/openai-codex/device/initiate",
         });
         const selection = await resolveOrProvisionOAuthProvider(
           deps.providerService,
@@ -1424,16 +2081,13 @@ export function createFridayProviderRoutes(
           );
         }
         const ticket = maybeRequireProviderMutationTicket({
-          action: "providers.oauth.openai_codex.device.complete",
+          descriptor: buildFridayProviderMutationDescriptor({
+            action: "providers.oauth.openai_codex.device.complete",
+            ownerUserId,
+            body: raw,
+          }),
           ctx,
           body: raw,
-          resourceId: typeof body.providerId === "string" ? body.providerId : "openai-codex",
-          parameters: {
-            ownerUserId,
-            selection: readOAuthSelectionInput(body, "openai-codex"),
-            deviceCodeIdPresent: true,
-          },
-          surface: "api:/v1/auth/oauth/openai-codex/device/complete",
         });
         const selection = await resolveExistingOAuthProvider(
           deps.providerService,

--- a/src/api/http/routes/friday-provider-routes.ts
+++ b/src/api/http/routes/friday-provider-routes.ts
@@ -44,6 +44,7 @@ import type {
   FridayProviderCapabilityHealthSnapshotSummary,
   FridayProviderHealthSnapshotItem,
   FridayProviderLane,
+  FridayProviderMutationOptions,
   FridayProviderProfile,
   FridayProviderRuntimeCapabilityDeclaration,
   FridayProviderService,
@@ -75,6 +76,7 @@ import {
   type FridayMutatingActionRequest,
   type FridayMutatingActionTicket,
 } from "../../../security/friday-mutating-action-gate.js";
+import type { FridayApprovalConsumptionStore } from "../persistence/friday-provider-approval-consumption-repository.js";
 import { deviceOwnerPrincipalId } from "../../../security/friday-device-owner-authority-precondition.js";
 import { isUnauthenticatedPublicPrincipal } from "../../../security/friday-owner-session-channel-capability.js";
 import type {
@@ -487,6 +489,16 @@ export interface FridayProviderRoutesDeps {
    * device-claim), a device-authored approval fails closed at the binding check.
    */
   resolveBoundDeviceOwnerSentinelHash?: (userId: string) => string | null;
+  /**
+   * SEC-APPROVAL-AUTHORITY-001 · Advisor round-2 finding #3: the DURABLE single-use ledger
+   * for canonical approvals — the SAME instance injected into the mutating-action gate. The
+   * provider create/update/delete handlers gate with `deferApprovalConsumption`, then finalize
+   * the reservation on this store INSIDE the provider mutation's write transaction
+   * (`completeConsumptionInTransaction`), so consume ⊗ mutation commit atomically; a clean
+   * pre-commit failure releases the reservation so the owner can retry the same approval. When
+   * absent (db-less test fixtures), the gate's inline consumption is the single-use enforcement.
+   */
+  approvalConsumptionStore?: FridayApprovalConsumptionStore;
 }
 
 // ─── Provider mutation plan / owner-confirm protocol (CORE-RUNNABLE-001) ───
@@ -1081,6 +1093,14 @@ export function createFridayProviderRoutes(
     descriptor: FridayProviderMutationDescriptor;
     ctx: { requestId: string; principal: FridayAuthPrincipal | null };
     body?: Record<string, unknown> | null;
+    /**
+     * DEFER the durable approval consumption to the caller so it can finalize it in the
+     * SAME transaction as the provider mutation (create/update/delete). When true the
+     * returned ticket carries `canonicalApprovalUseKey`; the handler MUST pass
+     * {@link buildApprovalConsumeInTransaction} into the service call and release the
+     * reservation on a caught pre-commit failure.
+     */
+    deferApprovalConsumption?: boolean;
   }): FridayMutatingActionTicket | undefined {
     const { action, surface, resourceId, parameters } = input.descriptor;
     if (!deps.providerMutationGateRequired) {
@@ -1132,10 +1152,13 @@ export function createFridayProviderRoutes(
       planDigest: controls.planDigest,
       idempotencyKey: controls.idempotencyKey,
     });
-    const gateResult = deps.canonicalMutationGate.evaluate({
-      ...request,
-      canonicalApproval: controls.canonicalApproval,
-    });
+    const gateResult = deps.canonicalMutationGate.evaluate(
+      {
+        ...request,
+        canonicalApproval: controls.canonicalApproval,
+      },
+      { deferApprovalConsumption: input.deferApprovalConsumption === true },
+    );
     if (gateResult.decision !== "allow" || !gateResult.ticket) {
       throw new FridayDomainError(
         gateResult.decision === "requires_approval"
@@ -1154,6 +1177,38 @@ export function createFridayProviderRoutes(
       );
     }
     return gateResult.ticket;
+  }
+
+  /**
+   * Run a provider mutation with the DEFERRED approval consumption finalized ATOMICALLY
+   * inside the mutation's own write transaction (`completeConsumptionInTransaction`), so a
+   * replayed approval (PK conflict) rolls back BOTH the consume and the mutation, and no
+   * durable effect commits without a durable consumption. On a clean pre-commit failure the
+   * in_flight reservation is released so the owner can retry the SAME confirmed approval; a
+   * crash instead leaves it in_flight → boot reconcile marks it indeterminate (fail-closed).
+   * When there is no deferred reservation (no gate, no durable store, or a non-deferred
+   * inline consumption already committed), the mutation runs unchanged with no consume hook.
+   */
+  async function runProviderMutationWithDeferredConsumption<T>(
+    ticket: FridayMutatingActionTicket | undefined,
+    run: (options?: FridayProviderMutationOptions) => Promise<T>,
+  ): Promise<T> {
+    const useKey = ticket?.canonicalApprovalUseKey;
+    const store = deps.approvalConsumptionStore;
+    if (useKey === undefined || !store) {
+      return run(undefined);
+    }
+    try {
+      return await run({
+        consumeApprovalInTransaction: (db) => store.completeConsumptionInTransaction(db, useKey),
+      });
+    } catch (err) {
+      // The mutation's write transaction rolled back (or never ran), so no side effect
+      // committed. releaseReservation is scoped to status='in_flight', so it is a no-op once
+      // the consume has committed (e.g. a post-commit throw) — never releasing a real effect.
+      store.releaseReservation(useKey);
+      throw err;
+    }
   }
 
   async function listHealthSnapshot(): Promise<FridayGetProviderHealthSnapshotResponse> {
@@ -1789,8 +1844,12 @@ export function createFridayProviderRoutes(
           descriptor: buildFridayProviderMutationDescriptor({ action: "providers.create", body: rawInput }),
           ctx,
           body: raw && typeof raw === "object" ? raw : undefined,
+          deferApprovalConsumption: true,
         });
-        const provider = await deps.providerService.createProvider(body);
+        const provider = await runProviderMutationWithDeferredConsumption(
+          ticket,
+          (options) => deps.providerService.createProvider(body, options),
+        );
         return withCanonicalGate({
           provider,
           validation: provider.config.validation,
@@ -1816,10 +1875,11 @@ export function createFridayProviderRoutes(
           descriptor: buildFridayProviderMutationDescriptor({ action: "providers.update", providerId, body: raw }),
           ctx,
           body: raw,
+          deferApprovalConsumption: true,
         });
-        const provider = await deps.providerService.updateProvider(
-          providerId,
-          body,
+        const provider = await runProviderMutationWithDeferredConsumption(
+          ticket,
+          (options) => deps.providerService.updateProvider(providerId, body, options),
         );
         return withCanonicalGate({
           provider,
@@ -1842,8 +1902,12 @@ export function createFridayProviderRoutes(
           descriptor: buildFridayProviderMutationDescriptor({ action: "providers.delete", providerId, body }),
           ctx,
           body,
+          deferApprovalConsumption: true,
         });
-        await deps.providerService.deleteProvider(providerId);
+        await runProviderMutationWithDeferredConsumption(
+          ticket,
+          (options) => deps.providerService.deleteProvider(providerId, options),
+        );
         return withCanonicalGate({ deleted: true as const }, ticket);
       },
     },

--- a/src/api/http/routes/friday-session-routes.ts
+++ b/src/api/http/routes/friday-session-routes.ts
@@ -133,6 +133,23 @@ export interface FridayRustSessionLifecycleBridge {
     sessionKey: string;
     principal: FridayAuthPrincipal;
   }): Promise<FridaySessionMemoryNamespaceResponse>;
+  /**
+   * (CORE-RUNNABLE-001 / CORE-A CR-3) Execute a session-scoped agent RUN on the Rust-owned loop and
+   * return the run result. OPTIONAL so a bridge that only implements the storage lifecycle ops
+   * still satisfies the interface (an absent `runSession` ⇒ `sessions.run` stays fail-closed 503,
+   * exactly as when the Rust route is off). The production adapter
+   * ({@link createFridayRustHubSessionLifecycleDispatchAdapter}) implements this REALLY over the
+   * sealed-WS agent-run transport + the owner-gated answer readback.
+   */
+  runSession?(input: {
+    sessionKey: string;
+    task: string;
+    principalId: string;
+    providerId?: string;
+    model?: string;
+    timezone?: string;
+    timeoutMs?: number;
+  }): Promise<FridaySessionRunResponse["run"]>;
 }
 
 // ─── Metadata sanitization (VULN-1: Prototype Pollution DoS) ───
@@ -1302,6 +1319,40 @@ export function createFridaySessionRoutes(
               : "task is required unless useLastUserMessage is explicitly true",
             { httpStatus: 400 },
           );
+        }
+
+        // (CORE-RUNNABLE-001 / CORE-A CR-3) Rust-owned session-run branch — mirrors the session
+        // lifecycle branches (create/messages.create). DEFAULT-OFF: only when `routeSessionsViaRust`
+        // is on AND a real bridge is wired does the run dispatch to the Rust-owned loop instead of
+        // fail-closing. An absent `runSession` on the bridge fails closed the same as a retired run,
+        // so a lifecycle-only bridge never silently no-ops. Placed BEFORE the TS-path oracle guard so
+        // flag-OFF is byte-identical (falls through to `assertSessionRunTestOracleAllowed` → 503).
+        if (deps.routeSessionsViaRust === true) {
+          const bridge = rustSessionLifecycleBridgeOrRetired(deps);
+          if (!bridge.runSession) {
+            throwRetiredSession(
+              "TS_RUNTIME_SESSION_RUN_RETIRED",
+              "TypeScript session agent-run execution",
+              "session_run",
+            );
+          }
+          const principal = assertSessionWritePrincipal(ctx.principal ?? null, "sessions.run");
+          const run = await bridge.runSession({
+            sessionKey: key,
+            task,
+            principalId: principal.principalId,
+            ...(body.providerId !== undefined ? { providerId: body.providerId } : {}),
+            ...(body.model !== undefined ? { model: body.model } : {}),
+            ...(body.timezone?.trim() ? { timezone: body.timezone.trim() } : {}),
+            ...(body.timeoutMs !== undefined ? { timeoutMs: body.timeoutMs } : {}),
+          });
+          return {
+            run,
+            messages: [
+              { role: "user" as const, content: task },
+              { role: "assistant" as const, content: run.response },
+            ],
+          };
         }
 
         assertSessionRunTestOracleAllowed(deps);

--- a/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
+++ b/src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.ts
@@ -440,6 +440,25 @@ export interface FridayRustHubAgentRunSealedClient {
   decideRunOutcomeLearning(
     request: FridayRustHubRunOutcomeLearningDecisionRequest,
   ): Promise<FridayRustHubRunOutcomeLearningDecisionResult>;
+  /**
+   * (CORE-A CR-3) Create/ensure ONE agent-session row over a sealed session —
+   * `Message::SessionCreateRequest`. PURE Hub `&Db` mutation (no model/provider call). Opens a fresh
+   * sealed session (the channel auth), sends the create envelope, and awaits the FIRST refs-only
+   * `SessionCreateResult`. Fails closed (503) on any non-clean settle or any other inbound (including
+   * the server's `Error` envelope — which is how an owner mismatch surfaces).
+   */
+  createSession(
+    request: FridayRustHubSessionCreateRequest,
+  ): Promise<FridayRustHubSessionCreateResult>;
+  /**
+   * (CORE-A CR-3) Append ONE conversation message to an existing session over a sealed session —
+   * `Message::SessionMessageAppendRequest`. PURE Hub `&Db` mutation. OWNER-GATED server-side. Awaits
+   * the FIRST refs-only `SessionMessageAppendResult`; fails closed (503) on any other inbound
+   * (including the server's `Error` — the owner-mismatch refusal). The body rides the sealed session.
+   */
+  appendSessionMessage(
+    request: FridayRustHubSessionMessageAppendRequest,
+  ): Promise<FridayRustHubSessionMessageAppendResult>;
 }
 
 /** (A3 courier) A resume relay: the run to resume + the operator's OPAQUE signed approval blob. */
@@ -673,6 +692,57 @@ export interface FridayRustHubRunOutcomeLearningDecisionResult {
   readonly state: string;
   readonly status: string;
   readonly blocker?: string;
+}
+
+/**
+ * (CORE-A CR-3) Create/ensure ONE agent-session row — `Message::SessionCreateRequest`. The OWNER is
+ * bound SERVER-side to the authenticated principal (single-peer session = channel auth); `userId`
+ * here is the forwarded owner (the server FIX-Q3b-refuses a value that disagrees), NOT an authority.
+ * The remaining axes are descriptive surface metadata.
+ */
+export interface FridayRustHubSessionCreateRequest {
+  /** The canonical session key (`agent_session_id`) to ensure. Non-empty. */
+  readonly sessionId: string;
+  readonly channel?: string;
+  readonly chatId?: string;
+  /** The forwarded OWNER principal (server binds the authenticated owner; a mismatch is refused). */
+  readonly userId?: string;
+  readonly accountId?: string;
+  readonly chatKind?: string;
+  /** Opaque client metadata as a JSON STRING (refs-only; not persisted by the minimal store). */
+  readonly metadataJson?: string;
+}
+
+/** (CORE-A CR-3) Refs-only session create receipt — `SessionCreateResultWire` (id + timestamps). */
+export interface FridayRustHubSessionCreateResult {
+  readonly truthLabel: "rust_wired";
+  readonly sessionId: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
+
+/**
+ * (CORE-A CR-3) Append ONE conversation message to a session — `Message::SessionMessageAppendRequest`.
+ * OWNER-GATED server-side: refused unless the authenticated principal owns `sessionId`. `content` is a
+ * BODY that rides the SEALED session (never a refs field).
+ */
+export interface FridayRustHubSessionMessageAppendRequest {
+  readonly sessionId: string;
+  /** Speaker role (e.g. `user` / `assistant`). Non-empty. */
+  readonly role: string;
+  /** Message body kept Hub-side (sealed on the wire). */
+  readonly content: string;
+  /** Optional soft-link ref (e.g. producing run id). */
+  readonly refs?: string;
+}
+
+/** (CORE-A CR-3) Refs-only append receipt — `SessionMessageAppendResultWire` (id + seq + timestamps). */
+export interface FridayRustHubSessionMessageAppendResult {
+  readonly truthLabel: "rust_wired";
+  readonly messageId: string;
+  readonly seq: number;
+  readonly createdAt: number;
+  readonly updatedAt: number;
 }
 
 function unavailable(message: string, details?: Record<string, unknown>): FridayDomainError {
@@ -1193,6 +1263,52 @@ export function buildMemoryDecisionEnvelope(
   });
 }
 
+/**
+ * (CORE-A CR-3) Build the `SessionCreateRequest` inner message — the EXACT `SessionCreateRequestWire`
+ * shape nested under `request` (single-field wrapper on the internally-tagged `Message`, same
+ * `{kind,request}` nesting as {@link buildMemoryDecisionEnvelope}; a flat shape 503s server-side).
+ * `session_id` is required; the descriptive axes + `metadata_json` use conditional-spread (absent ⇒
+ * key OMITTED, byte-clean, round-trips to `None`). EXPORTED + pure for socket-free wire testing.
+ */
+export function buildSessionCreateEnvelope(
+  request: FridayRustHubSessionCreateRequest,
+): Record<string, unknown> {
+  const inner: Record<string, unknown> = {
+    session_id: request.sessionId,
+    ...(request.channel !== undefined ? { channel: request.channel } : {}),
+    ...(request.chatId !== undefined ? { chat_id: request.chatId } : {}),
+    ...(request.userId !== undefined ? { user_id: request.userId } : {}),
+    ...(request.accountId !== undefined ? { account_id: request.accountId } : {}),
+    ...(request.chatKind !== undefined ? { chat_kind: request.chatKind } : {}),
+    ...(request.metadataJson !== undefined ? { metadata_json: request.metadataJson } : {}),
+  };
+  return buildMissionEnvelope(`session-create-${request.sessionId}`, {
+    kind: "SessionCreateRequest",
+    request: inner,
+  });
+}
+
+/**
+ * (CORE-A CR-3) Build the `SessionMessageAppendRequest` inner message — the EXACT
+ * `SessionMessageAppendRequestWire` shape nested under `request`. `session_id`/`role`/`content` are
+ * required; `refs` uses conditional-spread (absent ⇒ OMITTED). EXPORTED + pure for socket-free wire
+ * testing.
+ */
+export function buildSessionMessageAppendEnvelope(
+  request: FridayRustHubSessionMessageAppendRequest,
+): Record<string, unknown> {
+  const inner: Record<string, unknown> = {
+    session_id: request.sessionId,
+    role: request.role,
+    content: request.content,
+    ...(request.refs !== undefined ? { refs: request.refs } : {}),
+  };
+  return buildMissionEnvelope(`session-message-append-${request.sessionId}`, {
+    kind: "SessionMessageAppendRequest",
+    request: inner,
+  });
+}
+
 /** Build the exact nested `RunOutcomeLearningDecisionRequest { request: ... }` wire message. */
 export function buildRunOutcomeLearningDecisionEnvelope(
   request: FridayRustHubRunOutcomeLearningDecisionRequest,
@@ -1451,6 +1567,49 @@ export function parseMemoryDecisionResult(
     recallable,
     ...(blocker !== undefined ? { blocker } : {}),
   };
+}
+
+/**
+ * (CORE-A CR-3) Parse a nested `SessionCreateResult { result: ... }` into the refs-only TS shape.
+ * Fail-closed: a missing/wrong-typed id or timestamp ⇒ `undefined` (the round-trip then rejects →
+ * 503), so a malformed receipt never surfaces as a fake success.
+ */
+export function parseSessionCreateResult(
+  fields: Record<string, unknown>,
+): FridayRustHubSessionCreateResult | undefined {
+  const r = unwrapResult(fields);
+  if (r === undefined) {
+    return undefined;
+  }
+  const sessionId = asString(r.session_id);
+  const createdAt = asNumber(r.created_at);
+  const updatedAt = asNumber(r.updated_at);
+  if (!sessionId || createdAt === undefined || updatedAt === undefined) {
+    return undefined;
+  }
+  return { truthLabel: "rust_wired", sessionId, createdAt, updatedAt };
+}
+
+/**
+ * (CORE-A CR-3) Parse a nested `SessionMessageAppendResult { result: ... }` into the refs-only TS
+ * shape. `seq` is validated with `asNumber` (accepts 0 — the first message's ordinal). Fail-closed on
+ * any missing/wrong-typed field.
+ */
+export function parseSessionMessageAppendResult(
+  fields: Record<string, unknown>,
+): FridayRustHubSessionMessageAppendResult | undefined {
+  const r = unwrapResult(fields);
+  if (r === undefined) {
+    return undefined;
+  }
+  const messageId = asString(r.message_id);
+  const seq = asNumber(r.seq);
+  const createdAt = asNumber(r.created_at);
+  const updatedAt = asNumber(r.updated_at);
+  if (!messageId || seq === undefined || createdAt === undefined || updatedAt === undefined) {
+    return undefined;
+  }
+  return { truthLabel: "rust_wired", messageId, seq, createdAt, updatedAt };
 }
 
 /** Parse a nested `RunOutcomeLearningDecisionResult { result: ... }` into refs-only TS shape. */
@@ -2634,6 +2793,46 @@ export function createFridayRustHubAgentRunSealedClient(
         expectedKind: "RunOutcomeLearningDecisionResult",
         parse: parseRunOutcomeLearningDecisionResult,
         leg: "run-outcome-learning-decision",
+      });
+    },
+
+    createSession(
+      request: FridayRustHubSessionCreateRequest,
+    ): Promise<FridayRustHubSessionCreateResult> {
+      if (!request.sessionId) {
+        return Promise.reject(
+          unavailable("Sealed session client create requires a session id."),
+        );
+      }
+      return runMissionRoundTrip<FridayRustHubSessionCreateResult>({
+        host,
+        port,
+        timeoutMs,
+        keypair,
+        envelope: buildSessionCreateEnvelope(request),
+        expectedKind: "SessionCreateResult",
+        parse: parseSessionCreateResult,
+        leg: "session-create",
+      });
+    },
+
+    appendSessionMessage(
+      request: FridayRustHubSessionMessageAppendRequest,
+    ): Promise<FridayRustHubSessionMessageAppendResult> {
+      if (!request.sessionId || !request.role) {
+        return Promise.reject(
+          unavailable("Sealed session client append requires a session id and role."),
+        );
+      }
+      return runMissionRoundTrip<FridayRustHubSessionMessageAppendResult>({
+        host,
+        port,
+        timeoutMs,
+        keypair,
+        envelope: buildSessionMessageAppendEnvelope(request),
+        expectedKind: "SessionMessageAppendResult",
+        parse: parseSessionMessageAppendResult,
+        leg: "session-message-append",
       });
     },
   };

--- a/src/api/mission-spine/friday-rust-hub-session-lifecycle-dispatch-adapter.ts
+++ b/src/api/mission-spine/friday-rust-hub-session-lifecycle-dispatch-adapter.ts
@@ -1,0 +1,251 @@
+import { FridayDomainError } from "#errors";
+
+import type { FridayRustSessionLifecycleBridge } from "../http/routes/friday-session-routes.js";
+import type { FridaySessionRunResponse } from "../model/friday-api-session.types.js";
+import {
+  createFridayRustHubAgentRunSealedClientService,
+  type CreateSealedClientFn,
+  type FridayRustHubAgentRunSealedClientService,
+  isPausedDispatchOutcome,
+} from "./friday-rust-hub-agent-run-sealed-client-service.js";
+import {
+  createFridayRustHubRunAnswerReadbackService,
+  type FridayRustHubRunAnswerReadbackService,
+} from "./friday-rust-hub-run-answer-readback-service.js";
+import type { FridayRustAgentRunWsClientX25519SecretResolver } from "./friday-rust-hub-agent-run-ws-client-x25519-secret.js";
+
+/**
+ * (CORE-RUNNABLE-001 / CORE-A CR-3) The bootstrap-side REAL ADAPTER that makes the SESSION
+ * Rust-owned lifecycle bridge PRODUCTION-WIRED — the sibling of
+ * {@link createFridayMissionSpineDispatchAdapter}. Until this exists, the session route's
+ * {@link FridayRustSessionLifecycleBridge} is only ever reachable in mock-injected route unit
+ * tests (nothing constructs a REAL one and threads it into the runtime), so the Rust session
+ * path is "mock-test-only". This adapter is what the DEFAULT-OFF operator flag
+ * (`FRIDAY_ROUTE_SESSIONS_VIA_RUST`, resolved by `resolveRouteSessionsViaRust`) wires in.
+ *
+ * ## What is REAL here (and what is honestly fail-closed)
+ * - `runSession` is REAL: it dispatches a session-scoped agent run over the SAME sealed-WS
+ *   ECDH transport the agent-run path uses ({@link createFridayRustHubAgentRunSealedClientService}
+ *   → the proven `friday-rust-hub-agent-run-ws-sealed-client`), forwarding the `sessionKey` as
+ *   the wire `session_id` (the sealed client explicitly supports a multi-turn session run), then
+ *   sources the answer body from the SAME owner-gated DB readback
+ *   ({@link FridayRustHubRunAnswerReadbackService.readAnswer}) `composeRustReadOnlyAgentRun`
+ *   uses. It is NOT a mock — the low-level sealed client + readback are injectable ONLY as a
+ *   test transport (a fake `createClient` / `readback` that maps/fail-closes WITHOUT a socket,
+ *   exactly like the agent-run + mission-spine adapters' tests); the default is the real client.
+ * - `createSession` / `appendMessage` / `getMemoryNamespace` are HONESTLY fail-closed (503).
+ *   These are pure Hub STORAGE lifecycle ops with NO agent-run analog: the existing sealed-WS
+ *   client exposes NO session-create / append-message / memory-namespace RPC, and the Rust hub
+ *   server exposes NO matching handler. Building a "real" round-trip for them would require
+ *   inventing a session-lifecycle wire protocol + a Rust server handler + a deploy — a
+ *   LIVE/operator dependency out of scope for this agent-doable wiring slice. Rather than FAKE a
+ *   success (a mock), this adapter surfaces the honest 503
+ *   `RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE` and FLAGS the gap. When the Rust session
+ *   lifecycle protocol ships, these become real round-trips here (the seam is already threaded).
+ *
+ * ## Construction seam (load-bearing for flag-OFF byte-identical)
+ * SIDE-EFFECT-FREE: the factory captures host/port/timeout + resolver/createClient/readback seams
+ * only. It resolves NO secret and opens NO socket until `runSession` is actually called on a real
+ * request — so a flag-ON-but-unprovisioned host FAILS CLOSED (503) per call rather than crashing
+ * boot, and when the flag is OFF the adapter is never constructed at all (bootstrap leaves the
+ * runtime dep unset ⇒ the session routes resolve their retired 503 ⇒ byte-identical to today).
+ *
+ * ## Fail-closed contract (never a fake success)
+ * - The X25519 secret resolver returns `null` (missing / disabled / non-32-byte / misconfigured)
+ *   ⇒ typed 503 BEFORE any socket is opened.
+ * - The owner-gated readback DB path is absent (no `FRIDAY_HUB_AGENT_RUN_DB_PATH`) ⇒ typed 503.
+ * - The underlying dispatch / readback rejects (connect / closed / timeout / bad seal / non-owner
+ *   / not-found) ⇒ its `FridayDomainError` (503) surfaces UNCHANGED; any non-domain throw is
+ *   wrapped as a typed 503. A PAUSED outcome (run-control off in this slice) fails closed.
+ *
+ * ## Truth label
+ * `rust_wired` ceiling: confers NO v1 GO. End-to-end session-loop closure ALSO needs the Rust
+ * server flags + the provisioned sealed-WS host + the answer-readback DB + an operator cutover
+ * (`FRIDAY_ROUTE_SESSIONS_VIA_RUST` default-off) + a real turn. This adapter only makes the TS
+ * session run route reachable-and-real when the flag is on.
+ */
+
+/** Plan lifetime is not relevant here; this adapter is stateless per call. */
+export interface CreateFridayRustHubSessionLifecycleDispatchAdapterOptions {
+  /** Loopback host for the Rust agent-run WS server. Defaults to `127.0.0.1` (in the client). */
+  readonly host?: string;
+  /** Port the Rust agent-run WS server listens on (the SAME server the agent-run path dials). */
+  readonly port: number;
+  /** Bounded await (ms) for one dispatch before failing closed. */
+  readonly timeoutMs?: number;
+  /**
+   * SecureStore resolver for the sealed WS client's X25519 SECRET — the SAME ECDH-model resolver
+   * the agent-run + mission-spine paths use. A `null`/short resolve fails closed → no WS call.
+   * Tests inject a fixture secret. NEVER logs it.
+   */
+  readonly secretResolver: FridayRustAgentRunWsClientX25519SecretResolver;
+  /** Mints the per-run id for a session run dispatch. */
+  readonly idGenerator: () => string;
+  /**
+   * Filesystem path to the Rust Hub DB the owner-gated answer readback reads from. Default =
+   * `process.env.FRIDAY_HUB_AGENT_RUN_DB_PATH`. Absent → `runSession` fails closed (no body).
+   */
+  readonly hubDbPath?: string;
+  /**
+   * Injectable factory for the underlying LOW-LEVEL sealed client (test seam). Default = the real
+   * sealed client. Constructed LAZILY per-call so this factory itself is side-effect-free. Tests
+   * inject a fake to map/fail-closed WITHOUT a socket (and without re-proving the proven interop).
+   */
+  readonly createClient?: CreateSealedClientFn;
+  /**
+   * Injectable owner-gated answer readback service (test seam). Default = the real service. Tests
+   * inject a fake `delivered`/`denied`/`not_found` receipt to map/fail-closed WITHOUT a Rust bin.
+   */
+  readonly readback?: FridayRustHubRunAnswerReadbackService;
+}
+
+function unavailable(message: string): FridayDomainError {
+  return new FridayDomainError("RUST_SESSION_LIFECYCLE_DISPATCH_UNAVAILABLE", message, {
+    httpStatus: 503,
+    details: {
+      surface: "service:rust_hub_session_lifecycle_dispatch_adapter",
+      bridge: "rust_wired",
+      proofOnly: true,
+      proofReady: false,
+    },
+  });
+}
+
+/**
+ * The three pure-storage lifecycle ops have NO Rust WS RPC + NO Rust server handler yet. Surface an
+ * honest 503 (never a fake success). This is the FLAGGED live/operator dependency — closing it is a
+ * later slice that ships the session-lifecycle wire protocol + a Rust handler + a deploy.
+ */
+function sessionLifecycleProtocolUnavailable(op: string): FridayDomainError {
+  return new FridayDomainError(
+    "RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE",
+    `Rust session lifecycle op '${op}' has no sealed-WS RPC / server handler yet; ` +
+      "it fails closed until the Rust session-lifecycle protocol ships (operator-gated).",
+    {
+      httpStatus: 503,
+      details: {
+        surface: "service:rust_hub_session_lifecycle_dispatch_adapter",
+        op,
+        bridge: "rust_wired",
+        proofOnly: true,
+        proofReady: false,
+      },
+    },
+  );
+}
+
+/**
+ * Build the session-lifecycle dispatch ADAPTER the bootstrap injects into the runtime's
+ * `rustSessionLifecycleBridge` dep when `FRIDAY_ROUTE_SESSIONS_VIA_RUST` is on. SIDE-EFFECT-FREE:
+ * captures host/port/timeout + resolver/createClient/readback seams only; resolves no secret and
+ * opens no socket until `runSession` actually runs on a real request.
+ */
+export function createFridayRustHubSessionLifecycleDispatchAdapter(
+  options: CreateFridayRustHubSessionLifecycleDispatchAdapterOptions,
+): FridayRustSessionLifecycleBridge {
+  const { host, port, timeoutMs, secretResolver, idGenerator } = options;
+  const readback = options.readback ?? createFridayRustHubRunAnswerReadbackService();
+  const hubDbPath = options.hubDbPath ?? process.env.FRIDAY_HUB_AGENT_RUN_DB_PATH;
+
+  /**
+   * Construct the sealed-WS SERVICE adapter (the SAME one the agent-run compose path uses) once —
+   * side-effect-free (no secret resolved, no socket opened at construction). The per-dispatch
+   * X25519 secret is passed to `dispatchRun` below.
+   */
+  const sealedService: FridayRustHubAgentRunSealedClientService =
+    createFridayRustHubAgentRunSealedClientService({
+      ...(host !== undefined ? { host } : {}),
+      port,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      ...(options.createClient !== undefined ? { createClient: options.createClient } : {}),
+    });
+
+  return {
+    // ── Pure-storage lifecycle ops: HONEST fail-closed (no Rust RPC/handler yet). ──
+    async createSession(): Promise<never> {
+      throw sessionLifecycleProtocolUnavailable("sessions.create");
+    },
+    async appendMessage(): Promise<never> {
+      throw sessionLifecycleProtocolUnavailable("sessions.messages.create");
+    },
+    async getMemoryNamespace(): Promise<never> {
+      throw sessionLifecycleProtocolUnavailable("sessions.memory.namespace.get");
+    },
+
+    // ── Session RUN: REAL — dispatch over the sealed-WS transport + owner-gated body readback. ──
+    async runSession(input: {
+      sessionKey: string;
+      task: string;
+      principalId: string;
+      providerId?: string;
+      model?: string;
+      timezone?: string;
+      timeoutMs?: number;
+    }): Promise<FridaySessionRunResponse["run"]> {
+      const callerPrincipal = input.principalId.trim();
+      if (!callerPrincipal) {
+        // Owner-binding requires a canonical, non-blank principal (the readback ownership gate
+        // matches `caller == owner`). A blank principal fails closed rather than reading anonymously.
+        throw unavailable("Session Rust run requires a bound owner principal.");
+      }
+      const clientSecret = secretResolver();
+      if (!clientSecret) {
+        throw unavailable("Session Rust run could not resolve the sealed-WS client secret.");
+      }
+      if (!hubDbPath) {
+        // The answer body is owner-gated in the Rust Hub DB; without a DB path there is nothing to
+        // read back → fail closed rather than returning a body-less (dishonest) run result.
+        throw unavailable("Session Rust run has no Hub DB path for the owner-gated answer readback.");
+      }
+
+      const runId = idGenerator();
+      // (1) Dispatch the session-scoped run over the sealed ECDH transport. `sessionKey` becomes the
+      //     wire `session_id`; the run is read-only in this slice (defense-in-depth on the wire).
+      let outcome;
+      try {
+        outcome = await sealedService.dispatchRun({
+          runId,
+          task: input.task,
+          forwardedPrincipal: callerPrincipal,
+          clientSecret,
+          sessionKey: input.sessionKey,
+          constraints: { readOnly: true },
+        });
+      } catch (error) {
+        throw error instanceof FridayDomainError ? error : unavailable("Session Rust run dispatch failed.");
+      }
+      // A PAUSED outcome (run-control transport) is not admitted in this slice → fail closed.
+      if (isPausedDispatchOutcome(outcome)) {
+        throw unavailable("Session Rust run returned a paused outcome, which is not supported in this slice.");
+      }
+      const wsResult = outcome;
+
+      // (2) Owner-gated body readback — the SAME authoritative body source `composeRustReadOnlyAgentRun`
+      //     uses. A non-`delivered` outcome carries no body ⇒ fail closed.
+      let receipt;
+      try {
+        receipt = await readback.readAnswer({ dbPath: hubDbPath, runId, callerPrincipal });
+      } catch (error) {
+        throw error instanceof FridayDomainError ? error : unavailable("Session Rust run readback failed.");
+      }
+      if (receipt.outcome !== "delivered") {
+        throw unavailable(`Session Rust run body readback was not delivered (outcome: ${receipt.outcome}).`);
+      }
+
+      // (3) Map the refs-only WS result + owner-released body to the session run response. The Rust
+      //     server's wire status echoes the persisted RunResult status ("finished" for a finished
+      //     loop) → map "finished" → "completed", else "failed". Token/tool counts are the carried
+      //     wire counts (0 when the server omits them — no fabricated numbers); `durationMs` stays 0
+      //     (the refs-only result carries no start time — honest 0, not invented).
+      return {
+        runId,
+        status: wsResult.status === "finished" ? "completed" : "failed",
+        response: receipt.answer,
+        toolCallCount: wsResult.executedTools ?? 0,
+        durationMs: 0,
+        usageInput: wsResult.promptTokens ?? 0,
+        usageOutput: wsResult.completionTokens ?? 0,
+      };
+    },
+  };
+}

--- a/src/api/mission-spine/friday-rust-hub-session-lifecycle-dispatch-adapter.ts
+++ b/src/api/mission-spine/friday-rust-hub-session-lifecycle-dispatch-adapter.ts
@@ -1,7 +1,26 @@
 import { FridayDomainError } from "#errors";
+import {
+  FRIDAY_SESSION_DEFAULT_ACCOUNT_ID,
+  normalizeFridaySessionKey,
+  parseFridaySessionKey,
+} from "#sessions";
+import type {
+  FridaySessionChatKind,
+  FridaySessionMessageRecord,
+  FridaySessionRecord,
+  FridaySessionRole,
+} from "#sessions";
 
 import type { FridayRustSessionLifecycleBridge } from "../http/routes/friday-session-routes.js";
-import type { FridaySessionRunResponse } from "../model/friday-api-session.types.js";
+import type {
+  FridaySessionCreateResponse,
+  FridaySessionMessageCreateResponse,
+  FridaySessionRunResponse,
+} from "../model/friday-api-session.types.js";
+import {
+  createFridayRustHubAgentRunSealedClient,
+  type FridayRustHubAgentRunSealedClient,
+} from "./friday-rust-hub-agent-run-ws-sealed-client.js";
 import {
   createFridayRustHubAgentRunSealedClientService,
   type CreateSealedClientFn,
@@ -33,15 +52,20 @@ import type { FridayRustAgentRunWsClientX25519SecretResolver } from "./friday-ru
  *   uses. It is NOT a mock — the low-level sealed client + readback are injectable ONLY as a
  *   test transport (a fake `createClient` / `readback` that maps/fail-closes WITHOUT a socket,
  *   exactly like the agent-run + mission-spine adapters' tests); the default is the real client.
- * - `createSession` / `appendMessage` / `getMemoryNamespace` are HONESTLY fail-closed (503).
- *   These are pure Hub STORAGE lifecycle ops with NO agent-run analog: the existing sealed-WS
- *   client exposes NO session-create / append-message / memory-namespace RPC, and the Rust hub
- *   server exposes NO matching handler. Building a "real" round-trip for them would require
- *   inventing a session-lifecycle wire protocol + a Rust server handler + a deploy — a
- *   LIVE/operator dependency out of scope for this agent-doable wiring slice. Rather than FAKE a
- *   success (a mock), this adapter surfaces the honest 503
- *   `RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE` and FLAGS the gap. When the Rust session
- *   lifecycle protocol ships, these become real round-trips here (the seam is already threaded).
+ * - `createSession` / `appendMessage` are now REAL (CR-3): they dispatch the CR-3 session-lifecycle
+ *   wire (`SessionCreateRequest` / `SessionMessageAppendRequest`) over the SAME low-level sealed
+ *   client ({@link createFridayRustHubAgentRunSealedClient}), whose Rust dispatch arms reuse the
+ *   EXISTING `ensure_session_with_owner` / owner-gated `append_session_message` storage primitives
+ *   (owner bound server-side to the authenticated principal; a foreign-owner append is refused →
+ *   the sealed client fails closed → 503). `createSession` derives the canonical session key with
+ *   the SAME `normalizeFridaySessionKey` the TS service uses (single source of truth), so the Rust
+ *   store keys on the identical id. Both receipts are REFS-ONLY (id + seq + timestamps); the
+ *   descriptive record fields are echoed from the caller's request (never a fabricated body).
+ * - `getMemoryNamespace` remains HONESTLY fail-closed (503). It is a pure owner-gated READ whose
+ *   faithful Rust port must replicate the TS effective-user-id resolution (DM-chatId fallback +
+ *   subagent parent-walk) to avoid a semantic-drift false-green; that parity proof is a bounded
+ *   follow-up. Rather than FAKE a namespace (a mock), this adapter surfaces the honest 503
+ *   `RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE` and FLAGS the gap.
  *
  * ## Construction seam (load-bearing for flag-OFF byte-identical)
  * SIDE-EFFECT-FREE: the factory captures host/port/timeout + resolver/createClient/readback seams
@@ -134,11 +158,87 @@ function sessionLifecycleProtocolUnavailable(op: string): FridayDomainError {
   );
 }
 
+type CreateSessionInput = Parameters<FridayRustSessionLifecycleBridge["createSession"]>[0];
+type AppendMessageInput = Parameters<FridayRustSessionLifecycleBridge["appendMessage"]>[0];
+
+/** ms → ISO-8601 for the response record timestamps (the Rust refs carry ms). */
+function msToIso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+/**
+ * (CR-3) Build the {@link FridaySessionCreateResponse} session RECORD from the caller's request +
+ * the Rust REFS-ONLY receipt. AUTHORITATIVE facts (canonical `key`, `createdAt`/`updatedAt`) come
+ * from the derived key + Rust timestamps; the DESCRIPTIVE axes are the canonical parse of the key
+ * (channel/account/chat) plus the caller's echoed `userId`/`chatKind`/`metadata`. A fresh session
+ * has `messageCount: 0` and zero context tokens (honest — no turn has run).
+ */
+function buildSessionRecord(
+  sessionKey: string,
+  input: CreateSessionInput,
+  createdAtMs: number,
+  updatedAtMs: number,
+): FridaySessionRecord {
+  const parts = parseFridaySessionKey(sessionKey);
+  return {
+    id: sessionKey,
+    key: sessionKey,
+    channel: parts.channel ?? input.channel,
+    accountId: parts.accountId ?? input.accountId ?? FRIDAY_SESSION_DEFAULT_ACCOUNT_ID,
+    chatId: parts.chatId ?? input.chatId,
+    ...(input.userId !== undefined ? { userId: input.userId } : {}),
+    chatKind: (input.chatKind ?? "channel") as FridaySessionChatKind,
+    status: "active",
+    metadata: input.metadata ?? {},
+    contextInputTokens: 0,
+    contextOutputTokens: 0,
+    contextTotalTokens: 0,
+    messageCount: 0,
+    createdAt: msToIso(createdAtMs),
+    updatedAt: msToIso(updatedAtMs),
+  };
+}
+
+/**
+ * (CR-3) Build the {@link FridaySessionMessageCreateResponse} message RECORD from the caller's
+ * request + the Rust REFS-ONLY receipt. AUTHORITATIVE facts (`id`, `sequence`, timestamps) come from
+ * Rust; the body/role/tool-calls/metadata are the caller's echoed input (never a fabricated body).
+ * `memoryExtractStatus` starts `pending` (extraction is a later, separate loop).
+ */
+function buildMessageRecord(
+  input: AppendMessageInput,
+  contentText: string,
+  messageId: string,
+  seq: number,
+  createdAtMs: number,
+  updatedAtMs: number,
+): FridaySessionMessageRecord {
+  const createdIso = msToIso(createdAtMs);
+  return {
+    id: messageId,
+    sessionId: input.sessionKey,
+    sessionKey: input.sessionKey,
+    sequence: seq,
+    role: input.role as FridaySessionRole,
+    content: input.content,
+    contentText,
+    ...(input.toolCalls !== undefined ? { toolCalls: input.toolCalls } : {}),
+    tokenCount: input.tokenCount ?? 0,
+    ...(input.idempotencyKey !== undefined ? { idempotencyKey: input.idempotencyKey } : {}),
+    ...(input.parentMessageId !== undefined ? { parentMessageId: input.parentMessageId } : {}),
+    metadata: input.metadata ?? {},
+    memoryExtractStatus: "pending",
+    occurredAt: input.timestamp ?? createdIso,
+    createdAt: createdIso,
+    updatedAt: msToIso(updatedAtMs),
+  };
+}
+
 /**
  * Build the session-lifecycle dispatch ADAPTER the bootstrap injects into the runtime's
  * `rustSessionLifecycleBridge` dep when `FRIDAY_ROUTE_SESSIONS_VIA_RUST` is on. SIDE-EFFECT-FREE:
  * captures host/port/timeout + resolver/createClient/readback seams only; resolves no secret and
- * opens no socket until `runSession` actually runs on a real request.
+ * opens no socket until a lifecycle op actually runs on a real request.
  */
 export function createFridayRustHubSessionLifecycleDispatchAdapter(
   options: CreateFridayRustHubSessionLifecycleDispatchAdapterOptions,
@@ -160,14 +260,104 @@ export function createFridayRustHubSessionLifecycleDispatchAdapter(
       ...(options.createClient !== undefined ? { createClient: options.createClient } : {}),
     });
 
+  // (CR-3) The low-level sealed client factory for the CREATE/APPEND lifecycle round-trips (the SAME
+  // seam the mission/memory-spine adapters use). Default = the real sealed client. Constructed
+  // LAZILY per-call so the adapter stays side-effect-free (no secret resolved, no socket opened at
+  // construction). Tests inject a fake that maps/fail-closes WITHOUT a socket.
+  const createClient: CreateSealedClientFn = options.createClient ?? createFridayRustHubAgentRunSealedClient;
+
+  /**
+   * (CR-3) Resolve the X25519 secret + construct the low-level sealed client for one create/append
+   * round-trip. Fail-closed (503): a `null`/short resolve → no client; a constructor throw (non-32
+   * byte secret) → mapped to 503. NEVER logs the secret.
+   */
+  function buildLifecycleClient(): FridayRustHubAgentRunSealedClient {
+    const clientSecret = secretResolver();
+    if (!clientSecret) {
+      throw unavailable("Session lifecycle dispatch could not resolve the sealed-WS client secret.");
+    }
+    try {
+      return createClient({
+        ...(host !== undefined ? { host } : {}),
+        port,
+        clientSecret,
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      });
+    } catch {
+      throw unavailable("Session lifecycle dispatch could not construct the sealed-WS client.");
+    }
+  }
+
   return {
-    // ── Pure-storage lifecycle ops: HONEST fail-closed (no Rust RPC/handler yet). ──
-    async createSession(): Promise<never> {
-      throw sessionLifecycleProtocolUnavailable("sessions.create");
+    // ── CREATE: REAL — ensure the session row over the sealed-WS transport (owner bound server-side). ──
+    async createSession(input): Promise<FridaySessionCreateResponse> {
+      const ownerPrincipal = (input.principal.principalId ?? "").trim();
+      if (!ownerPrincipal) {
+        // The session owner is the authenticated principal; a blank one fails closed (no anon owner).
+        throw unavailable("Session create requires a bound owner principal.");
+      }
+      // Derive the canonical session key with the SAME normalizer the TS service uses (single source
+      // of truth) so the Rust store keys on the identical id.
+      const sessionKey = normalizeFridaySessionKey({
+        channel: input.channel,
+        chatId: input.chatId,
+        ...(input.userId !== undefined ? { userId: input.userId } : {}),
+        ...(input.accountId !== undefined ? { accountId: input.accountId } : {}),
+        ...(input.chatKind !== undefined ? { chatKind: input.chatKind } : {}),
+      });
+      const client = buildLifecycleClient();
+      let result;
+      try {
+        result = await client.createSession({
+          sessionId: sessionKey,
+          channel: input.channel,
+          chatId: input.chatId,
+          // The forwarded OWNER is the authenticated principal (the server binds it + FIX-Q3b-refuses
+          // a disagreeing value); the descriptive channel userId is echoed in the record below.
+          userId: ownerPrincipal,
+          ...(input.accountId !== undefined ? { accountId: input.accountId } : {}),
+          ...(input.chatKind !== undefined ? { chatKind: input.chatKind } : {}),
+          ...(input.metadata !== undefined ? { metadataJson: JSON.stringify(input.metadata) } : {}),
+        });
+      } catch (error) {
+        throw error instanceof FridayDomainError ? error : unavailable("Session create dispatch failed.");
+      }
+      return { session: buildSessionRecord(sessionKey, input, result.createdAt, result.updatedAt) };
     },
-    async appendMessage(): Promise<never> {
-      throw sessionLifecycleProtocolUnavailable("sessions.messages.create");
+
+    // ── APPEND: REAL — owner-gated message append over the sealed-WS transport. ──
+    async appendMessage(input): Promise<FridaySessionMessageCreateResponse> {
+      const ownerPrincipal = (input.principal.principalId ?? "").trim();
+      if (!ownerPrincipal) {
+        throw unavailable("Session append requires a bound owner principal.");
+      }
+      const role = (input.role ?? "").trim();
+      if (!role) {
+        throw unavailable("Session append requires a non-empty message role.");
+      }
+      // The Rust minimal store holds ONE string content body; serialize deterministically. Prefer the
+      // caller's `contentText`, else the string content, else a JSON-encoded structured content.
+      const contentText =
+        input.contentText ??
+        (typeof input.content === "string" ? input.content : JSON.stringify(input.content ?? ""));
+      const client = buildLifecycleClient();
+      let result;
+      try {
+        result = await client.appendSessionMessage({
+          sessionId: input.sessionKey,
+          role,
+          content: contentText,
+          ...(input.idempotencyKey !== undefined ? { refs: input.idempotencyKey } : {}),
+        });
+      } catch (error) {
+        throw error instanceof FridayDomainError ? error : unavailable("Session append dispatch failed.");
+      }
+      return {
+        message: buildMessageRecord(input, contentText, result.messageId, result.seq, result.createdAt, result.updatedAt),
+      };
     },
+
+    // ── Memory-namespace READ: HONEST fail-closed (Rust owner-gated port deferred; see module doc). ──
     async getMemoryNamespace(): Promise<never> {
       throw sessionLifecycleProtocolUnavailable("sessions.memory.namespace.get");
     },

--- a/src/api/model/friday-api-auth.types.ts
+++ b/src/api/model/friday-api-auth.types.ts
@@ -217,6 +217,51 @@ export interface FridayAuthBootstrapChallengeResponse {
   expiresAt: ISODateTime;
 }
 
+// ─── Device-key LOGIN challenge (SEC-SETUP-BOOTSTRAP-001 · CR-1) ───
+//
+// Advisor #1628 finding #2: the device-key login proof was replayable because no
+// server-issued single-use nonce gated the login. The device now first requests a
+// single-use `device_login_challenge` nonce bound to THIS device (deviceId +
+// devicePublicKeyHash) + origin + action, signs it into the owner-login transcript,
+// and presents it. deviceKeyLogin CAS-consumes the nonce in the SAME transaction
+// that mints the session, so a replayed login finds it consumed and mints nothing.
+
+export interface FridayAuthLoginChallengeRequest {
+  /** Stable installation id for this hub install (echoed into the challenge). */
+  installId: string;
+  /** OS user the install runs as (echoed into the challenge). */
+  osUser: string;
+  /** Loopback origin the login will be presented from (binds the nonce). */
+  origin: string;
+  /** Device identifier the challenge is bound to (gated at consume). */
+  deviceId: string;
+  /**
+   * Device public key (SPKI DER base64/base64url, P-256). The server binds its
+   * SHA-256 hash into the challenge so a nonce minted for one key can never be
+   * consumed by a login presenting a different key.
+   */
+  devicePublicKey: string;
+  /** Optional bound action label; defaults to "owner-login". */
+  action?: string;
+}
+
+export interface FridayAuthLoginChallengeResponse {
+  challengeId: UUID;
+  /** Raw single-use nonce — returned exactly ONCE; only its hash is persisted. */
+  nonce: string;
+  kind: "device_login_challenge";
+  hubId: string;
+  installId: string;
+  osUser: string;
+  origin: string;
+  action: string;
+  deviceId: string;
+  /** SHA-256 hex of the bound device public key (echoed for the caller). */
+  devicePublicKeyHash: string;
+  createdAt: ISODateTime;
+  expiresAt: ISODateTime;
+}
+
 // SEC-SETUP-BOOTSTRAP-001 Slice 3 — proof-of-possession (PoP) over the server
 // nonce. The device MUST prove possession of the PRIVATE key by signing the
 // canonical owner-claim transcript; nonce-possession alone no longer suffices.

--- a/src/api/model/friday-api-auth.types.ts
+++ b/src/api/model/friday-api-auth.types.ts
@@ -124,6 +124,26 @@ export interface FridayLoginRequest {
   password?: string;
   localPassphrase?: string;
   rememberMe?: boolean;
+  // ─── SEC-SETUP-BOOTSTRAP-001 · device-bound owner login (CR-1) ───
+  // Device-key login for a machine whose owner slot was claimed by a device
+  // (users.password_hash = the non-scrypt device sentinel). The device proves
+  // possession of the bound private key by signing a FRESH owner-login transcript;
+  // no passphrase is involved and the passphrase path can NEVER satisfy the device
+  // sentinel (and vice-versa). Minting a session additionally requires the
+  // server-derived native-IPC attestation precondition — fail-closed until it lands.
+  /** Device public key, SPKI DER base64/base64url (P-256), bound at claim time. */
+  devicePublicKey?: string;
+  /** Device identifier presented in the login transcript. */
+  deviceId?: string;
+  /** Loopback origin the login is presented from (bound into the transcript). */
+  origin?: string;
+  /**
+   * REQUIRED for the device-key login path. Its presence selects the device path.
+   * The device signs a canonical transcript minted for action `owner-login`; the
+   * server verifies the signature against the presented (bound) public key. A
+   * missing/invalid proof fails closed with no session minted.
+   */
+  deviceLoginProof?: FridayDeviceClaimProof;
 }
 
 export interface FridayLoginResponse {
@@ -142,6 +162,16 @@ export interface FridayLoginResponse {
 
 export interface FridayAuthBootstrapStatusResponse {
   bootstrapRequired: boolean;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 (CR-1): whether device-bound owner claim is the
+   * AUTHORITATIVE first-run path on this build. Server-derived and fail-closed —
+   * it is `true` ONLY when device-owner authority is enabled (which requires the
+   * native-IPC attestation precondition). On the current release build it is
+   * `false`, so the UI honestly falls back to the passphrase gate. When it is
+   * `true`, the UI routes first-run to the device-claim gate instead, and the
+   * passphrase gate is NOT offered as the authoritative path.
+   */
+  deviceClaimAvailable: boolean;
 }
 
 export interface FridayAuthBootstrapRequest {

--- a/src/api/model/friday-api-provider.types.ts
+++ b/src/api/model/friday-api-provider.types.ts
@@ -91,6 +91,93 @@ export interface FridayProviderCanonicalGateEvidence {
   planDigest?: string;
 }
 
+// ─── Provider mutation plan / owner-confirm (CORE-RUNNABLE-001 / CORE-A CR-2) ───
+//
+// Two-step owner-confirmation protocol that lets a normal (non-operator) client
+// SATISFY the canonical mutating-action gate for provider setup/routing writes
+// without the gate ever being weakened:
+//
+//   1. POST /v1/providers/plan     → server sanitizes the intended parameters,
+//                                    derives the plan + action digests itself, and
+//                                    returns a secret-free human-readable summary.
+//   2. POST /v1/providers/plan/confirm
+//                                  → the SAME authenticated owner explicitly
+//                                    confirms that exact plan digest; only then is a
+//                                    signed, short-lived, single-use canonical
+//                                    approval minted, bound to the server-computed
+//                                    action digest.
+//   3. the real mutation is replayed with `planDigest` + `canonicalApproval`; the
+//      gate recomputes the action digest server-side from the request that actually
+//      arrived, so any parameter drift fails closed.
+//
+// No field of these shapes ever carries an API key, token or other secret: the plan
+// is built over `sanitizeProviderMutationParameters` output and the summary is an
+// explicit, allow-listed, secret-free projection.
+
+export type FridayProviderPlannableAction =
+  | "providers.create"
+  | "providers.update"
+  | "providers.delete"
+  | "providers.validate"
+  | "providers.routing.set"
+  | "providers.routing.pin"
+  | "providers.routing.penalty.clear"
+  | "providers.auth.profiles.activate"
+  | "providers.oauth.openai_codex.device.initiate"
+  | "providers.oauth.openai_codex.device.complete"
+  | "capabilities.doctor";
+
+export interface FridayPlanProviderMutationRequest {
+  action: FridayProviderPlannableAction;
+  /** Target provider id for update / delete / validate / auth-profile actions. */
+  providerId?: string;
+  /** Target auth-profile key for `providers.auth.profiles.activate`. */
+  profileKey?: string;
+  /** The exact body the follow-up mutation will send (control fields are ignored). */
+  params?: Record<string, unknown> | null;
+  /** Optional idempotency key; it MUST be replayed unchanged on the mutation. */
+  idempotencyKey?: string;
+}
+
+export interface FridayProviderMutationPlan {
+  planDigest: string;
+  actionDigest: string;
+  action: FridayProviderPlannableAction;
+  surface: string;
+  resourceId?: string;
+  idempotencyKey?: string;
+  /** Secret-free, human-readable description of exactly what will change. */
+  humanReadableSummary: string[];
+  /** True when this profile's canonical gate requires an owner confirmation. */
+  approvalRequired: boolean;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface FridayPlanProviderMutationResponse {
+  plan: FridayProviderMutationPlan;
+}
+
+export interface FridayConfirmProviderMutationRequest {
+  planDigest: string;
+  /** Must be exactly `true`: the explicit owner confirmation. Never defaulted. */
+  confirm: boolean;
+}
+
+export interface FridayConfirmProviderMutationResponse {
+  approval: {
+    planDigest: string;
+    actionDigest: string;
+    action: FridayProviderPlannableAction;
+    resourceId?: string;
+    idempotencyKey?: string;
+    confirmedAt: string;
+    expiresAt: string;
+    /** Signed, single-use canonical approval to replay on the mutation request. */
+    canonicalApproval: unknown;
+  };
+}
+
 // ─── Response types ───
 
 export interface FridayListProvidersResponse {

--- a/src/api/model/friday-api-provider.types.ts
+++ b/src/api/model/friday-api-provider.types.ts
@@ -25,6 +25,7 @@ import type {
   FridayProviderUsageSummary,
   FridayProviderValidationState,
 } from "#providers";
+import type { ProviderApprovalDeviceProof } from "../auth/device-attest/friday-provider-approval-transcript.types.js";
 
 // ─── Request types ───
 
@@ -162,6 +163,15 @@ export interface FridayConfirmProviderMutationRequest {
   planDigest: string;
   /** Must be exactly `true`: the explicit owner confirmation. Never defaulted. */
   confirm: boolean;
+  /**
+   * SEC-APPROVAL-AUTHORITY-001 (CORE-A CR-2): the DEVICE-AUTHORED approval proof.
+   * The owner device signs a P-256 transcript binding the exact `actionDigest`
+   * (from the reviewed plan) + the owner principal + expiry. The Hub holds NO
+   * signing key — it only VERIFIES this proof with the presented PUBLIC key and,
+   * on success, returns the device-authored canonical approval. Absent ⇒ the
+   * confirm fails closed (no Hub self-signed approval is ever minted).
+   */
+  deviceApproval: ProviderApprovalDeviceProof;
 }
 
 export interface FridayConfirmProviderMutationResponse {

--- a/src/api/persistence/friday-setup-bootstrap-nonce-repository.ts
+++ b/src/api/persistence/friday-setup-bootstrap-nonce-repository.ts
@@ -26,14 +26,20 @@ export interface FridaySetupBootstrapNonceRow {
  * Ledger `kind` discriminator. `install_owner_claim` is the first-boot
  * device-bound owner claim (SEC-SETUP-BOOTSTRAP-001 Slice 1). Slice 5 adds
  * `device_migration_claim` — the SECOND consumer of this same ledger, minted for
- * an AUTHENTICATED existing-passphrase-owner → device migration. The DB CHECK
- * (v104) enforces this closed set; the distinct kind keeps a first-boot nonce
- * from being replayed into a migration and vice-versa (the consume CAS matches
- * on `kind`).
+ * an AUTHENTICATED existing-passphrase-owner → device migration. CR-1 adds
+ * `device_login_challenge` (v107) — the THIRD consumer, a server-issued single-use
+ * nonce minted PER device-key login attempt so the login proof-of-possession is
+ * NOT replayable (Advisor #1628 finding #2). The DB CHECK (v107) enforces this
+ * closed set; the distinct kind keeps a nonce minted for one leg from being
+ * replayed into another (the consume CAS matches on `kind`). NOTE: unlike the two
+ * single-shot kinds, MANY `device_login_challenge` rows are consumed over a
+ * machine's lifetime, so the single-owner partial UNIQUE(kind) belt EXCLUDES it
+ * (v107) — its single-use guarantee is the per-row CAS, not that index.
  */
 export type FridaySetupBootstrapNonceKind =
   | "install_owner_claim"
-  | "device_migration_claim";
+  | "device_migration_claim"
+  | "device_login_challenge";
 
 // ─── Insert / consume inputs ───
 
@@ -65,6 +71,51 @@ export interface ConsumeFridaySetupBootstrapNonceInput {
   deviceId: string;
   /** Owner user id being claimed (e.g. admin-001). */
   claimedUserId: string;
+}
+
+/**
+ * SEC-SETUP-BOOTSTRAP-001 (CR-1): insert input for a `device_login_challenge`
+ * nonce. UNLIKE the claim/migration challenges (whose device columns are written
+ * at CONSUME time), the login challenge binds the device + key hash at ISSUE time
+ * so the consume CAS can gate on them — a challenge minted for device A can never
+ * be consumed by a login presenting device B (or a different key), even if the raw
+ * nonce leaked. Only the nonce HASH is stored; the raw nonce is returned once.
+ */
+export interface InsertFridayLoginChallengeNonceInput {
+  id: string;
+  nonceHash: string;
+  hubId: string;
+  installId: string;
+  osUser: string;
+  origin: string;
+  action: string;
+  /** Device identifier the login challenge is bound to (gated at consume). */
+  deviceId: string;
+  /** Device public key (opaque) recorded at issue for audit. */
+  devicePublicKey: string;
+  /** Deterministic hash of the bound device public key (gated at consume). */
+  devicePublicKeyHash: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+/**
+ * SEC-SETUP-BOOTSTRAP-001 (CR-1): single-use compare-and-consume input for a
+ * `device_login_challenge` nonce. The CAS gates on origin + bound deviceId + bound
+ * devicePublicKeyHash + single-use (consumed_at IS NULL) + freshness (expires_at >
+ * now), so a replayed / expired / cross-origin / wrong-device / wrong-key login
+ * yields `changes = 0` and mints nothing.
+ */
+export interface ConsumeFridayLoginChallengeNonceInput {
+  nonceHash: string;
+  /** Origin the login is presented from; MUST equal the bound issue origin. */
+  origin: string;
+  /** Wall-clock ISO used for the `expires_at > now` freshness gate. */
+  nowIso: string;
+  /** Device identifier presented in the login; MUST equal the bound device. */
+  deviceId: string;
+  /** Hash of the presented device key; MUST equal the bound key hash. */
+  devicePublicKeyHash: string;
 }
 
 // ─── Sweep (reaper / TTL) inputs ───
@@ -137,6 +188,31 @@ export interface FridaySetupBootstrapNonceRepository {
   consumeOwnerClaimNonce(
     db: Database.Database,
     input: ConsumeFridaySetupBootstrapNonceInput,
+  ): number;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 (CR-1): insert a `device_login_challenge` nonce with
+   * its device binding stamped at ISSUE time. Only the nonce HASH is persisted.
+   */
+  insertLoginChallengeNonce(
+    db: Database.Database,
+    input: InsertFridayLoginChallengeNonceInput,
+  ): void;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 (CR-1): single-use compare-and-consume of a
+   * `device_login_challenge` nonce.
+   *
+   * The `WHERE consumed_at IS NULL AND expires_at > :now AND origin = :origin AND
+   * device_id = :deviceId AND device_public_key_hash = :devicePublicKeyHash`
+   * predicate is the atomic replay/expiry/cross-origin/wrong-device gate: a
+   * consumed, expired, origin-mismatched, or device/key-mismatched login yields
+   * `changes = 0`. Intended to run in the SAME write transaction that mints the
+   * session so a replayed login mints NO second token pair (ZERO state change).
+   *
+   * Returns the number of affected rows (1 = won, 0 = replay/expired/mismatch).
+   */
+  consumeLoginChallengeNonce(
+    db: Database.Database,
+    input: ConsumeFridayLoginChallengeNonceInput,
   ): number;
 }
 
@@ -247,6 +323,52 @@ export function createFridaySetupBootstrapNonceRepository(): FridaySetupBootstra
           nonceHash: input.nonceHash,
           kind: input.kind,
           origin: input.origin,
+        });
+      return res.changes;
+    },
+
+    insertLoginChallengeNonce(db, input) {
+      db.prepare(
+        `INSERT INTO friday_setup_bootstrap_nonces (
+           id, nonce_hash, kind, hub_id, install_id, os_user, origin, action,
+           device_id, device_public_key, device_public_key_hash, claimed_user_id,
+           created_at, expires_at, consumed_at
+         ) VALUES (?, ?, 'device_login_challenge', ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, NULL)`,
+      ).run(
+        input.id,
+        input.nonceHash,
+        input.hubId,
+        input.installId,
+        input.osUser,
+        input.origin,
+        input.action,
+        input.deviceId,
+        input.devicePublicKey,
+        input.devicePublicKeyHash,
+        input.createdAt,
+        input.expiresAt,
+      );
+    },
+
+    consumeLoginChallengeNonce(db, input) {
+      const res = db
+        .prepare(
+          `UPDATE friday_setup_bootstrap_nonces
+              SET consumed_at = :nowIso
+            WHERE nonce_hash = :nonceHash
+              AND kind = 'device_login_challenge'
+              AND origin = :origin
+              AND device_id = :deviceId
+              AND device_public_key_hash = :devicePublicKeyHash
+              AND consumed_at IS NULL
+              AND expires_at > :nowIso`,
+        )
+        .run({
+          nowIso: input.nowIso,
+          nonceHash: input.nonceHash,
+          origin: input.origin,
+          deviceId: input.deviceId,
+          devicePublicKeyHash: input.devicePublicKeyHash,
         });
       return res.changes;
     },

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -58,6 +58,7 @@ import type {
   FridayApiRuntime,
 } from "./friday-api-runtime.types.js";
 import { createFridayAuthService } from "../auth/friday-auth-service.js";
+import { isFridayCanonicalGateProtectedProfile } from "../../hub/friday-hub-bootstrap.js";
 import { createFridayTokenValidator } from "../auth/friday-token-validator.js";
 import { createFridayRateLimitService } from "../auth/friday-rate-limit-service.js";
 import { createFridayAuthMiddlewareFactory } from "../auth/friday-auth-middleware.js";
@@ -2114,6 +2115,13 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       });
     },
     rateLimiter,
+    // CR-1 Option C: `resolveNativeOwnerClaimContext` + `nativeOwnerClaimSurfaceAvailable`
+    // default to honestly-absent (no native IPC accept boundary on this tree), so
+    // device owner-claim/login fail closed until a signed release wires the
+    // Companion Unix-socket peercred+codesign accept boundary (the external leaf).
+    // On a fresh RELEASE profile, passphrase bootstrap is retired (device-native
+    // only) per finding #6; dev/CI keeps it (non-release profile).
+    releaseProfileNativeOnly: () => isFridayCanonicalGateProtectedProfile(process.env),
     resolveTenantId: (input) =>
       deps.resolveAuthTenantId?.({
         principalType: input.principalType,

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { join } from "node:path";
+import type { Socket as NodeNetSocket } from "node:net";
 import type Database from "better-sqlite3";
 
 import { FridayDomainError } from "#errors";
@@ -59,6 +60,17 @@ import type {
 } from "./friday-api-runtime.types.js";
 import { createFridayAuthService } from "../auth/friday-auth-service.js";
 import { isFridayCanonicalGateProtectedProfile } from "../../hub/friday-hub-bootstrap.js";
+import {
+  createAbsentNativePeerAttestationProvider,
+  createMacosCodesignPeerVerifier,
+  verifyNativePeerAttestation,
+} from "../../security/attestation/friday-native-peer-attestation-verifier.js";
+import { createMacosSecureEnclaveKeyCustodyProvider, resolveDeviceKeyProtection } from "../../security/attestation/friday-native-key-custody-provider.js";
+import {
+  deriveNativeOwnerExchangeConnectionId,
+  mintVerifiedNativeOwnerClaimContext,
+  type NativeOwnerClaimContextResolver,
+} from "../../security/attestation/friday-verified-native-owner-claim-context.js";
 import { createFridayTokenValidator } from "../auth/friday-token-validator.js";
 import { createFridayRateLimitService } from "../auth/friday-rate-limit-service.js";
 import { createFridayAuthMiddlewareFactory } from "../auth/friday-auth-middleware.js";
@@ -1962,6 +1974,83 @@ async function composeRustReadOnlyAgentRun(args: {
   };
 }
 
+// ─── CR-1 Option C: DEFAULT native-owner claim wiring (SEC-NATIVE-*-001) ───
+//
+// The pinned code-sign identity a genuine owner-device release binary must carry.
+// On this UNSIGNED source/dev/CI tree it is inert (attestation is honestly absent, so
+// the mint is never reached); a signed release supplies the real signing identity (and
+// a real LOCAL_PEERCRED provider) from its build/signing slice. It is NEVER a way to
+// forge authority — the capability brand + `attested:true` requirement make that
+// impossible, and `NATIVE_IPC_ATTESTATION_AVAILABLE` stays `false`.
+const RELEASE_OWNER_DEVICE_CODESIGN_IDENTITY = "com.friday.owner-device.release";
+
+/**
+ * The DEFAULT native-owner claim resolver the runtime passes to the auth service when
+ * a caller injects none. It runs the REAL CR-4 pipeline — the macOS codesign peer
+ * verifier + the native LOCAL_PEERCRED provider + Secure-Enclave key custody →
+ * `mintVerifiedNativeOwnerClaimContext`. On this source/dev/CI tree there is NO AF_UNIX
+ * peer connection and NO native addon, so the peer provider is honestly ABSENT →
+ * `verifyNativePeerAttestation` is `attested:false` → NOTHING is minted (device
+ * claim/login fail closed). A signed release replaces the peer provider with a real
+ * LOCAL_PEERCRED reader and drives this from the Companion Unix-socket accept boundary
+ * (per native connection, not per HTTP request). It fakes nothing and reads no
+ * request/env fact for a POSITIVE (the only env input is the kill switch, honoured by
+ * the mint).
+ */
+function createReleaseNativeOwnerClaimResolver(env: NodeJS.ProcessEnv): NativeOwnerClaimContextResolver {
+  const codesignVerifier = createMacosCodesignPeerVerifier();
+  // Honest-absent on this tree (no getsockopt(LOCAL_PEERCRED) addon) → returns null.
+  const peerProvider = createAbsentNativePeerAttestationProvider();
+  const custodyProvider = createMacosSecureEnclaveKeyCustodyProvider();
+  return (binding) => {
+    const attestation = verifyNativePeerAttestation({
+      provider: peerProvider,
+      codesignVerifier,
+      expectedReleaseIdentity: RELEASE_OWNER_DEVICE_CODESIGN_IDENTITY,
+      // No live native peer socket in the HTTP runtime on this tree; the absent
+      // provider ignores it and returns null (→ attested:false). A signed release
+      // supplies the accepted native connection here.
+      socket: undefined as unknown as NodeNetSocket,
+    });
+    if (!attestation.attested || !attestation.peerCredential) {
+      return null;
+    }
+    const keyProtection = resolveDeviceKeyProtection(custodyProvider, binding.devicePublicKeyHash);
+    const result = mintVerifiedNativeOwnerClaimContext({
+      attestation,
+      keyProtection,
+      binding,
+      evidence: {
+        osUid: attestation.peerCredential.uid,
+        peerPid: attestation.peerCredential.pid,
+        acceptedConnectionId: deriveNativeOwnerExchangeConnectionId(binding),
+        auditTokenIdentity: attestation.codesignIdentity ?? "",
+        codesignIdentity: attestation.codesignIdentity ?? "",
+      },
+      policy: {
+        expectedReleaseIdentity: RELEASE_OWNER_DEVICE_CODESIGN_IDENTITY,
+        expectedArtifactRole: binding.artifactRole,
+      },
+      env,
+    });
+    return result.ok ? result.capability : null;
+  };
+}
+
+/**
+ * The DEFAULT native device-claim SURFACE presence signal for
+ * `getBootstrapStatus().deviceClaimAvailable` (UI routing ONLY — it authorizes
+ * nothing). Present ONLY on a RELEASE profile running on macOS (where a signed release
+ * WOULD ship the native accept boundary); honestly FALSE on dev/CI (non-release) so the
+ * UI keeps the passphrase gate. HONESTY: on a release macOS tree the surface may be
+ * `true` (UI shows the device gate) while the per-claim capability stays UNMINTABLE on
+ * an UNSIGNED build (`attested:true` unreachable) — that is the honest state; it is
+ * never faked, and it is a presence signal, NOT authority.
+ */
+function createReleaseNativeOwnerClaimSurfaceSignal(env: NodeJS.ProcessEnv): () => boolean {
+  return () => isFridayCanonicalGateProtectedProfile(env) && process.platform === "darwin";
+}
+
 export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): FridayApiRuntime {
   const accessTokenTtlSec = deps.accessTokenTtlSec ?? DEFAULT_ACCESS_TTL;
   const refreshTokenTtlSec = deps.refreshTokenTtlSec ?? DEFAULT_REFRESH_TTL;
@@ -2097,12 +2186,16 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     nowIso: deps.nowIso,
   });
 
-  // CR-1 Option C native-owner claim wiring. F2 seam: an injected resolver/surface
-  // (tests, or a future signed-release native boundary) overrides the auth service's
-  // honest-absent defaults. When absent, the auth service keeps its own honest-absent
-  // defaults (device claim/login fail closed; surface false → passphrase gate).
-  const nativeOwnerClaimResolver = deps.resolveNativeOwnerClaimContext;
-  const nativeOwnerClaimSurfaceAvailable = deps.nativeOwnerClaimSurfaceAvailable;
+  // CR-1 Option C native-owner claim wiring (F1). An injected resolver/surface (tests,
+  // or a future signed-release native boundary) overrides the runtime DEFAULTS. The
+  // defaults run the REAL macOS attestation pipeline (honest-ABSENT on this unsigned
+  // tree → device claim/login fail closed) and gate the surface on a release macOS
+  // profile (honest-FALSE on dev/CI → the UI keeps the passphrase gate). Nothing is
+  // faked; NATIVE_IPC_ATTESTATION_AVAILABLE stays `false`.
+  const nativeOwnerClaimResolver =
+    deps.resolveNativeOwnerClaimContext ?? createReleaseNativeOwnerClaimResolver(process.env);
+  const nativeOwnerClaimSurfaceAvailable =
+    deps.nativeOwnerClaimSurfaceAvailable ?? createReleaseNativeOwnerClaimSurfaceSignal(process.env);
 
   const authService = createFridayAuthService({
     db: deps.db,
@@ -2129,10 +2222,8 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     // defaults (resolver returns null → every device owner-claim/login fails closed;
     // surface false → the UI keeps the passphrase gate). This never fabricates
     // authority and never flips NATIVE_IPC_ATTESTATION_AVAILABLE.
-    ...(nativeOwnerClaimResolver ? { resolveNativeOwnerClaimContext: nativeOwnerClaimResolver } : {}),
-    ...(nativeOwnerClaimSurfaceAvailable
-      ? { nativeOwnerClaimSurfaceAvailable }
-      : {}),
+    resolveNativeOwnerClaimContext: nativeOwnerClaimResolver,
+    nativeOwnerClaimSurfaceAvailable,
     // On a fresh RELEASE profile, passphrase bootstrap is retired (device-native
     // only) per finding #6; dev/CI keeps it (non-release profile).
     releaseProfileNativeOnly: () => isFridayCanonicalGateProtectedProfile(process.env),

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -4343,6 +4343,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     allowTestOnlyProviderRoutingControlsExecution: deps.allowTestOnlyProviderRoutingControlsExecution,
     routeProvidersViaRust: deps.routeProvidersViaRust,
     rustCapabilityDoctor: rustCapabilityDoctorService,
+    nowIso: deps.nowIso,
+    // CORE-A CR-2: the owner-confirm approval minter. Same signing seam the plugin /
+    // upgrade lifecycles use; consulted ONLY by POST /v1/providers/plan/confirm after
+    // an owner explicitly confirms a server-produced plan digest.
+    signCanonicalApproval: signCanonicalApprovalForRequest,
   })) {
     routes.register(route);
   }
@@ -4930,6 +4935,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     channelRegistry: deps.channels?.registry,
     nowIso: deps.nowIso,
     runSession,
+    // (CORE-RUNNABLE-001 / CORE-A CR-3) Rust-owned session lifecycle/run bridge (DARK, default-off).
+    // With nothing set (the default) `routeSessionsViaRust` is falsy AND `rustSessionLifecycleBridge`
+    // is omitted, so the session routes resolve today's fail-closed 503 → byte-identical to today.
+    ...(deps.routeSessionsViaRust !== undefined ? { routeSessionsViaRust: deps.routeSessionsViaRust } : {}),
+    ...(deps.rustSessionLifecycleBridge ? { rustSessionLifecycleBridge: deps.rustSessionLifecycleBridge } : {}),
     allowTestOnlySessionExecution: deps.allowTestOnlySessionExecution,
     allowTestOnlySessionRunExecution: deps.allowTestOnlySessionRunExecution,
     allowTestOnlySessionMemoryExtractionExecution: deps.allowTestOnlySessionMemoryExtractionExecution,

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -2097,6 +2097,13 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     nowIso: deps.nowIso,
   });
 
+  // CR-1 Option C native-owner claim wiring. F2 seam: an injected resolver/surface
+  // (tests, or a future signed-release native boundary) overrides the auth service's
+  // honest-absent defaults. When absent, the auth service keeps its own honest-absent
+  // defaults (device claim/login fail closed; surface false → passphrase gate).
+  const nativeOwnerClaimResolver = deps.resolveNativeOwnerClaimContext;
+  const nativeOwnerClaimSurfaceAvailable = deps.nativeOwnerClaimSurfaceAvailable;
+
   const authService = createFridayAuthService({
     db: deps.db,
     idGenerator: deps.idGenerator,
@@ -2115,10 +2122,17 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
       });
     },
     rateLimiter,
-    // CR-1 Option C: `resolveNativeOwnerClaimContext` + `nativeOwnerClaimSurfaceAvailable`
-    // default to honestly-absent (no native IPC accept boundary on this tree), so
-    // device owner-claim/login fail closed until a signed release wires the
-    // Companion Unix-socket peercred+codesign accept boundary (the external leaf).
+    // CR-1 Option C: `resolveNativeOwnerClaimContext` + `nativeOwnerClaimSurfaceAvailable`.
+    // When a caller injects them (tests, or a signed release wiring the real
+    // Companion Unix-socket peercred+codesign accept boundary) they are threaded to
+    // the auth service; otherwise the auth service falls back to its honest-ABSENT
+    // defaults (resolver returns null → every device owner-claim/login fails closed;
+    // surface false → the UI keeps the passphrase gate). This never fabricates
+    // authority and never flips NATIVE_IPC_ATTESTATION_AVAILABLE.
+    ...(nativeOwnerClaimResolver ? { resolveNativeOwnerClaimContext: nativeOwnerClaimResolver } : {}),
+    ...(nativeOwnerClaimSurfaceAvailable
+      ? { nativeOwnerClaimSurfaceAvailable }
+      : {}),
     // On a fresh RELEASE profile, passphrase bootstrap is retired (device-native
     // only) per finding #6; dev/CI keeps it (non-release profile).
     releaseProfileNativeOnly: () => isFridayCanonicalGateProtectedProfile(process.env),
@@ -4384,6 +4398,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     // proof-of-possession over the reviewed action digest — the Hub holds NO signing
     // key on this path and never self-mints an approval.
     providerApprovalVerifier,
+    // SEC-APPROVAL-AUTHORITY-001 (CORE-A CR-2, Option B*): resolve the authenticated
+    // owner's durable owner↔device binding SERVER-SIDE, so a device-authored approval
+    // binds to the owner's REGISTERED device while the session principal stays
+    // `user.id` (token minting unchanged).
+    resolveBoundDeviceOwnerSentinelHash: authService.resolveBoundDeviceOwnerSentinelHash,
   })) {
     routes.register(route);
   }

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -207,11 +207,13 @@ import {
   createFridayMutatingActionDigest,
   createFridayMutatingActionGate,
   type FridayCanonicalApprovalResolution,
+  type FridayDeviceApprovalVerifyResult,
   type FridayMutatingActionActor,
   type FridayMutatingActionRequest,
   type FridayMutatingActionTicket,
   signFridayCanonicalApproval,
 } from "../../security/friday-mutating-action-gate.js";
+import { createFridayProviderApprovalPoPVerifier } from "../auth/device-attest/index.js";
 import {
   assertBoundPrincipalAuthorityForOperation,
   assertBoundPrincipalForOperation,
@@ -1964,11 +1966,36 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   const refreshTokenTtlSec = deps.refreshTokenTtlSec ?? DEFAULT_REFRESH_TTL;
   const serverVersion = deps.serverVersion ?? "1.0.0";
   const stateDir = deps.stateDir ?? ".";
+  // SEC-APPROVAL-AUTHORITY-001 (CORE-A CR-2): the ASYMMETRIC device-approval
+  // verifier. The Hub holds ONLY the public key on the provider approval path —
+  // it verifies the owner device's P-256 proof-of-possession and NEVER signs. The
+  // legacy symmetric `approvalSignatureSecret` remains ONLY for the plugin/mcp/
+  // channel/skill/workflow lifecycle path (a separate, out-of-CR-2-scope surface).
+  const providerApprovalVerifier = createFridayProviderApprovalPoPVerifier();
   const canonicalMutationGate = createFridayMutatingActionGate({
     nowIso: deps.nowIso,
     ticketIdGenerator: () => deps.idGenerator(),
     approvalSignatureSecret: deps.tokenSecret,
     requireApprovalSignature: true,
+    deviceApprovalVerifier: (proof, nowMs): FridayDeviceApprovalVerifyResult => {
+      const result = providerApprovalVerifier.verifyPossession({
+        transcript: proof.transcript,
+        devicePublicKey: proof.devicePublicKey,
+        signature: proof.signature,
+        nowMs,
+      });
+      if (!result.ok) {
+        return { ok: false, reason: result.reason };
+      }
+      return {
+        ok: true,
+        devicePublicKeyHash: result.devicePublicKeyHash,
+        approvalId: result.approvalId,
+        actionDigest: result.actionDigest,
+        decidedByPrincipalId: result.decidedByPrincipalId,
+        expiresAt: result.expiresAt,
+      };
+    },
   });
   const providerMutationGateRequired = deps.canonicalMutatingActionGate
     ?? resolveApiRuntimeCanonicalGateRequired(process.env);
@@ -4344,10 +4371,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     routeProvidersViaRust: deps.routeProvidersViaRust,
     rustCapabilityDoctor: rustCapabilityDoctorService,
     nowIso: deps.nowIso,
-    // CORE-A CR-2: the owner-confirm approval minter. Same signing seam the plugin /
-    // upgrade lifecycles use; consulted ONLY by POST /v1/providers/plan/confirm after
-    // an owner explicitly confirms a server-produced plan digest.
-    signCanonicalApproval: signCanonicalApprovalForRequest,
+    // SEC-APPROVAL-AUTHORITY-001 (CORE-A CR-2): the ASYMMETRIC device-approval
+    // verifier. POST /v1/providers/plan/confirm VERIFIES the owner device's P-256
+    // proof-of-possession over the reviewed action digest — the Hub holds NO signing
+    // key on this path and never self-mints an approval.
+    providerApprovalVerifier,
   })) {
     routes.register(route);
   }

--- a/src/api/runtime/friday-api-runtime.ts
+++ b/src/api/runtime/friday-api-runtime.ts
@@ -227,6 +227,7 @@ import {
   signFridayCanonicalApproval,
 } from "../../security/friday-mutating-action-gate.js";
 import { createFridayProviderApprovalPoPVerifier } from "../auth/device-attest/index.js";
+import { FridaySqliteApprovalConsumptionStore } from "../http/persistence/friday-provider-approval-consumption-repository.js";
 import {
   assertBoundPrincipalAuthorityForOperation,
   assertBoundPrincipalForOperation,
@@ -2062,11 +2063,19 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
   // legacy symmetric `approvalSignatureSecret` remains ONLY for the plugin/mcp/
   // channel/skill/workflow lifecycle path (a separate, out-of-CR-2-scope surface).
   const providerApprovalVerifier = createFridayProviderApprovalPoPVerifier();
+  // SEC-APPROVAL-AUTHORITY-001 · Advisor round-2 finding #3: DURABLE single-use ledger for
+  // canonical approvals (migration v108), replacing the gate's process-local in-memory Set so
+  // a confirmed device-authored approval consumed once cannot be replayed after a restart or
+  // by a concurrent process. Boot-time reconcile marks any crash-orphaned in_flight
+  // reservation indeterminate (fail-closed) BEFORE the runtime serves requests.
+  const approvalConsumptionStore = new FridaySqliteApprovalConsumptionStore(deps.db);
+  approvalConsumptionStore.reconcileOrphanedReservations();
   const canonicalMutationGate = createFridayMutatingActionGate({
     nowIso: deps.nowIso,
     ticketIdGenerator: () => deps.idGenerator(),
     approvalSignatureSecret: deps.tokenSecret,
     requireApprovalSignature: true,
+    approvalConsumptionStore,
     deviceApprovalVerifier: (proof, nowMs): FridayDeviceApprovalVerifyResult => {
       const result = providerApprovalVerifier.verifyPossession({
         transcript: proof.transcript,
@@ -4494,6 +4503,11 @@ export function createFridayApiRuntime(deps: CreateFridayApiRuntimeDeps): Friday
     // binds to the owner's REGISTERED device while the session principal stays
     // `user.id` (token minting unchanged).
     resolveBoundDeviceOwnerSentinelHash: authService.resolveBoundDeviceOwnerSentinelHash,
+    // SEC-APPROVAL-AUTHORITY-001 · Advisor round-2 finding #3: the SAME durable single-use
+    // ledger the gate consumes. create/update/delete gate with deferred consumption, then
+    // finalize the reservation INSIDE the provider mutation's write transaction so consume ⊗
+    // mutation commit atomically.
+    approvalConsumptionStore,
   })) {
     routes.register(route);
   }

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -40,6 +40,7 @@ import type { FridayRustAgentRunWsClientX25519SecretResolver } from "../mission-
 import type { FridayRustHubWorkflowCatalogBridgeService } from "../mission-spine/friday-rust-hub-workflow-catalog-bridge-service.js";
 import type { FridayRustHubWorkflowRunBridgeService } from "../mission-spine/friday-rust-hub-workflow-run-bridge-service.js";
 import type { FridayD20SignedBatchWorktreeService } from "../mission-spine/friday-rust-hub-d20-signed-batch-worktree-service.js";
+import type { FridayRustSessionLifecycleBridge } from "../http/routes/friday-session-routes.js";
 import type { FridayMediaUnderstandingRoutesDeps } from "../http/routes/friday-media-understanding-routes.js";
 import type { FridaySocialImportRoutesDeps } from "../http/routes/friday-social-import-routes.js";
 import type { FridayTaskWorkflowRoutesDeps } from "../http/routes/friday-task-workflow-routes.js";
@@ -521,6 +522,23 @@ export interface CreateFridayApiRuntimeDeps {
    * fail-closed until Rust owns the session memory extraction entrypoint.
    */
   allowTestOnlySessionMemoryExtractionExecution?: boolean;
+  /**
+   * (CORE-RUNNABLE-001 / CORE-A CR-3) SESSION Rust-owned lifecycle/run bridge (DARK): the resolved
+   * default-false master flag for routing the session run (`POST /v1/sessions/:sessionKey/run`) to
+   * the Rust-owned loop instead of fail-closing. DEFAULT-FALSE — leave unset in production/runtime so
+   * the session routes stay byte-identical to today's fail-closed 503. Sourced (in bootstrap) from
+   * `FRIDAY_ROUTE_SESSIONS_VIA_RUST` / explicit config via `resolveRouteSessionsViaRust`. When
+   * unset/false the {@link rustSessionLifecycleBridge} is never consulted.
+   */
+  routeSessionsViaRust?: boolean;
+  /**
+   * (CORE-RUNNABLE-001 / CORE-A CR-3) The REAL Rust-owned session lifecycle/run bridge consulted by
+   * the session routes ONLY when {@link routeSessionsViaRust} is true. OPTIONAL — bootstrap builds +
+   * injects the real sealed-WS adapter ONLY when the flag is on; when omitted (the DEFAULT) the
+   * session routes fail closed (503). Tests inject the real adapter over a test transport (a fake
+   * sealed client + readback) to prove reachability WITHOUT a socket.
+   */
+  rustSessionLifecycleBridge?: FridayRustSessionLifecycleBridge;
   /**
    * Test-oracle only: allow the legacy TypeScript realtime checkpoint-ack
    * mutation (POST /v1/realtime/ack). Production/runtime callers must leave this

--- a/src/api/runtime/friday-api-runtime.types.ts
+++ b/src/api/runtime/friday-api-runtime.types.ts
@@ -5,6 +5,7 @@ import type { FridayLearningEventAppendInput } from "#ledger";
 import type { FridayOutboxQueueService } from "#satellites";
 import type { FridayAccessTokenClaims, FridayRole } from "../model/friday-api-auth.types.js";
 import type { FridayAuthService } from "../auth/friday-auth-service.types.js";
+import type { NativeOwnerClaimContextResolver } from "../../security/attestation/friday-verified-native-owner-claim-context.js";
 import type { FridayRateLimitService } from "../auth/friday-rate-limit-service.types.js";
 import type { FridayTokenValidator } from "../auth/friday-token-validator.js";
 import type { FridayAuthMiddlewareFactory } from "../auth/friday-auth-middleware.js";
@@ -199,6 +200,25 @@ export interface CreateFridayApiRuntimeDeps {
   tokenSecret: string;
   accessTokenTtlSec?: number;
   refreshTokenTtlSec?: number;
+  /**
+   * SEC-NATIVE-OWNER-CLAIM-CAPABILITY-001 · CORE-A CR-1 (Option C) INJECTION SEAM.
+   * When provided, overrides the runtime's DEFAULT native-owner claim resolver that
+   * is passed to the auth service (device owner-claim/login). Production leaves this
+   * UNSET so the runtime builds the real macOS peercred+codesign accept-boundary
+   * resolver (honest-ABSENT on this unsigned dev/CI tree → returns null → every
+   * device claim/login fails closed). Tests inject a resolver that runs the REAL
+   * capability mint over injected native-evidence doubles (the capability brand makes
+   * a forged literal impossible). NEVER flips `NATIVE_IPC_ATTESTATION_AVAILABLE`.
+   */
+  resolveNativeOwnerClaimContext?: NativeOwnerClaimContextResolver;
+  /**
+   * Presence signal for `getBootstrapStatus().deviceClaimAvailable` ONLY. When
+   * provided, overrides the runtime's DEFAULT native-surface presence signal.
+   * Reports whether the native device-claim SURFACE exists; NEVER authorizes a claim
+   * (authority is the per-claim capability). The surface flag MAY be true while the
+   * capability stays UNMINTABLE on an unsigned tree — that is the honest state.
+   */
+  nativeOwnerClaimSurfaceAvailable?: () => boolean;
   /** Optional tenant resolver shared by auth claim issuance and validation. */
   resolveAuthTenantId?: (input: {
     principalType: string;

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -1957,6 +1957,18 @@ export interface FridayHubConfig {
    */
   routeAgentRunViaRust?: boolean;
   /**
+   * (CORE-RUNNABLE-001 / CORE-A CR-3) SESSION Rust-owned lifecycle/run bridge (DARK): "route the
+   * session run (`POST /v1/sessions/:sessionKey/run`) to the Rust-owned loop instead of fail-closing
+   * with 503" flag. DEFAULT-FALSE — production hub creation must leave this unset so the runtime
+   * threads NO `rustSessionLifecycleBridge` and every session route stays byte-identical to today's
+   * fail-closed 503. When true, bootstrap builds the REAL sealed-WS session dispatch adapter
+   * (mirroring the agent-run sealed-WS config) and injects it. End-to-end closure ALSO needs the
+   * provisioned sealed-WS host + answer-readback DB + a real turn (operator-gated). Resolution:
+   * `resolveRouteSessionsViaRust` (explicit config wins; otherwise the `FRIDAY_ROUTE_SESSIONS_VIA_RUST`
+   * env knob).
+   */
+  routeSessionsViaRust?: boolean;
+  /**
    * GATE-AGENT-REPLACE A3 courier (DARK): master ON/OFF arming the pause/resume PRODUCT
    * TRANSPORT (the sealed WS courier's `AgentRunPaused` inbound + `resumeWithApproval` relay).
    * DEFAULT-FALSE — production hub creation must leave this unset so the courier's paused/resume

--- a/src/hub/bootstrap/hub-helpers.ts
+++ b/src/hub/bootstrap/hub-helpers.ts
@@ -48,6 +48,7 @@ import type { FridaySkillSecurityProfile } from "#skills";
 import type { FridaySkillGeneratorService } from "#skills/generator";
 import type { FridaySkillConverterService } from "#skills/converter";
 import type { FridayProviderService } from "#providers";
+import type { NativeOwnerClaimContextResolver } from "../../security/attestation/friday-verified-native-owner-claim-context.js";
 import {
   normalizeFridayModelRoutingConfig,
   normalizeFridayProviderSupportedModels,
@@ -2049,6 +2050,22 @@ export interface FridayHubConfig {
    * wins; otherwise the `FRIDAY_MISSION_AUTO_DISPATCH` env knob).
    */
   missionAutoDispatch?: boolean;
+  /**
+   * SEC-NATIVE-OWNER-CLAIM-CAPABILITY-001 · CORE-A CR-1 (Option C) INJECTION SEAM.
+   * Overrides the api-runtime's DEFAULT native-owner claim resolver (device
+   * owner-claim/login). Production leaves this UNSET so the runtime builds the real
+   * macOS peercred+codesign accept-boundary resolver (honest-absent on this unsigned
+   * tree). Tests inject a resolver that runs the REAL capability mint over injected
+   * native-evidence doubles. NEVER fabricates authority; NEVER flips
+   * `NATIVE_IPC_ATTESTATION_AVAILABLE`.
+   */
+  resolveNativeOwnerClaimContext?: NativeOwnerClaimContextResolver;
+  /**
+   * Overrides the api-runtime's DEFAULT native-surface presence signal for
+   * `getBootstrapStatus().deviceClaimAvailable`. Reports whether the native
+   * device-claim SURFACE exists; NEVER authorizes a claim.
+   */
+  nativeOwnerClaimSurfaceAvailable?: () => boolean;
 }
 
 // ─── Resolved Hub Config ───

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -7475,6 +7475,15 @@ export async function createFridayHub(
     skillExecutor: executor,
     updateSkillStatus: (skillId, status) => memoryState.updateSkillStatus(skillId, status),
     tokenSecret,
+    // CR-1 Option C (Option B* / F1 injection seam): thread an injected native-owner
+    // claim resolver + surface signal (tests, or a future signed-release native
+    // boundary). Unset in production → the runtime builds its honest-absent default.
+    ...(config.resolveNativeOwnerClaimContext
+      ? { resolveNativeOwnerClaimContext: config.resolveNativeOwnerClaimContext }
+      : {}),
+    ...(config.nativeOwnerClaimSurfaceAvailable
+      ? { nativeOwnerClaimSurfaceAvailable: config.nativeOwnerClaimSurfaceAvailable }
+      : {}),
     pluginRuntimeMode,
     supportedChannelKinds: [...runtimeSupportedChannelKinds],
     enabledChannelKinds: getEnabledChannelKinds,

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -968,15 +968,20 @@ export function resolveFridayCanonicalMutatingActionGate(
  * and, only as a fallback, (2) the `FRIDAY_ROUTE_AGENT_RUN_VIA_RUST` env var — the operator
  * knob that lets the Rust read-only execrun route be flipped WITHOUT a source edit.
  *
- * PRECEDENCE: an explicit config boolean (true OR false) ALWAYS wins; the env is consulted
- * ONLY when config does not specify (the previously-unsettable gap). This preserves the
- * prior `config.routeAgentRunViaRust` precedence exactly.
+ * PRECEDENCE: an explicit config boolean (true OR false) ALWAYS wins; then an EXPLICIT env token
+ * (`1|true|0|false`); ONLY when BOTH config AND env are unset does the RELEASE-DEFAULT apply.
  *
- * PARSE (fail-safe OFF): case-insensitive, trimmed `"1"` or `"true"` ⇒ true; ABSENT, `""`,
- * `"0"`, `"false"`, or ANY other value ⇒ false. DEFAULT (env unset, config unset) ⇒ false,
- * so the downstream `deps.routeAgentRunViaRust === true` gate stays off → byte-identical to
- * today's fail-closed 503. Intentionally NARROWER than the canonical-gate true-set
- * (no yes/on/enabled) so any ambiguity resolves OFF.
+ * PARSE: case-insensitive, trimmed `"1"`/`"true"` ⇒ true; `"0"`/`"false"` ⇒ false (an explicit
+ * off — the operator KILL-SWITCH that forces the TS/mock lane even on a release build). ABSENT
+ * (`""`) or any UNRECOGNIZED value falls through to the RELEASE-DEFAULT.
+ *
+ * RELEASE-DEFAULT (R14, CR-3): when config AND env are both unset, the value is
+ * {@link isFridayCanonicalGateProtectedProfile} — i.e. a release/production build (NODE_ENV=production
+ * OR FRIDAY_RELEASE_TAG set) routes the agent run to the Rust path with NO flag (the FLAGLESS
+ * production-default the R14 finding requires), while dev/test (an unprotected profile) stays OFF →
+ * byte-identical to today's fail-closed 503 for the default dev/test lane. Fail-closed downstream is
+ * preserved: a release build with the Rust transport ABSENT surfaces the transport's 503, never a
+ * silent TS fallback.
  *
  * The sibling `FRIDAY_HUB_AGENT_RUN_*` knobs (WS host/port, DB path) are read and documented
  * at the deps/runtime construction point in `friday-api-runtime.ts`; this flag's resolve +
@@ -986,12 +991,19 @@ export function resolveRouteAgentRunViaRust(
   configValue: boolean | undefined,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  // Config explicit (true OR false) wins — env is the fallback for the unset gap only.
+  // Config explicit (true OR false) wins — then explicit env, then the release-default.
   if (typeof configValue === "boolean") {
     return configValue;
   }
   const raw = (env.FRIDAY_ROUTE_AGENT_RUN_VIA_RUST ?? "").trim().toLowerCase();
-  return raw === "1" || raw === "true";
+  if (raw === "1" || raw === "true") {
+    return true;
+  }
+  if (raw === "0" || raw === "false") {
+    return false;
+  }
+  // Both config AND env unset ⇒ FLAGLESS release-default (R14): route to Rust on a protected profile.
+  return isFridayCanonicalGateProtectedProfile(env);
 }
 
 /**
@@ -1001,22 +1013,34 @@ export function resolveRouteAgentRunViaRust(
  * run route be flipped WITHOUT a source edit.
  *
  * PRECEDENCE + PARSE MIRROR {@link resolveRouteAgentRunViaRust} EXACTLY: an explicit config boolean
- * (true OR false) ALWAYS wins; the env is consulted ONLY when config does not specify. Case-
- * insensitive, trimmed `"1"` or `"true"` ⇒ true; ABSENT / `""` / `"0"` / `"false"` / ANY other
- * value ⇒ false. DEFAULT (both unset) ⇒ false, so the runtime threads NO `rustSessionLifecycleBridge`
- * and the session routes stay byte-identical to today's fail-closed 503. Intentionally NARROWER than
- * the canonical-gate true-set so any ambiguity resolves OFF.
+ * (true OR false) ALWAYS wins; then an EXPLICIT env token (`"1"`/`"true"` ⇒ true; `"0"`/`"false"` ⇒
+ * false — the operator KILL-SWITCH that forces the TS/mock lane even on a release build); ONLY when
+ * BOTH config AND env are unset does the RELEASE-DEFAULT apply.
+ *
+ * RELEASE-DEFAULT (R14, CR-3): both-unset resolves to {@link isFridayCanonicalGateProtectedProfile}
+ * — a release/production build (NODE_ENV=production OR FRIDAY_RELEASE_TAG) routes sessions to the
+ * Rust path with NO flag (FLAGLESS), threading a REAL `rustSessionLifecycleBridge`; a dev/test
+ * (unprotected) profile stays OFF so the session routes remain byte-identical to today's fail-closed
+ * 503 (the CR-0 baseline). Fail-closed is preserved: a release build with the Rust Hub transport
+ * ABSENT surfaces the transport's 503 per call (the retired TS session path is NOT silently served).
  */
 export function resolveRouteSessionsViaRust(
   configValue: boolean | undefined,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  // Config explicit (true OR false) wins — env is the fallback for the unset gap only.
+  // Config explicit (true OR false) wins — then explicit env, then the release-default.
   if (typeof configValue === "boolean") {
     return configValue;
   }
   const raw = (env.FRIDAY_ROUTE_SESSIONS_VIA_RUST ?? "").trim().toLowerCase();
-  return raw === "1" || raw === "true";
+  if (raw === "1" || raw === "true") {
+    return true;
+  }
+  if (raw === "0" || raw === "false") {
+    return false;
+  }
+  // Both config AND env unset ⇒ FLAGLESS release-default (R14): route to Rust on a protected profile.
+  return isFridayCanonicalGateProtectedProfile(env);
 }
 
 /**

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -917,7 +917,7 @@ export function resolveFridayHubConfig(
   };
 }
 
-function isFridayCanonicalGateProtectedProfile(env: NodeJS.ProcessEnv): boolean {
+export function isFridayCanonicalGateProtectedProfile(env: NodeJS.ProcessEnv): boolean {
   return env.NODE_ENV?.trim().toLowerCase() === "production"
     || Boolean(env.FRIDAY_RELEASE_TAG?.trim());
 }

--- a/src/hub/friday-hub-bootstrap.ts
+++ b/src/hub/friday-hub-bootstrap.ts
@@ -144,6 +144,7 @@ import {
   readRunOutcomeLearningRustWsPort,
 } from "../api/mission-spine/friday-run-outcome-learning-dispatch-adapter.js";
 import { resolveRustAgentRunWsClientX25519Secret } from "../api/mission-spine/friday-rust-hub-agent-run-ws-client-x25519-secret.js";
+import { createFridayRustHubSessionLifecycleDispatchAdapter } from "../api/mission-spine/friday-rust-hub-session-lifecycle-dispatch-adapter.js";
 import type { FridayChannelPersonaConfig, FridayGuideLensRoutesDeps, FridaySystemRoutesDeps } from "#api";
 import type { FridayPackagingRoutesDeps } from "../api/http/routes/friday-packaging-routes.js";
 import {
@@ -990,6 +991,31 @@ export function resolveRouteAgentRunViaRust(
     return configValue;
   }
   const raw = (env.FRIDAY_ROUTE_AGENT_RUN_VIA_RUST ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+/**
+ * (CORE-RUNNABLE-001 / CORE-A CR-3) Single source of truth resolving the `routeSessionsViaRust`
+ * flag from (1) an EXPLICIT {@link FridayHubConfig.routeSessionsViaRust} and, only as a fallback,
+ * (2) the `FRIDAY_ROUTE_SESSIONS_VIA_RUST` env var — the operator knob that lets the Rust session
+ * run route be flipped WITHOUT a source edit.
+ *
+ * PRECEDENCE + PARSE MIRROR {@link resolveRouteAgentRunViaRust} EXACTLY: an explicit config boolean
+ * (true OR false) ALWAYS wins; the env is consulted ONLY when config does not specify. Case-
+ * insensitive, trimmed `"1"` or `"true"` ⇒ true; ABSENT / `""` / `"0"` / `"false"` / ANY other
+ * value ⇒ false. DEFAULT (both unset) ⇒ false, so the runtime threads NO `rustSessionLifecycleBridge`
+ * and the session routes stay byte-identical to today's fail-closed 503. Intentionally NARROWER than
+ * the canonical-gate true-set so any ambiguity resolves OFF.
+ */
+export function resolveRouteSessionsViaRust(
+  configValue: boolean | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  // Config explicit (true OR false) wins — env is the fallback for the unset gap only.
+  if (typeof configValue === "boolean") {
+    return configValue;
+  }
+  const raw = (env.FRIDAY_ROUTE_SESSIONS_VIA_RUST ?? "").trim().toLowerCase();
   return raw === "1" || raw === "true";
 }
 
@@ -7389,6 +7415,25 @@ export async function createFridayHub(
     })
     : null;
 
+  // (CORE-RUNNABLE-001 / CORE-A CR-3) SESSION Rust-owned lifecycle/run bridge (DARK, default-off).
+  // SINGLE SOURCE OF TRUTH for resolution = `resolveRouteSessionsViaRust` (explicit config wins; else
+  // the `FRIDAY_ROUTE_SESSIONS_VIA_RUST` env knob, case-insensitive "1"/"true" → true; anything else
+  // incl. unset → false). When OFF (the default) the bridge is NOT constructed and the runtime dep
+  // stays unset → the session routes resolve today's fail-closed 503 → byte-identical. When ON, build
+  // the REAL sealed-WS session dispatch adapter (mirrors the agent-run sealed-WS host/port/secret
+  // config exactly) so the session run route is reachable-and-real; the adapter is SIDE-EFFECT-FREE
+  // (resolves no secret + opens no socket until a real run). `readMissionSpineRustWsPort` parses the
+  // SAME `FRIDAY_HUB_AGENT_RUN_WS_PORT` the agent-run path dials.
+  const routeSessionsViaRust = resolveRouteSessionsViaRust(config.routeSessionsViaRust);
+  const rustSessionLifecycleBridge = routeSessionsViaRust
+    ? createFridayRustHubSessionLifecycleDispatchAdapter({
+      host: process.env.FRIDAY_HUB_AGENT_RUN_WS_HOST ?? "127.0.0.1",
+      port: readMissionSpineRustWsPort(process.env.FRIDAY_HUB_AGENT_RUN_WS_PORT),
+      secretResolver: resolveRustAgentRunWsClientX25519Secret,
+      idGenerator,
+    })
+    : undefined;
+
   const runtimeSupportedChannelKinds = FRIDAY_SUPPORTED_CHANNEL_KINDS.filter(isFridayChannelKindSupported);
 
   const apiRuntime = createFridayApiRuntime({
@@ -7674,6 +7719,12 @@ export async function createFridayHub(
     // set (the default) this is `false`, so the `=== true` gate is never satisfied → the
     // predicate is never evaluated → byte-identical to today's fail-closed 503.
     routeAgentRunViaRust: resolveRouteAgentRunViaRust(config.routeAgentRunViaRust),
+    // (CORE-RUNNABLE-001 / CORE-A CR-3) SESSION Rust-owned lifecycle/run bridge (DARK): the resolved
+    // default-false flag + the REAL bridge (constructed above ONLY when the flag is on). With nothing
+    // set (the default) `routeSessionsViaRust` is false AND `rustSessionLifecycleBridge` is undefined,
+    // so the session routes resolve today's fail-closed 503 → byte-identical to today.
+    routeSessionsViaRust,
+    ...(rustSessionLifecycleBridge ? { rustSessionLifecycleBridge } : {}),
     // GATE-AGENT-REPLACE A3 courier (DARK): default-false master flag arming the pause/resume
     // PRODUCT TRANSPORT (the sealed WS courier's `AgentRunPaused` inbound + `resumeWithApproval`
     // relay). SINGLE SOURCE OF TRUTH = `resolveAgentRunControlViaRust` (explicit config wins; else

--- a/src/hub/index.ts
+++ b/src/hub/index.ts
@@ -39,6 +39,7 @@ export {
   resolveFridayHubConfig,
   resolveAgentRunControlViaRust,
   resolveRouteAgentRunViaRust,
+  resolveRouteSessionsViaRust,
   resolveRouteMissionSpineViaRust,
   resolveRouteMemorySpineViaRust,
   resolveRouteRunOutcomeLearningViaRust,

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -180,6 +180,8 @@ export {
 // Service
 export type {
   FridayProviderService,
+  FridayProviderMutationOptions,
+  FridayProviderMutationConsumeInTransaction,
   CreateFridayProviderServiceDeps,
   FridayProviderTenantContext,
   FridayProviderCredentialScope,

--- a/src/providers/services/friday-provider-service.ts
+++ b/src/providers/services/friday-provider-service.ts
@@ -2825,7 +2825,7 @@ export function createFridayProviderService(
       );
     },
 
-    async createProvider(input) {
+    async createProvider(input, options) {
       const id = deps.idGenerator();
       const now = deps.nowIso();
       const preset = getFridayProviderPreset(input.kind, input.baseUrl);
@@ -2943,6 +2943,9 @@ export function createFridayProviderService(
       }
 
       deps.db.withWriteTransaction((db) => {
+        // Durable single-use approval consumption commits ATOMICALLY with the create — a
+        // replayed approval throws a PK conflict here and rolls the whole insert back.
+        options?.consumeApprovalInTransaction?.(db);
         profileRepo.insert(db, normalizeProviderConfig(profile));
         syncDefaultAuthProfile(db, normalizeProviderConfig(profile));
       });
@@ -2950,7 +2953,7 @@ export function createFridayProviderService(
       return normalizeProviderConfig(profile);
     },
 
-    async updateProvider(providerId, patch) {
+    async updateProvider(providerId, patch, options) {
       const existing = deps.db.withReadConnection((db) =>
         profileRepo.getById(db, providerId),
       );
@@ -3120,6 +3123,8 @@ export function createFridayProviderService(
       }
 
       deps.db.withWriteTransaction((db) => {
+        // Durable single-use approval consumption commits ATOMICALLY with the update.
+        options?.consumeApprovalInTransaction?.(db);
         profileRepo.update(db, normalizeProviderConfig(updated));
         syncDefaultAuthProfile(db, normalizeProviderConfig(updated));
       });
@@ -3127,7 +3132,7 @@ export function createFridayProviderService(
       return normalizeProviderConfig(updated);
     },
 
-    async deleteProvider(providerId) {
+    async deleteProvider(providerId, options) {
       const existing = deps.db.withReadConnection((db) =>
         profileRepo.getById(db, providerId),
       );
@@ -3141,6 +3146,8 @@ export function createFridayProviderService(
       oauthTokenManager.clearProviderProfile(providerId);
 
       deps.db.withWriteTransaction((db) => {
+        // Durable single-use approval consumption commits ATOMICALLY with the delete.
+        options?.consumeApprovalInTransaction?.(db);
         authProfileRepo.deleteByProviderProfileId(db, providerId);
         // Delete secret if stored
         if (existing.config.keySource.kind === "secret-ref") {

--- a/src/providers/services/friday-provider-service.types.ts
+++ b/src/providers/services/friday-provider-service.types.ts
@@ -1,3 +1,5 @@
+import type Database from "better-sqlite3";
+
 import type { FridaySqliteLayer } from "#state";
 
 import type {
@@ -37,6 +39,20 @@ import type {
 } from "../model/friday-provider-cost.types.js";
 
 // ─── Service interface ───
+
+/**
+ * A hook the provider MUTATION methods (create/update/delete) invoke as the FIRST
+ * statement INSIDE their persist `withWriteTransaction`, so a durable single-use approval
+ * consumption commits ATOMICALLY with the mutation write — a rollback (or a throw from the
+ * hook, e.g. a PK conflict on a replayed approval) unwinds BOTH the consumption and the
+ * mutation (no effect without a durable consumption). Wired by the provider routes from a
+ * DEFERRED mutating-action gate ticket. Absent for callers that do not gate mutations.
+ */
+export type FridayProviderMutationConsumeInTransaction = (db: Database.Database) => void;
+
+export interface FridayProviderMutationOptions {
+  readonly consumeApprovalInTransaction?: FridayProviderMutationConsumeInTransaction;
+}
 
 export interface FridayProviderService {
   listProviders(): Promise<FridayProviderProfile[]>;
@@ -105,7 +121,7 @@ export interface FridayProviderService {
     enabled?: boolean;
     validateOnSave?: boolean;
     preserveEnvRef?: boolean;
-  }): Promise<FridayProviderProfile>;
+  }, options?: FridayProviderMutationOptions): Promise<FridayProviderProfile>;
 
   updateProvider(
     providerId: string,
@@ -127,9 +143,10 @@ export interface FridayProviderService {
       validateOnSave?: boolean;
       preserveEnvRef?: boolean;
     },
+    options?: FridayProviderMutationOptions,
   ): Promise<FridayProviderProfile>;
 
-  deleteProvider(providerId: string): Promise<void>;
+  deleteProvider(providerId: string, options?: FridayProviderMutationOptions): Promise<void>;
 
   validateProvider(
     providerId: string,

--- a/src/security/attestation/friday-native-key-custody-provider.ts
+++ b/src/security/attestation/friday-native-key-custody-provider.ts
@@ -1,0 +1,88 @@
+// ─── SEC-NATIVE-KEY-CUSTODY-001 · CORE-A CR-1 (Advisor Option C, finding #4) ───
+//
+// The SEAM for durable native device-key custody: native P-256 key generation +
+// signing whose private key lives in the Secure Enclave (or, where the Enclave is
+// unavailable, a Keychain ACL-guarded key), attested by the OS. This module holds
+// the PROVIDER INTERFACE and the honest-absent defaults; the actual Secure-Enclave
+// binding activates ONLY on a signed release running on a physical device — that is
+// the EXTERNAL leaf (EXT-MAC-PHYSICAL-INSTALL-LIFECYCLE-001), honest-false/absent
+// on this dev/CI tree.
+//
+// `deriveDeviceKeyProtection` (in the authority-precondition module) CONSUMES the
+// evidence this provider yields. A WebCrypto/browser key is a NEGATIVE/dev seam
+// only: it yields `webcrypto_software` custody, which can NEVER be release-trusted.
+
+import type {
+  FridayDeviceKeyProtection,
+  NativeKeyCustodyEvidence,
+} from "../friday-device-owner-authority-precondition.js";
+import { deriveDeviceKeyProtection } from "../friday-device-owner-authority-precondition.js";
+
+/**
+ * A durable native key-custody provider. `attestCustody` returns OS-vouched
+ * evidence about where the device signing key lives, or `null` when no native
+ * custody is available (unsigned/dev/CI). It NEVER fabricates a hardware posture.
+ */
+export interface NativeKeyCustodyProvider {
+  /** The device public key (SPKI-DER, base64) whose custody is being attested. */
+  attestCustody(devicePublicKeyHash: string): NativeKeyCustodyEvidence | null;
+}
+
+/**
+ * The DEFAULT provider on this source/dev/CI tree: no native custody bridge is
+ * installed, so it yields `null` → `deriveDeviceKeyProtection` returns
+ * `"unverified"` (fails closed). We NEVER fabricate a Secure-Enclave label.
+ */
+export function createAbsentNativeKeyCustodyProvider(): NativeKeyCustodyProvider {
+  return {
+    attestCustody(_devicePublicKeyHash: string): NativeKeyCustodyEvidence | null {
+      return null;
+    },
+  };
+}
+
+/**
+ * The WebCrypto/browser dev seam. It reports `webcrypto_software` custody, which
+ * `deriveDeviceKeyProtection` maps to `"software_dev_only"` — NEVER release-trusted.
+ * This exists only so a non-release/dev profile can exercise the device flows with
+ * a software key; it must NEVER be wired on a release profile (the caller gates it
+ * on `!isFridayCanonicalGateProtectedProfile(env)`).
+ */
+export function createWebCryptoDevKeyCustodyProvider(): NativeKeyCustodyProvider {
+  return {
+    attestCustody(_devicePublicKeyHash: string): NativeKeyCustodyEvidence | null {
+      // Honest dev posture: a software key the OS did NOT vouch for.
+      return { custody: "webcrypto_software", osVerified: false };
+    },
+  };
+}
+
+/**
+ * The macOS Secure-Enclave custody provider SEAM (release residual — NOT wired,
+ * NOT the default). On this dev/CI tree there is no Secure Enclave binding and no
+ * signed release, so it honestly yields `null` (→ `"unverified"`). The real
+ * SecKeyCreateRandomKey(kSecAttrTokenIDSecureEnclave) + LAContext ACL binding is
+ * the physical external leaf; this function is where a signed release plugs it in.
+ * It never fabricates an OS-verified posture on an unsigned/dev tree.
+ */
+export function createMacosSecureEnclaveKeyCustodyProvider(): NativeKeyCustodyProvider {
+  return {
+    attestCustody(_devicePublicKeyHash: string): NativeKeyCustodyEvidence | null {
+      // No Secure Enclave binding is reachable from this dev/CI process — a signed
+      // release on a physical device replaces this body with a real SecKey +
+      // LAContext attestation. Until then: honestly absent (fails closed).
+      return null;
+    },
+  };
+}
+
+/**
+ * Convenience: resolve the release keyProtection posture from a provider by
+ * consuming its evidence. Absent custody → `"unverified"` (fails closed).
+ */
+export function resolveDeviceKeyProtection(
+  provider: NativeKeyCustodyProvider,
+  devicePublicKeyHash: string,
+): FridayDeviceKeyProtection {
+  return deriveDeviceKeyProtection(provider.attestCustody(devicePublicKeyHash));
+}

--- a/src/security/attestation/friday-native-peer-attestation-verifier.ts
+++ b/src/security/attestation/friday-native-peer-attestation-verifier.ts
@@ -1,0 +1,338 @@
+// ─── SEC-NATIVE-PEER-ATTESTATION-001 · CORE-A CR-1 (SLICE 4) — VERIFIER SEAM ───
+//
+// PREREQUISITE for the native-IPC caller-identity precondition (Advisor #1628,
+// finding #1). A SIGNED release proves the connecting UI peer is the genuine
+// owner device by checking TWO kernel/OS-vouched facts about the AF_UNIX peer on
+// the other end of the local socket:
+//
+//   (a) the peer's process credential (LOCAL_PEERCRED: pid/uid/gid), read from
+//       the kernel — NOT self-reported by the caller, and
+//   (b) that peer binary's code signature, verified by the OS to be VALID and to
+//       carry EXACTLY the expected release signing identity.
+//
+// This module is PURE VERIFY. It holds NO signing key and NO secret: it mints no
+// identity, issues no token, and imports no crypto. Durable owner-key custody
+// (Secure Enclave) is a PHYSICAL operator leaf that lives elsewhere; here we only
+// *check a connecting peer*. There is deliberately NO import of `node:crypto`.
+//
+// HONESTY on this dev/CI SOURCE tree:
+//   - Node's `net` layer exposes no `getsockopt(LOCAL_PEERCRED)`, so a genuine
+//     peer-credential read needs a native addon that is NOT present here. The
+//     DEFAULT provider therefore returns `null` → the verifier is honestly
+//     `attested:false, reason:NATIVE_PROVIDER_ABSENT`. We NEVER fabricate a
+//     peercred value.
+//   - This tree is UNSIGNED, so the DEFAULT codesign verifier returns `null`; a
+//     signed release wires `createMacosCodesignPeerVerifier` instead.
+//   - Consequently `attested:true` is UNREACHABLE on source/dev/CI. It becomes
+//     reachable ONLY when a real native provider AND a valid, identity-matching
+//     codesign verifier are BOTH supplied (a signed-release/native slice) — and
+//     is exercised in tests solely through injected doubles.
+//
+// This seam is standalone. It does NOT flip, shadow, wire, or depend on the
+// operator-locked honesty anchor
+// `src/security/friday-device-owner-authority-precondition.ts` →
+// `NATIVE_IPC_ATTESTATION_AVAILABLE`. Wiring is a pending operator decision.
+
+import { spawnSync } from "node:child_process";
+import type { Socket } from "node:net";
+
+// ─── Public value objects ─────────────────────────────────────────────────
+
+/**
+ * Kernel-vouched credential of the connecting AF_UNIX peer (LOCAL_PEERCRED).
+ * Every field is a non-negative safe integer supplied by the OS — NOT a value
+ * the peer self-reports over the wire.
+ */
+export interface FridayPeerCredential {
+  readonly pid: number;
+  readonly uid: number;
+  readonly gid: number;
+}
+
+/**
+ * Result of an OS code-signature check on the peer binary.
+ *   - `valid`    — the OS confirmed the signature is intact and trusted.
+ *   - `identity` — the peer binary's signing identity (e.g. its code-sign
+ *                  Identifier / designated-requirement id) that must equal the
+ *                  expected release identity.
+ */
+export interface FridayCodesignIdentity {
+  readonly identity: string;
+  readonly valid: boolean;
+}
+
+/**
+ * Reads the connecting peer's kernel credential from the socket. On source/dev/CI
+ * the DEFAULT implementation returns `null` (no native addon) — see
+ * `createAbsentNativePeerAttestationProvider`. A signed release installs a native
+ * provider that performs a real `getsockopt(LOCAL_PEERCRED)`.
+ */
+export interface NativePeerAttestationProvider {
+  readPeerCredential(socket: Socket): FridayPeerCredential | null;
+}
+
+/**
+ * Verifies the code signature of the peer identified by `pid`. Returns `null`
+ * when the check cannot be performed (unsigned/dev build, no toolchain). NEVER
+ * returns `{ valid: true }` for an unsigned or foreign-identity peer.
+ */
+export type CodesignPeerVerifier = (pid: number) => FridayCodesignIdentity | null;
+
+// ─── Reason codes ─────────────────────────────────────────────────────────
+
+/**
+ * Every terminal outcome of {@link verifyNativePeerAttestation}. Exactly one —
+ * `ATTESTED` — accompanies `attested:true`; all others accompany `false`.
+ */
+export const NATIVE_PEER_ATTESTATION_REASON = {
+  /** The one success reason: real peercred + valid codesign + matching identity. */
+  ATTESTED: "ATTESTED",
+  /** No native LOCAL_PEERCRED provider yielded a credential (default on this tree). */
+  NATIVE_PROVIDER_ABSENT: "NATIVE_PROVIDER_ABSENT",
+  /** The provider threw while reading the peer credential. */
+  PROVIDER_READ_ERROR: "PROVIDER_READ_ERROR",
+  /** The peer credential was partial/ill-typed (missing or non-integer field). */
+  MALFORMED_PEER_CREDENTIAL: "MALFORMED_PEER_CREDENTIAL",
+  /** Caller supplied a blank expected release identity — fail closed. */
+  EXPECTED_IDENTITY_MISSING: "EXPECTED_IDENTITY_MISSING",
+  /** Codesign check could not run (unsigned/dev build, no toolchain) → null. */
+  CODESIGN_UNVERIFIED: "CODESIGN_UNVERIFIED",
+  /** Codesign ran but the signature is not valid. */
+  CODESIGN_INVALID: "CODESIGN_INVALID",
+  /** Codesign is valid but its identity ≠ the expected release identity. */
+  CODESIGN_IDENTITY_MISMATCH: "CODESIGN_IDENTITY_MISMATCH",
+  /** The codesign verifier threw. */
+  CODESIGN_VERIFY_ERROR: "CODESIGN_VERIFY_ERROR",
+} as const;
+
+export type NativePeerAttestationReason =
+  (typeof NATIVE_PEER_ATTESTATION_REASON)[keyof typeof NATIVE_PEER_ATTESTATION_REASON];
+
+// ─── Verify contract ──────────────────────────────────────────────────────
+
+export interface VerifyNativePeerAttestationInput {
+  /** Reads the peer's kernel credential (LOCAL_PEERCRED). */
+  readonly provider: NativePeerAttestationProvider;
+  /** Verifies the peer binary's code signature. */
+  readonly codesignVerifier: CodesignPeerVerifier;
+  /** The signing identity a genuine owner-device release binary must carry. */
+  readonly expectedReleaseIdentity: string;
+  /** The connecting local socket (forwarded to the provider only). */
+  readonly socket: Socket;
+}
+
+export interface NativePeerAttestationResult {
+  /** True IFF real peercred AND valid codesign AND identity === expected. */
+  readonly attested: boolean;
+  readonly reason: NativePeerAttestationReason;
+  /** Present once a well-formed peer credential was read. */
+  readonly peerCredential?: FridayPeerCredential;
+  /** Present once codesign produced an identity (attested or mismatched). */
+  readonly codesignIdentity?: string;
+}
+
+function isValidPeerCredential(value: unknown): value is FridayPeerCredential {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const cred = value as Record<string, unknown>;
+  return (
+    isNonNegativeSafeInteger(cred.pid)
+    && cred.pid > 0
+    && isNonNegativeSafeInteger(cred.uid)
+    && isNonNegativeSafeInteger(cred.gid)
+  );
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function deny(
+  reason: NativePeerAttestationReason,
+  extra?: { peerCredential?: FridayPeerCredential; codesignIdentity?: string },
+): NativePeerAttestationResult {
+  return { attested: false, reason, ...extra };
+}
+
+/**
+ * PURE verify. Returns `attested:true` ONLY when ALL hold:
+ *   1. the native provider yields a well-formed peer credential,
+ *   2. the codesign verifier confirms `valid === true`, and
+ *   3. that codesign identity equals a non-blank `expectedReleaseIdentity`.
+ *
+ * Anything else — absent provider, malformed payload, provider/verifier throw,
+ * unverified/invalid codesign, identity mismatch, blank expected identity —
+ * yields `attested:false` with a precise reason. It NEVER throws and NEVER
+ * coerces a failure into `true`. It holds no key and mints no identity.
+ */
+export function verifyNativePeerAttestation(
+  input: VerifyNativePeerAttestationInput,
+): NativePeerAttestationResult {
+  const { provider, codesignVerifier, expectedReleaseIdentity, socket } = input;
+
+  // Fail closed on a blank expected identity — there is nothing to match against.
+  if (typeof expectedReleaseIdentity !== "string" || expectedReleaseIdentity.trim() === "") {
+    return deny(NATIVE_PEER_ATTESTATION_REASON.EXPECTED_IDENTITY_MISSING);
+  }
+
+  // (a) Read the kernel-vouched peer credential.
+  let rawCred: FridayPeerCredential | null;
+  try {
+    rawCred = provider.readPeerCredential(socket);
+  } catch {
+    return deny(NATIVE_PEER_ATTESTATION_REASON.PROVIDER_READ_ERROR);
+  }
+  if (rawCred === null || rawCred === undefined) {
+    return deny(NATIVE_PEER_ATTESTATION_REASON.NATIVE_PROVIDER_ABSENT);
+  }
+  if (!isValidPeerCredential(rawCred)) {
+    return deny(NATIVE_PEER_ATTESTATION_REASON.MALFORMED_PEER_CREDENTIAL);
+  }
+  const peerCredential: FridayPeerCredential = {
+    pid: rawCred.pid,
+    uid: rawCred.uid,
+    gid: rawCred.gid,
+  };
+
+  // (b) Verify the peer binary's code signature.
+  let codesign: FridayCodesignIdentity | null;
+  try {
+    codesign = codesignVerifier(peerCredential.pid);
+  } catch {
+    return deny(NATIVE_PEER_ATTESTATION_REASON.CODESIGN_VERIFY_ERROR, { peerCredential });
+  }
+  if (codesign === null || codesign === undefined) {
+    return deny(NATIVE_PEER_ATTESTATION_REASON.CODESIGN_UNVERIFIED, { peerCredential });
+  }
+  if (codesign.valid !== true) {
+    return deny(NATIVE_PEER_ATTESTATION_REASON.CODESIGN_INVALID, {
+      peerCredential,
+      codesignIdentity: codesign.identity,
+    });
+  }
+  if (codesign.identity !== expectedReleaseIdentity) {
+    return deny(NATIVE_PEER_ATTESTATION_REASON.CODESIGN_IDENTITY_MISMATCH, {
+      peerCredential,
+      codesignIdentity: codesign.identity,
+    });
+  }
+
+  // All three facts hold — the peer is the genuine, expected owner-device binary.
+  return {
+    attested: true,
+    reason: NATIVE_PEER_ATTESTATION_REASON.ATTESTED,
+    peerCredential,
+    codesignIdentity: codesign.identity,
+  };
+}
+
+// ─── DEFAULT (honest-absent) implementations for source/dev/CI ─────────────
+
+/**
+ * The DEFAULT native provider on this tree. Returns `null` because Node's `net`
+ * layer exposes no `getsockopt(LOCAL_PEERCRED)` and no native addon is installed
+ * — so the verifier is honestly `attested:false, reason:NATIVE_PROVIDER_ABSENT`.
+ * We NEVER fabricate a peercred value. A signed release installs a real provider.
+ */
+export function createAbsentNativePeerAttestationProvider(): NativePeerAttestationProvider {
+  return {
+    readPeerCredential(_socket: Socket): FridayPeerCredential | null {
+      // No native LOCAL_PEERCRED addon present → honestly no credential.
+      return null;
+    },
+  };
+}
+
+/**
+ * The DEFAULT codesign verifier on this tree. Returns `null` because this source
+ * build is UNSIGNED — there is no valid signature to check. A signed release
+ * wires {@link createMacosCodesignPeerVerifier} instead.
+ */
+export function createAbsentCodesignPeerVerifier(): CodesignPeerVerifier {
+  return (_pid: number): FridayCodesignIdentity | null => null;
+}
+
+// ─── Real macOS codesign verifier (release residual — NOT wired, NOT default) ─
+
+export interface MacosCodesignPeerVerifierOptions {
+  /** Path to the `codesign` binary. Default `/usr/bin/codesign`. */
+  readonly codesignPath?: string;
+  /** Path to the `ps` binary (peer pid → executable path). Default `/bin/ps`. */
+  readonly psPath?: string;
+  /** Hard timeout for each shelled command, in ms. Default 4000. */
+  readonly timeoutMs?: number;
+}
+
+/** Extract the `Identifier=…` line from `codesign -dvvv` (printed to stderr). */
+function parseCodesignIdentifier(codesignDisplayOutput: string): string | null {
+  const match = /^Identifier=(.+)$/m.exec(codesignDisplayOutput);
+  if (match === null) {
+    return null;
+  }
+  const identity = match[1].trim();
+  return identity.length > 0 ? identity : null;
+}
+
+/**
+ * A REAL macOS codesign verifier that a SIGNED release would wire in place of the
+ * absent default. It resolves the peer's executable from its pid (`ps -o comm=`)
+ * and asks the OS to verify the code signature (`codesign --verify --strict`) and
+ * report its signing identifier (`codesign -dvvv`).
+ *
+ * It is deliberately NOT the default and is NOT wired to any live socket path in
+ * this slice. It never throws (returns `null` on any error) and can only return
+ * `{ valid: true }` when the OS itself confirms a valid signature — so on this
+ * UNSIGNED dev/CI tree it yields `null`/`{ valid:false }`, keeping the composed
+ * verifier honestly `attested:false`. It holds no key: the OS performs the
+ * cryptographic verification; this function only reads its verdict.
+ */
+export function createMacosCodesignPeerVerifier(
+  options: MacosCodesignPeerVerifierOptions = {},
+): CodesignPeerVerifier {
+  const codesignPath = options.codesignPath ?? "/usr/bin/codesign";
+  const psPath = options.psPath ?? "/bin/ps";
+  const timeoutMs = options.timeoutMs ?? 4_000;
+
+  return (pid: number): FridayCodesignIdentity | null => {
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+      return null;
+    }
+    try {
+      // Resolve the peer's executable path from its pid (BSD `ps` prints the full
+      // path with `-o comm=`).
+      const ps = spawnSync(psPath, ["-p", String(pid), "-o", "comm="], {
+        timeout: timeoutMs,
+        encoding: "utf8",
+      });
+      if (ps.status !== 0 || ps.error) {
+        return null;
+      }
+      const executablePath = (ps.stdout ?? "").trim();
+      if (executablePath.length === 0) {
+        return null;
+      }
+
+      // Ask the OS to verify the signature (strict) — exit 0 iff valid & trusted.
+      const verify = spawnSync(codesignPath, ["--verify", "--strict", executablePath], {
+        timeout: timeoutMs,
+        encoding: "utf8",
+      });
+      const valid = verify.status === 0 && !verify.error;
+
+      // Read the signing identifier (codesign prints display info to stderr).
+      const display = spawnSync(codesignPath, ["-dvvv", executablePath], {
+        timeout: timeoutMs,
+        encoding: "utf8",
+      });
+      const identity = parseCodesignIdentifier(display.stderr ?? "");
+      if (identity === null) {
+        // Unsigned / adhoc / unreadable → no trustworthy identity.
+        return { identity: "", valid: false };
+      }
+      return { identity, valid };
+    } catch {
+      return null;
+    }
+  };
+}

--- a/src/security/attestation/friday-verified-native-owner-claim-context.ts
+++ b/src/security/attestation/friday-verified-native-owner-claim-context.ts
@@ -1,0 +1,410 @@
+// ─── SEC-NATIVE-OWNER-CLAIM-CAPABILITY-001 · CORE-A CR-1 (Advisor Option C) ───
+//
+// An OPAQUE, PER-CLAIM, single-use owner-claim capability. This is the Option-C
+// REPLACEMENT for the retired GLOBAL boolean authority
+// (`NATIVE_IPC_ATTESTATION_AVAILABLE` + `FRIDAY_DEVICE_OWNER_AUTHORITY_ENABLED`):
+// the Advisor rejected any global boolean because "once true on a real release it
+// authorizes EVERY HTTP caller, not just the attested peer." Nothing global
+// authorizes anymore — THIS capability does, and ONLY for the EXACT request it is
+// bound to.
+//
+// PROVENANCE (mint): a `VerifiedNativeOwnerClaimContext` is minted ONLY from
+//   (a) a `NativePeerAttestationResult` with `attested === true` — i.e. real
+//       kernel-derived LOCAL_PEERCRED evidence + a valid, identity-matching code
+//       signature verified by the OS (the CR-4 verifier), PLUS
+//   (b) a PINNED code-sign / artifact-role policy, PLUS
+//   (c) release-trusted native key custody (`deriveDeviceKeyProtection` over
+//       verified native evidence — never WebCrypto, never self-reported).
+// There is structurally NO env / request / header / body / test path to a `true`
+// attestation, so there is no way to forge a capability.
+//
+// OPAQUE: a module-private Symbol brand + a module-private WeakSet single-use
+// ledger mean a request body, env var, header, hand-built object literal, or test
+// double can NEVER masquerade as a capability — the SOLE constructor is
+// {@link mintVerifiedNativeOwnerClaimContext}. Callers receive an opaque handle and
+// can only VERIFY/CONSUME it; they cannot read authority out of a self-assertion.
+//
+// BINDING: the capability is bound to hubId, installId, OS user + UID, origin,
+// channel, action, nonce, expiry, deviceId, device public-key hash, the accepted
+// native connection/audit-token identity, and the exact artifact role. Consume
+// EXACT-matches every request-derived field; any drift, expiry, connection
+// substitution, replay (single-use), or "one attested peer authorizing a DIFFERENT
+// request" yields a refusal with ZERO authority — the caller then performs ZERO
+// state change.
+
+import {
+  type FridayDeviceKeyProtection,
+  isDeviceOwnerAuthorityKillSwitchEngaged,
+  isReleaseTrustedKeyProtection,
+} from "../friday-device-owner-authority-precondition.js";
+import type { NativePeerAttestationResult } from "./friday-native-peer-attestation-verifier.js";
+
+// ─── Request-derived binding (the EXACT-match subset) ──────────────────────
+
+/**
+ * The request-derived fields a capability is bound to and that CONSUME must
+ * exact-match. Every field is authoritative context for THIS one claim/login —
+ * none of it is trusted from the capability's own self-assertion at consume time;
+ * the consumer supplies the expected values from the live request and they must
+ * match the values frozen into the capability at mint.
+ */
+export interface NativeOwnerClaimBinding {
+  readonly hubId: string;
+  readonly installId: string;
+  readonly osUser: string;
+  readonly origin: string;
+  readonly channel: string;
+  /** owner-claim | owner-login | owner-migrate | owner-readback (domain separator). */
+  readonly action: string;
+  readonly nonce: string;
+  /** Absolute expiry (epoch ms). The capability is dead past this instant. */
+  readonly expiresAtMs: number;
+  readonly deviceId: string;
+  readonly devicePublicKeyHash: string;
+  /** The exact artifact role the attested peer binary must fill (pinned policy). */
+  readonly artifactRole: string;
+}
+
+// ─── Native-evidence binding (kernel/OS-derived; never request-asserted) ───
+
+/**
+ * Kernel/OS-derived facts about the accepted native peer, frozen into the
+ * capability at mint. These are NEVER supplied by the request — they come from the
+ * native IPC accept boundary (LOCAL_PEERCRED + the accepted connection identity).
+ * `osUid`/`peerPid` MUST equal the verifier's peer credential, and
+ * `acceptedConnectionId` binds the capability to the exact accepted connection so a
+ * capability minted for connection C1 can never be replayed on connection C2.
+ */
+export interface NativeOwnerPeerEvidence {
+  readonly osUid: number;
+  readonly peerPid: number;
+  readonly acceptedConnectionId: string;
+  /** The audit-token / connection identity vouched by the accept boundary. */
+  readonly auditTokenIdentity: string;
+  /** The verified code-sign identity of the accepted peer binary. */
+  readonly codesignIdentity: string;
+}
+
+// ─── Pinned policy ─────────────────────────────────────────────────────────
+
+/**
+ * The pinned code-sign / artifact-role policy the accepted peer must satisfy.
+ * `expectedReleaseIdentity` must equal the verifier's attested code-sign identity
+ * and `expectedArtifactRole` must equal the binding's artifact role — a peer that
+ * is validly signed but for the WRONG artifact role (helper vs. main app) is
+ * refused.
+ */
+export interface PinnedNativeOwnerPolicy {
+  readonly expectedReleaseIdentity: string;
+  readonly expectedArtifactRole: string;
+}
+
+// ─── Opaque capability handle ──────────────────────────────────────────────
+
+const OWNER_CLAIM_CONTEXT_BRAND: unique symbol = Symbol("friday.verified-native-owner-claim-context");
+
+/**
+ * OPAQUE per-claim capability. Its fields are readable for audit but carry NO
+ * authority on their own — authority is conferred ONLY by having been produced by
+ * {@link mintVerifiedNativeOwnerClaimContext} (brand-checked) and by passing
+ * {@link consumeVerifiedNativeOwnerClaimContext} against the live request. A plain
+ * object literal with the same fields is NOT a capability (no brand) and is
+ * refused.
+ */
+export interface VerifiedNativeOwnerClaimContext {
+  readonly [OWNER_CLAIM_CONTEXT_BRAND]: true;
+  readonly binding: NativeOwnerClaimBinding;
+  readonly evidence: NativeOwnerPeerEvidence;
+  readonly keyProtection: FridayDeviceKeyProtection;
+}
+
+/** Module-private single-use ledger — a consumed capability can never re-authorize. */
+const consumedCapabilities = new WeakSet<VerifiedNativeOwnerClaimContext>();
+
+// ─── Mint outcomes ─────────────────────────────────────────────────────────
+
+export type NativeOwnerClaimMintDenyReason =
+  | "kill-switch-engaged"
+  | "attestation-not-attested"
+  | "codesign-identity-mismatch"
+  | "key-protection-not-release-trusted"
+  | "artifact-role-mismatch"
+  | "peer-evidence-inconsistent"
+  | "binding-incomplete"
+  | "evidence-incomplete";
+
+export type NativeOwnerClaimMintResult =
+  | { readonly ok: true; readonly capability: VerifiedNativeOwnerClaimContext }
+  | { readonly ok: false; readonly reason: NativeOwnerClaimMintDenyReason };
+
+export interface MintVerifiedNativeOwnerClaimContextInput {
+  /** The CR-4 verifier result — MUST be `attested: true` (real peercred + codesign). */
+  readonly attestation: NativePeerAttestationResult;
+  /** Native key custody posture, derived from verified native evidence. */
+  readonly keyProtection: FridayDeviceKeyProtection;
+  readonly binding: NativeOwnerClaimBinding;
+  readonly evidence: NativeOwnerPeerEvidence;
+  readonly policy: PinnedNativeOwnerPolicy;
+  /** Env — consulted ONLY for the kill switch (can force FALSE; never TRUE). */
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+function nonBlank(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function bindingComplete(b: NativeOwnerClaimBinding): boolean {
+  return (
+    nonBlank(b.hubId)
+    && nonBlank(b.installId)
+    && nonBlank(b.osUser)
+    && nonBlank(b.origin)
+    && nonBlank(b.channel)
+    && nonBlank(b.action)
+    && nonBlank(b.nonce)
+    && isPositiveSafeInteger(b.expiresAtMs)
+    && nonBlank(b.deviceId)
+    && nonBlank(b.devicePublicKeyHash)
+    && nonBlank(b.artifactRole)
+  );
+}
+
+function evidenceComplete(e: NativeOwnerPeerEvidence): boolean {
+  return (
+    isNonNegativeSafeInteger(e.osUid)
+    && isPositiveSafeInteger(e.peerPid)
+    && nonBlank(e.acceptedConnectionId)
+    && nonBlank(e.auditTokenIdentity)
+    && nonBlank(e.codesignIdentity)
+  );
+}
+
+/**
+ * Mint an opaque per-claim capability. Returns `{ ok: true, capability }` IFF ALL
+ * of the following hold (any failure → `{ ok: false, reason }`, ZERO authority):
+ *   1. the authority kill switch is NOT engaged (env / policy);
+ *   2. `attestation.attested === true` (real LOCAL_PEERCRED + valid codesign);
+ *   3. the attested code-sign identity equals `policy.expectedReleaseIdentity`;
+ *   4. `keyProtection` is release-trusted (Secure-Enclave / Keychain-ACL — never
+ *      WebCrypto/software/unverified);
+ *   5. `binding.artifactRole === policy.expectedArtifactRole`;
+ *   6. the native evidence is internally consistent with the verified peercred
+ *      (`evidence.osUid === peerCredential.uid`, `evidence.peerPid === .pid`);
+ *   7. the binding and evidence are structurally complete (no blank/invalid field).
+ *
+ * It NEVER reads the request/env for a POSITIVE — the only env input is the kill
+ * switch, which can force a refusal but never an authorization.
+ */
+export function mintVerifiedNativeOwnerClaimContext(
+  input: MintVerifiedNativeOwnerClaimContextInput,
+): NativeOwnerClaimMintResult {
+  const { attestation, keyProtection, binding, evidence, policy, env } = input;
+
+  if (isDeviceOwnerAuthorityKillSwitchEngaged(env ?? process.env)) {
+    return { ok: false, reason: "kill-switch-engaged" };
+  }
+  if (attestation.attested !== true) {
+    return { ok: false, reason: "attestation-not-attested" };
+  }
+  // The verifier already matched identity against expectedReleaseIdentity, but we
+  // RE-PIN it here so the capability cannot be minted from an attestation that was
+  // verified against a different expected identity than this policy pins.
+  if (
+    !nonBlank(policy.expectedReleaseIdentity)
+    || attestation.codesignIdentity !== policy.expectedReleaseIdentity
+  ) {
+    return { ok: false, reason: "codesign-identity-mismatch" };
+  }
+  if (!isReleaseTrustedKeyProtection(keyProtection)) {
+    return { ok: false, reason: "key-protection-not-release-trusted" };
+  }
+  if (!bindingComplete(binding)) {
+    return { ok: false, reason: "binding-incomplete" };
+  }
+  if (!evidenceComplete(evidence)) {
+    return { ok: false, reason: "evidence-incomplete" };
+  }
+  if (!nonBlank(policy.expectedArtifactRole) || binding.artifactRole !== policy.expectedArtifactRole) {
+    return { ok: false, reason: "artifact-role-mismatch" };
+  }
+  // Evidence MUST agree with the kernel-vouched peer credential the verifier read.
+  const cred = attestation.peerCredential;
+  if (
+    !cred
+    || cred.uid !== evidence.osUid
+    || cred.pid !== evidence.peerPid
+    || attestation.codesignIdentity !== evidence.codesignIdentity
+  ) {
+    return { ok: false, reason: "peer-evidence-inconsistent" };
+  }
+
+  const capability: VerifiedNativeOwnerClaimContext = Object.freeze({
+    [OWNER_CLAIM_CONTEXT_BRAND]: true as const,
+    binding: Object.freeze({ ...binding }),
+    evidence: Object.freeze({ ...evidence }),
+    keyProtection,
+  });
+  return { ok: true, capability };
+}
+
+// ─── Consume ───────────────────────────────────────────────────────────────
+
+export type NativeOwnerClaimConsumeDenyReason =
+  | "no-capability"
+  | "kill-switch-engaged"
+  | "already-consumed"
+  | "expired"
+  | "binding-drift"
+  | "connection-substituted"
+  | "key-protection-not-release-trusted";
+
+export type NativeOwnerClaimConsumeResult =
+  | { readonly ok: true; readonly keyProtection: FridayDeviceKeyProtection }
+  | { readonly ok: false; readonly reason: NativeOwnerClaimConsumeDenyReason };
+
+/**
+ * What the CONSUMER (claim/login) expects THIS request to be. Every field is
+ * derived from the live request/connection — NOT from the capability — and must
+ * exact-match the capability's frozen binding + accepted-connection identity.
+ */
+export interface NativeOwnerClaimConsumeExpectation {
+  readonly binding: NativeOwnerClaimBinding;
+  /** The connection/audit-token identity the live request arrived on. */
+  readonly expectedConnectionId: string;
+  readonly nowMs: number;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Derive the stable exchange-connection identity for a request binding. The
+ * consumer supplies this as `expectedConnectionId`, and the native-boundary
+ * resolver stamps the SAME value into `evidence.acceptedConnectionId`, so a
+ * capability minted for one exchange can never be consumed against another
+ * (connection substitution → refused). It is an identity string, not a secret.
+ */
+export function deriveNativeOwnerExchangeConnectionId(binding: NativeOwnerClaimBinding): string {
+  return [
+    binding.hubId,
+    binding.installId,
+    binding.origin,
+    binding.channel,
+    binding.action,
+    binding.deviceId,
+    binding.devicePublicKeyHash,
+    binding.nonce,
+  ].join(" ");
+}
+
+/** Brand check — the ONLY way to recognize a genuine minted capability. */
+export function isVerifiedNativeOwnerClaimContext(
+  value: unknown,
+): value is VerifiedNativeOwnerClaimContext {
+  return (
+    typeof value === "object"
+    && value !== null
+    && (value as Record<PropertyKey, unknown>)[OWNER_CLAIM_CONTEXT_BRAND] === true
+  );
+}
+
+function bindingsMatch(a: NativeOwnerClaimBinding, b: NativeOwnerClaimBinding): boolean {
+  return (
+    a.hubId === b.hubId
+    && a.installId === b.installId
+    && a.osUser === b.osUser
+    && a.origin === b.origin
+    && a.channel === b.channel
+    && a.action === b.action
+    && a.nonce === b.nonce
+    && a.expiresAtMs === b.expiresAtMs
+    && a.deviceId === b.deviceId
+    && a.devicePublicKeyHash === b.devicePublicKeyHash
+    && a.artifactRole === b.artifactRole
+  );
+}
+
+/**
+ * Verify + atomically consume (single-use) an opaque capability against the live
+ * request. Returns `{ ok: true, keyProtection }` IFF the value is a genuine minted
+ * capability (brand), the kill switch is off, it has not already been consumed, it
+ * is unexpired, its frozen binding EXACT-matches the request-derived expectation,
+ * the accepted-connection identity matches the live connection, and its key
+ * protection is still release-trusted. On the FIRST success the capability is
+ * marked consumed (single-use). ANY other outcome — absent/forged, killed, replayed,
+ * expired, field drift (wrong hub/install/owner/origin/channel/action/nonce/device/
+ * key/role), connection substitution, or a capability minted for a DIFFERENT
+ * request — returns `{ ok: false }`, so the caller performs ZERO state change.
+ *
+ * Single-use marking happens only on full success, so a caller that verifies inside
+ * a DB transaction which then rolls back has NOT burned the capability's ledger for
+ * a legitimate retry (the authoritative single-use gate for the DB flows remains the
+ * server-issued nonce CAS; this ledger is defence-in-depth against re-presenting the
+ * exact same capability object twice).
+ */
+export function consumeVerifiedNativeOwnerClaimContext(
+  capability: unknown,
+  expectation: NativeOwnerClaimConsumeExpectation,
+): NativeOwnerClaimConsumeResult {
+  if (!isVerifiedNativeOwnerClaimContext(capability)) {
+    return { ok: false, reason: "no-capability" };
+  }
+  if (isDeviceOwnerAuthorityKillSwitchEngaged(expectation.env ?? process.env)) {
+    return { ok: false, reason: "kill-switch-engaged" };
+  }
+  if (consumedCapabilities.has(capability)) {
+    return { ok: false, reason: "already-consumed" };
+  }
+  if (
+    !isPositiveSafeInteger(capability.binding.expiresAtMs)
+    || capability.binding.expiresAtMs <= expectation.nowMs
+  ) {
+    return { ok: false, reason: "expired" };
+  }
+  if (!bindingsMatch(capability.binding, expectation.binding)) {
+    return { ok: false, reason: "binding-drift" };
+  }
+  if (
+    !nonBlank(expectation.expectedConnectionId)
+    || capability.evidence.acceptedConnectionId !== expectation.expectedConnectionId
+  ) {
+    return { ok: false, reason: "connection-substituted" };
+  }
+  if (!isReleaseTrustedKeyProtection(capability.keyProtection)) {
+    return { ok: false, reason: "key-protection-not-release-trusted" };
+  }
+
+  consumedCapabilities.add(capability);
+  return { ok: true, keyProtection: capability.keyProtection };
+}
+
+// ─── Resolver seam (the native-IPC exchange) ───────────────────────────────
+
+/**
+ * The seam by which claim/login OBTAIN a capability for the live request. In
+ * production this is backed by the macOS Companion Unix-socket accept boundary: it
+ * reads LOCAL_PEERCRED, runs the CR-4 verifier + pinned policy, and exchanges the
+ * result for a single-use capability bound to THIS request. On this source/dev/CI
+ * tree the native boundary is honestly ABSENT, so the default resolver returns
+ * `null` (see {@link createAbsentNativeOwnerClaimResolver}) and every device
+ * claim/login fails closed — nothing global authorizes.
+ */
+export type NativeOwnerClaimContextResolver = (
+  binding: NativeOwnerClaimBinding,
+) => VerifiedNativeOwnerClaimContext | null;
+
+/**
+ * The DEFAULT resolver on this tree: no native IPC boundary is wired, so it mints
+ * NOTHING. This is the honest, fail-closed state — a device owner-claim/login is
+ * refused with ZERO state change until a signed release wires a real
+ * peercred+codesign accept boundary (the external leaf).
+ */
+export function createAbsentNativeOwnerClaimResolver(): NativeOwnerClaimContextResolver {
+  return (_binding: NativeOwnerClaimBinding): VerifiedNativeOwnerClaimContext | null => null;
+}

--- a/src/security/friday-device-owner-authority-precondition.ts
+++ b/src/security/friday-device-owner-authority-precondition.ts
@@ -41,43 +41,65 @@ export function isDeviceOwnerPrincipalId(actorId: string | null | undefined): bo
   return typeof actorId === "string" && actorId.startsWith(DEVICE_OWNER_PRINCIPAL_ID_PREFIX);
 }
 
-// ─── (b) native-IPC caller-identity precondition (ABSENT today) ───
+// ─── (b) native-IPC honesty anchor — RETIRED AS AN AUTHORITY SOURCE (Option C) ───
 //
-// This is a compile-time constant, NOT a config flag. It flips to `true` ONLY in
-// the future slice that lands a trusted native-app IPC caller-identity bridge
-// (SO_PEERCRED / signed-shell attestation). Until then, no amount of env / header
-// / request / loopback fact can make a device principal trusted.
+// This compile-time constant is RETIRED as an authority source (Advisor Option C).
+// It is DELIBERATELY LEFT in place as a truthful honesty anchor — it remains
+// `false` on this unsigned dev/CI tree and is NEVER read to authorize anything —
+// but NO code path derives authority from it any longer. The Advisor rejected any
+// global boolean ("once true on a real release it authorizes EVERY HTTP caller, not
+// just the attested peer"); authority now flows ONLY through the opaque, per-claim
+// `VerifiedNativeOwnerClaimContext`
+// (src/security/attestation/friday-verified-native-owner-claim-context.ts), minted
+// solely inside the native IPC accept boundary. It is NEVER flipped `true`.
 export const NATIVE_IPC_ATTESTATION_AVAILABLE = false as const;
 
-// ─── Server-derived, off-by-default authority switch ───
+// ─── Emergency kill switch (can force OFF; can NEVER force ON) ───
 
 /**
- * Explicit server-side opt-in env var. Even when set, it does NOT enable device
- * authority on its own — precondition (b) (`NATIVE_IPC_ATTESTATION_AVAILABLE`)
- * must ALSO be present. This var is read ONLY from the process environment; it is
- * never derived from a request body, header, Origin, cookie, User-Agent,
- * bundle-id, loopback fact, or any nonce-holding process.
+ * Protected emergency kill switch. When engaged it FORCES device-owner authority
+ * OFF (mint + consume of every per-claim capability refuse). There is NO
+ * counterpart that forces authority ON — the Option-C flagless-positive contract
+ * means no env / config / header / body / test seam can make a capability mint;
+ * only real native attestation can. This env is read ONLY from the process
+ * environment, never from request data.
  */
-export const DEVICE_OWNER_AUTHORITY_ENABLED_ENV = "FRIDAY_DEVICE_OWNER_AUTHORITY_ENABLED";
+export const DEVICE_OWNER_AUTHORITY_KILL_SWITCH_ENV = "FRIDAY_DEVICE_OWNER_AUTHORITY_KILL_SWITCH";
+
+const KILL_SWITCH_ENGAGED_VALUES: ReadonlySet<string> = new Set([
+  "1",
+  "true",
+  "on",
+  "engage",
+  "engaged",
+  "disable",
+  "disabled",
+]);
 
 /**
- * True IFF a device-bound owner principal may carry release-profile owner
- * authority. Server-derived and fail-closed: requires BOTH the explicit
- * server-side env opt-in AND the native-IPC precondition (b). Because (b) is a
- * hard-wired `false` today, this ALWAYS returns `false` in the current build —
- * the truthful state of the requirement (NOT "passed").
- *
- * Takes NO request-derived input by design: there is structurally no way for a
- * caller to flip it via request data.
+ * True iff the emergency kill switch is engaged (forces device-owner authority
+ * OFF). Case-insensitive, trimmed. Consulted by the capability mint + consume.
  */
-export function isDeviceOwnerAuthorityEnabled(
+export function isDeviceOwnerAuthorityKillSwitchEngaged(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  if (!NATIVE_IPC_ATTESTATION_AVAILABLE) {
-    // Precondition (b) absent — fail closed regardless of any config.
-    return false;
-  }
-  return env[DEVICE_OWNER_AUTHORITY_ENABLED_ENV] === "1";
+  const raw = env[DEVICE_OWNER_AUTHORITY_KILL_SWITCH_ENV]?.trim().toLowerCase();
+  return raw !== undefined && KILL_SWITCH_ENGAGED_VALUES.has(raw);
+}
+
+/**
+ * RETIRED (Option C): there is NO global "device authority enabled" switch any
+ * more. Authority is conferred per-claim by a `VerifiedNativeOwnerClaimContext`,
+ * never by a process-wide boolean. This predicate is kept ONLY as a fail-closed
+ * floor signal — it is ALWAYS `false` (no env / config / request can flip it),
+ * so every enforcement floor that consults it continues to treat a device
+ * principal as unauthenticated. It takes NO request-derived input by design.
+ */
+export function isDeviceOwnerAuthorityEnabled(
+  _env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  // No global enable exists under Option C. Fail closed, always.
+  return false;
 }
 
 // ─── keyProtection — server-derived 4-state (NEVER request-reported) ───
@@ -108,13 +130,54 @@ export function isReleaseTrustedKeyProtection(kp: FridayDeviceKeyProtection): bo
 }
 
 /**
- * Derive the device key-protection posture SERVER-SIDE. Today there is no OS
- * attestation bridge, so the only honest, reachable value is `"unverified"` —
- * which fails closed. A FUTURE native slice sets the hardware-backed states here
- * from a verified OS attestation, never from the request.
+ * The custody kind reported by a native key-custody provider (see
+ * src/security/attestation/friday-native-key-custody-provider.ts). This is
+ * OS-derived evidence, NEVER a request-reported or global posture.
  */
-export function deriveDeviceKeyProtection(): FridayDeviceKeyProtection {
-  return "unverified";
+export type NativeKeyCustodyKind =
+  | "secure_enclave"
+  | "keychain_acl"
+  | "webcrypto_software";
+
+/**
+ * Verified native key-custody evidence CONSUMED by {@link deriveDeviceKeyProtection}.
+ * A signed release supplies this from the OS (Secure Enclave / Keychain ACL); the
+ * WebCrypto dev seam supplies `webcrypto_software`, which can NEVER be
+ * release-trusted. There is no field a caller can set to self-report a hardware
+ * posture — `osVerified` is only ever true when the OS itself vouched for it.
+ */
+export interface NativeKeyCustodyEvidence {
+  readonly custody: NativeKeyCustodyKind;
+  /** Only ever `true` when the OS attested the custody (Secure Enclave / ACL). */
+  readonly osVerified: boolean;
+}
+
+/**
+ * Derive the device key-protection posture SERVER-SIDE by CONSUMING verified
+ * native key-custody evidence (Option C, finding #4). It NEVER returns/accepts a
+ * self-reported or global posture:
+ *   - absent evidence (`null`/`undefined`) → `"unverified"` (honest-absent on this
+ *     unsigned dev/CI tree — fails closed);
+ *   - `secure_enclave` + OS-verified → `"secure_enclave_os_verified"` (release-trusted);
+ *   - `keychain_acl` + OS-verified → `"keychain_acl_verified"` (release-trusted);
+ *   - `webcrypto_software` (or any non-OS-verified custody) → `"software_dev_only"`
+ *     — a dev/negative seam that is NEVER release-trusted.
+ * WebCrypto can therefore never yield a release-trusted keyProtection.
+ */
+export function deriveDeviceKeyProtection(
+  evidence?: NativeKeyCustodyEvidence | null,
+): FridayDeviceKeyProtection {
+  if (!evidence) {
+    return "unverified";
+  }
+  if (evidence.custody === "secure_enclave" && evidence.osVerified === true) {
+    return "secure_enclave_os_verified";
+  }
+  if (evidence.custody === "keychain_acl" && evidence.osVerified === true) {
+    return "keychain_acl_verified";
+  }
+  // WebCrypto software keys, and any custody the OS did NOT verify, are dev-only.
+  return "software_dev_only";
 }
 
 // ─── Fail-closed device-owner mint seam ───

--- a/src/security/friday-mutating-action-gate.ts
+++ b/src/security/friday-mutating-action-gate.ts
@@ -1,5 +1,8 @@
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 
+import type { ProviderApprovalDeviceProof } from "../api/auth/device-attest/friday-provider-approval-transcript.types.js";
+import { deviceOwnerPrincipalId } from "./friday-device-owner-authority-precondition.js";
+
 export const FRIDAY_MUTATING_ACTION_RISKS = [
   "read_only",
   "low",
@@ -55,8 +58,48 @@ export interface FridayCanonicalApprovalResolution {
   readonly reason?: string;
   readonly expiresAt?: string;
   readonly childOfLifecycleTicketId?: string;
-  readonly issuer?: "friday_canonical_gate";
+  /**
+   * The authority that authored this approval:
+   *  - `friday_canonical_gate` — a symmetric HMAC the Hub both mints AND verifies
+   *    with `deps.tokenSecret` (the LEGACY plugin/mcp/channel/skill/workflow
+   *    lifecycle path; out of CORE-A CR-2 scope).
+   *  - `friday_device_owner` — a DEVICE-AUTHORED (P-256 ECDSA) approval. The Hub
+   *    holds NO signing key; it only VERIFIES the `deviceProof` with the presented
+   *    PUBLIC key. This is the SEC-APPROVAL-AUTHORITY-001 verify-only Hub path used
+   *    by provider-setup mutations, where a Hub self-signed HMAC is refused.
+   */
+  readonly issuer?: "friday_canonical_gate" | "friday_device_owner";
+  /** Symmetric-HMAC signature (LEGACY `friday_canonical_gate` issuer only). */
   readonly signature?: string;
+  /**
+   * The self-describing P-256 device proof (`friday_device_owner` issuer only):
+   * the signed approval transcript + the device PUBLIC key + the raw signature.
+   * Verified asymmetrically — the Hub never holds the private key.
+   */
+  readonly deviceProof?: ProviderApprovalDeviceProof;
+}
+
+/**
+ * The injected ASYMMETRIC verifier for a `friday_device_owner` approval. Performs
+ * the PURE P-256 proof-of-possession + transcript-field check ONLY (no request /
+ * owner binding — the gate does that with the returned fields). Wired by the
+ * runtime from `createFridayProviderApprovalPoPVerifier`. When absent, a
+ * device-authored approval fails CLOSED (the gate cannot verify it).
+ */
+export type FridayDeviceApprovalVerifier = (
+  proof: ProviderApprovalDeviceProof,
+  nowMs: number,
+) => FridayDeviceApprovalVerifyResult;
+
+export interface FridayDeviceApprovalVerifyResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+  /** Canonical SHA-256 hex of the verified SPKI DER public key (present iff ok). */
+  readonly devicePublicKeyHash?: string;
+  readonly approvalId?: string;
+  readonly actionDigest?: string;
+  readonly decidedByPrincipalId?: string;
+  readonly expiresAt?: string;
 }
 
 export interface FridayMutatingActionRequest {
@@ -161,6 +204,12 @@ export interface FridayMutatingActionGateOptions {
   readonly ticketIdGenerator?: () => string;
   readonly approvalSignatureSecret?: string;
   readonly requireApprovalSignature?: boolean;
+  /**
+   * ASYMMETRIC verifier for `friday_device_owner` (device-authored) approvals.
+   * When absent, a device-authored approval fails closed. The Hub holds ONLY the
+   * public key here — no signing secret is involved on the device-owner path.
+   */
+  readonly deviceApprovalVerifier?: FridayDeviceApprovalVerifier;
 }
 
 export interface FridayMutatingActionGate {
@@ -325,6 +374,109 @@ export function verifyFridayCanonicalApprovalSignature(
     && timingSafeEqual(actualBuffer, expectedBuffer);
 }
 
+/**
+ * Verify the AUTHORITY of an `approved` canonical approval. Returns a deny reason
+ * string, or `null` when the approval is authentic AND (for a device-authored
+ * approval) bound to the exact action + owner device.
+ *
+ * Two disjoint authorities:
+ *   - `friday_device_owner` — ASYMMETRIC P-256 proof-of-possession (the Hub holds
+ *     NO signing key). ALWAYS cryptographically verified, then bound to the
+ *     request action digest + acting owner + the owner's device key hash. This is
+ *     the SEC-APPROVAL-AUTHORITY-001 verify-only path.
+ *   - otherwise (`friday_canonical_gate` / unset) — the LEGACY symmetric HMAC,
+ *     verified only when a signature is required/available (unchanged behaviour;
+ *     used by the plugin/mcp/channel/skill/workflow lifecycle, NOT by providers).
+ */
+function verifyCanonicalApprovalAuthority(input: {
+  approval: FridayCanonicalApprovalResolution;
+  actionDigest: string;
+  actorPrincipalId: string | undefined;
+  evaluatedAt: string;
+  requireApprovalSignature: boolean;
+  approvalSignatureSecret: string | undefined;
+  deviceApprovalVerifier: FridayDeviceApprovalVerifier | undefined;
+}): string | null {
+  const { approval } = input;
+
+  if (approval.issuer === "friday_device_owner") {
+    return verifyDeviceOwnerApprovalAuthority(input);
+  }
+
+  // LEGACY symmetric-HMAC authority (plugin/mcp/channel/skill/workflow lifecycle).
+  if (input.requireApprovalSignature || input.approvalSignatureSecret !== undefined) {
+    if (
+      input.approvalSignatureSecret === undefined
+      || !verifyFridayCanonicalApprovalSignature(approval, input.approvalSignatureSecret)
+    ) {
+      return "canonical_approval_signature_invalid";
+    }
+  }
+  return null;
+}
+
+/** Map a pure-verifier reject reason to a stable, non-sensitive gate deny reason. */
+function mapDeviceApprovalRejectReason(reason: string | undefined): string {
+  if (reason === "expired") return "canonical_approval_expired";
+  return "device_approval_signature_invalid";
+}
+
+function verifyDeviceOwnerApprovalAuthority(input: {
+  approval: FridayCanonicalApprovalResolution;
+  actionDigest: string;
+  actorPrincipalId: string | undefined;
+  evaluatedAt: string;
+  deviceApprovalVerifier: FridayDeviceApprovalVerifier | undefined;
+}): string | null {
+  const { approval, deviceApprovalVerifier } = input;
+  // Fail closed: a device-authored approval that cannot be verified never admits.
+  if (deviceApprovalVerifier === undefined) {
+    return "device_approval_verifier_unavailable";
+  }
+  if (approval.deviceProof === undefined) {
+    return "device_approval_proof_missing";
+  }
+  const nowMs = Date.parse(input.evaluatedAt);
+  if (!Number.isFinite(nowMs)) {
+    return "canonical_approval_expiration_invalid";
+  }
+
+  // (1) PURE asymmetric proof-of-possession over the signed transcript.
+  const verified = deviceApprovalVerifier(approval.deviceProof, nowMs);
+  if (!verified.ok || verified.devicePublicKeyHash === undefined) {
+    return mapDeviceApprovalRejectReason(verified.reason);
+  }
+
+  // (2) The SIGNED transcript must cover EXACTLY the approval's claimed fields, and
+  //     the approval's action digest must equal the request's recomputed digest —
+  //     so a proof cannot be lifted onto a different action, owner, or expiry.
+  if (
+    verified.actionDigest !== approval.actionDigest
+    || verified.actionDigest !== input.actionDigest
+  ) {
+    return "device_approval_action_digest_mismatch";
+  }
+  if (verified.approvalId !== approval.approvalId) {
+    return "device_approval_id_mismatch";
+  }
+  if (verified.decidedByPrincipalId !== approval.decidedByPrincipalId) {
+    return "device_approval_principal_mismatch";
+  }
+  if (verified.expiresAt !== approval.expiresAt) {
+    return "device_approval_expiry_mismatch";
+  }
+
+  // (3) OWNER-DEVICE binding: the approving principal must be the acting principal,
+  //     AND the signing device public key must hash to that owner's bound device.
+  if (approval.decidedByPrincipalId !== input.actorPrincipalId) {
+    return "device_approval_actor_mismatch";
+  }
+  if (deviceOwnerPrincipalId(verified.devicePublicKeyHash) !== approval.decidedByPrincipalId) {
+    return "device_approval_device_not_bound_to_owner";
+  }
+  return null;
+}
+
 function normalizeCanonicalApprovalSignatureText(signature: string | undefined): string | null {
   if (typeof signature !== "string" || !/^[0-9a-fA-F]{64}$/.test(signature)) {
     return null;
@@ -333,11 +485,16 @@ function normalizeCanonicalApprovalSignatureText(signature: string | undefined):
 }
 
 function createCanonicalApprovalUseKey(approval: FridayCanonicalApprovalResolution): string {
+  // Single-use is keyed on the approval identity AND the exact signing material, so
+  // replaying a consumed approval (HMAC OR device proof) is refused. For a
+  // device-authored approval the raw P-1363 signature is the single-use token.
+  const deviceSignature = approval.deviceProof?.signature?.value ?? "";
   return [
     approval.approvalId,
     approval.actionDigest,
     approval.issuer ?? "",
     normalizeCanonicalApprovalSignatureText(approval.signature) ?? "",
+    deviceSignature,
   ].join(":");
 }
 
@@ -377,6 +534,7 @@ export function createFridayMutatingActionGate(
   const ticketIdGenerator = options.ticketIdGenerator ?? createDefaultTicketId;
   const approvalSignatureSecret = options.approvalSignatureSecret;
   const requireApprovalSignature = options.requireApprovalSignature ?? false;
+  const deviceApprovalVerifier = options.deviceApprovalVerifier;
   const consumedCanonicalApprovalKeys = new Set<string>();
 
   return {
@@ -432,26 +590,30 @@ export function createFridayMutatingActionGate(
         });
       }
 
-      if (
-        canonicalApproval?.decision === "approved"
-        && (requireApprovalSignature || approvalSignatureSecret !== undefined)
-        && (
-          approvalSignatureSecret === undefined
-          || !verifyFridayCanonicalApprovalSignature(canonicalApproval, approvalSignatureSecret)
-        )
-      ) {
-        return buildResult({
-          request,
+      if (canonicalApproval?.decision === "approved") {
+        const authorityDenyReason = verifyCanonicalApprovalAuthority({
+          approval: canonicalApproval,
           actionDigest,
-          risk,
-          localClaims,
+          actorPrincipalId: request.actor.principalId,
           evaluatedAt,
-          decision: "deny",
-          reason: "canonical_approval_signature_invalid",
-          approvalRequired,
-          deniedBy: "canonical_gate",
-          approvalId: canonicalApproval.approvalId,
+          requireApprovalSignature,
+          approvalSignatureSecret,
+          deviceApprovalVerifier,
         });
+        if (authorityDenyReason !== null) {
+          return buildResult({
+            request,
+            actionDigest,
+            risk,
+            localClaims,
+            evaluatedAt,
+            decision: "deny",
+            reason: authorityDenyReason,
+            approvalRequired,
+            deniedBy: "canonical_gate",
+            approvalId: canonicalApproval.approvalId,
+          });
+        }
       }
 
       if (canonicalApproval?.decision === "denied") {

--- a/src/security/friday-mutating-action-gate.ts
+++ b/src/security/friday-mutating-action-gate.ts
@@ -26,6 +26,17 @@ export interface FridayMutatingActionActor {
   readonly id: string;
   readonly principalId?: string;
   readonly displayName?: string;
+  /**
+   * SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 (Option B*): the sentinel hash of the
+   * device bound to this authenticated owner (`users.password_hash =
+   * device-owner$v1$<hash>`), resolved SERVER-SIDE — `undefined` when the actor is
+   * not a device-claimed owner. A device-authored approval admits ONLY when the
+   * approval's signing key hashes (via the sentinel's own `sha256Hex` convention) to
+   * THIS value, binding the approval to the authenticated owner's registered device
+   * WITHOUT relying on the acting `principalId` (which stays `user.id`). It is NEVER
+   * folded into the action digest (server-derived, not part of the signed action).
+   */
+  readonly boundDeviceOwnerSentinelHash?: string;
 }
 
 export interface FridayMutatingActionResource {
@@ -391,7 +402,7 @@ export function verifyFridayCanonicalApprovalSignature(
 function verifyCanonicalApprovalAuthority(input: {
   approval: FridayCanonicalApprovalResolution;
   actionDigest: string;
-  actorPrincipalId: string | undefined;
+  actorBoundDeviceOwnerSentinelHash: string | undefined;
   evaluatedAt: string;
   requireApprovalSignature: boolean;
   approvalSignatureSecret: string | undefined;
@@ -424,7 +435,12 @@ function mapDeviceApprovalRejectReason(reason: string | undefined): string {
 function verifyDeviceOwnerApprovalAuthority(input: {
   approval: FridayCanonicalApprovalResolution;
   actionDigest: string;
-  actorPrincipalId: string | undefined;
+  /**
+   * SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 (Option B*): the authenticated owner's
+   * durable device-binding sentinel hash, resolved SERVER-SIDE from
+   * `users.password_hash` (`undefined` when the actor is not a device-claimed owner).
+   */
+  actorBoundDeviceOwnerSentinelHash: string | undefined;
   evaluatedAt: string;
   deviceApprovalVerifier: FridayDeviceApprovalVerifier | undefined;
 }): string | null {
@@ -466,15 +482,32 @@ function verifyDeviceOwnerApprovalAuthority(input: {
     return "device_approval_expiry_mismatch";
   }
 
-  // (3) OWNER-DEVICE binding: the approving principal must be the acting principal,
-  //     AND the signing device public key must hash to that owner's bound device.
-  if (approval.decidedByPrincipalId !== input.actorPrincipalId) {
+  // (3) DURABLE OWNER-DEVICE binding (Option B*): the approval's signing device MUST
+  //     be the device registered to the AUTHENTICATED owner. We compare the signing
+  //     key against the owner's durable sentinel using the SENTINEL'S OWN hashing
+  //     convention (`sha256Hex(devicePublicKey)` — the same one `deviceKeyLogin`
+  //     already trusts), NOT the acting `principalId` (which is `user.id`, by design).
+  //     A passphrase / unclaimed owner has NO sentinel (`undefined`) → refused.
+  const boundSentinelHash = input.actorBoundDeviceOwnerSentinelHash;
+  if (
+    boundSentinelHash === undefined
+    || boundSentinelHash.length === 0
+    || sha256Hex(approval.deviceProof.devicePublicKey.value) !== boundSentinelHash
+  ) {
     return "device_approval_actor_mismatch";
   }
+  // (4) CANONICAL self-consistency (unchanged): the approval's declared principal
+  //     must match its signing device key hash (`canonicalDevicePublicKeyHash`), so a
+  //     valid proof cannot carry a foreign owner principal.
   if (deviceOwnerPrincipalId(verified.devicePublicKeyHash) !== approval.decidedByPrincipalId) {
     return "device_approval_device_not_bound_to_owner";
   }
   return null;
+}
+
+/** sha256 hex of a value — the sentinel's hashing convention (see auth-service). */
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
 }
 
 function normalizeCanonicalApprovalSignatureText(signature: string | undefined): string | null {
@@ -594,7 +627,7 @@ export function createFridayMutatingActionGate(
         const authorityDenyReason = verifyCanonicalApprovalAuthority({
           approval: canonicalApproval,
           actionDigest,
-          actorPrincipalId: request.actor.principalId,
+          actorBoundDeviceOwnerSentinelHash: request.actor.boundDeviceOwnerSentinelHash,
           evaluatedAt,
           requireApprovalSignature,
           approvalSignatureSecret,

--- a/src/security/friday-mutating-action-gate.ts
+++ b/src/security/friday-mutating-action-gate.ts
@@ -1,6 +1,10 @@
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 
 import type { ProviderApprovalDeviceProof } from "../api/auth/device-attest/friday-provider-approval-transcript.types.js";
+import {
+  type FridayApprovalConsumptionStore,
+  FridayInMemoryApprovalConsumptionStore,
+} from "../api/http/persistence/friday-provider-approval-consumption-repository.js";
 import { deviceOwnerPrincipalId } from "./friday-device-owner-authority-precondition.js";
 
 export const FRIDAY_MUTATING_ACTION_RISKS = [
@@ -175,6 +179,15 @@ export interface FridayMutatingActionTicket {
   readonly planDigest?: string;
   readonly childOfLifecycleTicketId?: string;
   readonly idempotencyKey?: string;
+  /**
+   * The canonical approval single-use key this ticket's approval was reserved under
+   * (`createCanonicalApprovalUseKey`). Present ONLY when the approval consumption was
+   * DEFERRED (`deferApprovalConsumption`): the caller must finalize it durably —
+   * `completeConsumptionInTransaction(db, useKey)` in the SAME write transaction as the
+   * mutation, or `releaseReservation(useKey)` on a clean pre-commit failure. Absent for
+   * the inline path (the gate already committed the consumption).
+   */
+  readonly canonicalApprovalUseKey?: string;
 }
 
 export interface FridayMutatingActionGateEvidenceRecord {
@@ -221,10 +234,35 @@ export interface FridayMutatingActionGateOptions {
    * public key here — no signing secret is involved on the device-owner path.
    */
   readonly deviceApprovalVerifier?: FridayDeviceApprovalVerifier;
+  /**
+   * DURABLE single-use ledger for canonical approvals (SEC-APPROVAL-AUTHORITY-001 ·
+   * Advisor finding #3). Defaults to an in-memory impl (equivalent to the previous
+   * process-local `Set`), so db-less callers/tests behave exactly as before. The runtime
+   * injects the SQLite-backed store so a confirmed approval consumed once cannot be
+   * replayed after a restart or by a concurrent process.
+   */
+  readonly approvalConsumptionStore?: FridayApprovalConsumptionStore;
+}
+
+/** Per-evaluate options. */
+export interface FridayMutatingActionGateEvaluateOptions {
+  /**
+   * DEFER the durable approval consumption to the caller instead of committing it inline.
+   * When true the gate atomically RESERVES the single-use key (status='in_flight', a
+   * replay is already refused here on a PK conflict) and returns the reservation on the
+   * ticket as `canonicalApprovalUseKey`; the caller must then finalize it durably in the
+   * SAME write transaction as its mutation (`completeConsumptionInTransaction`) or release
+   * it on a clean failure. Used by provider create/update/delete so consume ⊗ mutation
+   * commit atomically. When false/absent the gate consumes inline in its own transaction.
+   */
+  readonly deferApprovalConsumption?: boolean;
 }
 
 export interface FridayMutatingActionGate {
-  evaluate(request: FridayMutatingActionRequest): FridayMutatingActionGateResult;
+  evaluate(
+    request: FridayMutatingActionRequest,
+    options?: FridayMutatingActionGateEvaluateOptions,
+  ): FridayMutatingActionGateResult;
 }
 
 const RISK_WEIGHT: Record<FridayMutatingActionRisk, number> = {
@@ -568,10 +606,14 @@ export function createFridayMutatingActionGate(
   const approvalSignatureSecret = options.approvalSignatureSecret;
   const requireApprovalSignature = options.requireApprovalSignature ?? false;
   const deviceApprovalVerifier = options.deviceApprovalVerifier;
-  const consumedCanonicalApprovalKeys = new Set<string>();
+  const approvalConsumptionStore =
+    options.approvalConsumptionStore ?? new FridayInMemoryApprovalConsumptionStore();
 
   return {
-    evaluate(request: FridayMutatingActionRequest): FridayMutatingActionGateResult {
+    evaluate(
+      request: FridayMutatingActionRequest,
+      evaluateOptions: FridayMutatingActionGateEvaluateOptions = {},
+    ): FridayMutatingActionGateResult {
       const localClaims = [...(request.localClaims ?? [])];
       const risk = deriveFridayMutatingActionRisk(request);
       const actionDigest = createFridayMutatingActionDigest(request, risk);
@@ -737,54 +779,100 @@ export function createFridayMutatingActionGate(
         });
       }
 
-      const canonicalApprovalUseKey = createCanonicalApprovalUseKey(canonicalApproval);
-      if (consumedCanonicalApprovalKeys.has(canonicalApprovalUseKey)) {
-        return buildResult({
-          request,
-          actionDigest,
-          risk,
-          localClaims,
-          evaluatedAt,
-          decision: "deny",
-          reason: "canonical_approval_already_used",
-          approvalRequired: true,
-          deniedBy: "canonical_gate",
-          approvalId: canonicalApproval.approvalId,
-        });
-      }
-
-      const ticket: FridayMutatingActionTicket = {
-        ticketId: ticketIdGenerator(),
-        actionDigest,
-        action: request.action,
-        actor: request.actor,
-        surface: request.surface,
-        resource: request.resource,
-        risk,
-        approvalId: canonicalApproval.approvalId,
-        approvedByPrincipalId: canonicalApproval.decidedByPrincipalId,
-        issuedAt: evaluatedAt,
-        expiresAt: canonicalApproval.expiresAt,
-        planDigest: request.planDigest,
-        childOfLifecycleTicketId: canonicalApproval.childOfLifecycleTicketId,
-        idempotencyKey: request.idempotencyKey,
-      };
-      consumedCanonicalApprovalKeys.add(canonicalApprovalUseKey);
-
-      return buildResult({
+      // DURABLE single-use (SEC-APPROVAL-AUTHORITY-001 · Advisor finding #3): reserve the
+      // canonical use key and mint the ticket (see helper for the atomic-INSERT semantics).
+      return reserveApprovalAndIssueTicket({
         request,
         actionDigest,
         risk,
         localClaims,
         evaluatedAt,
-        decision: "allow",
-        reason: "canonical_approval_ticket_issued",
-        approvalRequired: true,
-        ticket,
-        approvalId: canonicalApproval.approvalId,
+        canonicalApproval,
+        deferApprovalConsumption: evaluateOptions.deferApprovalConsumption === true,
+        store: approvalConsumptionStore,
+        ticketIdGenerator,
       });
     },
   };
+}
+
+/**
+ * Reserve the canonical approval's single-use key and, on success, mint the mutating-action
+ * ticket. The reserve is an atomic single INSERT keyed on the use key, so a replay of the
+ * same signed approval — a concurrent request OR a fresh process after restart — collides on
+ * the PRIMARY KEY and is refused as `canonical_approval_already_used`. In the DEFERRED path
+ * the reservation is `in_flight` and the ticket carries `canonicalApprovalUseKey` for the
+ * caller to finalize durably in the mutation's transaction; otherwise it is consumed inline.
+ */
+function reserveApprovalAndIssueTicket(input: {
+  request: FridayMutatingActionRequest;
+  actionDigest: string;
+  risk: FridayMutatingActionRisk;
+  localClaims: readonly FridayMutatingActionLocalClaim[];
+  evaluatedAt: string;
+  canonicalApproval: FridayCanonicalApprovalResolution;
+  deferApprovalConsumption: boolean;
+  store: FridayApprovalConsumptionStore;
+  ticketIdGenerator: () => string;
+}): FridayMutatingActionGateResult {
+  const { request, actionDigest, risk, localClaims, evaluatedAt, canonicalApproval } = input;
+  const canonicalApprovalUseKey = createCanonicalApprovalUseKey(canonicalApproval);
+  const reservation = {
+    useKey: canonicalApprovalUseKey,
+    actionDigest,
+    idempotencyKey: request.idempotencyKey,
+    mutationOperationId: request.action,
+  };
+  const reserveOutcome = input.deferApprovalConsumption
+    ? input.store.reserveInFlight(reservation)
+    : input.store.reserveConsumed(reservation);
+  if (!reserveOutcome.ok) {
+    return buildResult({
+      request,
+      actionDigest,
+      risk,
+      localClaims,
+      evaluatedAt,
+      decision: "deny",
+      reason: "canonical_approval_already_used",
+      approvalRequired: true,
+      deniedBy: "canonical_gate",
+      approvalId: canonicalApproval.approvalId,
+    });
+  }
+
+  const ticket: FridayMutatingActionTicket = {
+    ticketId: input.ticketIdGenerator(),
+    actionDigest,
+    action: request.action,
+    actor: request.actor,
+    surface: request.surface,
+    resource: request.resource,
+    risk,
+    approvalId: canonicalApproval.approvalId,
+    approvedByPrincipalId: canonicalApproval.decidedByPrincipalId,
+    issuedAt: evaluatedAt,
+    expiresAt: canonicalApproval.expiresAt,
+    planDigest: request.planDigest,
+    childOfLifecycleTicketId: canonicalApproval.childOfLifecycleTicketId,
+    idempotencyKey: request.idempotencyKey,
+    // Only the DEFERRED path hands the caller a reservation to finalize durably in the
+    // mutation's transaction; the inline path already committed the consumption.
+    ...(input.deferApprovalConsumption ? { canonicalApprovalUseKey } : {}),
+  };
+
+  return buildResult({
+    request,
+    actionDigest,
+    risk,
+    localClaims,
+    evaluatedAt,
+    decision: "allow",
+    reason: "canonical_approval_ticket_issued",
+    approvalRequired: true,
+    ticket,
+    approvalId: canonicalApproval.approvalId,
+  });
 }
 
 function deriveFridayMutatingActionRisk(

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -22,6 +22,7 @@ export type FridayPublicMutationOperation =
   | "capability.grant.revoke"
   | "sessions.create"
   | "sessions.messages.create"
+  | "sessions.run"
   | "workflow.create"
   | "workflow.update"
   | "workflow.archive"

--- a/src/security/friday-owner-session-channel-capability.ts
+++ b/src/security/friday-owner-session-channel-capability.ts
@@ -8,7 +8,6 @@ import {
 import type { FridayAuthPrincipal, FridayRole, FridayScope } from "../api/model/friday-api-auth.types.js";
 import {
   DEVICE_OWNER_PRINCIPAL_TYPE,
-  isDeviceOwnerAuthorityEnabled,
   isDeviceOwnerPrincipalId,
 } from "./friday-device-owner-authority-precondition.js";
 
@@ -166,10 +165,12 @@ export function isReleaseDisabledDevicePrincipal(
   principal: FridayAuthPrincipal | null | undefined,
 ): boolean {
   if (!principal) return false;
-  if (principal.principalType !== DEVICE_OWNER_PRINCIPAL_TYPE) return false;
-  // Fail closed: the device principal carries authority ONLY when the
-  // server-derived switch is on. Off (today) ⇒ treat as unauthenticated.
-  return !isDeviceOwnerAuthorityEnabled();
+  // Option C: there is NO global "device authority enabled" switch. A device
+  // principal presented as an HTTP bearer carries NO per-claim capability, so it
+  // is ALWAYS release-disabled here (fail closed) — the ONLY thing that confers
+  // owner authority is a `VerifiedNativeOwnerClaimContext` consumed at claim/login
+  // mint time, which produces a normal user session, never a device-type bearer.
+  return principal.principalType === DEVICE_OWNER_PRINCIPAL_TYPE;
 }
 
 export function isUnauthenticatedPublicPrincipal(
@@ -267,12 +268,11 @@ export function assertBoundActorForSessionOperation(
   // (which is truthy in JavaScript) cannot pass the bound-principal gate or be
   // propagated downstream as an audit identity.
   const normalized = typeof actorId === "string" ? actorId.trim() : "";
-  // SEC-SETUP-BOOTSTRAP-001 Slice 3: a device-owner actor id is refused here
-  // exactly like the synthetic public actor while the server-derived
-  // device-authority switch is off (always, today) — conversational dispatch
-  // never grants owner authority from a disabled device identity.
-  const isDisabledDeviceActor =
-    isDeviceOwnerPrincipalId(normalized) && !isDeviceOwnerAuthorityEnabled();
+  // Option C: a device-owner actor id is ALWAYS refused here exactly like the
+  // synthetic public actor — there is no global device-authority switch, and a
+  // conversational dispatch actor string can never carry a per-claim native
+  // capability, so it never confers owner authority.
+  const isDisabledDeviceActor = isDeviceOwnerPrincipalId(normalized);
   if (
     normalized.length === 0 ||
     normalized === FRIDAY_DEFAULT_PUBLIC_HTTP_PRINCIPAL_ID ||

--- a/src/state/sqlite/migrations/index.ts
+++ b/src/state/sqlite/migrations/index.ts
@@ -105,6 +105,7 @@ import { V103_SETUP_BOOTSTRAP_DEVICE_CLAIM_MIGRATION } from "./v103-setup-bootst
 import { V104_SETUP_BOOTSTRAP_MIGRATION_STATE_MIGRATION } from "./v104-setup-bootstrap-migration-state.js";
 import { V105_RETENTION_SETTINGS_MIGRATION } from "./v105-retention-settings.js";
 import { V106_REALTIME_EVENTS_OWNER_MIGRATION } from "./v106-realtime-events-owner.js";
+import { V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION } from "./v107-setup-bootstrap-login-challenge.js";
 
 /**
  * Ordered migration list, always ascending by version.
@@ -216,6 +217,7 @@ export const FRIDAY_SQLITE_MIGRATIONS: readonly FridaySqliteMigration[] = [
   V104_SETUP_BOOTSTRAP_MIGRATION_STATE_MIGRATION,
   V105_RETENTION_SETTINGS_MIGRATION,
   V106_REALTIME_EVENTS_OWNER_MIGRATION,
+  V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION,
 ];
 
 export { V003_PROVIDER_USAGE_COST_ROUTING_MIGRATION };

--- a/src/state/sqlite/migrations/index.ts
+++ b/src/state/sqlite/migrations/index.ts
@@ -106,6 +106,7 @@ import { V104_SETUP_BOOTSTRAP_MIGRATION_STATE_MIGRATION } from "./v104-setup-boo
 import { V105_RETENTION_SETTINGS_MIGRATION } from "./v105-retention-settings.js";
 import { V106_REALTIME_EVENTS_OWNER_MIGRATION } from "./v106-realtime-events-owner.js";
 import { V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION } from "./v107-setup-bootstrap-login-challenge.js";
+import { V108_PROVIDER_MUTATION_APPROVAL_CONSUMPTION_MIGRATION } from "./v108-provider-mutation-approval-consumption.js";
 
 /**
  * Ordered migration list, always ascending by version.
@@ -218,6 +219,7 @@ export const FRIDAY_SQLITE_MIGRATIONS: readonly FridaySqliteMigration[] = [
   V105_RETENTION_SETTINGS_MIGRATION,
   V106_REALTIME_EVENTS_OWNER_MIGRATION,
   V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION,
+  V108_PROVIDER_MUTATION_APPROVAL_CONSUMPTION_MIGRATION,
 ];
 
 export { V003_PROVIDER_USAGE_COST_ROUTING_MIGRATION };

--- a/src/state/sqlite/migrations/v107-setup-bootstrap-login-challenge.ts
+++ b/src/state/sqlite/migrations/v107-setup-bootstrap-login-challenge.ts
@@ -1,0 +1,96 @@
+import { computeFridayMigrationChecksum } from "./friday-migration.types.js";
+import type { FridaySqliteMigration } from "./friday-migration.types.js";
+
+export const V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_SQL = `
+-- ============================================================
+-- V107: server-issued single-use device-key LOGIN challenge
+-- (SEC-SETUP-BOOTSTRAP-001 CR-1 · Advisor #1628 finding #2). ADDITIVE.
+-- ============================================================
+--
+-- Advisor #1628 finding #2: the device-key LOGIN proof was replayable — there was
+-- no server-issued single-use nonce gating the login mint, so a captured signed
+-- owner-login transcript could be resubmitted to mint further token pairs. The fix
+-- adds a THIRD consumer of the install-nonce ledger: a 'device_login_challenge'
+-- nonce minted per login attempt, bound to the device + origin + action, that
+-- deviceKeyLogin CAS-consumes atomically in the SAME transaction that mints the
+-- session — a replayed 2nd login finds it already consumed (changes=0) and mints
+-- NOTHING. This migration does TWO things and removes/disables NOTHING:
+--
+--   1. Widen the nonce 'kind' CHECK to accept 'device_login_challenge' (a third,
+--      strictly-additive value — a SUPERSET of the previous closed set).
+--   2. RE-SCOPE the single-owner partial UNIQUE(kind) WHERE consumed_at IS NOT NULL
+--      index to EXCLUDE the login kind. That belt guarantees "at most ONE consumed
+--      row PER kind", which is correct for install_owner_claim (single owner) and
+--      device_migration_claim (single migration) but WRONG for the login challenge:
+--      a machine logs in MANY times, so MANY consumed 'device_login_challenge' rows
+--      must coexist. Left unchanged, the 2nd consumed login row would hit the UNIQUE
+--      index and wrongly fail the login. The re-scoped predicate keeps the belt for
+--      the two single-shot kinds while letting login challenges accumulate (they are
+--      reaped by the existing bounded retention sweep).
+--
+-- SQLite bakes CHECK into the table definition, so widening it requires a table
+-- rebuild (mirrors v104). No table has a FOREIGN KEY into friday_setup_bootstrap_
+-- nonces, so the drop/rename triggers no cascade. All rows + all columns are copied
+-- verbatim; the whole migration pass runs under one BEGIN IMMEDIATE transaction (the
+-- runner), serialized against all other writers, so the rebuild is atomic.
+
+CREATE TABLE friday_setup_bootstrap_nonces__v107 (
+  id TEXT PRIMARY KEY,
+  nonce_hash TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (
+    kind IN ('install_owner_claim', 'device_migration_claim', 'device_login_challenge')
+  ),
+  hub_id TEXT NOT NULL,
+  install_id TEXT NOT NULL,
+  os_user TEXT NOT NULL,
+  origin TEXT NOT NULL,
+  action TEXT NOT NULL,
+  device_id TEXT,
+  device_public_key TEXT,
+  device_public_key_hash TEXT,
+  claimed_user_id TEXT,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  consumed_at TEXT
+);
+
+INSERT INTO friday_setup_bootstrap_nonces__v107 (
+  id, nonce_hash, kind, hub_id, install_id, os_user, origin, action,
+  device_id, device_public_key, device_public_key_hash, claimed_user_id,
+  created_at, expires_at, consumed_at
+)
+SELECT
+  id, nonce_hash, kind, hub_id, install_id, os_user, origin, action,
+  device_id, device_public_key, device_public_key_hash, claimed_user_id,
+  created_at, expires_at, consumed_at
+FROM friday_setup_bootstrap_nonces;
+
+DROP TABLE friday_setup_bootstrap_nonces;
+
+ALTER TABLE friday_setup_bootstrap_nonces__v107 RENAME TO friday_setup_bootstrap_nonces;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_friday_setup_bootstrap_nonces_hash
+  ON friday_setup_bootstrap_nonces (nonce_hash);
+
+-- RE-SCOPED single-owner belt: at most ONE consumed row for each SINGLE-SHOT kind
+-- (install_owner_claim / device_migration_claim). The login-challenge kind is
+-- EXCLUDED so many consumed login rows can coexist (one per login) without hitting
+-- the UNIQUE index — the single-use guarantee for logins is the per-row CAS
+-- (consumed_at IS NULL), not this index.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_friday_setup_bootstrap_nonces_single_owner
+  ON friday_setup_bootstrap_nonces (kind)
+  WHERE consumed_at IS NOT NULL
+    AND kind IN ('install_owner_claim', 'device_migration_claim');
+
+CREATE INDEX IF NOT EXISTS idx_friday_setup_bootstrap_nonces_expires
+  ON friday_setup_bootstrap_nonces (expires_at, consumed_at);
+`;
+
+const V107_CHECKSUM = computeFridayMigrationChecksum(V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_SQL);
+
+export const V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION: FridaySqliteMigration = {
+  version: 107,
+  name: "v107-setup-bootstrap-login-challenge",
+  sql: V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_SQL,
+  checksum: V107_CHECKSUM,
+};

--- a/src/state/sqlite/migrations/v108-provider-mutation-approval-consumption.ts
+++ b/src/state/sqlite/migrations/v108-provider-mutation-approval-consumption.ts
@@ -1,0 +1,61 @@
+import { computeFridayMigrationChecksum } from "./friday-migration.types.js";
+import type { FridaySqliteMigration } from "./friday-migration.types.js";
+
+export const V108_PROVIDER_MUTATION_APPROVAL_CONSUMPTION_SQL = `
+-- ============================================================
+-- V108: Durable single-use ledger for canonical mutating-action approvals
+-- (SEC-APPROVAL-AUTHORITY-001 · CORE-A round-3 Lane B · Advisor round-2 finding #3).
+-- ADDITIVE — creates ONE new table, removes/disables NOTHING.
+-- ============================================================
+--
+-- Advisor finding #3: provider-approval single-use lived ONLY in a process-local
+-- in-memory Set (\`consumedCanonicalApprovalKeys\` in the mutating-action gate) plus the
+-- in-memory \`providerMutationPlans\` confirmed marker. Both die on restart, so a fresh
+-- process re-admitted the SAME device-authored approval — the signed \`deviceProof\` is
+-- re-verified asymmetrically, so a captured confirmed approval could be replayed after a
+-- restart to drive a SECOND provider mutation. This durable ledger closes that: the
+-- canonical approval USE KEY (approvalId:actionDigest:issuer:hmac:deviceSignature — see
+-- \`createCanonicalApprovalUseKey\`) is the PRIMARY KEY, so a replayed approval hits a PK
+-- conflict and is refused as \`canonical_approval_already_used\` across restarts and across
+-- concurrent processes. It is a SEPARATE table from the append-only audit ledger and from
+-- the http_operation_journal (v100); the two guard different keys (approval use key vs.
+-- principal:operation:idempotencyKey).
+
+CREATE TABLE IF NOT EXISTS provider_mutation_approval_consumption (
+  -- The canonical approval USE KEY (createCanonicalApprovalUseKey): approvalId, the exact
+  -- recomputed action digest, the issuer, the normalized symmetric HMAC (if any) AND the
+  -- raw device P-1363 signature. A replay of the identical signed approval reproduces this
+  -- key EXACTLY and so collides on the PK.
+  use_key TEXT PRIMARY KEY,
+  action_digest TEXT NOT NULL,
+  idempotency_key TEXT,
+  -- The mutating action this approval was consumed for (e.g. 'providers.create'), for
+  -- provenance/observability only — it is NOT part of the single-use key.
+  mutation_operation_id TEXT NOT NULL,
+  -- 'in_flight'    = a two-phase reservation whose paired mutation has not yet committed
+  --                  (the consume completes to 'consumed' in the SAME write transaction as
+  --                  the provider mutation, so a rollback unwinds BOTH). A crash between the
+  --                  reserve and that commit leaves an 'in_flight' orphan.
+  -- 'consumed'     = the approval was durably spent (single-INSERT inline, or two-phase
+  --                  completion committed atomically with the mutation).
+  -- 'indeterminate'= an 'in_flight' orphan reconciled at boot: fail-closed, never re-admitted.
+  -- ALL three statuses collide on the PK, so a replay is refused regardless of status.
+  status TEXT NOT NULL DEFAULT 'consumed'
+    CHECK (status IN ('in_flight', 'consumed', 'indeterminate')),
+  consumed_at_ms INTEGER,
+  created_at_ms INTEGER NOT NULL
+);
+
+-- Supports the boot-time reconcile scan (mark orphaned in_flight rows indeterminate).
+CREATE INDEX IF NOT EXISTS idx_provider_mutation_approval_consumption_status
+  ON provider_mutation_approval_consumption (status);
+`;
+
+const V108_CHECKSUM = computeFridayMigrationChecksum(V108_PROVIDER_MUTATION_APPROVAL_CONSUMPTION_SQL);
+
+export const V108_PROVIDER_MUTATION_APPROVAL_CONSUMPTION_MIGRATION: FridaySqliteMigration = {
+  version: 108,
+  name: "v108-provider-mutation-approval-consumption",
+  sql: V108_PROVIDER_MUTATION_APPROVAL_CONSUMPTION_SQL,
+  checksum: V108_CHECKSUM,
+};

--- a/test/adversarial/_native-owner-capability.helpers.ts
+++ b/test/adversarial/_native-owner-capability.helpers.ts
@@ -1,0 +1,139 @@
+// ─── CR-1 Option C — test helpers: REAL native-owner capability resolvers ───
+//
+// These helpers mint a GENUINE `VerifiedNativeOwnerClaimContext` by running the
+// REAL CR-4 peer-attestation verifier + the REAL capability mint over INJECTED
+// native-evidence doubles (a peercred provider double + a codesign verifier
+// double), exactly as a signed-release/native slice supplies the real native
+// provider + a valid codesign check. This is NOT a forge: the capability brand
+// means the ONLY way to obtain a valid capability is this real mint, which REQUIRES
+// `attested: true` — there is no env / request / header path to it. Flipping a
+// double to a failing state (wrong identity, absent provider, unverified codesign,
+// software custody, …) yields NO capability, so the negative matrix is exercised
+// through the same real pipeline.
+
+import type { Socket } from "node:net";
+
+import {
+  verifyNativePeerAttestation,
+} from "../../src/security/attestation/friday-native-peer-attestation-verifier.js";
+import type {
+  FridayPeerCredential,
+} from "../../src/security/attestation/friday-native-peer-attestation-verifier.js";
+import {
+  deriveNativeOwnerExchangeConnectionId,
+  mintVerifiedNativeOwnerClaimContext,
+  type NativeOwnerClaimBinding,
+  type NativeOwnerClaimContextResolver,
+  type VerifiedNativeOwnerClaimContext,
+} from "../../src/security/attestation/friday-verified-native-owner-claim-context.js";
+import {
+  deriveDeviceKeyProtection,
+  type NativeKeyCustodyKind,
+} from "../../src/security/friday-device-owner-authority-precondition.js";
+
+/** MUST match the auth-service pinned constants (OWNER_DEVICE_ARTIFACT_ROLE). */
+export const TEST_OWNER_ARTIFACT_ROLE = "friday.owner-device.app";
+export const TEST_OWNER_RELEASE_IDENTITY = "com.friday.owner-device.release";
+export const TEST_PEER_UID = 501;
+export const TEST_PEER_PID = 4242;
+
+export interface TestNativeOwnerCapabilityOverrides {
+  readonly uid?: number;
+  readonly pid?: number;
+  /** The code-sign identity BOTH the attestation and the pinned policy carry. */
+  readonly identity?: string;
+  /** A DIFFERENT expected identity to pin (identity-mismatch negative). */
+  readonly policyIdentity?: string;
+  readonly artifactRole?: string;
+  readonly policyArtifactRole?: string;
+  readonly custody?: NativeKeyCustodyKind;
+  /** Force a non-OS-verified custody (software/dev). */
+  readonly osUnverified?: boolean;
+  /** Stamp a DIFFERENT accepted connection id (connection-substitution negative). */
+  readonly connectionId?: string;
+  /** Make the composed attestation NOT attested (absent provider). */
+  readonly providerAbsent?: boolean;
+  /** Make the codesign check unverified (null). */
+  readonly codesignUnverified?: boolean;
+  /** Make the codesign check invalid. */
+  readonly codesignInvalid?: boolean;
+  /** Engage the emergency kill switch for the mint. */
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+const FAKE_SOCKET = {} as unknown as Socket;
+
+/**
+ * Mint a genuine capability for `binding` from injected native doubles, or return
+ * `null` if the (possibly-degraded) doubles do not attest / the mint refuses.
+ */
+export function mintTestNativeOwnerCapability(
+  binding: NativeOwnerClaimBinding,
+  over: TestNativeOwnerCapabilityOverrides = {},
+): VerifiedNativeOwnerClaimContext | null {
+  const uid = over.uid ?? TEST_PEER_UID;
+  const pid = over.pid ?? TEST_PEER_PID;
+  const identity = over.identity ?? TEST_OWNER_RELEASE_IDENTITY;
+
+  const attestation = verifyNativePeerAttestation({
+    provider: {
+      readPeerCredential(): FridayPeerCredential | null {
+        return over.providerAbsent === true ? null : { pid, uid, gid: 20 };
+      },
+    },
+    codesignVerifier: () => {
+      if (over.codesignUnverified === true) return null;
+      return { identity, valid: over.codesignInvalid !== true };
+    },
+    expectedReleaseIdentity: identity,
+    socket: FAKE_SOCKET,
+  });
+
+  const custody: NativeKeyCustodyKind = over.custody ?? "secure_enclave";
+  const keyProtection = deriveDeviceKeyProtection({
+    custody,
+    osVerified: over.osUnverified !== true && custody !== "webcrypto_software",
+  });
+
+  const result = mintVerifiedNativeOwnerClaimContext({
+    attestation,
+    keyProtection,
+    binding,
+    evidence: {
+      osUid: uid,
+      peerPid: pid,
+      acceptedConnectionId: over.connectionId ?? deriveNativeOwnerExchangeConnectionId(binding),
+      auditTokenIdentity: `audit-token-${pid}`,
+      codesignIdentity: identity,
+    },
+    policy: {
+      expectedReleaseIdentity: over.policyIdentity ?? identity,
+      expectedArtifactRole: over.policyArtifactRole ?? over.artifactRole ?? binding.artifactRole,
+    },
+    env: over.env,
+  });
+  return result.ok ? result.capability : null;
+}
+
+/**
+ * A resolver that mints a genuine capability for the exact request binding it is
+ * given. This is what the auth-service consumes; it is the SAME shape a signed
+ * release supplies from the Companion Unix-socket accept boundary.
+ */
+export function createTestNativeOwnerResolver(
+  over: TestNativeOwnerCapabilityOverrides = {},
+): NativeOwnerClaimContextResolver {
+  return (binding) => mintTestNativeOwnerCapability(binding, over);
+}
+
+/**
+ * A resolver that mints a capability bound to a FIXED (foreign) binding, IGNORING
+ * the request's binding — used to prove "one attested peer authorizing a DIFFERENT
+ * request" is refused (binding drift → zero state change).
+ */
+export function createForeignBindingNativeOwnerResolver(
+  foreignBinding: NativeOwnerClaimBinding,
+  over: TestNativeOwnerCapabilityOverrides = {},
+): NativeOwnerClaimContextResolver {
+  return () => mintTestNativeOwnerCapability(foreignBinding, over);
+}

--- a/test/adversarial/_secsetup-s2a.helpers.ts
+++ b/test/adversarial/_secsetup-s2a.helpers.ts
@@ -89,11 +89,19 @@ export function toLowS(raw: Buffer): Buffer {
   return Buffer.concat([r, bigIntTo32(s)]);
 }
 
-/** Produce the high-S malleable twin (s → n − s) of a raw P-1363 signature. */
+/**
+ * Produce the high-S malleable twin of a raw P-1363 signature.
+ * DETERMINISTIC: normalize to low-S first, then reflect (n − s_low). A fresh
+ * ECDSA signature's s is random-parity (~50% already high-S), and an
+ * unconditional `n − s` would yield a *low*-S value for those, silently making
+ * this a canonical (verifier-accepted) signature and flaking any "rejects
+ * high-S" assertion. Reflecting the low form guarantees s_high > n/2 every time.
+ */
 export function toHighSTwin(raw: Buffer): Buffer {
   const r = raw.subarray(0, 32);
-  const s = bufToBigInt(raw.subarray(32, 64));
-  return Buffer.concat([r, bigIntTo32(P256_ORDER_N - s)]);
+  let s = bufToBigInt(raw.subarray(32, 64));
+  if (s > P256_ORDER_N >> 1n) s = P256_ORDER_N - s; // normalize to low-S
+  return Buffer.concat([r, bigIntTo32(P256_ORDER_N - s)]); // reflect → always high-S
 }
 
 /**

--- a/test/adversarial/bootstrap-device-claim.test.ts
+++ b/test/adversarial/bootstrap-device-claim.test.ts
@@ -43,6 +43,7 @@ import type { FridaySqliteLayer } from "#state";
 // transcript's expiresAt is far-future so the AUTHORITATIVE single-use + TTL gate
 // stays server-side at nonce-consume — keeping every error code unchanged.
 import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "./_secsetup-s2a.helpers.js";
+import { createTestNativeOwnerResolver } from "./_native-owner-capability.helpers.js";
 
 const OWNER_ID = "admin-001";
 const NOW = "2026-07-13T00:00:00.000Z";
@@ -83,6 +84,12 @@ function makeService(db: FridaySqliteLayer, nowIso: string = NOW) {
     refreshTokenTtlSec: 604_800,
     hubId: "test-hub",
     bootstrapNonceTtlSec: 300,
+    // Option C: the owner-sentinel write requires a per-claim native capability.
+    // These tests exercise NONCE mechanics (single-use/replay/race/expiry), so we
+    // inject a resolver that mints a real capability over injected native-evidence
+    // doubles — the capability gate is transparent and the nonce gate is what's
+    // under test. (Capability-absent refusal is covered in the s3 suite.)
+    resolveNativeOwnerClaimContext: createTestNativeOwnerResolver(),
   });
 }
 

--- a/test/adversarial/bootstrap-nonce-lifecycle.test.ts
+++ b/test/adversarial/bootstrap-nonce-lifecycle.test.ts
@@ -35,6 +35,7 @@ import { createFridaySqliteLayer } from "#state";
 import type { FridaySqliteLayer } from "#state";
 // SEC-SETUP-BOOTSTRAP-001 Slice 3: device-claim now requires proof-of-possession.
 import { generateTestDeviceKey, makeTranscript, signTranscriptLowS, type TestDeviceKey } from "./_secsetup-s2a.helpers.js";
+import { createTestNativeOwnerResolver } from "./_native-owner-capability.helpers.js";
 
 const OWNER_ID = "admin-001";
 const NOW = "2026-07-13T00:00:00.000Z";
@@ -78,6 +79,11 @@ function makeService(db: FridaySqliteLayer, nowIso: string = NOW) {
     refreshTokenTtlSec: 604_800,
     hubId: "test-hub",
     bootstrapNonceTtlSec: BOOTSTRAP_TTL_SEC,
+    // Option C: the owner-sentinel write requires a per-claim native capability.
+    // These tests exercise NONCE lifecycle mechanics, so inject a resolver that
+    // mints a real capability over injected native-evidence doubles — the nonce
+    // gate remains what's under test.
+    resolveNativeOwnerClaimContext: createTestNativeOwnerResolver(),
   });
 }
 

--- a/test/adversarial/bootstrap-nonce-lifecycle.test.ts
+++ b/test/adversarial/bootstrap-nonce-lifecycle.test.ts
@@ -389,3 +389,119 @@ describe("SEC-SETUP-BOOTSTRAP-001 s4: crash / restart recovery", () => {
     expect(readOwnerHash(db)).toBe(afterPass);
   });
 });
+
+// ─── SEC-SETUP-BOOTSTRAP-001 CR-1: device_login_challenge repo lifecycle ───
+//
+// Repo-level proofs (against the REAL full migration chain, incl. v107) for the
+// single-use login-challenge nonce that makes the device-key login non-replayable
+// (Advisor #1628 finding #2). No authority seam needed — this exercises the
+// insert/consume CAS + the re-scoped single-owner index directly.
+
+const LOGIN_EXP = "2026-07-13T00:05:00.000Z"; // NOW + 300s
+const DEVICE_KEY_HASH = sha256Hex(DEVICE_PUBKEY);
+
+function insertLoginChallenge(
+  layer: FridaySqliteLayer,
+  over: Partial<{
+    nonce: string;
+    origin: string;
+    deviceId: string;
+    devicePublicKeyHash: string;
+    expiresAt: string;
+  }> = {},
+): string {
+  const nonce = over.nonce ?? `login-nonce-${++idCounter}`;
+  layer.withWriteTransaction((conn) =>
+    nonceRepo.insertLoginChallengeNonce(conn, {
+      id: `lc-${idCounter}-${Math.random().toString(36).slice(2, 8)}`,
+      nonceHash: sha256Hex(nonce),
+      hubId: "test-hub",
+      installId: "install-1",
+      osUser: "jarvis",
+      origin: over.origin ?? ORIGIN,
+      action: "owner-login",
+      deviceId: over.deviceId ?? DEVICE_ID,
+      devicePublicKey: DEVICE_PUBKEY,
+      devicePublicKeyHash: over.devicePublicKeyHash ?? DEVICE_KEY_HASH,
+      createdAt: NOW,
+      expiresAt: over.expiresAt ?? LOGIN_EXP,
+    }),
+  );
+  return nonce;
+}
+
+function consumeLogin(
+  layer: FridaySqliteLayer,
+  over: {
+    nonce: string;
+    origin?: string;
+    nowIso?: string;
+    deviceId?: string;
+    devicePublicKeyHash?: string;
+  },
+): number {
+  return layer.withWriteTransaction((conn) =>
+    nonceRepo.consumeLoginChallengeNonce(conn, {
+      nonceHash: sha256Hex(over.nonce),
+      origin: over.origin ?? ORIGIN,
+      nowIso: over.nowIso ?? NOW,
+      deviceId: over.deviceId ?? DEVICE_ID,
+      devicePublicKeyHash: over.devicePublicKeyHash ?? DEVICE_KEY_HASH,
+    }),
+  );
+}
+
+describe("SEC-SETUP-BOOTSTRAP-001 CR-1: device_login_challenge nonce", () => {
+  it("is single-use: first consume wins (1), a replay yields 0", () => {
+    const nonce = insertLoginChallenge(db);
+    expect(consumeLogin(db, { nonce })).toBe(1);
+    expect(readNonceRow(db, nonce)?.consumed_at).not.toBeNull();
+    // Replay of the SAME nonce → already consumed → 0.
+    expect(consumeLogin(db, { nonce })).toBe(0);
+  });
+
+  it("binds device + origin + key hash: any mismatch yields 0, the exact match yields 1", () => {
+    const nonce = insertLoginChallenge(db);
+    expect(consumeLogin(db, { nonce, deviceId: "other-device" })).toBe(0);
+    expect(consumeLogin(db, { nonce, origin: "https://evil.localhost" })).toBe(0);
+    expect(consumeLogin(db, { nonce, devicePublicKeyHash: sha256Hex("other-key") })).toBe(0);
+    // Still unconsumed after all the mismatched attempts.
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+    // The exact match consumes it once.
+    expect(consumeLogin(db, { nonce })).toBe(1);
+  });
+
+  it("cannot be consumed past its expiry", () => {
+    const nonce = insertLoginChallenge(db, { expiresAt: "2026-07-12T00:00:00.000Z" });
+    expect(consumeLogin(db, { nonce, nowIso: NOW })).toBe(0);
+    expect(readNonceRow(db, nonce)?.consumed_at).toBeNull();
+  });
+
+  it("a consumed login challenge stays consumed across a restart (single-use holds)", () => {
+    const nonce = insertLoginChallenge(db);
+    expect(consumeLogin(db, { nonce })).toBe(1);
+
+    restart();
+
+    expect(readNonceRow(db, nonce)?.consumed_at).not.toBeNull();
+    // A replay after restart still finds it consumed → 0.
+    expect(consumeLogin(db, { nonce })).toBe(0);
+  });
+
+  it("MANY login challenges can be consumed (the re-scoped single-owner index excludes the login kind)", () => {
+    // Two DISTINCT login challenges, both consumed — this would violate the pre-v107
+    // single-owner UNIQUE(kind) belt, but v107 re-scoped it to exclude the login kind.
+    const a = insertLoginChallenge(db, { nonce: "login-a" });
+    const b = insertLoginChallenge(db, { nonce: "login-b" });
+    expect(consumeLogin(db, { nonce: a })).toBe(1);
+    expect(consumeLogin(db, { nonce: b })).toBe(1);
+    const consumed = db.withReadConnection((conn) =>
+      (conn
+        .prepare(
+          "SELECT COUNT(*) AS c FROM friday_setup_bootstrap_nonces WHERE kind = 'device_login_challenge' AND consumed_at IS NOT NULL",
+        )
+        .get() as { c: number }).c,
+    );
+    expect(consumed).toBe(2);
+  });
+});

--- a/test/adversarial/secsetup-s3-device-principal-failclosed.test.ts
+++ b/test/adversarial/secsetup-s3-device-principal-failclosed.test.ts
@@ -39,17 +39,20 @@ import {
   isUnauthenticatedPublicPrincipal,
 } from "../../src/security/friday-owner-session-channel-capability.js";
 import {
-  DEVICE_OWNER_AUTHORITY_ENABLED_ENV,
+  DEVICE_OWNER_AUTHORITY_KILL_SWITCH_ENV,
   DEVICE_OWNER_PRINCIPAL_TYPE,
   NATIVE_IPC_ATTESTATION_AVAILABLE,
   deriveDeviceKeyProtection,
   deviceOwnerPrincipalId,
   isDeviceOwnerAuthorityEnabled,
+  isDeviceOwnerAuthorityKillSwitchEngaged,
   isReleaseTrustedKeyProtection,
   mintDeviceOwnerPrincipal,
   type FridayDeviceKeyProtection,
 } from "../../src/security/friday-device-owner-authority-precondition.js";
 import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "./_secsetup-s2a.helpers.js";
+import { createTestNativeOwnerResolver } from "./_native-owner-capability.helpers.js";
+import type { NativeOwnerClaimContextResolver } from "../../src/security/attestation/friday-verified-native-owner-claim-context.js";
 
 const OWNER_ID = "admin-001";
 const NOW = "2026-07-13T00:00:00.000Z";
@@ -93,7 +96,7 @@ function seedOwner(db: FridaySqliteLayer): void {
   });
 }
 
-function makeService(db: FridaySqliteLayer) {
+function makeService(db: FridaySqliteLayer, resolver?: NativeOwnerClaimContextResolver) {
   return createFridayAuthService({
     db,
     idGenerator: (() => {
@@ -106,6 +109,10 @@ function makeService(db: FridaySqliteLayer) {
     refreshTokenTtlSec: 604_800,
     hubId: "test-hub",
     bootstrapNonceTtlSec: 300,
+    // Option C: default (no resolver) → absent native boundary → device claim
+    // fails closed. A test that exercises the granted path injects a resolver that
+    // runs the REAL capability mint over injected native-evidence doubles.
+    ...(resolver ? { resolveNativeOwnerClaimContext: resolver } : {}),
   });
 }
 
@@ -229,30 +236,45 @@ describe("S3 Group A — device mint seam + authority switch (fail-closed)", () 
     expect(result.reason).toBe("pop-unverified");
   });
 
-  it("switch is server-derived + hard-wired off: native-IPC precondition (b) is absent", () => {
+  it("Option C: retired global authority is ALWAYS off; NO env forces it on; honesty anchor untouched", () => {
+    // Honesty anchor is retired-as-authority but LEFT in place and still false.
     expect(NATIVE_IPC_ATTESTATION_AVAILABLE).toBe(false);
+    // There is no global "device authority enabled" — always false, no positive path.
     expect(isDeviceOwnerAuthorityEnabled()).toBe(false);
-    // Cannot be flipped by config while (b) is absent.
-    expect(isDeviceOwnerAuthorityEnabled({ [DEVICE_OWNER_AUTHORITY_ENABLED_ENV]: "1" })).toBe(false);
+    // The RETIRED positive opt-in cannot flip it on any more (env is inert here).
+    expect(isDeviceOwnerAuthorityEnabled({ FRIDAY_DEVICE_OWNER_AUTHORITY_ENABLED: "1" })).toBe(false);
     // keyProtection derives to a fail-closed state server-side (never trusted).
     const kp: FridayDeviceKeyProtection = deriveDeviceKeyProtection();
     expect(kp).toBe("unverified");
     expect(isReleaseTrustedKeyProtection(kp)).toBe(false);
   });
 
-  it("the switch takes NO request-derived input (cannot be flipped by request-body/header/Origin/loopback facts)", () => {
-    // The function's ONLY input is the process env. Passing request-shaped facts
-    // as an env-like object does nothing — there is structurally no request path.
+  it("the retired predicate takes NO request-derived input and no env can force it true", () => {
+    // Passing request-shaped facts — or even the retired positive opt-in — as an
+    // env-like object does nothing: there is structurally no path to `true`.
     const hostileEnvs: NodeJS.ProcessEnv[] = [
       { origin: "https://friday.localhost" } as unknown as NodeJS.ProcessEnv,
       { "user-agent": "Friday-Native/1.0" } as unknown as NodeJS.ProcessEnv,
       { "x-forwarded-for": "127.0.0.1" } as unknown as NodeJS.ProcessEnv,
       { nonce: "attacker-nonce" } as unknown as NodeJS.ProcessEnv,
       { bundleId: "com.friday.native" } as unknown as NodeJS.ProcessEnv,
+      { FRIDAY_DEVICE_OWNER_AUTHORITY_ENABLED: "1" } as unknown as NodeJS.ProcessEnv,
     ];
     for (const env of hostileEnvs) {
       expect(isDeviceOwnerAuthorityEnabled(env)).toBe(false);
     }
+  });
+
+  it("kill switch can force OFF but there is NO counterpart that forces ON", () => {
+    expect(isDeviceOwnerAuthorityKillSwitchEngaged({})).toBe(false);
+    for (const v of ["1", "true", "on", "disable", "disabled"]) {
+      expect(
+        isDeviceOwnerAuthorityKillSwitchEngaged({ [DEVICE_OWNER_AUTHORITY_KILL_SWITCH_ENV]: v }),
+      ).toBe(true);
+    }
+    // No env value engages "authority ON" — the predicate only ever forces OFF.
+    expect(isDeviceOwnerAuthorityKillSwitchEngaged({ [DEVICE_OWNER_AUTHORITY_KILL_SWITCH_ENV]: "off" }))
+      .toBe(false);
   });
 });
 
@@ -405,15 +427,41 @@ describe("S3 PoP — device-claim refuses a PoP-unverified key (nonce-possession
     expect(readNonceConsumedAt(db, nonce)).toBeNull();
   });
 
-  it("positive: a valid PoP claim succeeds but grants ZERO authority (deviceAuthorityEnabled=false, keyProtection=unverified)", () => {
+  // ── LIVE-DEFECT CLOSURE (Advisor Option C, finding #7) ──
+  // At head, a valid-PoP claim ATOMICALLY consumed the nonce AND wrote
+  // `device-owner$v1$…` while carrying NO native authority — any loopback process
+  // with a software key could seize the single owner slot. Option C gates the
+  // owner-sentinel write + nonce consume on a per-claim VerifiedNativeOwnerClaimContext.
+  it("LIVE-DEFECT CLOSED: a valid-PoP claim with NO native capability is REFUSED with ZERO state change", () => {
     const nonce = issueNonce(db);
-    const res = makeService(db).claimOwnerWithDeviceKey(
+    let caught: unknown;
+    try {
+      // Default service → absent native boundary → no capability.
+      makeService(db).claimOwnerWithDeviceKey(
+        { ...baseClaim(nonce), deviceClaimProof: validProof(nonce) },
+        LOOPBACK,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FridayDomainError);
+    expect((caught as FridayDomainError).code).toBe("AUTH_BOOTSTRAP_DEVICE_AUTHORITY_UNVERIFIED");
+    // ZERO state change: no owner written (recovery path intact), nonce NOT burned.
+    expect(readOwnerHash(db)).toBeNull();
+    expect(readNonceConsumedAt(db, nonce)).toBeNull();
+  });
+
+  it("granted: a valid-PoP claim WITH a per-claim native capability writes the owner + grants authority", () => {
+    const nonce = issueNonce(db);
+    const res = makeService(db, createTestNativeOwnerResolver()).claimOwnerWithDeviceKey(
       { ...baseClaim(nonce), deviceClaimProof: validProof(nonce) },
       LOOPBACK,
     );
     expect(res.claimed).toBe(true);
-    expect(res.deviceAuthorityEnabled).toBe(false);
-    expect(res.keyProtection).toBe("unverified");
+    // A release-trusted native capability was consumed → authority granted + the
+    // key-protection posture is the OS-verified Secure-Enclave state.
+    expect(res.deviceAuthorityEnabled).toBe(true);
+    expect(res.keyProtection).toBe("secure_enclave_os_verified");
     // Owner slot bound to the device sentinel; nonce consumed.
     expect(readOwnerHash(db)).toBe(`device-owner$v1$${sha256Hex(DEVICE_PUBKEY)}`);
     expect(readNonceConsumedAt(db, nonce)).not.toBeNull();

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: every public mutating route maps to an accepted gate family 1`] = `
 {
   "classified": {
-    "bound_principal": 69,
+    "bound_principal": 71,
     "channel_signature": 4,
     "hmac_or_bearer_opt_in": 1,
     "public_low_risk": 2,
     "rate_limited_pending": 6,
     "unclassified": 251,
   },
-  "total_public_mutating": 333,
+  "total_public_mutating": 335,
   "unclassified_sample_max_5": [
     "capabilities.acquisition.runs.create",
     "capabilities.acquisition.runs.approve",
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `433`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `435`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -2002,6 +2002,26 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   {
     "authKind": "public",
     "index": 197,
+    "method": "POST",
+    "operationId": "providers.plan",
+    "path": "/v1/providers/plan",
+    "rateLimitPolicyId": "provider.write",
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 198,
+    "method": "POST",
+    "operationId": "providers.plan.confirm",
+    "path": "/v1/providers/plan/confirm",
+    "rateLimitPolicyId": "provider.write",
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 199,
     "method": "GET",
     "operationId": "providers.templates.get",
     "path": "/v1/providers/templates/:templateId",
@@ -2011,7 +2031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 198,
+    "index": 200,
     "method": "GET",
     "operationId": "providers.list",
     "path": "/v1/providers",
@@ -2021,7 +2041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 199,
+    "index": 201,
     "method": "GET",
     "operationId": "providers.health.list",
     "path": "/v1/providers/health",
@@ -2031,7 +2051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 200,
+    "index": 202,
     "method": "GET",
     "operationId": "providers.capability.health.list",
     "path": "/v1/providers/capability-health",
@@ -2041,7 +2061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 201,
+    "index": 203,
     "method": "POST",
     "operationId": "capabilities.doctor",
     "path": "/v1/capabilities/doctor",
@@ -2051,7 +2071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 202,
+    "index": 204,
     "method": "GET",
     "operationId": "providers.get",
     "path": "/v1/providers/:providerId",
@@ -2061,7 +2081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 203,
+    "index": 205,
     "method": "POST",
     "operationId": "providers.create",
     "path": "/v1/providers",
@@ -2071,7 +2091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 204,
+    "index": 206,
     "method": "PATCH",
     "operationId": "providers.update",
     "path": "/v1/providers/:providerId",
@@ -2081,7 +2101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 205,
+    "index": 207,
     "method": "DELETE",
     "operationId": "providers.delete",
     "path": "/v1/providers/:providerId",
@@ -2091,7 +2111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 206,
+    "index": 208,
     "method": "POST",
     "operationId": "providers.validate",
     "path": "/v1/providers/:providerId/validate",
@@ -2101,7 +2121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 207,
+    "index": 209,
     "method": "GET",
     "operationId": "providers.doctor",
     "path": "/v1/providers/:providerId/doctor",
@@ -2111,7 +2131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 208,
+    "index": 210,
     "method": "GET",
     "operationId": "providers.routing.explain",
     "path": "/v1/providers/routing/explain",
@@ -2121,7 +2141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 209,
+    "index": 211,
     "method": "POST",
     "operationId": "providers.routing.pin",
     "path": "/v1/providers/routing/pin",
@@ -2131,7 +2151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 210,
+    "index": 212,
     "method": "POST",
     "operationId": "providers.routing.penalty.clear",
     "path": "/v1/providers/routing/penalties/clear",
@@ -2141,7 +2161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 211,
+    "index": 213,
     "method": "GET",
     "operationId": "providers.auth.profiles.list",
     "path": "/v1/providers/:providerId/auth-profiles",
@@ -2151,7 +2171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 212,
+    "index": 214,
     "method": "POST",
     "operationId": "providers.auth.profiles.activate",
     "path": "/v1/providers/:providerId/auth-profiles/:profileKey/activate",
@@ -2161,7 +2181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 213,
+    "index": 215,
     "method": "GET",
     "operationId": "providers.routing.get",
     "path": "/v1/model-routing",
@@ -2171,7 +2191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 214,
+    "index": 216,
     "method": "PUT",
     "operationId": "providers.routing.set",
     "path": "/v1/model-routing",
@@ -2181,7 +2201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 215,
+    "index": 217,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.initiate",
     "path": "/v1/auth/oauth/anthropic/initiate",
@@ -2191,7 +2211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 216,
+    "index": 218,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.callback",
     "path": "/v1/auth/oauth/anthropic/callback",
@@ -2201,7 +2221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 217,
+    "index": 219,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.initiate",
     "path": "/v1/auth/oauth/openai-codex/device/initiate",
@@ -2211,7 +2231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 218,
+    "index": 220,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.complete",
     "path": "/v1/auth/oauth/openai-codex/device/complete",
@@ -2221,7 +2241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 219,
+    "index": 221,
     "method": "POST",
     "operationId": "media.understanding.doctor",
     "path": "/v1/media-understanding/doctor",
@@ -2231,7 +2251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 220,
+    "index": 222,
     "method": "POST",
     "operationId": "media.understanding.analyze",
     "path": "/v1/media-understanding/analyze",
@@ -2241,7 +2261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 223,
     "method": "GET",
     "operationId": "task.workflows.boundaries.list",
     "path": "/v1/task-workflows/boundaries",
@@ -2251,7 +2271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 224,
     "method": "GET",
     "operationId": "task.workflows.gates.list",
     "path": "/v1/task-workflows/gates",
@@ -2261,7 +2281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 225,
     "method": "POST",
     "operationId": "task.workflows.preview",
     "path": "/v1/task-workflows/preview",
@@ -2271,7 +2291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 226,
     "method": "POST",
     "operationId": "task.workflows.create",
     "path": "/v1/task-workflows",
@@ -2281,7 +2301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 227,
     "method": "GET",
     "operationId": "task.workflows.list",
     "path": "/v1/task-workflows",
@@ -2291,7 +2311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 228,
     "method": "GET",
     "operationId": "task.workflows.get",
     "path": "/v1/task-workflows/:workflowId",
@@ -2301,7 +2321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 229,
     "method": "POST",
     "operationId": "task.workflows.revise",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2311,7 +2331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 230,
     "method": "GET",
     "operationId": "task.workflows.revisions.list",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2321,7 +2341,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 231,
     "method": "POST",
     "operationId": "task.workflows.claims.create",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2331,7 +2351,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 232,
     "method": "GET",
     "operationId": "task.workflows.claims.list",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2341,7 +2361,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 233,
     "method": "GET",
     "operationId": "task.workflows.claims.get",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId",
@@ -2351,7 +2371,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 234,
     "method": "POST",
     "operationId": "task.workflows.claims.evidence.attach",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-ref",
@@ -2361,7 +2381,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 235,
     "method": "GET",
     "operationId": "task.workflows.claims.evidence.list",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-refs",
@@ -2371,7 +2391,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 236,
     "method": "POST",
     "operationId": "task.workflows.claims.verify",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/verify",
@@ -2381,7 +2401,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 237,
     "method": "POST",
     "operationId": "task.workflows.claims.block",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/block",
@@ -2391,7 +2411,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 238,
     "method": "POST",
     "operationId": "task.workflows.closeout",
     "path": "/v1/task-workflows/:workflowId/closeout",
@@ -2401,7 +2421,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 239,
     "method": "POST",
     "operationId": "task.workflows.lanes.executor.open",
     "path": "/v1/task-workflows/:workflowId/lanes/executor",
@@ -2411,7 +2431,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 240,
     "method": "POST",
     "operationId": "task.workflows.lanes.verifier.open",
     "path": "/v1/task-workflows/:workflowId/lanes/verifier",
@@ -2421,7 +2441,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 241,
     "method": "POST",
     "operationId": "task.workflows.lanes.complete",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/complete",
@@ -2431,7 +2451,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 242,
     "method": "POST",
     "operationId": "task.workflows.lanes.verdict",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/verdict",
@@ -2441,7 +2461,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 243,
     "method": "GET",
     "operationId": "task.workflows.lanes.list",
     "path": "/v1/task-workflows/:workflowId/lanes",
@@ -2451,7 +2471,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 244,
     "method": "GET",
     "operationId": "task.workflows.lanes.get",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId",
@@ -2461,7 +2481,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 245,
     "method": "POST",
     "operationId": "task.workflows.lanes.cli.handoff.record",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2471,7 +2491,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 246,
     "method": "GET",
     "operationId": "task.workflows.lanes.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2481,7 +2501,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 247,
     "method": "GET",
     "operationId": "task.workflows.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/cli-handoffs",
@@ -2491,7 +2511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 248,
     "method": "GET",
     "operationId": "task.workflows.supervisor.read",
     "path": "/v1/task-workflows/:workflowId/supervisor",
@@ -2501,7 +2521,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 249,
     "method": "POST",
     "operationId": "task.workflows.channel.command.issue",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2511,7 +2531,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 250,
     "method": "GET",
     "operationId": "task.workflows.channel.command.list",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2521,7 +2541,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 251,
     "method": "POST",
     "operationId": "task.workflows.channel.command.confirm",
     "path": "/v1/task-workflows/:workflowId/channel-commands/confirm",
@@ -2531,7 +2551,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 252,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.query",
     "path": "/v1/task-workflows/evidence",
@@ -2541,7 +2561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 253,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.raw",
     "path": "/v1/task-workflows/evidence/:evidenceRefId/raw",
@@ -2551,7 +2571,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 254,
     "method": "POST",
     "operationId": "skills.social.import",
     "path": "/v1/skills/social-import",
@@ -2561,7 +2581,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 255,
     "method": "GET",
     "operationId": "setup.status",
     "path": "/v1/setup/status",
@@ -2571,7 +2591,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 256,
     "method": "POST",
     "operationId": "providers.detect",
     "path": "/v1/providers/detect",
@@ -2581,7 +2601,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 257,
     "method": "GET",
     "operationId": "setup.network.get",
     "path": "/v1/setup/network",
@@ -2591,7 +2611,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 258,
     "method": "POST",
     "operationId": "setup.network.save",
     "path": "/v1/setup/network",
@@ -2601,7 +2621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 259,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.begin",
     "path": "/v1/setup/channels/feishu/registration/begin",
@@ -2611,7 +2631,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 260,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.poll",
     "path": "/v1/setup/channels/feishu/registration/poll",
@@ -2621,7 +2641,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 261,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.begin",
     "path": "/v1/setup/channels/telegram/verification/begin",
@@ -2631,7 +2651,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 262,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.poll",
     "path": "/v1/setup/channels/telegram/verification/poll",
@@ -2641,7 +2661,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 263,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.begin",
     "path": "/v1/setup/channels/discord/verification/begin",
@@ -2651,7 +2671,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 264,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.complete",
     "path": "/v1/setup/channels/discord/verification/complete",
@@ -2661,7 +2681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 265,
     "method": "POST",
     "operationId": "setup.channels.test",
     "path": "/v1/setup/channels/test",
@@ -2671,7 +2691,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 266,
     "method": "POST",
     "operationId": "setup.channels.save",
     "path": "/v1/setup/channels",
@@ -2681,7 +2701,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 267,
     "method": "POST",
     "operationId": "setup.complete",
     "path": "/v1/setup/complete",
@@ -2691,7 +2711,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 268,
     "method": "GET",
     "operationId": "skills.list",
     "path": "/v1/skills",
@@ -2701,7 +2721,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 269,
     "method": "GET",
     "operationId": "skills.catalog.list",
     "path": "/v1/skills/catalog",
@@ -2711,7 +2731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 270,
     "method": "GET",
     "operationId": "skills.get",
     "path": "/v1/skills/:skillId",
@@ -2721,7 +2741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 271,
     "method": "POST",
     "operationId": "skills.install",
     "path": "/v1/skills/install",
@@ -2731,7 +2751,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 272,
     "method": "POST",
     "operationId": "skills.update",
     "path": "/v1/skills/:skillId/update",
@@ -2741,7 +2761,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 273,
     "method": "DELETE",
     "operationId": "skills.delete",
     "path": "/v1/skills/:skillId",
@@ -2751,7 +2771,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 274,
     "method": "POST",
     "operationId": "skills.manifest.validate",
     "path": "/v1/skills/validate-manifest",
@@ -2761,7 +2781,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 275,
     "method": "POST",
     "operationId": "skills.verify",
     "path": "/v1/skills/:skillId/verify",
@@ -2771,7 +2791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 276,
     "method": "POST",
     "operationId": "skills.upgrade.analyze",
     "path": "/v1/skills/:skillId/upgrade/analyze",
@@ -2781,7 +2801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 277,
     "method": "POST",
     "operationId": "skills.upgrade.decide",
     "path": "/v1/skills/:skillId/upgrade/decide",
@@ -2791,7 +2811,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 278,
     "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
@@ -2801,7 +2821,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 279,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2811,7 +2831,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 280,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2821,7 +2841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 281,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2831,7 +2851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 282,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2841,7 +2861,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 283,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2851,7 +2871,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 284,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2861,7 +2881,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 285,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2871,7 +2891,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 286,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2881,7 +2901,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 287,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2891,7 +2911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 288,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2901,7 +2921,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 289,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2911,7 +2931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 290,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2921,7 +2941,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 291,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2931,7 +2951,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 292,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2941,7 +2961,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 293,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2951,7 +2971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 294,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2961,7 +2981,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 295,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2971,7 +2991,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 296,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -2981,7 +3001,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 297,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -2991,7 +3011,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 298,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -3001,7 +3021,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 299,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -3011,7 +3031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 300,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -3021,7 +3041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 301,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -3031,7 +3051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 302,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -3041,7 +3061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 303,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -3051,7 +3071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 304,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -3061,7 +3081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 305,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -3071,7 +3091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 306,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -3081,7 +3101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 307,
     "method": "PATCH",
     "operationId": "uix.learnedfacts.update",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3091,7 +3111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 308,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3101,7 +3121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 309,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -3111,7 +3131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 310,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -3121,7 +3141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 311,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -3131,7 +3151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 312,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -3141,7 +3161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 313,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -3151,7 +3171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 314,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -3161,7 +3181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 315,
     "method": "POST",
     "operationId": "packs.cross.border.run.evidence.capture",
     "path": "/v1/packs/cross-border/run-evidence",
@@ -3171,7 +3191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 316,
     "method": "PATCH",
     "operationId": "packs.cross.border.import.stale",
     "path": "/v1/packs/cross-border/imports/:importBatchId/stale",
@@ -3181,7 +3201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 317,
     "method": "POST",
     "operationId": "packs.cross.border.workflows.disable.all",
     "path": "/v1/packs/cross-border/workflows/disable-all",
@@ -3191,7 +3211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 318,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -3201,7 +3221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 319,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -3211,7 +3231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 320,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -3221,7 +3241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 321,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -3231,7 +3251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 322,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -3241,7 +3261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 323,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3251,7 +3271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 324,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -3261,7 +3281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 325,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -3271,7 +3291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 326,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -3281,7 +3301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 327,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -3291,7 +3311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 328,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3301,7 +3321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 329,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -3311,7 +3331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 330,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3321,7 +3341,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 331,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -3331,7 +3351,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 332,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3341,7 +3361,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 333,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -3351,7 +3371,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 334,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -3361,7 +3381,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 335,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -3371,7 +3391,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 336,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -3381,7 +3401,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 337,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -3391,7 +3411,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 338,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -3401,7 +3421,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 339,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -3411,7 +3431,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 340,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -3421,7 +3441,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 341,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -3431,7 +3451,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 342,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -3441,7 +3461,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 343,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -3451,7 +3471,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 344,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -3461,7 +3481,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 345,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -3471,7 +3491,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 346,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -3481,7 +3501,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 347,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -3491,7 +3511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 348,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -3501,7 +3521,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 349,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -3511,7 +3531,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 350,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -3521,7 +3541,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 351,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -3531,7 +3551,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 352,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -3541,7 +3561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 353,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -3551,7 +3571,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 354,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -3561,7 +3581,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 355,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -3571,7 +3591,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 356,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -3581,7 +3601,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 357,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -3591,7 +3611,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 358,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -3601,7 +3621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 359,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -3611,7 +3631,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 360,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -3621,7 +3641,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 361,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -3631,7 +3651,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 362,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3641,7 +3661,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 363,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3651,7 +3671,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 364,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3661,7 +3681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 365,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3671,7 +3691,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 366,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3681,7 +3701,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 367,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3691,7 +3711,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 368,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3701,7 +3721,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 369,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3711,7 +3731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 370,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3721,7 +3741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 369,
+    "index": 371,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3731,7 +3751,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 370,
+    "index": 372,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3741,7 +3761,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 371,
+    "index": 373,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3751,7 +3771,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 372,
+    "index": 374,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3761,7 +3781,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 373,
+    "index": 375,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3771,7 +3791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 374,
+    "index": 376,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3781,7 +3801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 375,
+    "index": 377,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3791,7 +3811,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 376,
+    "index": 378,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3801,7 +3821,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 377,
+    "index": 379,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3811,7 +3831,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 378,
+    "index": 380,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3821,7 +3841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 379,
+    "index": 381,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3831,7 +3851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 380,
+    "index": 382,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3841,7 +3861,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 381,
+    "index": 383,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3851,7 +3871,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 382,
+    "index": 384,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3861,7 +3881,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 383,
+    "index": 385,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3871,7 +3891,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 384,
+    "index": 386,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3881,7 +3901,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 385,
+    "index": 387,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3891,7 +3911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 386,
+    "index": 388,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3901,7 +3921,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 387,
+    "index": 389,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3911,7 +3931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 388,
+    "index": 390,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3921,7 +3941,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 389,
+    "index": 391,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3931,7 +3951,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 390,
+    "index": 392,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3941,7 +3961,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 391,
+    "index": 393,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3951,7 +3971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 392,
+    "index": 394,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3961,7 +3981,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 393,
+    "index": 395,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3971,7 +3991,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 394,
+    "index": 396,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -3981,7 +4001,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 395,
+    "index": 397,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -3991,7 +4011,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 396,
+    "index": 398,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -4001,7 +4021,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 397,
+    "index": 399,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -4011,7 +4031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 398,
+    "index": 400,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -4021,7 +4041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 399,
+    "index": 401,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -4031,7 +4051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 400,
+    "index": 402,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -4041,7 +4061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 401,
+    "index": 403,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -4051,7 +4071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 402,
+    "index": 404,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -4061,7 +4081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 403,
+    "index": 405,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -4071,7 +4091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 404,
+    "index": 406,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -4081,7 +4101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 405,
+    "index": 407,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -4091,7 +4111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 406,
+    "index": 408,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -4101,7 +4121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 407,
+    "index": 409,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -4111,7 +4131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 408,
+    "index": 410,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -4121,7 +4141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 411,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -4131,7 +4151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 410,
+    "index": 412,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -4141,7 +4161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 411,
+    "index": 413,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -4151,7 +4171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 412,
+    "index": 414,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -4161,7 +4181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 413,
+    "index": 415,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -4171,7 +4191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 414,
+    "index": 416,
     "method": "POST",
     "operationId": "agent.runs.resume",
     "path": "/v1/agent/runs/:runId/resume",
@@ -4181,7 +4201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 415,
+    "index": 417,
     "method": "POST",
     "operationId": "agent.d20.worktree.batch.dispatch",
     "path": "/v1/agent/d20/worktree-batches/dispatch",
@@ -4191,7 +4211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 416,
+    "index": 418,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -4201,7 +4221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 417,
+    "index": 419,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -4211,7 +4231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 418,
+    "index": 420,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -4221,7 +4241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 419,
+    "index": 421,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -4231,7 +4251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 420,
+    "index": 422,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4241,7 +4261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 421,
+    "index": 423,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4251,7 +4271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 422,
+    "index": 424,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4261,7 +4281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 423,
+    "index": 425,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4271,7 +4291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 424,
+    "index": 426,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4281,7 +4301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 425,
+    "index": 427,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4291,7 +4311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 426,
+    "index": 428,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4301,7 +4321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 427,
+    "index": 429,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4311,7 +4331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 428,
+    "index": 430,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4321,7 +4341,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 429,
+    "index": 431,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4331,7 +4351,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 430,
+    "index": 432,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4341,7 +4361,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 431,
+    "index": 433,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4351,7 +4371,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 432,
+    "index": 434,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
+++ b/test/contracts/api/__snapshots__/friday-api-route-contract.snapshot.test.ts.snap
@@ -7,10 +7,10 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
     "channel_signature": 4,
     "hmac_or_bearer_opt_in": 1,
     "public_low_risk": 2,
-    "rate_limited_pending": 6,
+    "rate_limited_pending": 7,
     "unclassified": 251,
   },
-  "total_public_mutating": 335,
+  "total_public_mutating": 336,
   "unclassified_sample_max_5": [
     "capabilities.acquisition.runs.create",
     "capabilities.acquisition.runs.approve",
@@ -21,7 +21,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > Phase 14.5A WP-001: eve
 }
 `;
 
-exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `435`;
+exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures route count to detect accidental additions/removals 1`] = `436`;
 
 exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route surface as a stable contract 1`] = `
 [
@@ -453,6 +453,16 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
     "authKind": "public",
     "index": 42,
     "method": "POST",
+    "operationId": "auth.login.challenge",
+    "path": "/v1/auth/login/challenge",
+    "rateLimitPolicyId": "auth.login",
+    "roles": [],
+    "scopes": [],
+  },
+  {
+    "authKind": "public",
+    "index": 43,
+    "method": "POST",
     "operationId": "auth.bootstrap.device.claim",
     "path": "/v1/auth/bootstrap/device-claim",
     "rateLimitPolicyId": "auth.login",
@@ -461,7 +471,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 43,
+    "index": 44,
     "method": "POST",
     "operationId": "auth.migrate.challenge",
     "path": "/v1/auth/migrate/challenge",
@@ -471,7 +481,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 44,
+    "index": 45,
     "method": "POST",
     "operationId": "auth.migrate.device.claim",
     "path": "/v1/auth/migrate/device-claim",
@@ -481,7 +491,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 45,
+    "index": 46,
     "method": "POST",
     "operationId": "auth.migrate.device.readback",
     "path": "/v1/auth/migrate/device-readback",
@@ -491,7 +501,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 46,
+    "index": 47,
     "method": "GET",
     "operationId": "auth.migrate.device.binding.read",
     "path": "/v1/auth/migrate/device-binding",
@@ -501,7 +511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 47,
+    "index": 48,
     "method": "POST",
     "operationId": "auth.login",
     "path": "/v1/auth/login",
@@ -511,7 +521,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 48,
+    "index": 49,
     "method": "POST",
     "operationId": "auth.refresh",
     "path": "/v1/auth/refresh",
@@ -521,7 +531,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 49,
+    "index": 50,
     "method": "POST",
     "operationId": "auth.logout",
     "path": "/v1/auth/logout",
@@ -531,7 +541,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 50,
+    "index": 51,
     "method": "GET",
     "operationId": "auth.me",
     "path": "/v1/auth/me",
@@ -541,7 +551,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 51,
+    "index": 52,
     "method": "GET",
     "operationId": "secrets.list",
     "path": "/v1/secrets",
@@ -551,7 +561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 52,
+    "index": 53,
     "method": "GET",
     "operationId": "secrets.get",
     "path": "/v1/secrets/:secretId",
@@ -561,7 +571,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 53,
+    "index": 54,
     "method": "POST",
     "operationId": "secrets.create",
     "path": "/v1/secrets",
@@ -571,7 +581,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 54,
+    "index": 55,
     "method": "PATCH",
     "operationId": "secrets.update",
     "path": "/v1/secrets/:secretId",
@@ -581,7 +591,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 55,
+    "index": 56,
     "method": "DELETE",
     "operationId": "secrets.delete",
     "path": "/v1/secrets/:secretId",
@@ -591,7 +601,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 56,
+    "index": 57,
     "method": "GET",
     "operationId": "workflows.list",
     "path": "/v1/workflows",
@@ -601,7 +611,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 57,
+    "index": 58,
     "method": "POST",
     "operationId": "workflows.create",
     "path": "/v1/workflows",
@@ -611,7 +621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 58,
+    "index": 59,
     "method": "GET",
     "operationId": "workflows.get",
     "path": "/v1/workflows/:workflowId",
@@ -621,7 +631,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 59,
+    "index": 60,
     "method": "PATCH",
     "operationId": "workflows.update",
     "path": "/v1/workflows/:workflowId",
@@ -631,7 +641,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 60,
+    "index": 61,
     "method": "DELETE",
     "operationId": "workflows.archive",
     "path": "/v1/workflows/:workflowId",
@@ -641,7 +651,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 61,
+    "index": 62,
     "method": "POST",
     "operationId": "workflows.publish",
     "path": "/v1/workflows/:workflowId/publish",
@@ -651,7 +661,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 62,
+    "index": 63,
     "method": "GET",
     "operationId": "workflows.list.versions",
     "path": "/v1/workflows/:workflowId/versions",
@@ -661,7 +671,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 63,
+    "index": 64,
     "method": "GET",
     "operationId": "workflow.versions.get",
     "path": "/v1/workflow-versions/:versionId",
@@ -671,7 +681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 64,
+    "index": 65,
     "method": "GET",
     "operationId": "templates.list",
     "path": "/v1/workflow-builder/templates",
@@ -681,7 +691,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 65,
+    "index": 66,
     "method": "GET",
     "operationId": "templates.get",
     "path": "/v1/workflow-builder/templates/:templateId",
@@ -691,7 +701,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 66,
+    "index": 67,
     "method": "POST",
     "operationId": "templates.instantiate",
     "path": "/v1/workflow-builder/templates/:templateId/instantiate",
@@ -701,7 +711,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 67,
+    "index": 68,
     "method": "GET",
     "operationId": "drafts.list",
     "path": "/v1/workflows/:workflowId/drafts",
@@ -711,7 +721,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 68,
+    "index": 69,
     "method": "POST",
     "operationId": "drafts.create",
     "path": "/v1/workflows/:workflowId/drafts",
@@ -721,7 +731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 69,
+    "index": 70,
     "method": "GET",
     "operationId": "drafts.get",
     "path": "/v1/workflows/:workflowId/drafts/:draftId",
@@ -731,7 +741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 70,
+    "index": 71,
     "method": "GET",
     "operationId": "drafts.export",
     "path": "/v1/workflows/:workflowId/drafts/:draftId/export",
@@ -741,7 +751,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 71,
+    "index": 72,
     "method": "POST",
     "operationId": "workflows.bundles.import",
     "path": "/v1/workflows/:workflowId/import",
@@ -751,7 +761,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 72,
+    "index": 73,
     "method": "PATCH",
     "operationId": "drafts.save",
     "path": "/v1/workflows/:workflowId/drafts/:draftId",
@@ -761,7 +771,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 73,
+    "index": 74,
     "method": "POST",
     "operationId": "drafts.autosave",
     "path": "/v1/workflows/:workflowId/drafts/:draftId/autosave",
@@ -771,7 +781,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 74,
+    "index": 75,
     "method": "POST",
     "operationId": "drafts.compile",
     "path": "/v1/workflows/:workflowId/drafts/:draftId/compile",
@@ -781,7 +791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 75,
+    "index": 76,
     "method": "POST",
     "operationId": "drafts.publish",
     "path": "/v1/workflows/:workflowId/drafts/:draftId/publish",
@@ -791,7 +801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 76,
+    "index": 77,
     "method": "POST",
     "operationId": "locks.acquire",
     "path": "/v1/workflows/:workflowId/locks/acquire",
@@ -801,7 +811,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 77,
+    "index": 78,
     "method": "POST",
     "operationId": "locks.renew",
     "path": "/v1/workflows/:workflowId/locks/renew",
@@ -811,7 +821,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 78,
+    "index": 79,
     "method": "POST",
     "operationId": "locks.release",
     "path": "/v1/workflows/:workflowId/locks/release",
@@ -821,7 +831,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 79,
+    "index": 80,
     "method": "GET",
     "operationId": "workflows.overview",
     "path": "/v1/workflows/:workflowId/overview",
@@ -831,7 +841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 80,
+    "index": 81,
     "method": "GET",
     "operationId": "workflows.visualization",
     "path": "/v1/workflows/:workflowId/visualization",
@@ -841,7 +851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 81,
+    "index": 82,
     "method": "POST",
     "operationId": "workflows.deploy",
     "path": "/v1/workflows/:workflowId/drafts/:draftId/deploy",
@@ -851,7 +861,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 82,
+    "index": 83,
     "method": "POST",
     "operationId": "runs.start",
     "path": "/v1/workflow-runs",
@@ -861,7 +871,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 83,
+    "index": 84,
     "method": "GET",
     "operationId": "runs.get",
     "path": "/v1/workflow-runs/:runId",
@@ -871,7 +881,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 84,
+    "index": 85,
     "method": "GET",
     "operationId": "runs.list.nodes",
     "path": "/v1/workflow-runs/:runId/nodes",
@@ -881,7 +891,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 85,
+    "index": 86,
     "method": "GET",
     "operationId": "runs.timeline",
     "path": "/v1/workflow-runs/:runId/timeline",
@@ -891,7 +901,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 86,
+    "index": 87,
     "method": "GET",
     "operationId": "runs.evidence",
     "path": "/v1/workflow-runs/:runId/evidence",
@@ -901,7 +911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 87,
+    "index": 88,
     "method": "GET",
     "operationId": "runs.evidence.exports.list",
     "path": "/v1/workflow-runs/:runId/evidence/exports",
@@ -911,7 +921,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 88,
+    "index": 89,
     "method": "POST",
     "operationId": "runs.evidence.export",
     "path": "/v1/workflow-runs/:runId/evidence/exports",
@@ -921,7 +931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 89,
+    "index": 90,
     "method": "GET",
     "operationId": "runs.evidence.exports.get",
     "path": "/v1/workflow-runs/:runId/evidence/exports/:exportId",
@@ -931,7 +941,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 90,
+    "index": 91,
     "method": "GET",
     "operationId": "runs.evidence.exports.download",
     "path": "/v1/workflow-runs/:runId/evidence/exports/:exportId/download",
@@ -941,7 +951,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 91,
+    "index": 92,
     "method": "POST",
     "operationId": "runs.cancel",
     "path": "/v1/workflow-runs/:runId/cancel",
@@ -951,7 +961,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 92,
+    "index": 93,
     "method": "POST",
     "operationId": "runs.retry",
     "path": "/v1/workflow-runs/:runId/retry",
@@ -961,7 +971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 93,
+    "index": 94,
     "method": "POST",
     "operationId": "workflows.runs.resume",
     "path": "/v1/workflow-runs/:runId/resume",
@@ -971,7 +981,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 94,
+    "index": 95,
     "method": "GET",
     "operationId": "workflows.approvals.list",
     "path": "/v1/workflow-approvals",
@@ -981,7 +991,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 95,
+    "index": 96,
     "method": "GET",
     "operationId": "workflows.approvals.get",
     "path": "/v1/workflow-approvals/:approvalId",
@@ -991,7 +1001,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 96,
+    "index": 97,
     "method": "POST",
     "operationId": "workflows.approvals.approve",
     "path": "/v1/workflow-approvals/:approvalId/approve",
@@ -1001,7 +1011,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 97,
+    "index": 98,
     "method": "POST",
     "operationId": "workflows.approvals.reject",
     "path": "/v1/workflow-approvals/:approvalId/reject",
@@ -1011,7 +1021,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 98,
+    "index": 99,
     "method": "GET",
     "operationId": "approvals.list",
     "path": "/v1/approvals",
@@ -1021,7 +1031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 99,
+    "index": 100,
     "method": "GET",
     "operationId": "approvals.get",
     "path": "/v1/approvals/:approvalId",
@@ -1031,7 +1041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 100,
+    "index": 101,
     "method": "POST",
     "operationId": "approvals.approve",
     "path": "/v1/approvals/:approvalId/approve",
@@ -1041,7 +1051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 101,
+    "index": 102,
     "method": "POST",
     "operationId": "approvals.reject",
     "path": "/v1/approvals/:approvalId/reject",
@@ -1051,7 +1061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 102,
+    "index": 103,
     "method": "GET",
     "operationId": "workflows.triggers.list",
     "path": "/v1/workflows/:workflowId/triggers",
@@ -1061,7 +1071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 103,
+    "index": 104,
     "method": "PATCH",
     "operationId": "workflows.triggers.update",
     "path": "/v1/workflow-triggers/:registrationId",
@@ -1071,7 +1081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 104,
+    "index": 105,
     "method": "POST",
     "operationId": "workflows.triggers.resync",
     "path": "/v1/workflows/:workflowId/triggers/resync",
@@ -1081,7 +1091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 105,
+    "index": 106,
     "method": "POST",
     "operationId": "workflows.webhooks.invoke",
     "path": "/v1/workflow-webhooks/:pathToken",
@@ -1091,7 +1101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 106,
+    "index": 107,
     "method": "GET",
     "operationId": "conflicts.list",
     "path": "/v1/workflows/:workflowId/conflicts",
@@ -1101,7 +1111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 107,
+    "index": 108,
     "method": "POST",
     "operationId": "conflicts.resolve",
     "path": "/v1/workflows/:workflowId/conflicts/:conflictId/resolve",
@@ -1111,7 +1121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 108,
+    "index": 109,
     "method": "GET",
     "operationId": "fleet.overview",
     "path": "/v1/fleet/overview",
@@ -1121,7 +1131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 109,
+    "index": 110,
     "method": "GET",
     "operationId": "fleet.list.satellites",
     "path": "/v1/fleet/satellites",
@@ -1131,7 +1141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 110,
+    "index": 111,
     "method": "GET",
     "operationId": "fleet.get.satellite.detail",
     "path": "/v1/fleet/satellites/:satelliteId",
@@ -1141,7 +1151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 111,
+    "index": 112,
     "method": "GET",
     "operationId": "fleet.get.satellite.remediation",
     "path": "/v1/fleet/satellites/:satelliteId/remediation",
@@ -1151,7 +1161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 112,
+    "index": 113,
     "method": "POST",
     "operationId": "fleet.execute.satellite.remediation",
     "path": "/v1/fleet/satellites/:satelliteId/remediation/:actionId/execute",
@@ -1161,7 +1171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 113,
+    "index": 114,
     "method": "GET",
     "operationId": "security.center",
     "path": "/v1/security/center",
@@ -1171,7 +1181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 114,
+    "index": 115,
     "method": "POST",
     "operationId": "security.revoke.token",
     "path": "/v1/security/tokens/revoke",
@@ -1181,7 +1191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 115,
+    "index": 116,
     "method": "POST",
     "operationId": "security.revoke.satellite",
     "path": "/v1/security/satellites/:satelliteId/revoke",
@@ -1191,7 +1201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 116,
+    "index": 117,
     "method": "POST",
     "operationId": "deeplink.preview",
     "path": "/v1/deeplink/preview",
@@ -1201,7 +1211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 117,
+    "index": 118,
     "method": "POST",
     "operationId": "deeplink.apply",
     "path": "/v1/deeplink/apply",
@@ -1211,7 +1221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 118,
+    "index": 119,
     "method": "GET",
     "operationId": "grants.list",
     "path": "/v1/grants",
@@ -1221,7 +1231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 119,
+    "index": 120,
     "method": "POST",
     "operationId": "grants.revoke",
     "path": "/v1/grants/:grantId/revoke",
@@ -1231,7 +1241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 120,
+    "index": 121,
     "method": "GET",
     "operationId": "diagnosis.incidents.list",
     "path": "/v1/diagnosis/incidents",
@@ -1241,7 +1251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 121,
+    "index": 122,
     "method": "GET",
     "operationId": "learning.incidents.list",
     "path": "/v1/learning/incidents",
@@ -1251,7 +1261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 122,
+    "index": 123,
     "method": "GET",
     "operationId": "diagnosis.incidents.get",
     "path": "/v1/diagnosis/incidents/:incidentId",
@@ -1261,7 +1271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 123,
+    "index": 124,
     "method": "GET",
     "operationId": "learning.incidents.get",
     "path": "/v1/learning/incidents/:incidentId",
@@ -1271,7 +1281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 124,
+    "index": 125,
     "method": "GET",
     "operationId": "diagnosis.incidents.diagnosis.get",
     "path": "/v1/diagnosis/incidents/:incidentId/diagnosis",
@@ -1281,7 +1291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 125,
+    "index": 126,
     "method": "GET",
     "operationId": "learning.incidents.diagnosis.get",
     "path": "/v1/learning/incidents/:incidentId/diagnosis",
@@ -1291,7 +1301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 126,
+    "index": 127,
     "method": "GET",
     "operationId": "diagnosis.learning.overview",
     "path": "/v1/diagnosis/learning/overview",
@@ -1301,7 +1311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 127,
+    "index": 128,
     "method": "GET",
     "operationId": "learning.overview.get",
     "path": "/v1/learning/overview",
@@ -1311,7 +1321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 128,
+    "index": 129,
     "method": "POST",
     "operationId": "diagnosis.incidents.manual.resolve",
     "path": "/v1/diagnosis/incidents/:incidentId/manual-resolve",
@@ -1321,7 +1331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 129,
+    "index": 130,
     "method": "POST",
     "operationId": "diagnosis.lessons.enabled.set",
     "path": "/v1/diagnosis/lessons/:lessonId/enabled",
@@ -1331,7 +1341,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 130,
+    "index": 131,
     "method": "POST",
     "operationId": "diagnosis.patterns.demote",
     "path": "/v1/diagnosis/patterns/:patternId/demote",
@@ -1341,7 +1351,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 131,
+    "index": 132,
     "method": "GET",
     "operationId": "autofix.actions.list",
     "path": "/v1/auto-fix/actions",
@@ -1351,7 +1361,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 132,
+    "index": 133,
     "method": "POST",
     "operationId": "autofix.actions.run.ready",
     "path": "/v1/auto-fix/actions/run-ready",
@@ -1361,7 +1371,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 133,
+    "index": 134,
     "method": "GET",
     "operationId": "autofix.actions.get",
     "path": "/v1/auto-fix/actions/:actionId",
@@ -1371,7 +1381,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 134,
+    "index": 135,
     "method": "POST",
     "operationId": "autofix.actions.approve",
     "path": "/v1/auto-fix/actions/:actionId/approve",
@@ -1381,7 +1391,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 135,
+    "index": 136,
     "method": "POST",
     "operationId": "autofix.actions.deny",
     "path": "/v1/auto-fix/actions/:actionId/deny",
@@ -1391,7 +1401,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 136,
+    "index": 137,
     "method": "POST",
     "operationId": "autofix.actions.execute",
     "path": "/v1/auto-fix/actions/:actionId/execute",
@@ -1401,7 +1411,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 137,
+    "index": 138,
     "method": "POST",
     "operationId": "autofix.actions.rollback",
     "path": "/v1/auto-fix/actions/:actionId/rollback",
@@ -1411,7 +1421,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 138,
+    "index": 139,
     "method": "GET",
     "operationId": "autofix.metrics.get",
     "path": "/v1/auto-fix/metrics",
@@ -1421,7 +1431,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 139,
+    "index": 140,
     "method": "POST",
     "operationId": "discovery.scan",
     "path": "/v1/discovery/scan",
@@ -1431,7 +1441,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 140,
+    "index": 141,
     "method": "GET",
     "operationId": "discovery.catalog.get",
     "path": "/v1/discovery/catalog",
@@ -1441,7 +1451,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 141,
+    "index": 142,
     "method": "GET",
     "operationId": "discovery.programs.list",
     "path": "/v1/discovery/programs",
@@ -1451,7 +1461,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 142,
+    "index": 143,
     "method": "GET",
     "operationId": "discovery.recommend",
     "path": "/v1/discovery/recommendations",
@@ -1461,7 +1471,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 143,
+    "index": 144,
     "method": "GET",
     "operationId": "discovery.policy.get",
     "path": "/v1/discovery/policy",
@@ -1471,7 +1481,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 144,
+    "index": 145,
     "method": "PATCH",
     "operationId": "discovery.policy.update",
     "path": "/v1/discovery/policy",
@@ -1481,7 +1491,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 145,
+    "index": 146,
     "method": "GET",
     "operationId": "discovery.status",
     "path": "/v1/discovery/status",
@@ -1491,7 +1501,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 146,
+    "index": 147,
     "method": "POST",
     "operationId": "discovery.integrate",
     "path": "/v1/discovery/integrate",
@@ -1501,7 +1511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 147,
+    "index": 148,
     "method": "POST",
     "operationId": "mcp.server.rpc",
     "path": "/v1/mcp",
@@ -1511,7 +1521,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 148,
+    "index": 149,
     "method": "POST",
     "operationId": "channels.webhooks.line",
     "path": "/v1/channel-webhooks/line",
@@ -1521,7 +1531,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 149,
+    "index": 150,
     "method": "GET",
     "operationId": "channels.webhooks.whatsapp.verify",
     "path": "/v1/channel-webhooks/whatsapp",
@@ -1531,7 +1541,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 150,
+    "index": 151,
     "method": "POST",
     "operationId": "channels.webhooks.whatsapp",
     "path": "/v1/channel-webhooks/whatsapp",
@@ -1541,7 +1551,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 151,
+    "index": 152,
     "method": "POST",
     "operationId": "channels.webhooks.telegram",
     "path": "/v1/channel-webhooks/telegram",
@@ -1551,7 +1561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 152,
+    "index": 153,
     "method": "POST",
     "operationId": "channels.webhooks.lark",
     "path": "/v1/channel-webhooks/lark",
@@ -1561,7 +1571,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 153,
+    "index": 154,
     "method": "POST",
     "operationId": "packaging.packages.publish",
     "path": "/v1/packages",
@@ -1571,7 +1581,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 154,
+    "index": 155,
     "method": "GET",
     "operationId": "packaging.packages.list",
     "path": "/v1/packages",
@@ -1581,7 +1591,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 155,
+    "index": 156,
     "method": "GET",
     "operationId": "packaging.packages.get",
     "path": "/v1/packages/:packageId",
@@ -1591,7 +1601,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 156,
+    "index": 157,
     "method": "GET",
     "operationId": "packaging.packages.versions.list",
     "path": "/v1/packages/:packageName/versions",
@@ -1601,7 +1611,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 157,
+    "index": 158,
     "method": "POST",
     "operationId": "packaging.packages.verify",
     "path": "/v1/packages/:packageId/verify",
@@ -1611,7 +1621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 158,
+    "index": 159,
     "method": "POST",
     "operationId": "packaging.packages.dependencies.check",
     "path": "/v1/packages/:packageName/check-dependencies",
@@ -1621,7 +1631,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 159,
+    "index": 160,
     "method": "POST",
     "operationId": "packaging.installs.install",
     "path": "/v1/packages/:packageName/install",
@@ -1631,7 +1641,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 160,
+    "index": 161,
     "method": "POST",
     "operationId": "packaging.installs.upgrade",
     "path": "/v1/packages/:packageName/upgrade",
@@ -1641,7 +1651,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 161,
+    "index": 162,
     "method": "POST",
     "operationId": "packaging.installs.rollback",
     "path": "/v1/packages/:packageName/rollback",
@@ -1651,7 +1661,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 162,
+    "index": 163,
     "method": "POST",
     "operationId": "packaging.installs.uninstall",
     "path": "/v1/packages/:packageName/uninstall",
@@ -1661,7 +1671,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 163,
+    "index": 164,
     "method": "GET",
     "operationId": "packaging.installs.list",
     "path": "/v1/packages/installs",
@@ -1671,7 +1681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 164,
+    "index": 165,
     "method": "GET",
     "operationId": "packaging.installs.get",
     "path": "/v1/packages/installs/:installId",
@@ -1681,7 +1691,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 165,
+    "index": 166,
     "method": "GET",
     "operationId": "packaging.lifecycle.list",
     "path": "/v1/packages/lifecycle",
@@ -1691,7 +1701,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 166,
+    "index": 167,
     "method": "GET",
     "operationId": "packaging.keys.list",
     "path": "/v1/packages/keys",
@@ -1701,7 +1711,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 167,
+    "index": 168,
     "method": "POST",
     "operationId": "packaging.keys.add",
     "path": "/v1/packages/keys",
@@ -1711,7 +1721,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 168,
+    "index": 169,
     "method": "POST",
     "operationId": "packaging.keys.revoke",
     "path": "/v1/packages/keys/:keyId/revoke",
@@ -1721,7 +1731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 169,
+    "index": 170,
     "method": "POST",
     "operationId": "packaging.keys.rotate",
     "path": "/v1/packages/keys/:keyId/rotate",
@@ -1731,7 +1741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 170,
+    "index": 171,
     "method": "GET",
     "operationId": "cloud.workers.catalog.list",
     "path": "/v1/cloud-workers/catalog",
@@ -1741,7 +1751,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 171,
+    "index": 172,
     "method": "GET",
     "operationId": "cloud.workers.preview.get",
     "path": "/v1/cloud-workers/preview/:providerId",
@@ -1751,7 +1761,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 172,
+    "index": 173,
     "method": "GET",
     "operationId": "cloud.workers.doctor.run",
     "path": "/v1/cloud-workers/doctor",
@@ -1761,7 +1771,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 173,
+    "index": 174,
     "method": "POST",
     "operationId": "cloud.workers.dns.validate",
     "path": "/v1/cloud-workers/dns/validate",
@@ -1771,7 +1781,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 174,
+    "index": 175,
     "method": "POST",
     "operationId": "cloud.workers.package.generate",
     "path": "/v1/cloud-workers/package",
@@ -1781,7 +1791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 175,
+    "index": 176,
     "method": "POST",
     "operationId": "cloud.workers.teardown.receipt",
     "path": "/v1/cloud-workers/teardown-receipt",
@@ -1791,7 +1801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 176,
+    "index": 177,
     "method": "GET",
     "operationId": "studio.products.list",
     "path": "/v1/studio/products",
@@ -1801,7 +1811,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 177,
+    "index": 178,
     "method": "POST",
     "operationId": "studio.runs.create",
     "path": "/v1/studio/runs",
@@ -1811,7 +1821,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 178,
+    "index": 179,
     "method": "GET",
     "operationId": "studio.runs.get",
     "path": "/v1/studio/runs/:runId",
@@ -1821,7 +1831,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 179,
+    "index": 180,
     "method": "GET",
     "operationId": "studio.artifacts.get",
     "path": "/v1/studio/runs/:runId/artifacts/:artifactId",
@@ -1831,7 +1841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 180,
+    "index": 181,
     "method": "GET",
     "operationId": "studio.runs.export",
     "path": "/v1/studio/runs/:runId/export",
@@ -1841,7 +1851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 181,
+    "index": 182,
     "method": "POST",
     "operationId": "studio.imports.create",
     "path": "/v1/studio/imports",
@@ -1851,7 +1861,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 182,
+    "index": 183,
     "method": "POST",
     "operationId": "studio.artifacts.validate.candidate",
     "path": "/v1/studio/runs/:runId/validate-candidate",
@@ -1861,7 +1871,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 183,
+    "index": 184,
     "method": "GET",
     "operationId": "mission.spine.workbench.get",
     "path": "/v1/mission-spine/workbench",
@@ -1871,7 +1881,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 184,
+    "index": 185,
     "method": "POST",
     "operationId": "mission.spine.intake.create",
     "path": "/v1/mission-spine/intake",
@@ -1881,7 +1891,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 185,
+    "index": 186,
     "method": "POST",
     "operationId": "mission.spine.lifecycle.transition",
     "path": "/v1/mission-spine/:missionId/lifecycle",
@@ -1891,7 +1901,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 186,
+    "index": 187,
     "method": "POST",
     "operationId": "mission.spine.workitem.status.transition",
     "path": "/v1/mission-spine/work-items/:workItemId/status",
@@ -1901,7 +1911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 187,
+    "index": 188,
     "method": "POST",
     "operationId": "mission.spine.routedecision.control",
     "path": "/v1/mission-spine/route-decisions/:decisionId/control",
@@ -1911,7 +1921,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 188,
+    "index": 189,
     "method": "POST",
     "operationId": "memory.spine.decide.apply",
     "path": "/v1/memory-spine/decide",
@@ -1921,7 +1931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 189,
+    "index": 190,
     "method": "POST",
     "operationId": "run.outcome.learning.decide.apply",
     "path": "/v1/run-outcome-learning/decide",
@@ -1931,7 +1941,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 190,
+    "index": 191,
     "method": "POST",
     "operationId": "realtime.subscribe",
     "path": "/v1/realtime/subscriptions",
@@ -1941,7 +1951,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 191,
+    "index": 192,
     "method": "POST",
     "operationId": "realtime.pull",
     "path": "/v1/realtime/pull",
@@ -1951,7 +1961,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 192,
+    "index": 193,
     "method": "POST",
     "operationId": "realtime.ack",
     "path": "/v1/realtime/ack",
@@ -1961,7 +1971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 193,
+    "index": 194,
     "method": "GET",
     "operationId": "providers.usage.get",
     "path": "/v1/providers/usage",
@@ -1971,7 +1981,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 194,
+    "index": 195,
     "method": "GET",
     "operationId": "providers.budget.get",
     "path": "/v1/providers/budget",
@@ -1981,7 +1991,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 195,
+    "index": 196,
     "method": "PUT",
     "operationId": "providers.budget.set",
     "path": "/v1/providers/budget",
@@ -1991,7 +2001,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 196,
+    "index": 197,
     "method": "GET",
     "operationId": "providers.templates.list",
     "path": "/v1/providers/templates",
@@ -2001,7 +2011,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 197,
+    "index": 198,
     "method": "POST",
     "operationId": "providers.plan",
     "path": "/v1/providers/plan",
@@ -2011,7 +2021,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 198,
+    "index": 199,
     "method": "POST",
     "operationId": "providers.plan.confirm",
     "path": "/v1/providers/plan/confirm",
@@ -2021,7 +2031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 199,
+    "index": 200,
     "method": "GET",
     "operationId": "providers.templates.get",
     "path": "/v1/providers/templates/:templateId",
@@ -2031,7 +2041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 200,
+    "index": 201,
     "method": "GET",
     "operationId": "providers.list",
     "path": "/v1/providers",
@@ -2041,7 +2051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 201,
+    "index": 202,
     "method": "GET",
     "operationId": "providers.health.list",
     "path": "/v1/providers/health",
@@ -2051,7 +2061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 202,
+    "index": 203,
     "method": "GET",
     "operationId": "providers.capability.health.list",
     "path": "/v1/providers/capability-health",
@@ -2061,7 +2071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 203,
+    "index": 204,
     "method": "POST",
     "operationId": "capabilities.doctor",
     "path": "/v1/capabilities/doctor",
@@ -2071,7 +2081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 204,
+    "index": 205,
     "method": "GET",
     "operationId": "providers.get",
     "path": "/v1/providers/:providerId",
@@ -2081,7 +2091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 205,
+    "index": 206,
     "method": "POST",
     "operationId": "providers.create",
     "path": "/v1/providers",
@@ -2091,7 +2101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 206,
+    "index": 207,
     "method": "PATCH",
     "operationId": "providers.update",
     "path": "/v1/providers/:providerId",
@@ -2101,7 +2111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 207,
+    "index": 208,
     "method": "DELETE",
     "operationId": "providers.delete",
     "path": "/v1/providers/:providerId",
@@ -2111,7 +2121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 208,
+    "index": 209,
     "method": "POST",
     "operationId": "providers.validate",
     "path": "/v1/providers/:providerId/validate",
@@ -2121,7 +2131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 209,
+    "index": 210,
     "method": "GET",
     "operationId": "providers.doctor",
     "path": "/v1/providers/:providerId/doctor",
@@ -2131,7 +2141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 210,
+    "index": 211,
     "method": "GET",
     "operationId": "providers.routing.explain",
     "path": "/v1/providers/routing/explain",
@@ -2141,7 +2151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 211,
+    "index": 212,
     "method": "POST",
     "operationId": "providers.routing.pin",
     "path": "/v1/providers/routing/pin",
@@ -2151,7 +2161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 212,
+    "index": 213,
     "method": "POST",
     "operationId": "providers.routing.penalty.clear",
     "path": "/v1/providers/routing/penalties/clear",
@@ -2161,7 +2171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 213,
+    "index": 214,
     "method": "GET",
     "operationId": "providers.auth.profiles.list",
     "path": "/v1/providers/:providerId/auth-profiles",
@@ -2171,7 +2181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 214,
+    "index": 215,
     "method": "POST",
     "operationId": "providers.auth.profiles.activate",
     "path": "/v1/providers/:providerId/auth-profiles/:profileKey/activate",
@@ -2181,7 +2191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 215,
+    "index": 216,
     "method": "GET",
     "operationId": "providers.routing.get",
     "path": "/v1/model-routing",
@@ -2191,7 +2201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 216,
+    "index": 217,
     "method": "PUT",
     "operationId": "providers.routing.set",
     "path": "/v1/model-routing",
@@ -2201,7 +2211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 217,
+    "index": 218,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.initiate",
     "path": "/v1/auth/oauth/anthropic/initiate",
@@ -2211,7 +2221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 218,
+    "index": 219,
     "method": "POST",
     "operationId": "auth.oauth.anthropic.callback",
     "path": "/v1/auth/oauth/anthropic/callback",
@@ -2221,7 +2231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 219,
+    "index": 220,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.initiate",
     "path": "/v1/auth/oauth/openai-codex/device/initiate",
@@ -2231,7 +2241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 220,
+    "index": 221,
     "method": "POST",
     "operationId": "auth.oauth.openai.codex.device.complete",
     "path": "/v1/auth/oauth/openai-codex/device/complete",
@@ -2241,7 +2251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 221,
+    "index": 222,
     "method": "POST",
     "operationId": "media.understanding.doctor",
     "path": "/v1/media-understanding/doctor",
@@ -2251,7 +2261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 222,
+    "index": 223,
     "method": "POST",
     "operationId": "media.understanding.analyze",
     "path": "/v1/media-understanding/analyze",
@@ -2261,7 +2271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 223,
+    "index": 224,
     "method": "GET",
     "operationId": "task.workflows.boundaries.list",
     "path": "/v1/task-workflows/boundaries",
@@ -2271,7 +2281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 224,
+    "index": 225,
     "method": "GET",
     "operationId": "task.workflows.gates.list",
     "path": "/v1/task-workflows/gates",
@@ -2281,7 +2291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 225,
+    "index": 226,
     "method": "POST",
     "operationId": "task.workflows.preview",
     "path": "/v1/task-workflows/preview",
@@ -2291,7 +2301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 226,
+    "index": 227,
     "method": "POST",
     "operationId": "task.workflows.create",
     "path": "/v1/task-workflows",
@@ -2301,7 +2311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 227,
+    "index": 228,
     "method": "GET",
     "operationId": "task.workflows.list",
     "path": "/v1/task-workflows",
@@ -2311,7 +2321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 228,
+    "index": 229,
     "method": "GET",
     "operationId": "task.workflows.get",
     "path": "/v1/task-workflows/:workflowId",
@@ -2321,7 +2331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 229,
+    "index": 230,
     "method": "POST",
     "operationId": "task.workflows.revise",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2331,7 +2341,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 230,
+    "index": 231,
     "method": "GET",
     "operationId": "task.workflows.revisions.list",
     "path": "/v1/task-workflows/:workflowId/revisions",
@@ -2341,7 +2351,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 231,
+    "index": 232,
     "method": "POST",
     "operationId": "task.workflows.claims.create",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2351,7 +2361,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 232,
+    "index": 233,
     "method": "GET",
     "operationId": "task.workflows.claims.list",
     "path": "/v1/task-workflows/:workflowId/claims",
@@ -2361,7 +2371,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 233,
+    "index": 234,
     "method": "GET",
     "operationId": "task.workflows.claims.get",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId",
@@ -2371,7 +2381,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 234,
+    "index": 235,
     "method": "POST",
     "operationId": "task.workflows.claims.evidence.attach",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-ref",
@@ -2381,7 +2391,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 235,
+    "index": 236,
     "method": "GET",
     "operationId": "task.workflows.claims.evidence.list",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/evidence-refs",
@@ -2391,7 +2401,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 236,
+    "index": 237,
     "method": "POST",
     "operationId": "task.workflows.claims.verify",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/verify",
@@ -2401,7 +2411,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 237,
+    "index": 238,
     "method": "POST",
     "operationId": "task.workflows.claims.block",
     "path": "/v1/task-workflows/:workflowId/claims/:claimId/block",
@@ -2411,7 +2421,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 238,
+    "index": 239,
     "method": "POST",
     "operationId": "task.workflows.closeout",
     "path": "/v1/task-workflows/:workflowId/closeout",
@@ -2421,7 +2431,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 239,
+    "index": 240,
     "method": "POST",
     "operationId": "task.workflows.lanes.executor.open",
     "path": "/v1/task-workflows/:workflowId/lanes/executor",
@@ -2431,7 +2441,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 240,
+    "index": 241,
     "method": "POST",
     "operationId": "task.workflows.lanes.verifier.open",
     "path": "/v1/task-workflows/:workflowId/lanes/verifier",
@@ -2441,7 +2451,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 241,
+    "index": 242,
     "method": "POST",
     "operationId": "task.workflows.lanes.complete",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/complete",
@@ -2451,7 +2461,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 242,
+    "index": 243,
     "method": "POST",
     "operationId": "task.workflows.lanes.verdict",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/verdict",
@@ -2461,7 +2471,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 243,
+    "index": 244,
     "method": "GET",
     "operationId": "task.workflows.lanes.list",
     "path": "/v1/task-workflows/:workflowId/lanes",
@@ -2471,7 +2481,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 244,
+    "index": 245,
     "method": "GET",
     "operationId": "task.workflows.lanes.get",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId",
@@ -2481,7 +2491,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 245,
+    "index": 246,
     "method": "POST",
     "operationId": "task.workflows.lanes.cli.handoff.record",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2491,7 +2501,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 246,
+    "index": 247,
     "method": "GET",
     "operationId": "task.workflows.lanes.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/lanes/:laneId/cli-handoffs",
@@ -2501,7 +2511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 247,
+    "index": 248,
     "method": "GET",
     "operationId": "task.workflows.cli.handoffs.list",
     "path": "/v1/task-workflows/:workflowId/cli-handoffs",
@@ -2511,7 +2521,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 248,
+    "index": 249,
     "method": "GET",
     "operationId": "task.workflows.supervisor.read",
     "path": "/v1/task-workflows/:workflowId/supervisor",
@@ -2521,7 +2531,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 249,
+    "index": 250,
     "method": "POST",
     "operationId": "task.workflows.channel.command.issue",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2531,7 +2541,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 250,
+    "index": 251,
     "method": "GET",
     "operationId": "task.workflows.channel.command.list",
     "path": "/v1/task-workflows/:workflowId/channel-commands",
@@ -2541,7 +2551,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 251,
+    "index": 252,
     "method": "POST",
     "operationId": "task.workflows.channel.command.confirm",
     "path": "/v1/task-workflows/:workflowId/channel-commands/confirm",
@@ -2551,7 +2561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 252,
+    "index": 253,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.query",
     "path": "/v1/task-workflows/evidence",
@@ -2561,7 +2571,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 253,
+    "index": 254,
     "method": "GET",
     "operationId": "task.workflows.evidence.explorer.raw",
     "path": "/v1/task-workflows/evidence/:evidenceRefId/raw",
@@ -2571,7 +2581,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 254,
+    "index": 255,
     "method": "POST",
     "operationId": "skills.social.import",
     "path": "/v1/skills/social-import",
@@ -2581,7 +2591,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 255,
+    "index": 256,
     "method": "GET",
     "operationId": "setup.status",
     "path": "/v1/setup/status",
@@ -2591,7 +2601,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 256,
+    "index": 257,
     "method": "POST",
     "operationId": "providers.detect",
     "path": "/v1/providers/detect",
@@ -2601,7 +2611,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 257,
+    "index": 258,
     "method": "GET",
     "operationId": "setup.network.get",
     "path": "/v1/setup/network",
@@ -2611,7 +2621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 258,
+    "index": 259,
     "method": "POST",
     "operationId": "setup.network.save",
     "path": "/v1/setup/network",
@@ -2621,7 +2631,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 259,
+    "index": 260,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.begin",
     "path": "/v1/setup/channels/feishu/registration/begin",
@@ -2631,7 +2641,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 260,
+    "index": 261,
     "method": "POST",
     "operationId": "setup.channels.feishu.registration.poll",
     "path": "/v1/setup/channels/feishu/registration/poll",
@@ -2641,7 +2651,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 261,
+    "index": 262,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.begin",
     "path": "/v1/setup/channels/telegram/verification/begin",
@@ -2651,7 +2661,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 262,
+    "index": 263,
     "method": "POST",
     "operationId": "setup.channels.telegram.verification.poll",
     "path": "/v1/setup/channels/telegram/verification/poll",
@@ -2661,7 +2671,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 263,
+    "index": 264,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.begin",
     "path": "/v1/setup/channels/discord/verification/begin",
@@ -2671,7 +2681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 264,
+    "index": 265,
     "method": "POST",
     "operationId": "setup.channels.discord.verification.complete",
     "path": "/v1/setup/channels/discord/verification/complete",
@@ -2681,7 +2691,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 265,
+    "index": 266,
     "method": "POST",
     "operationId": "setup.channels.test",
     "path": "/v1/setup/channels/test",
@@ -2691,7 +2701,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 266,
+    "index": 267,
     "method": "POST",
     "operationId": "setup.channels.save",
     "path": "/v1/setup/channels",
@@ -2701,7 +2711,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 267,
+    "index": 268,
     "method": "POST",
     "operationId": "setup.complete",
     "path": "/v1/setup/complete",
@@ -2711,7 +2721,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 268,
+    "index": 269,
     "method": "GET",
     "operationId": "skills.list",
     "path": "/v1/skills",
@@ -2721,7 +2731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 269,
+    "index": 270,
     "method": "GET",
     "operationId": "skills.catalog.list",
     "path": "/v1/skills/catalog",
@@ -2731,7 +2741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 270,
+    "index": 271,
     "method": "GET",
     "operationId": "skills.get",
     "path": "/v1/skills/:skillId",
@@ -2741,7 +2751,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 271,
+    "index": 272,
     "method": "POST",
     "operationId": "skills.install",
     "path": "/v1/skills/install",
@@ -2751,7 +2761,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 272,
+    "index": 273,
     "method": "POST",
     "operationId": "skills.update",
     "path": "/v1/skills/:skillId/update",
@@ -2761,7 +2771,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 273,
+    "index": 274,
     "method": "DELETE",
     "operationId": "skills.delete",
     "path": "/v1/skills/:skillId",
@@ -2771,7 +2781,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 274,
+    "index": 275,
     "method": "POST",
     "operationId": "skills.manifest.validate",
     "path": "/v1/skills/validate-manifest",
@@ -2781,7 +2791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 275,
+    "index": 276,
     "method": "POST",
     "operationId": "skills.verify",
     "path": "/v1/skills/:skillId/verify",
@@ -2791,7 +2801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 276,
+    "index": 277,
     "method": "POST",
     "operationId": "skills.upgrade.analyze",
     "path": "/v1/skills/:skillId/upgrade/analyze",
@@ -2801,7 +2811,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 277,
+    "index": 278,
     "method": "POST",
     "operationId": "skills.upgrade.decide",
     "path": "/v1/skills/:skillId/upgrade/decide",
@@ -2811,7 +2821,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 278,
+    "index": 279,
     "method": "POST",
     "operationId": "skills.run",
     "path": "/v1/skills/:skillId/run",
@@ -2821,7 +2831,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 279,
+    "index": 280,
     "method": "POST",
     "operationId": "skills.generator.sessions.create",
     "path": "/v1/skills/generator/sessions",
@@ -2831,7 +2841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 280,
+    "index": 281,
     "method": "GET",
     "operationId": "skills.generator.sessions.get",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2841,7 +2851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 281,
+    "index": 282,
     "method": "POST",
     "operationId": "skills.generator.sessions.messages.create",
     "path": "/v1/skills/generator/sessions/:sessionId/messages",
@@ -2851,7 +2861,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 282,
+    "index": 283,
     "method": "POST",
     "operationId": "skills.generator.sessions.generate",
     "path": "/v1/skills/generator/sessions/:sessionId/generate",
@@ -2861,7 +2871,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 283,
+    "index": 284,
     "method": "POST",
     "operationId": "skills.generator.sessions.test",
     "path": "/v1/skills/generator/sessions/:sessionId/test",
@@ -2871,7 +2881,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 284,
+    "index": 285,
     "method": "GET",
     "operationId": "skills.generator.sessions.evidence.get",
     "path": "/v1/skills/generator/sessions/:sessionId/evidence",
@@ -2881,7 +2891,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 285,
+    "index": 286,
     "method": "POST",
     "operationId": "skills.generator.sessions.approve",
     "path": "/v1/skills/generator/sessions/:sessionId/approve",
@@ -2891,7 +2901,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 286,
+    "index": 287,
     "method": "DELETE",
     "operationId": "skills.generator.sessions.cancel",
     "path": "/v1/skills/generator/sessions/:sessionId",
@@ -2901,7 +2911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 287,
+    "index": 288,
     "method": "GET",
     "operationId": "skills.ui.get",
     "path": "/v1/skills/:skillId/ui",
@@ -2911,7 +2921,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 288,
+    "index": 289,
     "method": "POST",
     "operationId": "uix.intents.resolve",
     "path": "/v1/uix/intents/resolve",
@@ -2921,7 +2931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 289,
+    "index": 290,
     "method": "GET",
     "operationId": "uix.templates.list",
     "path": "/v1/uix/templates",
@@ -2931,7 +2941,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 290,
+    "index": 291,
     "method": "GET",
     "operationId": "uix.home.snapshot.get",
     "path": "/v1/uix/home-snapshot",
@@ -2941,7 +2951,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 291,
+    "index": 292,
     "method": "GET",
     "operationId": "uix.assistant.inbox.snapshot.get",
     "path": "/v1/uix/assistant-inbox-snapshot",
@@ -2951,7 +2961,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 292,
+    "index": 293,
     "method": "GET",
     "operationId": "uix.diagnostics.get",
     "path": "/v1/uix/diagnostics",
@@ -2961,7 +2971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 293,
+    "index": 294,
     "method": "GET",
     "operationId": "uix.preferences.list",
     "path": "/v1/uix/preferences",
@@ -2971,7 +2981,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 294,
+    "index": 295,
     "method": "PUT",
     "operationId": "uix.preferences.update",
     "path": "/v1/uix/preferences",
@@ -2981,7 +2991,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 295,
+    "index": 296,
     "method": "DELETE",
     "operationId": "uix.preferences.delete",
     "path": "/v1/uix/preferences/:preferenceId",
@@ -2991,7 +3001,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 296,
+    "index": 297,
     "method": "GET",
     "operationId": "uix.persona.get",
     "path": "/v1/uix/persona",
@@ -3001,7 +3011,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 297,
+    "index": 298,
     "method": "PUT",
     "operationId": "uix.persona.update",
     "path": "/v1/uix/persona",
@@ -3011,7 +3021,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 298,
+    "index": 299,
     "method": "POST",
     "operationId": "uix.templates.execute",
     "path": "/v1/uix/templates/:templateId/execute",
@@ -3021,7 +3031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 299,
+    "index": 300,
     "method": "POST",
     "operationId": "uix.wizards.start",
     "path": "/v1/uix/wizards/:wizardId/start",
@@ -3031,7 +3041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 300,
+    "index": 301,
     "method": "POST",
     "operationId": "uix.wizards.continue",
     "path": "/v1/uix/wizards/:wizardId/continue",
@@ -3041,7 +3051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 301,
+    "index": 302,
     "method": "GET",
     "operationId": "uix.issues.list",
     "path": "/v1/uix/issues",
@@ -3051,7 +3061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 302,
+    "index": 303,
     "method": "GET",
     "operationId": "uix.user.profile.get",
     "path": "/v1/uix/user-profile",
@@ -3061,7 +3071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 303,
+    "index": 304,
     "method": "PUT",
     "operationId": "uix.user.profile.update",
     "path": "/v1/uix/user-profile",
@@ -3071,7 +3081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 304,
+    "index": 305,
     "method": "POST",
     "operationId": "uix.investigate",
     "path": "/v1/uix/investigate",
@@ -3081,7 +3091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 305,
+    "index": 306,
     "method": "GET",
     "operationId": "uix.learnedfacts.list",
     "path": "/v1/uix/learned-facts",
@@ -3091,7 +3101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 306,
+    "index": 307,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.clear",
     "path": "/v1/uix/learned-facts",
@@ -3101,7 +3111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 307,
+    "index": 308,
     "method": "PATCH",
     "operationId": "uix.learnedfacts.update",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3111,7 +3121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 308,
+    "index": 309,
     "method": "DELETE",
     "operationId": "uix.learnedfacts.delete",
     "path": "/v1/uix/learned-facts/:factKey",
@@ -3121,7 +3131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 309,
+    "index": 310,
     "method": "GET",
     "operationId": "packs.cross.border.profile.get",
     "path": "/v1/packs/cross-border/profile",
@@ -3131,7 +3141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 310,
+    "index": 311,
     "method": "PUT",
     "operationId": "packs.cross.border.profile.put",
     "path": "/v1/packs/cross-border/profile",
@@ -3141,7 +3151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 311,
+    "index": 312,
     "method": "GET",
     "operationId": "packs.cross.border.snapshot.get",
     "path": "/v1/packs/cross-border/snapshot",
@@ -3151,7 +3161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 312,
+    "index": 313,
     "method": "POST",
     "operationId": "packs.cross.border.import.post",
     "path": "/v1/packs/cross-border/import",
@@ -3161,7 +3171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 313,
+    "index": 314,
     "method": "POST",
     "operationId": "packs.cross.border.workflow.presets.apply",
     "path": "/v1/packs/cross-border/workflow-presets/apply",
@@ -3171,7 +3181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 314,
+    "index": 315,
     "method": "PATCH",
     "operationId": "packs.cross.border.workflow.presets.toggle",
     "path": "/v1/packs/cross-border/workflow-presets/:workflowId",
@@ -3181,7 +3191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 315,
+    "index": 316,
     "method": "POST",
     "operationId": "packs.cross.border.run.evidence.capture",
     "path": "/v1/packs/cross-border/run-evidence",
@@ -3191,7 +3201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 316,
+    "index": 317,
     "method": "PATCH",
     "operationId": "packs.cross.border.import.stale",
     "path": "/v1/packs/cross-border/imports/:importBatchId/stale",
@@ -3201,7 +3211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 317,
+    "index": 318,
     "method": "POST",
     "operationId": "packs.cross.border.workflows.disable.all",
     "path": "/v1/packs/cross-border/workflows/disable-all",
@@ -3211,7 +3221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 318,
+    "index": 319,
     "method": "GET",
     "operationId": "skills.converters.list",
     "path": "/v1/skills/converters",
@@ -3221,7 +3231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 319,
+    "index": 320,
     "method": "POST",
     "operationId": "skills.convert",
     "path": "/v1/skills/convert",
@@ -3231,7 +3241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 320,
+    "index": 321,
     "method": "POST",
     "operationId": "skills.import",
     "path": "/v1/skills/import",
@@ -3241,7 +3251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 321,
+    "index": 322,
     "method": "POST",
     "operationId": "skills.pack",
     "path": "/v1/skills/pack",
@@ -3251,7 +3261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 322,
+    "index": 323,
     "method": "POST",
     "operationId": "workflows.generator.sessions.create",
     "path": "/v1/workflows/generator/sessions",
@@ -3261,7 +3271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 323,
+    "index": 324,
     "method": "GET",
     "operationId": "workflows.generator.sessions.get",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3271,7 +3281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 324,
+    "index": 325,
     "method": "POST",
     "operationId": "workflows.generator.sessions.messages.create",
     "path": "/v1/workflows/generator/sessions/:sessionId/messages",
@@ -3281,7 +3291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 325,
+    "index": 326,
     "method": "POST",
     "operationId": "workflows.generator.sessions.generate",
     "path": "/v1/workflows/generator/sessions/:sessionId/generate",
@@ -3291,7 +3301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 326,
+    "index": 327,
     "method": "GET",
     "operationId": "workflows.generator.sessions.evidence.get",
     "path": "/v1/workflows/generator/sessions/:sessionId/evidence",
@@ -3301,7 +3311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 327,
+    "index": 328,
     "method": "POST",
     "operationId": "workflows.generator.sessions.approve",
     "path": "/v1/workflows/generator/sessions/:sessionId/approve",
@@ -3311,7 +3321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 328,
+    "index": 329,
     "method": "DELETE",
     "operationId": "workflows.generator.sessions.cancel",
     "path": "/v1/workflows/generator/sessions/:sessionId",
@@ -3321,7 +3331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 329,
+    "index": 330,
     "method": "GET",
     "operationId": "rules.bundles.list",
     "path": "/v1/rules/bundles",
@@ -3331,7 +3341,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 330,
+    "index": 331,
     "method": "GET",
     "operationId": "rules.bundles.get",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3341,7 +3351,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 331,
+    "index": 332,
     "method": "POST",
     "operationId": "rules.bundles.create",
     "path": "/v1/rules/bundles",
@@ -3351,7 +3361,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 332,
+    "index": 333,
     "method": "PATCH",
     "operationId": "rules.bundles.update",
     "path": "/v1/rules/bundles/:bundleId",
@@ -3361,7 +3371,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 333,
+    "index": 334,
     "method": "GET",
     "operationId": "rules.bundles.versions.list",
     "path": "/v1/rules/bundles/:bundleId/versions",
@@ -3371,7 +3381,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 334,
+    "index": 335,
     "method": "GET",
     "operationId": "rules.list",
     "path": "/v1/rules/bundles/:bundleId/rules",
@@ -3381,7 +3391,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 335,
+    "index": 336,
     "method": "POST",
     "operationId": "rules.evaluate",
     "path": "/v1/rules/evaluate",
@@ -3391,7 +3401,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 336,
+    "index": 337,
     "method": "POST",
     "operationId": "rules.simulate",
     "path": "/v1/rules/simulate",
@@ -3401,7 +3411,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 337,
+    "index": 338,
     "method": "GET",
     "operationId": "rules.versions.list",
     "path": "/v1/rules/:ruleId/versions",
@@ -3411,7 +3421,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 338,
+    "index": 339,
     "method": "GET",
     "operationId": "rules.audit.log.list",
     "path": "/v1/rules/audit-log",
@@ -3421,7 +3431,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 339,
+    "index": 340,
     "method": "POST",
     "operationId": "node.runner.execute",
     "path": "/v1/node-runner/execute",
@@ -3431,7 +3441,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 340,
+    "index": 341,
     "method": "GET",
     "operationId": "node.runner.executions.get",
     "path": "/v1/node-runner/executions/:executionId",
@@ -3441,7 +3451,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 341,
+    "index": 342,
     "method": "GET",
     "operationId": "node.runner.executions.list",
     "path": "/v1/node-runner/executions",
@@ -3451,7 +3461,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 342,
+    "index": 343,
     "method": "POST",
     "operationId": "acceptance.run",
     "path": "/v1/acceptance/run",
@@ -3461,7 +3471,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 343,
+    "index": 344,
     "method": "GET",
     "operationId": "acceptance.results.get",
     "path": "/v1/acceptance/results/:resultId",
@@ -3471,7 +3481,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 344,
+    "index": 345,
     "method": "GET",
     "operationId": "acceptance.results.list",
     "path": "/v1/acceptance/results",
@@ -3481,7 +3491,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 345,
+    "index": 346,
     "method": "GET",
     "operationId": "acceptance.runs.get",
     "path": "/v1/acceptance/runs/:runId",
@@ -3491,7 +3501,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 346,
+    "index": 347,
     "method": "GET",
     "operationId": "acceptance.tests.list",
     "path": "/v1/acceptance/tests",
@@ -3501,7 +3511,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 347,
+    "index": 348,
     "method": "GET",
     "operationId": "acceptance.tests.get",
     "path": "/v1/acceptance/tests/:testId",
@@ -3511,7 +3521,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 348,
+    "index": 349,
     "method": "POST",
     "operationId": "acceptance.tests.create",
     "path": "/v1/acceptance/tests",
@@ -3521,7 +3531,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 349,
+    "index": 350,
     "method": "PUT",
     "operationId": "acceptance.tests.update",
     "path": "/v1/acceptance/tests/:testId",
@@ -3531,7 +3541,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 350,
+    "index": 351,
     "method": "DELETE",
     "operationId": "acceptance.tests.delete",
     "path": "/v1/acceptance/tests/:testId",
@@ -3541,7 +3551,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 351,
+    "index": 352,
     "method": "GET",
     "operationId": "acceptance.tests.versions.list",
     "path": "/v1/acceptance/tests/:testId/versions",
@@ -3551,7 +3561,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 352,
+    "index": 353,
     "method": "GET",
     "operationId": "acceptance.artifacts.history",
     "path": "/v1/acceptance/artifacts/history",
@@ -3561,7 +3571,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 353,
+    "index": 354,
     "method": "GET",
     "operationId": "retry.policies.list",
     "path": "/v1/retry/policies",
@@ -3571,7 +3581,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 354,
+    "index": 355,
     "method": "GET",
     "operationId": "retry.policies.get",
     "path": "/v1/retry/policies/:policyId",
@@ -3581,7 +3591,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 355,
+    "index": 356,
     "method": "POST",
     "operationId": "retry.policies.create",
     "path": "/v1/retry/policies",
@@ -3591,7 +3601,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 356,
+    "index": 357,
     "method": "PUT",
     "operationId": "retry.policies.update",
     "path": "/v1/retry/policies/:policyId",
@@ -3601,7 +3611,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 357,
+    "index": 358,
     "method": "DELETE",
     "operationId": "retry.policies.delete",
     "path": "/v1/retry/policies/:policyId",
@@ -3611,7 +3621,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 358,
+    "index": 359,
     "method": "POST",
     "operationId": "retry.classify",
     "path": "/v1/retry/classify",
@@ -3621,7 +3631,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 359,
+    "index": 360,
     "method": "POST",
     "operationId": "retry.decide",
     "path": "/v1/retry/decide",
@@ -3631,7 +3641,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 360,
+    "index": 361,
     "method": "GET",
     "operationId": "retry.traces.list",
     "path": "/v1/retry/traces",
@@ -3641,7 +3651,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 361,
+    "index": 362,
     "method": "GET",
     "operationId": "retry.traces.get",
     "path": "/v1/retry/traces/:traceId",
@@ -3651,7 +3661,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 362,
+    "index": 363,
     "method": "GET",
     "operationId": "retry.costs.summary",
     "path": "/v1/retry/costs",
@@ -3661,7 +3671,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 363,
+    "index": 364,
     "method": "GET",
     "operationId": "retry.escalations.list",
     "path": "/v1/retry/escalations",
@@ -3671,7 +3681,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 364,
+    "index": 365,
     "method": "POST",
     "operationId": "retry.escalations.acknowledge",
     "path": "/v1/retry/escalations/:escalationId/acknowledge",
@@ -3681,7 +3691,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 365,
+    "index": 366,
     "method": "GET",
     "operationId": "retry.circuit.breakers.list",
     "path": "/v1/retry/circuit-breakers",
@@ -3691,7 +3701,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 366,
+    "index": 367,
     "method": "GET",
     "operationId": "playbook.list",
     "path": "/v1/playbooks",
@@ -3701,7 +3711,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 367,
+    "index": 368,
     "method": "GET",
     "operationId": "playbook.get",
     "path": "/v1/playbooks/:playbookId",
@@ -3711,7 +3721,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 368,
+    "index": 369,
     "method": "POST",
     "operationId": "playbook.select",
     "path": "/v1/playbooks/select",
@@ -3721,7 +3731,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 369,
+    "index": 370,
     "method": "GET",
     "operationId": "playbook.candidates.list",
     "path": "/v1/playbooks/candidates",
@@ -3731,7 +3741,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 370,
+    "index": 371,
     "method": "POST",
     "operationId": "playbook.candidates.promote",
     "path": "/v1/playbooks/candidates/:candidateId/promote",
@@ -3741,7 +3751,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 371,
+    "index": 372,
     "method": "POST",
     "operationId": "playbook.rollback",
     "path": "/v1/playbooks/:playbookId/rollback",
@@ -3751,7 +3761,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 372,
+    "index": 373,
     "method": "GET",
     "operationId": "playbook.scores",
     "path": "/v1/playbooks/:playbookId/scores",
@@ -3761,7 +3771,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 373,
+    "index": 374,
     "method": "POST",
     "operationId": "memory.store",
     "path": "/v1/memory/store",
@@ -3771,7 +3781,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 374,
+    "index": 375,
     "method": "POST",
     "operationId": "memory.items.create",
     "path": "/v1/memory/items",
@@ -3781,7 +3791,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 375,
+    "index": 376,
     "method": "POST",
     "operationId": "memory.search",
     "path": "/v1/memory/search",
@@ -3791,7 +3801,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 376,
+    "index": 377,
     "method": "GET",
     "operationId": "memory.get",
     "path": "/v1/memory/items/:id",
@@ -3801,7 +3811,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 377,
+    "index": 378,
     "method": "GET",
     "operationId": "memory.list",
     "path": "/v1/memory/items",
@@ -3811,7 +3821,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 378,
+    "index": 379,
     "method": "DELETE",
     "operationId": "memory.delete",
     "path": "/v1/memory/items/:id",
@@ -3821,7 +3831,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 379,
+    "index": 380,
     "method": "POST",
     "operationId": "memory.prune",
     "path": "/v1/memory/prune",
@@ -3831,7 +3841,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 380,
+    "index": 381,
     "method": "GET",
     "operationId": "sessions.usage.get",
     "path": "/v1/sessions/:sessionKey/usage",
@@ -3841,7 +3851,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 381,
+    "index": 382,
     "method": "GET",
     "operationId": "sessions.usage.list",
     "path": "/v1/sessions/usage",
@@ -3851,7 +3861,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 382,
+    "index": 383,
     "method": "GET",
     "operationId": "sessions.list",
     "path": "/v1/sessions",
@@ -3861,7 +3871,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 383,
+    "index": 384,
     "method": "POST",
     "operationId": "sessions.create",
     "path": "/v1/sessions",
@@ -3871,7 +3881,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 384,
+    "index": 385,
     "method": "GET",
     "operationId": "sessions.get",
     "path": "/v1/sessions/:sessionKey",
@@ -3881,7 +3891,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 385,
+    "index": 386,
     "method": "DELETE",
     "operationId": "sessions.delete",
     "path": "/v1/sessions/:sessionKey",
@@ -3891,7 +3901,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 386,
+    "index": 387,
     "method": "POST",
     "operationId": "sessions.archive",
     "path": "/v1/sessions/:sessionKey/archive",
@@ -3901,7 +3911,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 387,
+    "index": 388,
     "method": "POST",
     "operationId": "sessions.reset",
     "path": "/v1/sessions/:sessionKey/reset",
@@ -3911,7 +3921,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 388,
+    "index": 389,
     "method": "POST",
     "operationId": "sessions.prune",
     "path": "/v1/sessions/prune",
@@ -3921,7 +3931,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 389,
+    "index": 390,
     "method": "POST",
     "operationId": "sessions.sweep",
     "path": "/v1/sessions/sweep",
@@ -3931,7 +3941,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 390,
+    "index": 391,
     "method": "POST",
     "operationId": "sessions.compact",
     "path": "/v1/sessions/:sessionKey/compact",
@@ -3941,7 +3951,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 391,
+    "index": 392,
     "method": "GET",
     "operationId": "sessions.messages.list",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3951,7 +3961,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 392,
+    "index": 393,
     "method": "GET",
     "operationId": "sessions.export",
     "path": "/v1/sessions/:sessionKey/export",
@@ -3961,7 +3971,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 393,
+    "index": 394,
     "method": "POST",
     "operationId": "sessions.messages.create",
     "path": "/v1/sessions/:sessionKey/messages",
@@ -3971,7 +3981,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 394,
+    "index": 395,
     "method": "POST",
     "operationId": "sessions.outbound.send",
     "path": "/v1/sessions/:sessionKey/outbound",
@@ -3981,7 +3991,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 395,
+    "index": 396,
     "method": "POST",
     "operationId": "sessions.run",
     "path": "/v1/sessions/:sessionKey/run",
@@ -3991,7 +4001,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 396,
+    "index": 397,
     "method": "GET",
     "operationId": "sessions.memory.namespace.get",
     "path": "/v1/sessions/:sessionKey/memory-namespace",
@@ -4001,7 +4011,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 397,
+    "index": 398,
     "method": "POST",
     "operationId": "sessions.forks.create",
     "path": "/v1/sessions/:sessionKey/fork",
@@ -4011,7 +4021,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 398,
+    "index": 399,
     "method": "GET",
     "operationId": "sessions.forks.list",
     "path": "/v1/sessions/:sessionKey/forks",
@@ -4021,7 +4031,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 399,
+    "index": 400,
     "method": "POST",
     "operationId": "sessions.forks.merge",
     "path": "/v1/sessions/:sessionKey/merge",
@@ -4031,7 +4041,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 400,
+    "index": 401,
     "method": "POST",
     "operationId": "sessions.memory.extract",
     "path": "/v1/sessions/:sessionKey/memory/extract",
@@ -4041,7 +4051,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 401,
+    "index": 402,
     "method": "POST",
     "operationId": "sessions.memory.remember",
     "path": "/v1/sessions/:sessionKey/memory/remember",
@@ -4051,7 +4061,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 402,
+    "index": 403,
     "method": "GET",
     "operationId": "sessions.memory.extraction.get",
     "path": "/v1/sessions/:sessionKey/memory/extraction",
@@ -4061,7 +4071,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 403,
+    "index": 404,
     "method": "POST",
     "operationId": "sessions.memory.extraction.retry",
     "path": "/v1/sessions/memory/extraction/retry",
@@ -4071,7 +4081,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 404,
+    "index": 405,
     "method": "GET",
     "operationId": "plugins.list",
     "path": "/v1/plugins",
@@ -4081,7 +4091,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 405,
+    "index": 406,
     "method": "GET",
     "operationId": "plugins.get",
     "path": "/v1/plugins/:id",
@@ -4091,7 +4101,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 406,
+    "index": 407,
     "method": "GET",
     "operationId": "plugins.versions.list",
     "path": "/v1/plugins/:id/versions",
@@ -4101,7 +4111,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 407,
+    "index": 408,
     "method": "POST",
     "operationId": "plugins.install",
     "path": "/v1/plugins/:id/install",
@@ -4111,7 +4121,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 408,
+    "index": 409,
     "method": "POST",
     "operationId": "plugins.enable",
     "path": "/v1/plugins/:id/enable",
@@ -4121,7 +4131,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 409,
+    "index": 410,
     "method": "POST",
     "operationId": "plugins.disable",
     "path": "/v1/plugins/:id/disable",
@@ -4131,7 +4141,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 410,
+    "index": 411,
     "method": "DELETE",
     "operationId": "plugins.uninstall",
     "path": "/v1/plugins/:id",
@@ -4141,7 +4151,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 411,
+    "index": 412,
     "method": "POST",
     "operationId": "agent.runs.start",
     "path": "/v1/agent/runs",
@@ -4151,7 +4161,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 412,
+    "index": 413,
     "method": "GET",
     "operationId": "agent.runs.list",
     "path": "/v1/agent/runs",
@@ -4161,7 +4171,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 413,
+    "index": 414,
     "method": "GET",
     "operationId": "agent.runs.summary",
     "path": "/v1/agent/runs/summary",
@@ -4171,7 +4181,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 414,
+    "index": 415,
     "method": "GET",
     "operationId": "agent.runs.get",
     "path": "/v1/agent/runs/:runId",
@@ -4181,7 +4191,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 415,
+    "index": 416,
     "method": "POST",
     "operationId": "agent.runs.cancel",
     "path": "/v1/agent/runs/:runId/cancel",
@@ -4191,7 +4201,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 416,
+    "index": 417,
     "method": "POST",
     "operationId": "agent.runs.resume",
     "path": "/v1/agent/runs/:runId/resume",
@@ -4201,7 +4211,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 417,
+    "index": 418,
     "method": "POST",
     "operationId": "agent.d20.worktree.batch.dispatch",
     "path": "/v1/agent/d20/worktree-batches/dispatch",
@@ -4211,7 +4221,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 418,
+    "index": 419,
     "method": "GET",
     "operationId": "agent.runs.audit",
     "path": "/v1/agent/runs/:runId/audit",
@@ -4221,7 +4231,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 419,
+    "index": 420,
     "method": "POST",
     "operationId": "agent.runs.rollback",
     "path": "/v1/agent/runs/:runId/rollback",
@@ -4231,7 +4241,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 420,
+    "index": 421,
     "method": "POST",
     "operationId": "agent.runs.approve.plan",
     "path": "/v1/agent/runs/:runId/approve-plan",
@@ -4241,7 +4251,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 421,
+    "index": 422,
     "method": "POST",
     "operationId": "agent.runs.reject.plan",
     "path": "/v1/agent/runs/:runId/reject-plan",
@@ -4251,7 +4261,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 422,
+    "index": 423,
     "method": "POST",
     "operationId": "agent.runs.approve.tool",
     "path": "/v1/agent/runs/:runId/approve-tool",
@@ -4261,7 +4271,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 423,
+    "index": 424,
     "method": "POST",
     "operationId": "agent.runs.reject.tool",
     "path": "/v1/agent/runs/:runId/reject-tool",
@@ -4271,7 +4281,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 424,
+    "index": 425,
     "method": "GET",
     "operationId": "agent.runs.events",
     "path": "/v1/agent/runs/:runId/events",
@@ -4281,7 +4291,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 425,
+    "index": 426,
     "method": "POST",
     "operationId": "agent.automations.create",
     "path": "/v1/agent/automations",
@@ -4291,7 +4301,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 426,
+    "index": 427,
     "method": "GET",
     "operationId": "agent.automations.list",
     "path": "/v1/agent/automations",
@@ -4301,7 +4311,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 427,
+    "index": 428,
     "method": "GET",
     "operationId": "agent.automations.get",
     "path": "/v1/agent/automations/:automationId",
@@ -4311,7 +4321,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 428,
+    "index": 429,
     "method": "PATCH",
     "operationId": "agent.automations.update",
     "path": "/v1/agent/automations/:automationId",
@@ -4321,7 +4331,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 429,
+    "index": 430,
     "method": "DELETE",
     "operationId": "agent.automations.delete",
     "path": "/v1/agent/automations/:automationId",
@@ -4331,7 +4341,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 430,
+    "index": 431,
     "method": "POST",
     "operationId": "agent.automations.run",
     "path": "/v1/agent/automations/:automationId/run",
@@ -4341,7 +4351,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 431,
+    "index": 432,
     "method": "GET",
     "operationId": "agent.subagents.list",
     "path": "/v1/agent/subagents",
@@ -4351,7 +4361,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 432,
+    "index": 433,
     "method": "GET",
     "operationId": "agent.subagents.get",
     "path": "/v1/agent/subagents/:subagentId",
@@ -4361,7 +4371,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 433,
+    "index": 434,
     "method": "GET",
     "operationId": "agent.runs.subagents.list",
     "path": "/v1/agent/runs/:runId/subagents",
@@ -4371,7 +4381,7 @@ exports[`MECHANISM-4 — API Route Contract (Snapshot) > captures the full route
   },
   {
     "authKind": "public",
-    "index": 434,
+    "index": 435,
     "method": "GET",
     "operationId": "assets.inventory.list",
     "path": "/v1/assets/inventory",

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -893,6 +893,16 @@ describe("MECHANISM-4 — API Route Contract (Snapshot)", () => {
         // provisional→active flip never touches password_hash and the device binding
         // still carries zero authority.
         "auth.migrate.device.readback",
+        // CORE-A CR-2: provider setup plan → owner-confirm handshake. Both public
+        // POST handlers unconditionally call requireProviderMutationOwnerPrincipalId
+        // at the top, which refuses the synthetic public principal via the same
+        // isUnauthenticatedPublicPrincipal guard used by assertBoundPrincipalForOperation
+        // (throws OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED / 401). This is a strictly
+        // stronger in-handler gate than the sibling providers.create/update/delete
+        // mutations (which rely only on the optional canonical-approval ticket and
+        // therefore remain in the unclassified reconciliation bucket).
+        "providers.plan",
+        "providers.plan.confirm",
       ]);
       // rate_limited_pending
       const RATE_LIMITED_PENDING: ReadonlySet<string> = new Set([

--- a/test/contracts/api/friday-api-route-contract.snapshot.test.ts
+++ b/test/contracts/api/friday-api-route-contract.snapshot.test.ts
@@ -915,6 +915,11 @@ describe("MECHANISM-4 — API Route Contract (Snapshot)", () => {
         // compare-and-set, under the auth.login rate-limit policy.
         "auth.bootstrap.challenge",
         "auth.bootstrap.device.claim",
+        // SEC-SETUP-BOOTSTRAP-001 (CR-1 · Advisor #1628 finding #2): the device-key
+        // LOGIN challenge. Same posture as auth.bootstrap.challenge — public loopback
+        // mutation gated by a localhost-only IP check + single-use device_login_challenge
+        // nonce (CAS-consumed atomically with the login mint), under auth.login rate limit.
+        "auth.login.challenge",
         "auth.login",
       ]);
       // public_low_risk

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -28,14 +28,17 @@ import type {
   FridayCanonicalApprovalResolution,
   FridayMutatingActionRequest,
 } from "../../../../src/security/friday-mutating-action-gate.js";
-import { encodeToken } from "../../../../src/api/auth/friday-token-validator.js";
-import { getScopesForRole } from "../../../../src/api/auth/friday-rbac-policy.js";
 import {
   deviceOwnerPrincipalIdFor,
   generateTestDeviceKey,
   makeApprovalProof,
   makeApprovalTranscript,
 } from "../../../helpers/friday-provider-approval-test-kit.js";
+import {
+  makeTranscript,
+  signTranscriptLowS,
+} from "../../../adversarial/_secsetup-s2a.helpers.js";
+import { createTestNativeOwnerResolver } from "../../../adversarial/_native-owner-capability.helpers.js";
 import {
   createMockFetch,
   resetMockCounters,
@@ -133,64 +136,43 @@ const AUTO_DETECT_PROVIDER_ENV_VARS = [
 const MOCK_E2E_TOKEN_SECRET = "mock-e2e-token-secret"; // pragma: allowlist secret -- deterministic signing key for canonical-gate mock E2E setup
 const MOCK_E2E_MASTER_KEY = Buffer.alloc(32, 23).toString("hex");
 
-// ─── SEC-APPROVAL-AUTHORITY-001 · CR-2: device-authored provider-mutation owner ───
+// ─── SEC-APPROVAL-AUTHORITY-001 · CR-2 (Option B*): REAL device-bound owner ───
 //
-// Provider mutations (create / routing.set / capabilities.doctor) now require a
+// Provider mutations (create / routing.set / capabilities.doctor) require a
 // DEVICE-AUTHORED owner approval: a P-256 `friday-provider-approval-v1` transcript
 // signed by the OWNER DEVICE and merely VERIFIED by the Hub (the Hub holds NO
-// signing key and REFUSES its own HMAC/unsigned approvals). We mint ONE software
-// dev/test owner device (NOT a Secure Enclave key; parity with the CR-2 runtime
-// tests) and drive the three provider-mutation setup calls AS that device owner:
-//   • the HTTP principal for those three calls is the owner's device-owner principal
-//     (`device-owner:<keyHash>`), minted directly with the PRODUCTION token encoder
-//     so `createActorFromPrincipal` recomputes the SAME action digest the owner
-//     device signed; and
-//   • each approval is the owner device's signed transcript bound to that exact
-//     action digest + owner principal.
-// The rest of the mock env is unchanged — the general session `accessToken` stays
-// the ordinary local-passphrase admin, so no other behaviour shifts.
-const MOCK_E2E_DEVICE_OWNER_KEY = generateTestDeviceKey();
-const MOCK_E2E_DEVICE_OWNER_PRINCIPAL = deviceOwnerPrincipalIdFor(MOCK_E2E_DEVICE_OWNER_KEY);
-// The digest actor MUST mirror the server's `createActorFromPrincipal(ctx.principal)`
-// for the device-owner HTTP principal: principalType "user", id/principalId = the
-// device-owner principal id.
-const MOCK_E2E_DEVICE_OWNER_ACTOR = {
-  kind: "user",
-  id: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
-  principalId: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
-} as const;
+// signing key and REFUSES its own HMAC/unsigned approvals). Instead of fabricating a
+// `device-owner:<hash>` token (which production never emits), we drive the REAL
+// production auth path: this hub is created with an INJECTED native-owner claim
+// resolver (`createTestNativeOwnerResolver()`, which runs the REAL capability mint
+// over injected native-evidence doubles), then we run the REAL owner-bootstrap →
+// deviceKeyLogin over HTTP with ONE software owner device key. The resulting session
+// token's principal is the ordinary local owner `user.id` (NOT a device-owner
+// principal); the server resolves the durable owner↔device binding
+// (`users.password_hash = device-owner$v1$<sha256Hex(devicePublicKey)>`) server-side
+// and binds each device-authored approval to that registered device. The SAME owner
+// device key signs both the owner-claim/login transcripts AND every provider
+// approval, so `sha256Hex(deviceKey)` matches the durable sentinel.
+const MOCK_E2E_OWNER_DEVICE_KEY = generateTestDeviceKey();
+const MOCK_E2E_OWNER_DEVICE_ID = "mock-e2e-owner-device";
+const MOCK_E2E_OWNER_ORIGIN = "https://friday.localhost";
+const MOCK_E2E_OWNER_INSTALL_ID = "mock-e2e-install";
+const MOCK_E2E_OWNER_OS_USER = "mock-e2e";
+// The device-authored approval's `decidedByPrincipalId` stays the CANONICAL device
+// principal (`device-owner:<canonicalDevicePublicKeyHash>`) — the verifier binds it
+// to the signing key via `canonicalDevicePublicKeyHash`. The DURABLE binding to the
+// authenticated owner is enforced separately, server-side, via the sentinel hash.
+const MOCK_E2E_DEVICE_OWNER_PRINCIPAL = deviceOwnerPrincipalIdFor(MOCK_E2E_OWNER_DEVICE_KEY);
 const MOCK_E2E_PROVIDER_APPROVAL_EXPIRES_AT = "2099-01-01T00:00:00.000Z";
 
-/**
- * Mint an access token whose bound principal IS the owner's device-owner principal
- * (`device-owner:<keyHash>`, principalType "user"), using the PRODUCTION token
- * encoder + the mock hub's token secret. No `sid` is set: the validator skips
- * session-state tracking for a token without a session id, so this stands in for a
- * device-owner principal that has already cleared attestation (exactly what the
- * CR-2 route tests model with an injected `device-owner:<hash>` "user" principal).
- * Used ONLY for the provider-mutation setup calls; the session token is unchanged.
- */
-function mintDeviceOwnerAccessToken(): string {
-  const nowSec = Math.floor(Date.now() / 1000);
-  return encodeToken(
-    {
-      tokenId: "mock-e2e-device-owner-token",
-      principalType: "user",
-      principalId: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
-      userId: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
-      role: "admin",
-      scopes: [...getScopesForRole("admin")],
-      iat: nowSec,
-      exp: nowSec + 60 * 60 * 24 * 365,
-    },
-    MOCK_E2E_TOKEN_SECRET,
-  );
-}
+/** The action-digest actor for a real owner session: `user` principal = `user.id`. */
+type OwnerSessionActor = { kind: "user"; id: string; principalId: string };
 
 /**
  * Build a DEVICE-AUTHORED approval for a provider mutation: recompute the request's
  * action digest, then have the owner device sign a transcript bound to that exact
- * digest + owner principal + approvalId + expiry. The Hub verifies (never signs) it.
+ * digest + canonical device principal + approvalId + expiry. The Hub verifies (never
+ * signs) it, and binds the signing key to the authenticated owner's durable device.
  */
 function mintDeviceOwnerApproval(
   request: FridayMutatingActionRequest,
@@ -198,7 +180,7 @@ function mintDeviceOwnerApproval(
 ): FridayCanonicalApprovalResolution {
   const actionDigest = createFridayMutatingActionDigest(request);
   const expiresAt = MOCK_E2E_PROVIDER_APPROVAL_EXPIRES_AT;
-  const transcript = makeApprovalTranscript(MOCK_E2E_DEVICE_OWNER_KEY, {
+  const transcript = makeApprovalTranscript(MOCK_E2E_OWNER_DEVICE_KEY, {
     actionDigest,
     approvalId,
     decidedByPrincipalId: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
@@ -211,7 +193,98 @@ function mintDeviceOwnerApproval(
     actionDigest,
     expiresAt,
     issuer: "friday_device_owner",
-    deviceProof: makeApprovalProof(MOCK_E2E_DEVICE_OWNER_KEY, transcript),
+    deviceProof: makeApprovalProof(MOCK_E2E_OWNER_DEVICE_KEY, transcript),
+  };
+}
+
+/**
+ * Drive the REAL production device-owner bootstrap over HTTP (challenge → owner-claim
+ * → login-challenge → deviceKeyLogin), signing every transcript with the owner device
+ * key. Returns the minted session token (principal = the local owner `user.id`) and
+ * that owner user id (for the action-digest actor). Requires the hub to have been
+ * created with an injected native-owner claim resolver (else claim/login fail closed).
+ */
+async function deviceOwnerBootstrapLogin(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<{ accessToken: string; ownerActor: OwnerSessionActor }> {
+  const key = MOCK_E2E_OWNER_DEVICE_KEY;
+  const deviceId = MOCK_E2E_OWNER_DEVICE_ID;
+  const post = async (pathname: string, body: unknown): Promise<any> => {
+    const res = await fetchImpl(`${baseUrl}${pathname}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", origin: MOCK_E2E_OWNER_ORIGIN },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as { ok?: boolean; data?: any; error?: any };
+    if (!res.ok || json.ok === false) {
+      throw new Error(
+        `device-owner bootstrap step ${pathname} failed (${res.status}): ${JSON.stringify(json)}`,
+      );
+    }
+    return json.data;
+  };
+
+  // 1) install challenge → 2) sign + claim the owner slot.
+  const challenge = await post("/v1/auth/bootstrap/challenge", {
+    installId: MOCK_E2E_OWNER_INSTALL_ID,
+    osUser: MOCK_E2E_OWNER_OS_USER,
+    origin: MOCK_E2E_OWNER_ORIGIN,
+  });
+  const claimTranscript = makeTranscript(key, {
+    action: challenge.action,
+    nonce: challenge.nonce,
+    origin: challenge.origin,
+    deviceId,
+    hubId: challenge.hubId,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    expiresAt: challenge.expiresAt,
+  });
+  await post("/v1/auth/bootstrap/device-claim", {
+    nonce: challenge.nonce,
+    devicePublicKey: key.spkiDerBase64,
+    deviceId,
+    origin: challenge.origin,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    deviceClaimProof: {
+      transcript: claimTranscript,
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(key, claimTranscript) },
+    },
+  });
+
+  // 3) server-issued single-use login challenge → 4) sign owner-login + mint session.
+  const loginChallenge = await post("/v1/auth/login/challenge", {
+    installId: MOCK_E2E_OWNER_INSTALL_ID,
+    osUser: MOCK_E2E_OWNER_OS_USER,
+    origin: MOCK_E2E_OWNER_ORIGIN,
+    deviceId,
+    devicePublicKey: key.spkiDerBase64,
+  });
+  const loginTranscript = makeTranscript(key, {
+    action: "owner-login",
+    nonce: loginChallenge.nonce,
+    origin: loginChallenge.origin,
+    deviceId,
+    hubId: loginChallenge.hubId,
+    installId: loginChallenge.installId,
+    osUser: loginChallenge.osUser,
+    expiresAt: loginChallenge.expiresAt,
+  });
+  const login = await post("/v1/auth/login", {
+    devicePublicKey: key.spkiDerBase64,
+    deviceId,
+    origin: loginChallenge.origin,
+    deviceLoginProof: {
+      transcript: loginTranscript,
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(key, loginTranscript) },
+    },
+  });
+  const ownerUserId = login.user.id as string;
+  return {
+    accessToken: login.accessToken as string,
+    ownerActor: { kind: "user", id: ownerUserId, principalId: ownerUserId },
   };
 }
 
@@ -260,58 +333,6 @@ async function apiFetch<T>(
   return { status: res.status, json };
 }
 
-type LoginEnvelope = {
-  ok: boolean;
-  data?: { accessToken: string };
-  error?: { code?: string; message?: string };
-};
-
-async function loginAdmin(
-  baseUrl: string,
-  fetchImpl: typeof fetch,
-): Promise<string> {
-  const tryLogin = async (
-    body: Record<string, unknown>,
-  ): Promise<LoginEnvelope> => {
-    const res = await fetchImpl(`${baseUrl}/v1/auth/login`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    return (await res.json()) as LoginEnvelope;
-  };
-
-  const passphrase = process.env.FRIDAY_TEST_LOCAL_PASSPHRASE ?? "friday-e2e-passphrase-123";
-  const bootstrapStatusRes = await fetchImpl(`${baseUrl}/v1/auth/bootstrap/status`, {
-    method: "GET",
-    headers: { "Content-Type": "application/json" },
-  });
-  const bootstrapStatus = (await bootstrapStatusRes.json()) as {
-    ok: boolean;
-    data?: {
-      bootstrapRequired: boolean;
-    };
-  };
-
-  const requiresBootstrap = Boolean(bootstrapStatus.data?.bootstrapRequired);
-  if (requiresBootstrap) {
-    await fetchImpl(`${baseUrl}/v1/auth/bootstrap/local-passphrase`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ passphrase }),
-    });
-  }
-
-  const passphraseAttempt = await tryLogin({ localPassphrase: passphrase });
-  if (passphraseAttempt.ok && passphraseAttempt.data?.accessToken) {
-    return passphraseAttempt.data.accessToken;
-  }
-
-  throw new Error(
-    `Admin login failed: passphrase=${JSON.stringify(passphraseAttempt)}`,
-  );
-}
-
 // ─── Track original fetch ───
 // NOTE: _originalFetch is only used inside createMockHubEnv closures.
 // Each env captures its own instance-local reference to avoid races.
@@ -330,6 +351,7 @@ async function loginAdmin(
 async function installProvider(
   baseUrl: string,
   ownerToken: string,
+  ownerActor: OwnerSessionActor,
   entry: ProviderMatrixEntry,
   fetchImpl?: typeof fetch,
 ): Promise<InstalledMockProvider> {
@@ -362,7 +384,7 @@ async function installProvider(
   const idempotencyKey = `mock-e2e-provider-create:${entry.kind}`;
   const request = createFridayProviderSetupMutatingActionRequest({
     action: "providers.create",
-    actor: MOCK_E2E_DEVICE_OWNER_ACTOR,
+    actor: ownerActor,
     surface: "api:/v1/providers/create",
     parameters: body,
     planDigest,
@@ -522,6 +544,13 @@ export async function createMockHubEnv(opts?: {
       logRequests: false,
       channels: opts?.channels,
       tokenSecret: MOCK_E2E_TOKEN_SECRET,
+      // Option C / Option B*: inject a native-owner claim resolver that runs the REAL
+      // capability mint over injected native-evidence doubles, so the REAL owner-claim
+      // → deviceKeyLogin path mints a genuine `user.id` session (no fabricated token).
+      // The surface flag reports device-claim availability honestly (native seam
+      // injected here). NEVER flips NATIVE_IPC_ATTESTATION_AVAILABLE.
+      resolveNativeOwnerClaimContext: createTestNativeOwnerResolver(),
+      nativeOwnerClaimSurfaceAvailable: () => true,
       allowTestOnlyWorkflowRunExecution: opts?.allowTestOnlyWorkflowRunExecution ?? true,
       allowTestOnlySkillRunExecution: opts?.allowTestOnlySkillRunExecution ?? true,
       allowTestOnlySkillVerifyExecution: opts?.allowTestOnlySkillVerifyExecution ?? true,
@@ -595,7 +624,10 @@ export async function createMockHubEnv(opts?: {
   const hubBaseUrl = `http://127.0.0.1:${String(port)}`;
 
   // 4. Login as admin with local passphrase auth.
-  const accessToken = await loginAdmin(hubBaseUrl, originalFetch);
+  // Real production owner-bootstrap → deviceKeyLogin (principal = local owner
+  // `user.id`). The injected native-owner claim resolver makes the claim/login mint;
+  // the server resolves the durable owner↔device binding for provider mutations.
+  const { accessToken, ownerActor } = await deviceOwnerBootstrapLogin(hubBaseUrl, originalFetch);
 
   // 5. Build mock fetches per API
   const mocks: Record<string, MockFetch> = {};
@@ -623,12 +655,13 @@ export async function createMockHubEnv(opts?: {
   installFetchRouter();
 
   // 7. Register providers via API.
-  // Provider mutations require a DEVICE-AUTHORED owner approval (CR-2), so drive
-  // them AS the owner's device-owner principal (bearer token + signed approval).
-  const deviceOwnerToken = mintDeviceOwnerAccessToken();
+  // Provider mutations require a DEVICE-AUTHORED owner approval (CR-2). We drive them
+  // AS the REAL owner session (principal = `user.id`); the server binds each approval
+  // to the authenticated owner's durable device (Option B*), and the SAME owner device
+  // key that claimed the owner slot signs every approval.
   const providers: Record<string, InstalledMockProvider> = {};
   for (const entry of selectedEntries) {
-    const installed = await installProvider(hubBaseUrl, deviceOwnerToken, entry, originalFetch);
+    const installed = await installProvider(hubBaseUrl, accessToken, ownerActor, entry, originalFetch);
     providers[installed.kind] = installed;
   }
 
@@ -643,14 +676,14 @@ export async function createMockHubEnv(opts?: {
     const idempotencyKey = "mock-e2e-provider-routing";
     const request = createFridayProviderSetupMutatingActionRequest({
       action: "providers.routing.set",
-      actor: MOCK_E2E_DEVICE_OWNER_ACTOR,
+      actor: ownerActor,
       surface: "api:/v1/model-routing/set",
       resourceId: "model-routing",
       parameters: routingBody,
       planDigest,
       idempotencyKey,
     });
-    await apiFetch(hubBaseUrl, deviceOwnerToken, "PUT", "/v1/model-routing", {
+    await apiFetch(hubBaseUrl, accessToken, "PUT", "/v1/model-routing", {
       ...routingBody,
       planDigest,
       idempotencyKey,
@@ -660,14 +693,14 @@ export async function createMockHubEnv(opts?: {
     const doctorPlanDigest = "mock-e2e-capability-doctor";
     const doctorRequest = createFridayProviderSetupMutatingActionRequest({
       action: "capabilities.doctor",
-      actor: MOCK_E2E_DEVICE_OWNER_ACTOR,
+      actor: ownerActor,
       surface: "api:/v1/capabilities/doctor",
       resourceId: providerIds.join(","),
       parameters: doctorBody,
       planDigest: doctorPlanDigest,
       idempotencyKey: doctorPlanDigest,
     });
-    await apiFetch(hubBaseUrl, deviceOwnerToken, "POST", "/v1/capabilities/doctor", {
+    await apiFetch(hubBaseUrl, accessToken, "POST", "/v1/capabilities/doctor", {
       ...doctorBody,
       planDigest: doctorPlanDigest,
       idempotencyKey: doctorPlanDigest,

--- a/test/e2e/mock/_helpers/mock-env.ts
+++ b/test/e2e/mock/_helpers/mock-env.ts
@@ -23,8 +23,19 @@ import type {
 } from "../../../../src/providers/model/friday-provider.types.js";
 import {
   createFridayMutatingActionDigest,
-  signFridayCanonicalApproval,
 } from "../../../../src/security/friday-mutating-action-gate.js";
+import type {
+  FridayCanonicalApprovalResolution,
+  FridayMutatingActionRequest,
+} from "../../../../src/security/friday-mutating-action-gate.js";
+import { encodeToken } from "../../../../src/api/auth/friday-token-validator.js";
+import { getScopesForRole } from "../../../../src/api/auth/friday-rbac-policy.js";
+import {
+  deviceOwnerPrincipalIdFor,
+  generateTestDeviceKey,
+  makeApprovalProof,
+  makeApprovalTranscript,
+} from "../../../helpers/friday-provider-approval-test-kit.js";
 import {
   createMockFetch,
   resetMockCounters,
@@ -121,11 +132,88 @@ const AUTO_DETECT_PROVIDER_ENV_VARS = [
 ] as const;
 const MOCK_E2E_TOKEN_SECRET = "mock-e2e-token-secret"; // pragma: allowlist secret -- deterministic signing key for canonical-gate mock E2E setup
 const MOCK_E2E_MASTER_KEY = Buffer.alloc(32, 23).toString("hex");
-const MOCK_E2E_ACTOR = {
+
+// ─── SEC-APPROVAL-AUTHORITY-001 · CR-2: device-authored provider-mutation owner ───
+//
+// Provider mutations (create / routing.set / capabilities.doctor) now require a
+// DEVICE-AUTHORED owner approval: a P-256 `friday-provider-approval-v1` transcript
+// signed by the OWNER DEVICE and merely VERIFIED by the Hub (the Hub holds NO
+// signing key and REFUSES its own HMAC/unsigned approvals). We mint ONE software
+// dev/test owner device (NOT a Secure Enclave key; parity with the CR-2 runtime
+// tests) and drive the three provider-mutation setup calls AS that device owner:
+//   • the HTTP principal for those three calls is the owner's device-owner principal
+//     (`device-owner:<keyHash>`), minted directly with the PRODUCTION token encoder
+//     so `createActorFromPrincipal` recomputes the SAME action digest the owner
+//     device signed; and
+//   • each approval is the owner device's signed transcript bound to that exact
+//     action digest + owner principal.
+// The rest of the mock env is unchanged — the general session `accessToken` stays
+// the ordinary local-passphrase admin, so no other behaviour shifts.
+const MOCK_E2E_DEVICE_OWNER_KEY = generateTestDeviceKey();
+const MOCK_E2E_DEVICE_OWNER_PRINCIPAL = deviceOwnerPrincipalIdFor(MOCK_E2E_DEVICE_OWNER_KEY);
+// The digest actor MUST mirror the server's `createActorFromPrincipal(ctx.principal)`
+// for the device-owner HTTP principal: principalType "user", id/principalId = the
+// device-owner principal id.
+const MOCK_E2E_DEVICE_OWNER_ACTOR = {
   kind: "user",
-  id: "admin-001",
-  principalId: "admin-001",
+  id: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
+  principalId: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
 } as const;
+const MOCK_E2E_PROVIDER_APPROVAL_EXPIRES_AT = "2099-01-01T00:00:00.000Z";
+
+/**
+ * Mint an access token whose bound principal IS the owner's device-owner principal
+ * (`device-owner:<keyHash>`, principalType "user"), using the PRODUCTION token
+ * encoder + the mock hub's token secret. No `sid` is set: the validator skips
+ * session-state tracking for a token without a session id, so this stands in for a
+ * device-owner principal that has already cleared attestation (exactly what the
+ * CR-2 route tests model with an injected `device-owner:<hash>` "user" principal).
+ * Used ONLY for the provider-mutation setup calls; the session token is unchanged.
+ */
+function mintDeviceOwnerAccessToken(): string {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return encodeToken(
+    {
+      tokenId: "mock-e2e-device-owner-token",
+      principalType: "user",
+      principalId: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
+      userId: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
+      role: "admin",
+      scopes: [...getScopesForRole("admin")],
+      iat: nowSec,
+      exp: nowSec + 60 * 60 * 24 * 365,
+    },
+    MOCK_E2E_TOKEN_SECRET,
+  );
+}
+
+/**
+ * Build a DEVICE-AUTHORED approval for a provider mutation: recompute the request's
+ * action digest, then have the owner device sign a transcript bound to that exact
+ * digest + owner principal + approvalId + expiry. The Hub verifies (never signs) it.
+ */
+function mintDeviceOwnerApproval(
+  request: FridayMutatingActionRequest,
+  approvalId: string,
+): FridayCanonicalApprovalResolution {
+  const actionDigest = createFridayMutatingActionDigest(request);
+  const expiresAt = MOCK_E2E_PROVIDER_APPROVAL_EXPIRES_AT;
+  const transcript = makeApprovalTranscript(MOCK_E2E_DEVICE_OWNER_KEY, {
+    actionDigest,
+    approvalId,
+    decidedByPrincipalId: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
+    expiresAt,
+  });
+  return {
+    decision: "approved",
+    approvalId,
+    decidedByPrincipalId: MOCK_E2E_DEVICE_OWNER_PRINCIPAL,
+    actionDigest,
+    expiresAt,
+    issuer: "friday_device_owner",
+    deviceProof: makeApprovalProof(MOCK_E2E_DEVICE_OWNER_KEY, transcript),
+  };
+}
 
 // ─── Helpers ───
 
@@ -241,7 +329,7 @@ async function loginAdmin(
 
 async function installProvider(
   baseUrl: string,
-  token: string,
+  ownerToken: string,
   entry: ProviderMatrixEntry,
   fetchImpl?: typeof fetch,
 ): Promise<InstalledMockProvider> {
@@ -274,7 +362,7 @@ async function installProvider(
   const idempotencyKey = `mock-e2e-provider-create:${entry.kind}`;
   const request = createFridayProviderSetupMutatingActionRequest({
     action: "providers.create",
-    actor: MOCK_E2E_ACTOR,
+    actor: MOCK_E2E_DEVICE_OWNER_ACTOR,
     surface: "api:/v1/providers/create",
     parameters: body,
     planDigest,
@@ -283,17 +371,14 @@ async function installProvider(
   const { status, json } = await apiFetch<{
     ok: boolean;
     data: { provider: { id: string } };
-  }>(baseUrl, token, "POST", "/v1/providers", {
+  }>(baseUrl, ownerToken, "POST", "/v1/providers", {
     ...body,
     planDigest,
     idempotencyKey,
-    canonicalApproval: signFridayCanonicalApproval({
-      decision: "approved",
-      approvalId: `mock-e2e-provider-create:${entry.kind}`,
-      decidedByPrincipalId: MOCK_E2E_ACTOR.principalId,
-      actionDigest: createFridayMutatingActionDigest(request),
-      expiresAt: "2099-01-01T00:00:00.000Z",
-    }, MOCK_E2E_TOKEN_SECRET),
+    canonicalApproval: mintDeviceOwnerApproval(
+      request,
+      `mock-e2e-provider-create:${entry.kind}`,
+    ),
   }, fetchImpl);
 
   if (status !== 200 || !json.ok) {
@@ -537,10 +622,13 @@ export async function createMockHubEnv(opts?: {
   };
   installFetchRouter();
 
-  // 7. Register providers via API
+  // 7. Register providers via API.
+  // Provider mutations require a DEVICE-AUTHORED owner approval (CR-2), so drive
+  // them AS the owner's device-owner principal (bearer token + signed approval).
+  const deviceOwnerToken = mintDeviceOwnerAccessToken();
   const providers: Record<string, InstalledMockProvider> = {};
   for (const entry of selectedEntries) {
-    const installed = await installProvider(hubBaseUrl, accessToken, entry, originalFetch);
+    const installed = await installProvider(hubBaseUrl, deviceOwnerToken, entry, originalFetch);
     providers[installed.kind] = installed;
   }
 
@@ -555,47 +643,35 @@ export async function createMockHubEnv(opts?: {
     const idempotencyKey = "mock-e2e-provider-routing";
     const request = createFridayProviderSetupMutatingActionRequest({
       action: "providers.routing.set",
-      actor: MOCK_E2E_ACTOR,
+      actor: MOCK_E2E_DEVICE_OWNER_ACTOR,
       surface: "api:/v1/model-routing/set",
       resourceId: "model-routing",
       parameters: routingBody,
       planDigest,
       idempotencyKey,
     });
-    await apiFetch(hubBaseUrl, accessToken, "PUT", "/v1/model-routing", {
+    await apiFetch(hubBaseUrl, deviceOwnerToken, "PUT", "/v1/model-routing", {
       ...routingBody,
       planDigest,
       idempotencyKey,
-      canonicalApproval: signFridayCanonicalApproval({
-        decision: "approved",
-        approvalId: "mock-e2e-provider-routing",
-        decidedByPrincipalId: MOCK_E2E_ACTOR.principalId,
-        actionDigest: createFridayMutatingActionDigest(request),
-        expiresAt: "2099-01-01T00:00:00.000Z",
-      }, MOCK_E2E_TOKEN_SECRET),
+      canonicalApproval: mintDeviceOwnerApproval(request, "mock-e2e-provider-routing"),
     }, originalFetch);
     const doctorBody = { providerIds };
     const doctorPlanDigest = "mock-e2e-capability-doctor";
     const doctorRequest = createFridayProviderSetupMutatingActionRequest({
       action: "capabilities.doctor",
-      actor: MOCK_E2E_ACTOR,
+      actor: MOCK_E2E_DEVICE_OWNER_ACTOR,
       surface: "api:/v1/capabilities/doctor",
       resourceId: providerIds.join(","),
       parameters: doctorBody,
       planDigest: doctorPlanDigest,
       idempotencyKey: doctorPlanDigest,
     });
-    await apiFetch(hubBaseUrl, accessToken, "POST", "/v1/capabilities/doctor", {
+    await apiFetch(hubBaseUrl, deviceOwnerToken, "POST", "/v1/capabilities/doctor", {
       ...doctorBody,
       planDigest: doctorPlanDigest,
       idempotencyKey: doctorPlanDigest,
-      canonicalApproval: signFridayCanonicalApproval({
-        decision: "approved",
-        approvalId: doctorPlanDigest,
-        decidedByPrincipalId: MOCK_E2E_ACTOR.principalId,
-        actionDigest: createFridayMutatingActionDigest(doctorRequest),
-        expiresAt: "2099-01-01T00:00:00.000Z",
-      }, MOCK_E2E_TOKEN_SECRET),
+      canonicalApproval: mintDeviceOwnerApproval(doctorRequest, doctorPlanDigest),
     }, originalFetch);
   }
   for (const mock of Object.values(mocks)) {

--- a/test/helpers/friday-provider-approval-test-kit.ts
+++ b/test/helpers/friday-provider-approval-test-kit.ts
@@ -1,0 +1,99 @@
+// ─── SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 — device-approval test kit ───
+//
+// TRUTH LABEL: every keypair + signature here is a SOFTWARE dev/test P-256 key
+// generated on the fly with Node crypto. NOT a Secure Enclave key, NOT final
+// attestation evidence. It exists ONLY to drive the REAL production verifier +
+// gate + confirm route through the device-authored approval model and its
+// adversarial negatives. Signing reuses the PRODUCTION canonical encoder
+// (`encodeProviderApprovalTranscript`), so the test signs exactly what the Hub
+// verifies. It NEVER re-implements ECDSA verification.
+
+import { sign as cryptoSign } from "node:crypto";
+
+import {
+  encodeProviderApprovalTranscript,
+  PROVIDER_APPROVAL_ALGORITHM,
+  PROVIDER_APPROVAL_KIND,
+  PROVIDER_APPROVAL_TRANSCRIPT_VERSION,
+} from "../../src/api/auth/device-attest/index.js";
+import type {
+  ProviderApprovalDeviceProof,
+  ProviderApprovalTranscript,
+} from "../../src/api/auth/device-attest/index.js";
+import { deviceOwnerPrincipalId } from "../../src/security/friday-device-owner-authority-precondition.js";
+import { generateTestDeviceKey, toHighSTwin, toLowS, type TestDeviceKey } from "../adversarial/_secsetup-s2a.helpers.js";
+
+export { generateTestDeviceKey, toHighSTwin, toLowS };
+export type { TestDeviceKey };
+
+/** The device-owner principal id bound to a test device key (device-owner:<hash>). */
+export function deviceOwnerPrincipalIdFor(key: TestDeviceKey): string {
+  return deviceOwnerPrincipalId(key.publicKeyHash);
+}
+
+/** Build a well-formed device-approval transcript bound to `key`, with overrides. */
+export function makeApprovalTranscript(
+  key: TestDeviceKey,
+  input: {
+    actionDigest: string;
+    decidedByPrincipalId?: string;
+    approvalId?: string;
+    expiresAt?: string;
+  },
+  overrides: Partial<ProviderApprovalTranscript> = {},
+): ProviderApprovalTranscript {
+  return {
+    transcriptVersion: PROVIDER_APPROVAL_TRANSCRIPT_VERSION,
+    algorithm: PROVIDER_APPROVAL_ALGORITHM,
+    kind: PROVIDER_APPROVAL_KIND,
+    approvalId: input.approvalId ?? "approval-0001",
+    actionDigest: input.actionDigest,
+    decidedByPrincipalId: input.decidedByPrincipalId ?? deviceOwnerPrincipalIdFor(key),
+    expiresAt: input.expiresAt ?? "2999-01-01T00:00:00.000Z",
+    devicePublicKeyHash: key.publicKeyHash,
+    ...overrides,
+  };
+}
+
+/** Raw (un-normalized) P-1363 signature bytes over the canonical transcript. */
+export function signApprovalRaw(
+  key: TestDeviceKey,
+  transcript: ProviderApprovalTranscript,
+): Buffer {
+  const bytes = encodeProviderApprovalTranscript(transcript);
+  return cryptoSign("sha256", Buffer.from(bytes), {
+    key: key.privateKey,
+    dsaEncoding: "ieee-p1363",
+  });
+}
+
+/**
+ * Build a full device-approval proof (transcript + public key + low-S signature).
+ * The `signWith` key may DIFFER from the transcript's bound key so "sign A, present
+ * B" attacks are expressible.
+ */
+export function makeApprovalProof(
+  signWith: TestDeviceKey,
+  transcript: ProviderApprovalTranscript,
+  presentKey: TestDeviceKey = signWith,
+): ProviderApprovalDeviceProof {
+  const raw = signApprovalRaw(signWith, transcript);
+  return {
+    transcript,
+    devicePublicKey: { encoding: "spki-der-base64", value: presentKey.spkiDerBase64 },
+    signature: { encoding: "ieee-p1363-base64", value: toLowS(raw).toString("base64") },
+  };
+}
+
+/** A high-S (malleable) variant of the proof — the verifier MUST reject it. */
+export function makeHighSApprovalProof(
+  key: TestDeviceKey,
+  transcript: ProviderApprovalTranscript,
+): ProviderApprovalDeviceProof {
+  const raw = signApprovalRaw(key, transcript);
+  return {
+    transcript,
+    devicePublicKey: { encoding: "spki-der-base64", value: key.spkiDerBase64 },
+    signature: { encoding: "ieee-p1363-base64", value: toHighSTwin(raw).toString("base64") },
+  };
+}

--- a/test/integration/api/friday-device-claim-surface-http-proof.test.ts
+++ b/test/integration/api/friday-device-claim-surface-http-proof.test.ts
@@ -1,0 +1,307 @@
+// ─── SEC-NATIVE-OWNER-CLAIM-CAPABILITY-001 · CORE-A CR-1 (F1) — surface wiring ──
+//
+// F1 acceptance: `createFridayApiRuntime` now wires the native-owner claim SURFACE +
+// resolver so `GET /v1/auth/bootstrap/status → deviceClaimAvailable` drives the UI's
+// first-run gate (router.tsx routes to the device-claim gate when true, else the
+// passphrase gate). This proves, over real HTTP through the production runtime:
+//   • a release-shaped fixture (resolver+surface injected) → deviceClaimAvailable:true,
+//     fresh passphrase CREATION is retired on a release profile, and device claim →
+//     deviceKeyLogin mints a REAL `user.id` session;
+//   • default dev/CI (no injection, non-release) → deviceClaimAvailable:false (passphrase
+//     gate) — the honest state on this unsigned tree;
+//   • HONESTY: the SURFACE flag may be true while the capability stays UNMINTABLE on an
+//     unsigned tree (resolver mints nothing) → device claim fails CLOSED, and the login
+//     challenge stays live — never fake-enabled;
+//   • the emergency kill switch forces a refusal even with a resolver present.
+//
+// `NATIVE_IPC_ATTESTATION_AVAILABLE` stays `false` throughout.
+
+import * as crypto from "node:crypto";
+import * as net from "node:net";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFridayApiRuntime, createFridayHttpServer } from "#api";
+import type { FridayHttpServer } from "#api";
+import type { FridayProviderService } from "#providers";
+import type { FridaySqliteLayer } from "#state";
+import type { NativeOwnerClaimContextResolver } from "../../../src/security/attestation/friday-verified-native-owner-claim-context.js";
+import { DEVICE_OWNER_AUTHORITY_KILL_SWITCH_ENV, NATIVE_IPC_ATTESTATION_AVAILABLE } from "../../../src/security/friday-device-owner-authority-precondition.js";
+import { createTestDb } from "../../helpers/friday-test-db.helper.js";
+import { createTestNativeOwnerResolver } from "../../adversarial/_native-owner-capability.helpers.js";
+import {
+  generateTestDeviceKey,
+  makeTranscript,
+  signTranscriptLowS,
+  type TestDeviceKey,
+} from "../../adversarial/_secsetup-s2a.helpers.js";
+
+const ORIGIN = "https://friday.localhost";
+const INSTALL_ID = "install-surface-1";
+const OS_USER = "jarvis";
+const DEVICE_ID = "device-surface-1";
+
+function mockProviderService(): FridayProviderService {
+  return {
+    listProviders: async () => [],
+    getProvider: async () => null,
+    createProvider: async () => ({}) as never,
+    updateProvider: async () => ({}) as never,
+    deleteProvider: async () => undefined,
+    validateProvider: async () => ({ status: "ok" as const, checkedAt: new Date(0).toISOString() }),
+    getRoutingConfig: async () => ({ defaultProviderId: "", fallbackProviderIds: [] }),
+    setRoutingConfig: async (input) => input,
+    resolveRoute: async () => ({}) as never,
+    runWithFallback: async () => ({}) as never,
+  } as unknown as FridayProviderService;
+}
+
+const usedPorts = new Set<number>();
+async function findEphemeralPortAbove(min: number): Promise<number> {
+  const lo = Math.max(min + 1, 49153);
+  const hi = 65535;
+  const span = hi - lo + 1;
+  for (let attempt = 0; attempt < 512; attempt += 1) {
+    const candidate = lo + ((attempt * 3671 + 5003) % span);
+    if (usedPorts.has(candidate)) continue;
+    const bound = await new Promise<number | null>((resolve) => {
+      const srv = net.createServer();
+      srv.once("error", () => resolve(null));
+      srv.listen(candidate, "127.0.0.1", () => srv.close((e) => resolve(e ? null : candidate)));
+    });
+    if (bound !== null && bound > min) {
+      usedPorts.add(bound);
+      return bound;
+    }
+  }
+  throw new Error(`could not allocate an ephemeral port > ${min}`);
+}
+
+interface Harness {
+  server: FridayHttpServer;
+  db: FridaySqliteLayer;
+  post(path: string, body: unknown): Promise<{ status: number; json: any }>;
+  get(path: string): Promise<{ status: number; json: any }>;
+}
+
+async function makeHarness(opts: {
+  resolver?: NativeOwnerClaimContextResolver;
+  surfaceAvailable?: () => boolean;
+}): Promise<Harness> {
+  const db = createTestDb();
+  const runtime = createFridayApiRuntime({
+    db,
+    idGenerator: (() => {
+      let n = 0;
+      return () => `id-${String(++n).padStart(5, "0")}`;
+    })(),
+    nowIso: () => new Date().toISOString(),
+    providerService: mockProviderService(),
+    tokenSecret: crypto.randomBytes(32).toString("hex"), // pragma: allowlist secret
+    computeChecksum: (content: string) => `checksum-${content.length}`,
+    resolveSkill: () => null,
+    invokeSkill: async () => ({}),
+    ...(opts.resolver ? { resolveNativeOwnerClaimContext: opts.resolver } : {}),
+    ...(opts.surfaceAvailable ? { nativeOwnerClaimSurfaceAvailable: opts.surfaceAvailable } : {}),
+  });
+  const port = await findEphemeralPortAbove(49152);
+  const server = createFridayHttpServer({
+    routes: runtime.routes,
+    wsGateway: runtime.wsGateway,
+    middleware: runtime.middleware,
+    port,
+    host: "127.0.0.1",
+    logRequests: false,
+  });
+  await server.listen();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  const request = async (method: string, path: string, body?: unknown) => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        const res = await fetch(`${baseUrl}${path}`, {
+          method,
+          headers: { "content-type": "application/json", origin: ORIGIN, connection: "close" },
+          ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+        });
+        let json: any = null;
+        try { json = await res.json(); } catch { json = null; }
+        return { status: res.status, json };
+      } catch (err) {
+        if (attempt === 2) throw err;
+      }
+    }
+    throw new Error("unreachable");
+  };
+  return {
+    server,
+    db,
+    post: (path, body) => request("POST", path, body),
+    get: (path) => request("GET", path),
+  };
+}
+
+/** Issue a bootstrap challenge and attempt to claim the owner slot with `key`. */
+async function attemptClaim(h: Harness, key: TestDeviceKey): Promise<{ status: number; json: any }> {
+  const challenge = (await h.post("/v1/auth/bootstrap/challenge", {
+    installId: INSTALL_ID,
+    osUser: OS_USER,
+    origin: ORIGIN,
+  })).json.data;
+  const transcript = makeTranscript(key, {
+    action: challenge.action,
+    nonce: challenge.nonce,
+    origin: challenge.origin,
+    deviceId: DEVICE_ID,
+    hubId: challenge.hubId,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    expiresAt: challenge.expiresAt,
+  });
+  return h.post("/v1/auth/bootstrap/device-claim", {
+    nonce: challenge.nonce,
+    devicePublicKey: key.spkiDerBase64,
+    deviceId: DEVICE_ID,
+    origin: challenge.origin,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    deviceClaimProof: {
+      transcript,
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(key, transcript) },
+    },
+  });
+}
+
+/** Claim (must succeed) then deviceKeyLogin with `key`; returns the login response. */
+async function claimAndLogin(h: Harness, key: TestDeviceKey): Promise<{ status: number; json: any }> {
+  const claim = await attemptClaim(h, key);
+  expect(claim.json?.data?.claimed).toBe(true);
+  const loginChallenge = (await h.post("/v1/auth/login/challenge", {
+    installId: INSTALL_ID,
+    osUser: OS_USER,
+    origin: ORIGIN,
+    deviceId: DEVICE_ID,
+    devicePublicKey: key.spkiDerBase64,
+  })).json.data;
+  const transcript = makeTranscript(key, {
+    action: "owner-login",
+    nonce: loginChallenge.nonce,
+    origin: loginChallenge.origin,
+    deviceId: DEVICE_ID,
+    hubId: loginChallenge.hubId,
+    installId: loginChallenge.installId,
+    osUser: loginChallenge.osUser,
+    expiresAt: loginChallenge.expiresAt,
+  });
+  return h.post("/v1/auth/login", {
+    devicePublicKey: key.spkiDerBase64,
+    deviceId: DEVICE_ID,
+    origin: loginChallenge.origin,
+    deviceLoginProof: {
+      transcript,
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(key, transcript) },
+    },
+  });
+}
+
+describe("SEC-NATIVE-OWNER-CLAIM-CAPABILITY-001 (F1): device-claim surface + resolver wiring", () => {
+  const servers: FridayHttpServer[] = [];
+  const dbs: FridaySqliteLayer[] = [];
+  const savedEnv: Record<string, string | undefined> = {
+    FRIDAY_RELEASE_TAG: process.env.FRIDAY_RELEASE_TAG,
+    [DEVICE_OWNER_AUTHORITY_KILL_SWITCH_ENV]: process.env[DEVICE_OWNER_AUTHORITY_KILL_SWITCH_ENV],
+  };
+
+  afterEach(async () => {
+    while (servers.length) await servers.pop()!.close();
+    while (dbs.length) dbs.pop()!.close();
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  async function harness(opts: Parameters<typeof makeHarness>[0]): Promise<Harness> {
+    const h = await makeHarness(opts);
+    servers.push(h.server);
+    dbs.push(h.db);
+    return h;
+  }
+
+  it("HONESTY: NATIVE_IPC_ATTESTATION_AVAILABLE stays false", () => {
+    expect(NATIVE_IPC_ATTESTATION_AVAILABLE).toBe(false);
+  });
+
+  it("RELEASE FIXTURE: deviceClaimAvailable:true, passphrase CREATION retired, device claim→login mints a user.id session", async () => {
+    // Release profile → passphrase creation retired; resolver+surface injected (as a
+    // signed native slice supplies) so the capability is actually mintable.
+    process.env.FRIDAY_RELEASE_TAG = "v1-f1-acceptance";
+    const h = await harness({
+      resolver: createTestNativeOwnerResolver(),
+      surfaceAvailable: () => true,
+    });
+
+    const status = await h.get("/v1/auth/bootstrap/status");
+    expect(status.json.data.deviceClaimAvailable).toBe(true);
+    expect(status.json.data.bootstrapRequired).toBe(true);
+
+    // On a release profile, creating a fresh passphrase owner is retired (device-native).
+    const passphrase = await h.post("/v1/auth/bootstrap/local-passphrase", { passphrase: "friday-f1-should-be-retired" });
+    expect(passphrase.status).toBe(403);
+    expect(passphrase.json.error.code).toBe("AUTH_BOOTSTRAP_PASSPHRASE_RETIRED");
+
+    const owner = generateTestDeviceKey();
+    const login = await claimAndLogin(h, owner);
+    expect(login.status).toBe(200);
+    expect(login.json.data.accessToken).toBeTruthy();
+    // The minted session principal is the ordinary local owner user.id — NOT device-owner:.
+    expect(login.json.data.user.id).not.toContain("device-owner:");
+  });
+
+  it("DEFAULT dev/CI: no resolver + non-release → deviceClaimAvailable:false (passphrase gate)", async () => {
+    delete process.env.FRIDAY_RELEASE_TAG;
+    const h = await harness({}); // runtime defaults: honest-absent resolver + release-gated surface
+    const status = await h.get("/v1/auth/bootstrap/status");
+    expect(status.json.data.deviceClaimAvailable).toBe(false);
+    expect(status.json.data.bootstrapRequired).toBe(true);
+  });
+
+  it("HONESTY: surface present but UNSIGNED (no mintable capability) → device claim fails CLOSED, login challenge still live", async () => {
+    // The surface is honestly present (UI shows the device gate) but the resolver mints
+    // NOTHING on this unsigned tree — the capability is UNMINTABLE. Never fake-enabled.
+    const h = await harness({ surfaceAvailable: () => true }); // NO resolver → runtime default → null
+
+    const status = await h.get("/v1/auth/bootstrap/status");
+    expect(status.json.data.deviceClaimAvailable).toBe(true);
+
+    const owner = generateTestDeviceKey();
+    const claim = await attemptClaim(h, owner);
+    expect(claim.status).toBe(401);
+    expect(claim.json.error.code).toBe("AUTH_BOOTSTRAP_DEVICE_AUTHORITY_UNVERIFIED");
+    // The owner slot stays unclaimed (fail-closed, zero state change).
+    const status2 = await h.get("/v1/auth/bootstrap/status");
+    expect(status2.json.data.bootstrapRequired).toBe(true);
+    // A fresh login challenge can still be issued (nothing was burned).
+    const lc = await h.post("/v1/auth/login/challenge", {
+      installId: INSTALL_ID,
+      osUser: OS_USER,
+      origin: ORIGIN,
+      deviceId: DEVICE_ID,
+      devicePublicKey: owner.spkiDerBase64,
+    });
+    expect(lc.status).toBe(200);
+    expect(lc.json.data.nonce).toBeTruthy();
+  });
+
+  it("KILL SWITCH: even with a resolver present, device claim is refused", async () => {
+    process.env[DEVICE_OWNER_AUTHORITY_KILL_SWITCH_ENV] = "1";
+    const h = await harness({
+      resolver: createTestNativeOwnerResolver(),
+      surfaceAvailable: () => true,
+    });
+    const owner = generateTestDeviceKey();
+    const claim = await attemptClaim(h, owner);
+    expect(claim.status).toBe(401);
+    expect(claim.json.error.code).toBe("AUTH_BOOTSTRAP_DEVICE_AUTHORITY_UNVERIFIED");
+  });
+});

--- a/test/integration/api/friday-provider-approval-consumption-durability-http-proof.test.ts
+++ b/test/integration/api/friday-provider-approval-consumption-durability-http-proof.test.ts
@@ -1,0 +1,371 @@
+// ─── SEC-APPROVAL-AUTHORITY-001 · CORE-A round-3 Lane B (Advisor round-2 finding #3) ──
+//
+// Authoritative DURABLE-SINK readback: a device-authored provider-mutation approval that
+// is confirmed + consumed ONCE cannot be replayed after a restart, nor by a concurrent
+// request. Everything runs through the REAL production public seam — a genuine
+// owner-bootstrap → deviceKeyLogin session, the REAL sqlite-backed provider service, and
+// the durable v108 consumption ledger — over real HTTP:
+//   bootstrap/challenge → device-claim → login → plan → confirm (device-authored) →
+//   POST /v1/providers, then a fresh runtime on the SAME db replays the identical approval.
+//
+// The provider TABLE is read directly to assert ZERO second durable side-effect. Native
+// attestation stays honestly ABSENT (`createTestNativeOwnerResolver` mints the claim/login
+// capability over injected native-evidence doubles, exactly as a signed release supplies).
+
+import * as crypto from "node:crypto";
+import * as net from "node:net";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFridayApiRuntime, createFridayHttpServer } from "#api";
+import type { FridayHttpServer } from "#api";
+import { createFridayProviderService, resetMasterKeyCache } from "#providers";
+import type { FridayProviderService } from "#providers";
+import type { FridaySqliteLayer } from "#state";
+import { createTestDb, createTestIdGenerator } from "../../helpers/friday-test-db.helper.js";
+import { createTestNativeOwnerResolver } from "../../adversarial/_native-owner-capability.helpers.js";
+import {
+  generateTestDeviceKey,
+  makeTranscript,
+  signTranscriptLowS,
+  type TestDeviceKey,
+} from "../../adversarial/_secsetup-s2a.helpers.js";
+import {
+  deviceOwnerPrincipalIdFor,
+  makeApprovalProof,
+  makeApprovalTranscript,
+} from "../../helpers/friday-provider-approval-test-kit.js";
+
+const ORIGIN = "https://friday.localhost";
+const INSTALL_ID = "install-approval-consumption-1";
+const OS_USER = "jarvis";
+
+// validateOnSave:false + an env-ref key → the real service persists with NO network probe
+// and NO secret encryption (no master key needed), so the create is a pure durable write.
+const CREATE_PARAMS = {
+  kind: "openai" as const,
+  name: "OpenAI",
+  baseUrl: "https://api.openai.com",
+  authMode: "api-key" as const,
+  api: "openai-completions" as const,
+  supportedModels: ["gpt-4o"],
+  apiKey: "$OPENAI_API_KEY",
+  preserveEnvRef: true,
+  validateOnSave: false,
+};
+
+const usedPorts = new Set<number>();
+
+async function findEphemeralPortAbove(min: number): Promise<number> {
+  const lo = Math.max(min + 1, 49153);
+  const hi = 65535;
+  const span = hi - lo + 1;
+  for (let attempt = 0; attempt < 512; attempt += 1) {
+    const candidate = lo + ((attempt * 2861 + 7919) % span);
+    if (usedPorts.has(candidate)) continue;
+    const bound = await new Promise<number | null>((resolve) => {
+      const srv = net.createServer();
+      srv.once("error", () => resolve(null));
+      srv.listen(candidate, "127.0.0.1", () => {
+        srv.close((e) => resolve(e ? null : candidate));
+      });
+    });
+    if (bound !== null && bound > min) {
+      usedPorts.add(bound);
+      return bound;
+    }
+  }
+  throw new Error(`could not allocate an ephemeral port > ${min}`);
+}
+
+interface Harness {
+  db: FridaySqliteLayer;
+  server: FridayHttpServer;
+  service: FridayProviderService;
+  post(path: string, body: unknown, token?: string): Promise<{ status: number; json: any }>;
+}
+
+/** Build a runtime + server on the given db, with the REAL sqlite-backed provider service. */
+async function makeHarness(db: FridaySqliteLayer, tokenSecret: string): Promise<Harness> {
+  const service = createFridayProviderService({
+    db,
+    idGenerator: createTestIdGenerator(),
+    nowIso: () => new Date().toISOString(),
+  });
+  const runtime = createFridayApiRuntime({
+    db,
+    idGenerator: (() => {
+      let n = 0;
+      return () => `id-${String(++n).padStart(5, "0")}`;
+    })(),
+    nowIso: () => new Date().toISOString(),
+    providerService: service,
+    tokenSecret,
+    canonicalMutatingActionGate: true,
+    computeChecksum: (content: string) => `checksum-${content.length}`,
+    resolveSkill: () => null,
+    invokeSkill: async () => ({}),
+    resolveNativeOwnerClaimContext: createTestNativeOwnerResolver(),
+    nativeOwnerClaimSurfaceAvailable: () => true,
+  });
+
+  // Allocate + listen with a bounded retry: the probe→bind window can race a sibling
+  // integration suite that dialed the same ephemeral port (EADDRINUSE), so re-allocate.
+  let port = 0;
+  let server: FridayHttpServer | null = null;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    port = await findEphemeralPortAbove(51000 + attempt * 500);
+    const candidate = createFridayHttpServer({
+      routes: runtime.routes,
+      wsGateway: runtime.wsGateway,
+      middleware: runtime.middleware,
+      port,
+      host: "127.0.0.1",
+      logRequests: false,
+    });
+    try {
+      await candidate.listen();
+      server = candidate;
+      break;
+    } catch (err) {
+      await candidate.close().catch(() => {});
+      if (attempt === 7 || (err as NodeJS.ErrnoException)?.code !== "EADDRINUSE") throw err;
+    }
+  }
+  if (!server) throw new Error("could not bind an ephemeral port for the test server");
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  const post = async (path: string, body: unknown, token?: string) => {
+    const doFetch = () =>
+      fetch(`${baseUrl}${path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: ORIGIN,
+          connection: "close",
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(body),
+      });
+    let res: Response | null = null;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        res = await doFetch();
+        break;
+      } catch (err) {
+        if (attempt === 2) throw err;
+      }
+    }
+    let json: any = null;
+    try {
+      json = await res!.json();
+    } catch {
+      json = null;
+    }
+    return { status: res!.status, json };
+  };
+
+  return { db, server, service, post };
+}
+
+async function bootstrapAndClaim(h: Harness, key: TestDeviceKey, deviceId: string): Promise<void> {
+  const challenge = (await h.post("/v1/auth/bootstrap/challenge", {
+    installId: INSTALL_ID,
+    osUser: OS_USER,
+    origin: ORIGIN,
+  })).json.data;
+  const claimTranscript = makeTranscript(key, {
+    action: challenge.action,
+    nonce: challenge.nonce,
+    origin: challenge.origin,
+    deviceId,
+    hubId: challenge.hubId,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    expiresAt: challenge.expiresAt,
+  });
+  const claim = await h.post("/v1/auth/bootstrap/device-claim", {
+    nonce: challenge.nonce,
+    devicePublicKey: key.spkiDerBase64,
+    deviceId,
+    origin: challenge.origin,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    deviceClaimProof: {
+      transcript: claimTranscript,
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(key, claimTranscript) },
+    },
+  });
+  expect(claim.json?.data?.claimed ?? claim.json?.claimed).toBe(true);
+}
+
+/** Login only (device already claimed) → session token + user id. */
+async function loginOnly(
+  h: Harness,
+  key: TestDeviceKey,
+  deviceId: string,
+): Promise<{ token: string; userId: string }> {
+  const loginChallenge = (await h.post("/v1/auth/login/challenge", {
+    installId: INSTALL_ID,
+    osUser: OS_USER,
+    origin: ORIGIN,
+    deviceId,
+    devicePublicKey: key.spkiDerBase64,
+  })).json.data;
+  const loginTranscript = makeTranscript(key, {
+    action: "owner-login",
+    nonce: loginChallenge.nonce,
+    origin: loginChallenge.origin,
+    deviceId,
+    hubId: loginChallenge.hubId,
+    installId: loginChallenge.installId,
+    osUser: loginChallenge.osUser,
+    expiresAt: loginChallenge.expiresAt,
+  });
+  const login = await h.post("/v1/auth/login", {
+    devicePublicKey: key.spkiDerBase64,
+    deviceId,
+    origin: loginChallenge.origin,
+    deviceLoginProof: {
+      transcript: loginTranscript,
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(key, loginTranscript) },
+    },
+  });
+  const data = login.json.data;
+  expect(data?.accessToken).toBeTruthy();
+  expect(data.user.id).not.toContain("device-owner:");
+  return { token: data.accessToken as string, userId: data.user.id as string };
+}
+
+/** Plan → device-authored confirm; returns the confirmed canonical approval + plan digest. */
+async function planAndConfirm(
+  h: Harness,
+  token: string,
+  approvalKey: TestDeviceKey,
+): Promise<{ planDigest: string; approval: any }> {
+  const planResp = await h.post("/v1/providers/plan", { action: "providers.create", params: CREATE_PARAMS }, token);
+  const planned = planResp.json?.data?.plan as { planDigest: string; actionDigest: string };
+  if (!planned) throw new Error(`plan failed (status ${planResp.status}): ${JSON.stringify(planResp.json)}`);
+  const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+  const transcript = makeApprovalTranscript(approvalKey, {
+    actionDigest: planned.actionDigest,
+    decidedByPrincipalId: deviceOwnerPrincipalIdFor(approvalKey),
+    approvalId: "approval-consumption-1",
+    expiresAt,
+  });
+  const deviceApproval = makeApprovalProof(approvalKey, transcript);
+  const confirm = await h.post(
+    "/v1/providers/plan/confirm",
+    { planDigest: planned.planDigest, confirm: true, deviceApproval },
+    token,
+  );
+  if (confirm.status !== 200) throw new Error(`confirm failed: ${JSON.stringify(confirm.json)}`);
+  return { planDigest: planned.planDigest, approval: confirm.json.data.approval.canonicalApproval };
+}
+
+function countProviderRows(db: FridaySqliteLayer): number {
+  return db.withReadConnection((c) =>
+    (c.prepare("SELECT COUNT(*) AS n FROM provider_profiles").get() as { n: number }).n,
+  );
+}
+
+function consumptionStatus(db: FridaySqliteLayer): string[] {
+  return db
+    .withReadConnection((c) =>
+      c.prepare("SELECT status FROM provider_mutation_approval_consumption").all() as Array<{ status: string }>,
+    )
+    .map((r) => r.status);
+}
+
+describe("SEC-APPROVAL-AUTHORITY-001: a consumed provider approval cannot be replayed (durable)", () => {
+  const servers: FridayHttpServer[] = [];
+  const dbs: FridaySqliteLayer[] = [];
+
+  afterEach(async () => {
+    while (servers.length) await servers.pop()!.close();
+    while (dbs.length) dbs.pop()!.close();
+    resetMasterKeyCache();
+  });
+
+  async function harness(db: FridaySqliteLayer, tokenSecret: string): Promise<Harness> {
+    // No global fetch mock: the test's own HTTP client uses fetch to hit the server, and
+    // validateOnSave:false means the provider service performs NO network probe.
+    const h = await makeHarness(db, tokenSecret);
+    servers.push(h.server);
+    return h;
+  }
+
+  it("RESTART REPLAY: a fresh process on the SAME db refuses the identical approval, ZERO second effect", async () => {
+    const db = createTestDb();
+    dbs.push(db);
+    const tokenSecret = crypto.randomBytes(32).toString("hex");
+    const deviceId = "device-consumption-1";
+    const owner = generateTestDeviceKey();
+
+    // ── Process 1: full flow, confirm + mutate ONCE ──
+    const h1 = await harness(db, tokenSecret);
+    await bootstrapAndClaim(h1, owner, deviceId);
+    const login1 = await loginOnly(h1, owner, deviceId);
+    const { planDigest, approval } = await planAndConfirm(h1, login1.token, owner);
+
+    const mutate1 = await h1.post(
+      "/v1/providers",
+      { ...CREATE_PARAMS, planDigest, canonicalApproval: approval },
+      login1.token,
+    );
+    if (mutate1.status !== 200) throw new Error(`first mutate failed: ${JSON.stringify(mutate1.json)}`);
+    expect(mutate1.json.ok).toBe(true);
+    expect(countProviderRows(db)).toBe(1);
+    // The approval is durably consumed.
+    expect(consumptionStatus(db)).toEqual(["consumed"]);
+
+    // ── "Restart": a brand-new runtime + gate + consumption store on the SAME db ──
+    // (same tokenSecret + the persisted session ⇒ the owner's token is still valid, so we
+    // isolate the variable under test to the fresh in-memory gate/store on the same db.)
+    await servers.pop()!.close(); // close process-1 server
+    const h2 = await harness(db, tokenSecret);
+
+    // Replay the IDENTICAL confirmed approval against the fresh process.
+    const replay = await h2.post(
+      "/v1/providers",
+      { ...CREATE_PARAMS, planDigest, canonicalApproval: approval },
+      login1.token,
+    );
+    expect(replay.status).toBe(403);
+    expect(JSON.stringify(replay.json)).toContain("canonical_approval_already_used");
+
+    // Authoritative durable-sink readback: NO second provider row was written.
+    expect(countProviderRows(db)).toBe(1);
+    expect(consumptionStatus(db)).toEqual(["consumed"]);
+  });
+
+  it("CONCURRENT REPLAY: two simultaneous mutates with the same approval → exactly ONE effect", async () => {
+    const db = createTestDb();
+    dbs.push(db);
+    const tokenSecret = crypto.randomBytes(32).toString("hex");
+    const deviceId = "device-consumption-2";
+    const owner = generateTestDeviceKey();
+
+    const h = await harness(db, tokenSecret);
+    await bootstrapAndClaim(h, owner, deviceId);
+    const { token } = await loginOnly(h, owner, deviceId);
+    const { planDigest, approval } = await planAndConfirm(h, token, owner);
+
+    const body = { ...CREATE_PARAMS, planDigest, canonicalApproval: approval };
+    const [a, b] = await Promise.all([
+      h.post("/v1/providers", body, token),
+      h.post("/v1/providers", body, token),
+    ]);
+
+    const statuses = [a.status, b.status].sort();
+    // Exactly one 200 winner; the other refused (403 already-used / denied).
+    expect(statuses.filter((s) => s === 200)).toHaveLength(1);
+    expect(statuses.filter((s) => s !== 200)).toHaveLength(1);
+    const refused = a.status === 200 ? b : a;
+    expect(JSON.stringify(refused.json)).toContain("canonical_approval_already_used");
+
+    // Exactly ONE durable provider effect.
+    expect(countProviderRows(db)).toBe(1);
+    expect(consumptionStatus(db)).toEqual(["consumed"]);
+  });
+});

--- a/test/integration/api/friday-provider-mutation-owner-binding-http-proof.test.ts
+++ b/test/integration/api/friday-provider-mutation-owner-binding-http-proof.test.ts
@@ -1,0 +1,389 @@
+// ─── SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 (Option B*) — production public-seam ──
+//
+// F2 acceptance: the device-authored provider-mutation approval path admits ONLY
+// when driven through the REAL production auth surface — a genuine owner-bootstrap →
+// deviceKeyLogin session whose principal is the ordinary local owner `user.id` (NOT a
+// fabricated `device-owner:` token) — and the server resolves the durable owner↔device
+// binding (`users.password_hash = device-owner$v1$<sha256Hex(devicePublicKey)>`)
+// SERVER-SIDE. Everything runs through `createFridayApiRuntime` over real HTTP:
+//   bootstrap/challenge → device-claim → login/challenge → deviceKeyLogin →
+//   POST /v1/providers/plan → /plan/confirm (device-authored) → POST /v1/providers.
+//
+// Native attestation is honestly ABSENT on this tree; the device claim/login are made
+// mintable ONLY by injecting a resolver that runs the REAL capability mint over
+// injected native-evidence doubles (`createTestNativeOwnerResolver`), exactly as a
+// signed release supplies from the Companion accept boundary. No test fabricates a
+// `device-owner:` token via `encodeToken`, and `NATIVE_IPC_ATTESTATION_AVAILABLE`
+// stays `false`.
+
+import * as crypto from "node:crypto";
+import * as net from "node:net";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFridayApiRuntime, createFridayHttpServer } from "#api";
+import type { FridayHttpServer } from "#api";
+import type { FridayProviderProfile, FridayProviderService } from "#providers";
+import type { FridaySqliteLayer } from "#state";
+import { createTestDb } from "../../helpers/friday-test-db.helper.js";
+import { createTestNativeOwnerResolver } from "../../adversarial/_native-owner-capability.helpers.js";
+import {
+  generateTestDeviceKey,
+  makeTranscript,
+  signTranscriptLowS,
+  type TestDeviceKey,
+} from "../../adversarial/_secsetup-s2a.helpers.js";
+import {
+  deviceOwnerPrincipalIdFor,
+  makeApprovalProof,
+  makeApprovalTranscript,
+} from "../../helpers/friday-provider-approval-test-kit.js";
+import { NATIVE_IPC_ATTESTATION_AVAILABLE } from "../../../src/security/friday-device-owner-authority-precondition.js";
+
+const ORIGIN = "https://friday.localhost";
+const INSTALL_ID = "install-owner-binding-1";
+const OS_USER = "jarvis";
+
+const CREATE_PARAMS = {
+  kind: "openai" as const,
+  name: "OpenAI",
+  baseUrl: "https://api.openai.com",
+  authMode: "api-key" as const,
+  api: "openai-completions" as const,
+  supportedModels: ["gpt-4o"],
+  apiKey: "sk-mock-owner-binding", // pragma: allowlist secret
+};
+
+function sampleProfile(): FridayProviderProfile {
+  return {
+    id: "p-owner-binding",
+    kind: "openai",
+    name: "OpenAI",
+    baseUrl: "https://api.openai.com",
+    enabled: true,
+    defaultModel: "gpt-4o",
+    config: {
+      api: "openai-completions",
+      authMode: "api-key",
+      keySource: { kind: "env-ref", envVar: "OPENAI_API_KEY" },
+      supportedModels: ["gpt-4o"],
+      validation: { status: "ok", checkedAt: new Date(0).toISOString() },
+    },
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+function mockProviderService(): FridayProviderService {
+  let created: FridayProviderProfile | null = null;
+  return {
+    listProviders: async () => (created ? [created] : []),
+    getProvider: async () => created,
+    createProvider: async () => {
+      created = sampleProfile();
+      return created;
+    },
+    updateProvider: async () => ({}) as never,
+    deleteProvider: async () => undefined,
+    validateProvider: async () => ({ status: "ok" as const, checkedAt: new Date(0).toISOString() }),
+    getRoutingConfig: async () => ({ defaultProviderId: "p-owner-binding", fallbackProviderIds: [] }),
+    setRoutingConfig: async (input) => input,
+    resolveRoute: async () => ({}) as never,
+    runWithFallback: async () => ({}) as never,
+  } as unknown as FridayProviderService;
+}
+
+// Track ports already handed out in this file so consecutive per-test servers NEVER
+// reuse a port — a reused port would let the global fetch (undici) keep-alive pool
+// dial a stale connection to a closed prior server → ECONNRESET.
+const usedPorts = new Set<number>();
+
+async function findEphemeralPortAbove(min: number): Promise<number> {
+  const lo = Math.max(min + 1, 49153);
+  const hi = 65535;
+  const span = hi - lo + 1;
+  for (let attempt = 0; attempt < 512; attempt += 1) {
+    const candidate = lo + ((attempt * 2861 + 7919) % span);
+    if (usedPorts.has(candidate)) continue;
+    const bound = await new Promise<number | null>((resolve) => {
+      const srv = net.createServer();
+      srv.once("error", () => resolve(null));
+      srv.listen(candidate, "127.0.0.1", () => {
+        srv.close((e) => resolve(e ? null : candidate));
+      });
+    });
+    if (bound !== null && bound > min) {
+      usedPorts.add(bound);
+      return bound;
+    }
+  }
+  throw new Error(`could not allocate an ephemeral port > ${min}`);
+}
+
+interface Harness {
+  baseUrl: string;
+  db: FridaySqliteLayer;
+  server: FridayHttpServer;
+  post(path: string, body: unknown, token?: string): Promise<{ status: number; json: any }>;
+}
+
+async function makeHarness(opts: { releaseNativeOnly?: boolean } = {}): Promise<Harness> {
+  const db = createTestDb();
+  const runtime = createFridayApiRuntime({
+    db,
+    idGenerator: (() => {
+      let n = 0;
+      return () => `id-${String(++n).padStart(5, "0")}`;
+    })(),
+    nowIso: () => new Date().toISOString(),
+    providerService: mockProviderService(),
+    tokenSecret: crypto.randomBytes(32).toString("hex"), // pragma: allowlist secret
+    canonicalMutatingActionGate: true,
+    computeChecksum: (content: string) => `checksum-${content.length}`,
+    resolveSkill: () => null,
+    invokeSkill: async () => ({}),
+    // Option C: inject a resolver that runs the REAL capability mint over injected
+    // native-evidence doubles, so the REAL device claim/login mint. Surface true →
+    // the bootstrap-status honestly reports device-claim availability. Absent for the
+    // passphrase-owner negative below (that hub keeps the passphrase path live).
+    ...(opts.releaseNativeOnly
+      ? {}
+      : {
+          resolveNativeOwnerClaimContext: createTestNativeOwnerResolver(),
+          nativeOwnerClaimSurfaceAvailable: () => true,
+        }),
+  });
+
+  const port = await findEphemeralPortAbove(49152);
+  const server = createFridayHttpServer({
+    routes: runtime.routes,
+    wsGateway: runtime.wsGateway,
+    middleware: runtime.middleware,
+    port,
+    host: "127.0.0.1",
+    logRequests: false,
+  });
+  await server.listen();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  const post = async (path: string, body: unknown, token?: string) => {
+    const doFetch = () =>
+      fetch(`${baseUrl}${path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: ORIGIN,
+          connection: "close", // avoid keep-alive pooling across per-test servers
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(body),
+      });
+    let res: Response | null = null;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        res = await doFetch();
+        break;
+      } catch (err) {
+        // A stale keep-alive connection to a prior server can surface as ECONNRESET;
+        // a fresh dial succeeds. Retry a bounded number of times.
+        if (attempt === 2) throw err;
+      }
+    }
+    let json: any = null;
+    try {
+      json = await res!.json();
+    } catch {
+      json = null;
+    }
+    return { status: res!.status, json };
+  };
+
+  return { baseUrl, db, server, post };
+}
+
+/** Real owner-bootstrap → deviceKeyLogin with `key`; returns the session token + user id. */
+async function deviceOwnerLogin(
+  h: Harness,
+  key: TestDeviceKey,
+  deviceId = "device-owner-binding-1",
+): Promise<{ token: string; userId: string }> {
+  const challenge = (await h.post("/v1/auth/bootstrap/challenge", {
+    installId: INSTALL_ID,
+    osUser: OS_USER,
+    origin: ORIGIN,
+  })).json.data;
+  const claimTranscript = makeTranscript(key, {
+    action: challenge.action,
+    nonce: challenge.nonce,
+    origin: challenge.origin,
+    deviceId,
+    hubId: challenge.hubId,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    expiresAt: challenge.expiresAt,
+  });
+  const claim = await h.post("/v1/auth/bootstrap/device-claim", {
+    nonce: challenge.nonce,
+    devicePublicKey: key.spkiDerBase64,
+    deviceId,
+    origin: challenge.origin,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    deviceClaimProof: {
+      transcript: claimTranscript,
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(key, claimTranscript) },
+    },
+  });
+  expect(claim.json?.data?.claimed ?? claim.json?.claimed).toBe(true);
+
+  const loginChallenge = (await h.post("/v1/auth/login/challenge", {
+    installId: INSTALL_ID,
+    osUser: OS_USER,
+    origin: ORIGIN,
+    deviceId,
+    devicePublicKey: key.spkiDerBase64,
+  })).json.data;
+  const loginTranscript = makeTranscript(key, {
+    action: "owner-login",
+    nonce: loginChallenge.nonce,
+    origin: loginChallenge.origin,
+    deviceId,
+    hubId: loginChallenge.hubId,
+    installId: loginChallenge.installId,
+    osUser: loginChallenge.osUser,
+    expiresAt: loginChallenge.expiresAt,
+  });
+  const login = await h.post("/v1/auth/login", {
+    devicePublicKey: key.spkiDerBase64,
+    deviceId,
+    origin: loginChallenge.origin,
+    deviceLoginProof: {
+      transcript: loginTranscript,
+      signature: { encoding: "ieee-p1363-base64", value: signTranscriptLowS(key, loginTranscript) },
+    },
+  });
+  const data = login.json.data;
+  expect(data?.accessToken).toBeTruthy();
+  // The session principal is the ordinary local owner user.id — NOT a device-owner id.
+  expect(data.user.id).not.toContain("device-owner:");
+  return { token: data.accessToken as string, userId: data.user.id as string };
+}
+
+/** Plan → device-authored confirm; returns { planDigest, canonicalApproval } (or throws on refusal). */
+async function planAndConfirm(
+  h: Harness,
+  token: string,
+  approvalKey: TestDeviceKey,
+  opts: { decidedByPrincipalId?: string } = {},
+): Promise<{ status: number; json: any }> {
+  const planResp = await h.post("/v1/providers/plan", { action: "providers.create", params: CREATE_PARAMS }, token);
+  if (!planResp.json?.data?.plan) {
+    throw new Error(`plan failed (status ${planResp.status}): ${JSON.stringify(planResp.json)}`);
+  }
+  const planned = planResp.json.data.plan as { planDigest: string; actionDigest: string };
+  const expiresAt = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+  const transcript = makeApprovalTranscript(approvalKey, {
+    actionDigest: planned.actionDigest,
+    decidedByPrincipalId: opts.decidedByPrincipalId ?? deviceOwnerPrincipalIdFor(approvalKey),
+    approvalId: "approval-owner-binding-1",
+    expiresAt,
+  });
+  const deviceApproval = makeApprovalProof(approvalKey, transcript);
+  const confirm = await h.post(
+    "/v1/providers/plan/confirm",
+    { planDigest: planned.planDigest, confirm: true, deviceApproval },
+    token,
+  );
+  return { status: confirm.status, json: { ...confirm.json, planDigest: planned.planDigest } };
+}
+
+describe("SEC-APPROVAL-AUTHORITY-001 (Option B*): provider mutation binds to the authenticated owner's device", () => {
+  const servers: FridayHttpServer[] = [];
+  const dbs: FridaySqliteLayer[] = [];
+
+  afterEach(async () => {
+    while (servers.length) await servers.pop()!.close();
+    while (dbs.length) dbs.pop()!.close();
+  });
+
+  async function harness(opts?: { releaseNativeOnly?: boolean }): Promise<Harness> {
+    const h = await makeHarness(opts);
+    servers.push(h.server);
+    dbs.push(h.db);
+    return h;
+  }
+
+  it("HONESTY: NATIVE_IPC_ATTESTATION_AVAILABLE stays false", () => {
+    expect(NATIVE_IPC_ATTESTATION_AVAILABLE).toBe(false);
+  });
+
+  it("ADMITS + PERSISTS a device-authored mutation through the REAL owner session (principal = user.id)", async () => {
+    const h = await harness();
+    const owner = generateTestDeviceKey();
+    const { token, userId } = await deviceOwnerLogin(h, owner);
+
+    // The durable binding is the sentinel — resolved server-side, principal stays user.id.
+    const storedHash = h.db.withReadConnection((c) =>
+      (c.prepare("SELECT password_hash AS h FROM users WHERE id = ?").get(userId) as { h: string }).h,
+    );
+    expect(storedHash).toBe(`device-owner$v1$${crypto.createHash("sha256").update(owner.spkiDerBase64).digest("hex")}`);
+
+    const confirmed = await planAndConfirm(h, token, owner);
+    expect(confirmed.status).toBe(200);
+    const approval = confirmed.json.data.approval.canonicalApproval;
+    expect(approval.issuer).toBe("friday_device_owner");
+
+    const mutate = await h.post(
+      "/v1/providers",
+      { ...CREATE_PARAMS, planDigest: confirmed.json.planDigest, canonicalApproval: approval },
+      token,
+    );
+    if (mutate.status !== 200) throw new Error(`mutate failed: ${JSON.stringify(mutate.json)}`);
+    expect(mutate.status).toBe(200);
+    expect(mutate.json.ok).toBe(true);
+    expect(mutate.json.data.provider.id).toBe("p-owner-binding");
+  });
+
+  it("NEGATIVE (1): an approval signed by a DIFFERENT owner device is refused", async () => {
+    const h = await harness();
+    const owner = generateTestDeviceKey();
+    const attacker = generateTestDeviceKey();
+    const { token } = await deviceOwnerLogin(h, owner);
+
+    // The attacker signs with its own key but claims to be the owner device.
+    const confirm = await planAndConfirm(h, token, attacker, {
+      decidedByPrincipalId: deviceOwnerPrincipalIdFor(attacker),
+    });
+    expect(confirm.status).toBe(403);
+    expect(confirm.json.error.code).toBe("PROVIDER_MUTATION_APPROVAL_DEVICE_NOT_BOUND");
+  });
+
+  it("NEGATIVE (2): a PASSPHRASE owner (no device binding) cannot use a device-authored approval", async () => {
+    const h = await harness({ releaseNativeOnly: false });
+    // Passphrase-bootstrap the local owner (no device sentinel is ever written).
+    await h.post("/v1/auth/bootstrap/local-passphrase", { passphrase: "friday-owner-binding-pass" });
+    const login = await h.post("/v1/auth/login", { localPassphrase: "friday-owner-binding-pass" });
+    const token = login.json.data.accessToken as string;
+    expect(token).toBeTruthy();
+
+    const some = generateTestDeviceKey();
+    const confirm = await planAndConfirm(h, token, some);
+    expect(confirm.status).toBe(403);
+    expect(confirm.json.error.code).toBe("PROVIDER_MUTATION_APPROVAL_DEVICE_NOT_BOUND");
+  });
+
+  it("NEGATIVE (3): cross-device — an approval bound to another owner's device is refused", async () => {
+    const h = await harness();
+    const owner = generateTestDeviceKey();
+    const otherOwnerDevice = generateTestDeviceKey();
+    const { token } = await deviceOwnerLogin(h, owner);
+
+    // A structurally valid, self-consistent approval — but for a DIFFERENT device than
+    // the one bound to the authenticated owner.
+    const confirm = await planAndConfirm(h, token, otherOwnerDevice, {
+      decidedByPrincipalId: deviceOwnerPrincipalIdFor(otherOwnerDevice),
+    });
+    expect(confirm.status).toBe(403);
+    expect(confirm.json.error.code).toBe("PROVIDER_MUTATION_APPROVAL_DEVICE_NOT_BOUND");
+  });
+});

--- a/test/integration/api/friday-secsetup-s3-device-principal-http-proof.test.ts
+++ b/test/integration/api/friday-secsetup-s3-device-principal-http-proof.test.ts
@@ -261,13 +261,19 @@ describe("S3 runtime proof A — device-claim requires PoP (real HTTP, productio
     expect(nonceConsumedAt(nonce)).toBeNull();
   });
 
-  it("ALLOW (owner-slot binding only): a valid PoP claim → 200 claimed, deviceAuthorityEnabled=false", async () => {
+  it("LIVE-DEFECT CLOSED (production posture, real HTTP): a valid PoP claim with NO native capability → 401 refused; owner NULL, nonce un-burned", async () => {
+    // At head this returned 200 claimed with deviceAuthorityEnabled=false — a valid
+    // software-key PoP seized the owner slot in a NODE_ENV=production posture with NO
+    // native authority. Option C gates the owner-sentinel write + nonce consume on a
+    // per-claim VerifiedNativeOwnerClaimContext; this authService is built with the
+    // DEFAULT absent resolver (no native accept boundary) → the claim is refused with
+    // ZERO state change.
     const nonce = await issue();
     const r = await post(claimBody(nonce));
-    expect(r.status).toBe(200);
-    expect(r.json.data.claimed).toBe(true);
-    expect(r.json.data.deviceAuthorityEnabled).toBe(false);
-    expect(r.json.data.keyProtection).toBe("unverified");
+    expect(r.status).toBe(401);
+    expect(r.json?.error?.code).toBe("AUTH_BOOTSTRAP_DEVICE_AUTHORITY_UNVERIFIED");
+    expect(ownerHash()).toBeNull();
+    expect(nonceConsumedAt(nonce)).toBeNull();
   });
 });
 

--- a/test/integration/api/friday-setup-device-claim-http-proof.test.ts
+++ b/test/integration/api/friday-setup-device-claim-http-proof.test.ts
@@ -34,6 +34,7 @@ import type { FridaySqliteLayer } from "#state";
 // SEC-SETUP-BOOTSTRAP-001 Slice 3: device-claim now requires a real PoP. Reuse
 // the S2a signing helpers so this runtime proof drives the REAL verifier.
 import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "../../adversarial/_secsetup-s2a.helpers.js";
+import { createTestNativeOwnerResolver } from "../../adversarial/_native-owner-capability.helpers.js";
 
 const OWNER_ID = "admin-001";
 const NOW = "2026-07-13T00:00:00.000Z";
@@ -163,6 +164,13 @@ describe("SEC-SETUP-BOOTSTRAP-001 runtime proof: device claim over real HTTP + r
       hubId: "http-proof-hub",
       bootstrapNonceTtlSec: 300,
       warn: () => {},
+      // Option C: seizing the owner slot for a device key REQUIRES a per-claim
+      // native capability. This proof drives the GRANTED path over real HTTP in a
+      // production posture by injecting a resolver that runs the REAL capability
+      // mint over injected native-evidence doubles (the same shape a signed release
+      // supplies from the Companion accept boundary). The capability-ABSENT refusal
+      // is proven in the sibling s3-device-principal-http-proof suite.
+      resolveNativeOwnerClaimContext: createTestNativeOwnerResolver(),
     });
 
     const routes = createFridayHttpRouteRegistry();
@@ -259,9 +267,11 @@ describe("SEC-SETUP-BOOTSTRAP-001 runtime proof: device claim over real HTTP + r
     expect(ok.status).toBe(200);
     expect(ok.json.data.claimed).toBe(true);
     expect(ok.json.data.devicePublicKeyHash).toBe(sha256Hex(DEVICE_PUBKEY));
-    // Slice 3 authoritative readback: the device binding carries ZERO authority.
-    expect(ok.json.data.deviceAuthorityEnabled).toBe(false);
-    expect(ok.json.data.keyProtection).toBe("unverified");
+    // Option C authoritative readback: a release-trusted per-claim native capability
+    // was consumed (Secure-Enclave OS-verified custody) → authority granted for THIS
+    // claim. Authority is the per-claim capability, never a global boolean.
+    expect(ok.json.data.deviceAuthorityEnabled).toBe(true);
+    expect(ok.json.data.keyProtection).toBe("secure_enclave_os_verified");
     const claimedHash = ownerHash();
     expect(claimedHash).toBe(`device-owner$v1$${sha256Hex(DEVICE_PUBKEY)}`);
     const consumedRow = nonceRow(nonce);

--- a/test/integration/core-runnable/core-loop-baseline.test.ts
+++ b/test/integration/core-runnable/core-loop-baseline.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createMockHubEnv, type MockHubEnv } from "../../e2e/mock/_helpers/mock-env.js";
+import { PROVIDER_MATRIX } from "../../e2e/mock/_helpers/provider-matrix.js";
+
+/**
+ * (CORE-RUNNABLE-001 / CORE-A CR-0) RED-FIRST black-box HONESTY baseline.
+ *
+ * This test drives the SERVED public HTTP seam (a real `createFridayHub` + HTTP server, stood up
+ * the SAME way the mock E2E tests do) on a clean, RELEASE-LIKE profile — the canonical mutation
+ * gate ON and every legacy TS execution oracle OFF — and ASSERTS the current HONEST state: the
+ * core public loop is RETIRED/DARK. Each core public entrypoint fail-closes with its documented
+ * code rather than doing real work.
+ *
+ * It ENCODES the R14 CR-0 STARTING STATE (the fixed "0/7" the closure measures against): this test
+ * PASSES NOW because it asserts the dark state. Later CORE-A slices FLIP these assertions to green,
+ * one Rust-owned entrypoint at a time — so a future failure here is a SIGNAL that a real path has
+ * landed and this baseline needs to advance, not a regression to paper over.
+ */
+
+interface ErrorEnvelope {
+  ok: boolean;
+  error?: { code?: string; message?: string };
+}
+
+async function apiFetch(
+  env: Pick<MockHubEnv, "baseUrl" | "accessToken">,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; json: ErrorEnvelope }> {
+  const res = await fetch(`${env.baseUrl}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${env.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  const json = (await res.json()) as ErrorEnvelope;
+  return { status: res.status, json };
+}
+
+describe("CORE-A CR-0 — core loop honest baseline (retired/dark, release-like profile)", () => {
+  let env: MockHubEnv;
+
+  beforeAll(async () => {
+    env = await createMockHubEnv({
+      // No mock providers needed: every assertion below fail-closes BEFORE any provider call.
+      providerKinds: [],
+      // Release-like profile: the canonical mutation gate is ON (so provider mutations require an
+      // approved plan digest) and every legacy TS execution oracle is OFF (so the retired public
+      // entrypoints stay fail-closed, exactly as a stock release build).
+      canonicalGate: true,
+      allowTestOnlySessionExecution: false,
+      allowTestOnlySessionRunExecution: false,
+      allowTestOnlyAgentRunStartExecution: false,
+      allowTestOnlySkillRunExecution: false,
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await env?.cleanup();
+  });
+
+  it("POST /v1/sessions → 503 TS_RUNTIME_SESSION_RETIRED", async () => {
+    const { status, json } = await apiFetch(env, "POST", "/v1/sessions", {
+      channel: "discord",
+      chatId: "core-a-baseline",
+    });
+    expect(status).toBe(503);
+    expect(json.error?.code).toBe("TS_RUNTIME_SESSION_RETIRED");
+  });
+
+  it("POST /v1/agent/runs → 503 TS_RUNTIME_AGENT_RUNS_RETIRED", async () => {
+    const { status, json } = await apiFetch(env, "POST", "/v1/agent/runs", {
+      task: "hello from the core-a baseline",
+    });
+    expect(status).toBe(503);
+    expect(json.error?.code).toBe("TS_RUNTIME_AGENT_RUNS_RETIRED");
+  });
+
+  it("POST /v1/skills/:id/run → 503 TS_RUNTIME_SKILL_RUNS_RETIRED", async () => {
+    const { status, json } = await apiFetch(
+      env,
+      "POST",
+      "/v1/skills/core-a-baseline-skill/run",
+      {},
+    );
+    expect(status).toBe(503);
+    expect(json.error?.code).toBe("TS_RUNTIME_SKILL_RUNS_RETIRED");
+  });
+
+  it("POST /v1/providers WITHOUT planDigest (canonical gate ON) → 403 PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED", async () => {
+    const entry = PROVIDER_MATRIX[0]!;
+    // A structurally VALID create body (so validation passes and the request reaches the gate) that
+    // deliberately OMITS the plan digest → the canonical gate refuses the mutation with 403.
+    const { status, json } = await apiFetch(env, "POST", "/v1/providers", {
+      kind: entry.kind,
+      name: `CORE-A baseline ${entry.kind}`,
+      baseUrl: entry.baseUrl,
+      authMode: entry.authMode,
+      api: entry.api,
+      supportedModels: [entry.model],
+      defaultModel: entry.model,
+      enabled: true,
+      validateOnSave: false,
+      apiKey: "mock-key-for-core-a-baseline", // pragma: allowlist secret -- deterministic non-secret for the 403 probe
+    });
+    expect(status).toBe(403);
+    expect(json.error?.code).toBe("PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED");
+  });
+});

--- a/test/integration/system/friday-desktop-release-pipeline.integration.test.ts
+++ b/test/integration/system/friday-desktop-release-pipeline.integration.test.ts
@@ -191,6 +191,51 @@ async function createFixtureRepo(): Promise<string> {
     "scripts/ops/friday-mobile-approval-approve-proof.sh",
     "#!/usr/bin/env bash\nset -euo pipefail\necho \"fixture mobile approval approve proof\"\n",
   );
+
+  // CORE-A round-3 Lane C (finding #4): the Rust agent-run WS server packaging contract now
+  // asserts the DMG + source distribution stage the server payload and the installer launches +
+  // enrolls it. Populate the fixture with files whose content satisfies the `containsAll` tokens
+  // (a placeholder alone would fail the new stronger contract).
+  await writeFileWithParents(
+    root,
+    "scripts/ops/build-friday-companion-dmg.sh",
+    "#!/usr/bin/env bash\nset -euo pipefail\n# fixture DMG build\n" +
+      "bash \"scripts/ops/launchd/stage-rust-agent-run-ws-server-payload.sh\" --repo-dir \"$PWD\" --dest-dir \"$STAGING_DIR\"\n",
+  );
+  await writeFileWithParents(
+    root,
+    "scripts/ops/build-friday-source-distribution.sh",
+    "#!/usr/bin/env bash\nset -euo pipefail\n# fixture source distribution build\n" +
+      "bash \"scripts/ops/launchd/stage-rust-agent-run-ws-server-payload.sh\" --repo-dir \"$PWD\" --dest-dir \"$OUTPUT_DIR\"\n",
+  );
+  await writeFileWithParents(
+    root,
+    "scripts/ops/launchd/stage-rust-agent-run-ws-server-payload.sh",
+    "#!/usr/bin/env bash\nset -euo pipefail\n# fixture staging helper\n" +
+      "PLIST_TEMPLATE=\"scripts/ops/launchd/com.friday.rust-agent-run-ws-server.plist\"\n" +
+      "cargo build --release --bin hub_agent_run_server --bin hub_agent_run_enroll\n" +
+      "# stages both bins + the plist template and writes payload-manifest.json\n",
+  );
+  await writeFileWithParents(
+    root,
+    "scripts/ops/launchd/com.friday.rust-agent-run-ws-server.plist",
+    "<?xml version=\"1.0\"?>\n<!-- fixture Rust agent-run WS server plist -->\n" +
+      "<string>__RUST_SERVER_BIN__</string>\n<string>--workspace</string>\n<string>--db</string>\n" +
+      "<string>--port</string>\n<string>--owner</string>\n<string>--store-dir</string>\n",
+  );
+  await writeFileWithParents(
+    root,
+    "scripts/ops/launchd/build-and-install-rust-agent-run-ws-server.sh",
+    "#!/usr/bin/env bash\nset -euo pipefail\necho \"fixture Rust agent-run cutover tool\"\n",
+  );
+  await writeFileWithParents(
+    root,
+    "scripts/ops/install-friday-launchagent.sh",
+    "#!/usr/bin/env bash\nset -euo pipefail\n# fixture installer\n" +
+      "# provision ~/.friday/master.key\n# plutil -lint the filled plist\n" +
+      "# hub_agent_run_enroll into the store dir\n" +
+      "# launchctl bootstrap com.friday.rust-agent-run-ws-server\n",
+  );
   return root;
 }
 
@@ -322,6 +367,32 @@ describe("client ship gate pipeline check", () => {
         }),
         expect.objectContaining({
           target: "proof:mobile:approval-approve",
+          status: "passed",
+        }),
+        // CORE-A round-3 Lane C (finding #4): the Rust agent-run WS server packaging contract.
+        expect.objectContaining({
+          kind: "rust-agent-run-packaging-contract",
+          target: "scripts/ops/launchd/com.friday.rust-agent-run-ws-server.plist",
+          status: "passed",
+        }),
+        expect.objectContaining({
+          kind: "rust-agent-run-packaging-contract",
+          target: "scripts/ops/launchd/stage-rust-agent-run-ws-server-payload.sh",
+          status: "passed",
+        }),
+        expect.objectContaining({
+          kind: "rust-agent-run-packaging-contract",
+          target: "scripts/ops/build-friday-companion-dmg.sh",
+          status: "passed",
+        }),
+        expect.objectContaining({
+          kind: "rust-agent-run-packaging-contract",
+          target: "scripts/ops/build-friday-source-distribution.sh",
+          status: "passed",
+        }),
+        expect.objectContaining({
+          kind: "rust-agent-run-packaging-contract",
+          target: "scripts/ops/install-friday-launchagent.sh",
           status: "passed",
         }),
       ]),

--- a/test/unit/api/auth/device-attest/friday-provider-approval-transcript.test.ts
+++ b/test/unit/api/auth/device-attest/friday-provider-approval-transcript.test.ts
@@ -1,0 +1,171 @@
+// ─── SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 ───
+//
+// Proof of the device-authored provider-approval PoP verifier + the UI⇄server
+// canonical encoder byte-match. Every keypair/signature here is a SOFTWARE dev
+// key; it drives the REAL production verifier through positive + adversarial paths.
+
+import { describe, it, expect } from "vitest";
+
+import {
+  createFridayProviderApprovalPoPVerifier,
+  encodeProviderApprovalTranscript as serverEncode,
+} from "../../../../../src/api/auth/device-attest/index.js";
+import type { ProviderApprovalTranscript } from "../../../../../src/api/auth/device-attest/index.js";
+import {
+  createWebCryptoDeviceKeyProvider,
+  deviceOwnerPrincipalId,
+  encodeProviderApprovalTranscript as uiEncode,
+  type ProviderApprovalTranscript as UiProviderApprovalTranscript,
+} from "../../../../../ui/src/lib/auth/device-key.js";
+import {
+  generateTestDeviceKey,
+  makeApprovalProof,
+  makeApprovalTranscript,
+  makeHighSApprovalProof,
+} from "../../../../helpers/friday-provider-approval-test-kit.js";
+
+const NOW_MS = Date.parse("2026-07-20T00:00:00.000Z");
+const ACTION_DIGEST = "a".repeat(64);
+
+describe("device-authored provider-approval PoP verifier", () => {
+  const verifier = createFridayProviderApprovalPoPVerifier();
+
+  // ── Encoder byte-match (UI signs what the server verifies) ──
+
+  it("the UI canonical encoder is byte-identical to the server encoder", () => {
+    const key = generateTestDeviceKey();
+    const t = makeApprovalTranscript(key, { actionDigest: ACTION_DIGEST });
+    const ui = Buffer.from(uiEncode(t as unknown as UiProviderApprovalTranscript));
+    const server = serverEncode(t);
+    expect(ui.equals(server)).toBe(true);
+  });
+
+  it("a WebCrypto (UI) signature verifies against the real server verifier", async () => {
+    const provider = createWebCryptoDeviceKeyProvider();
+    const key = await provider.getOrCreateDeviceKey();
+    const transcript: UiProviderApprovalTranscript = {
+      transcriptVersion: "friday-provider-approval-v1",
+      algorithm: "ECDSA_P256_SHA256",
+      kind: "provider_mutation_approval",
+      approvalId: "approval-ui-1",
+      actionDigest: ACTION_DIGEST,
+      decidedByPrincipalId: deviceOwnerPrincipalId(key.devicePublicKeyHash),
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      devicePublicKeyHash: key.devicePublicKeyHash,
+    };
+    const signature = await provider.signApprovalTranscript(transcript);
+    const result = verifier.verifyPossession({
+      transcript: transcript as unknown as ProviderApprovalTranscript,
+      devicePublicKey: { encoding: "spki-der-base64", value: key.devicePublicKeySpkiBase64 },
+      signature,
+      nowMs: NOW_MS,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.actionDigest).toBe(ACTION_DIGEST);
+      expect(result.devicePublicKeyHash).toBe(key.devicePublicKeyHash);
+    }
+  });
+
+  // ── Positive ──
+
+  it("verifies a well-formed device proof and returns the bound fields", () => {
+    const key = generateTestDeviceKey();
+    const transcript = makeApprovalTranscript(key, { actionDigest: ACTION_DIGEST });
+    const proof = makeApprovalProof(key, transcript);
+    const result = verifier.verifyPossession({ ...proof, nowMs: NOW_MS });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.actionDigest).toBe(ACTION_DIGEST);
+      expect(result.decidedByPrincipalId).toBe(transcript.decidedByPrincipalId);
+      expect(result.devicePublicKeyHash).toBe(key.publicKeyHash);
+      expect(result.expiresAt).toBe(transcript.expiresAt);
+    }
+  });
+
+  // ── Adversarial negatives ──
+
+  it("rejects an unsupported transcript version", () => {
+    const key = generateTestDeviceKey();
+    const transcript = makeApprovalTranscript(key, { actionDigest: ACTION_DIGEST }, {
+      transcriptVersion: "friday-provider-approval-v2" as ProviderApprovalTranscript["transcriptVersion"],
+    });
+    const proof = makeApprovalProof(key, transcript);
+    const result = verifier.verifyPossession({ ...proof, nowMs: NOW_MS });
+    expect(result).toMatchObject({ ok: false, reason: "unsupported_transcript_version" });
+  });
+
+  it("rejects an unsupported algorithm (bound INTO the transcript)", () => {
+    const key = generateTestDeviceKey();
+    const transcript = makeApprovalTranscript(key, { actionDigest: ACTION_DIGEST }, {
+      algorithm: "RSA_PSS_SHA256" as ProviderApprovalTranscript["algorithm"],
+    });
+    const proof = makeApprovalProof(key, transcript);
+    const result = verifier.verifyPossession({ ...proof, nowMs: NOW_MS });
+    expect(result).toMatchObject({ ok: false, reason: "unsupported_algorithm" });
+  });
+
+  it("rejects a malformed transcript (missing actionDigest)", () => {
+    const key = generateTestDeviceKey();
+    const transcript = makeApprovalTranscript(key, { actionDigest: ACTION_DIGEST }, { actionDigest: "" });
+    const proof = makeApprovalProof(key, transcript);
+    const result = verifier.verifyPossession({ ...proof, nowMs: NOW_MS });
+    expect(result).toMatchObject({ ok: false, reason: "malformed_transcript" });
+  });
+
+  it("rejects an EXPIRED transcript", () => {
+    const key = generateTestDeviceKey();
+    const transcript = makeApprovalTranscript(key, {
+      actionDigest: ACTION_DIGEST,
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    const proof = makeApprovalProof(key, transcript);
+    const result = verifier.verifyPossession({ ...proof, nowMs: NOW_MS });
+    expect(result).toMatchObject({ ok: false, reason: "expired" });
+  });
+
+  it("rejects a public-key-hash mismatch (transcript bound to a different key)", () => {
+    const key = generateTestDeviceKey();
+    const other = generateTestDeviceKey();
+    const transcript = makeApprovalTranscript(key, { actionDigest: ACTION_DIGEST }, {
+      devicePublicKeyHash: other.publicKeyHash,
+    });
+    // Sign with `key` (whose hash the transcript now lies about) and present `key`.
+    const proof = makeApprovalProof(key, transcript);
+    const result = verifier.verifyPossession({ ...proof, nowMs: NOW_MS });
+    expect(result).toMatchObject({ ok: false, reason: "public_key_hash_mismatch" });
+  });
+
+  it("rejects a high-S (malleable) signature", () => {
+    const key = generateTestDeviceKey();
+    const transcript = makeApprovalTranscript(key, { actionDigest: ACTION_DIGEST });
+    const proof = makeHighSApprovalProof(key, transcript);
+    const result = verifier.verifyPossession({ ...proof, nowMs: NOW_MS });
+    expect(result).toMatchObject({ ok: false, reason: "non_canonical_signature" });
+  });
+
+  it("rejects a signature over a DIFFERENT action digest (sign A, present B)", () => {
+    const key = generateTestDeviceKey();
+    const signedTranscript = makeApprovalTranscript(key, { actionDigest: ACTION_DIGEST });
+    const presentedTranscript = { ...signedTranscript, actionDigest: "b".repeat(64) };
+    // Sign the A-transcript bytes but present the B-transcript.
+    const proof = makeApprovalProof(key, signedTranscript);
+    const result = verifier.verifyPossession({
+      transcript: presentedTranscript,
+      devicePublicKey: proof.devicePublicKey,
+      signature: proof.signature,
+      nowMs: NOW_MS,
+    });
+    expect(result).toMatchObject({ ok: false, reason: "signature_mismatch" });
+  });
+
+  it("rejects a proof signed by a DIFFERENT device than the one presented", () => {
+    const owner = generateTestDeviceKey();
+    const attacker = generateTestDeviceKey();
+    const transcript = makeApprovalTranscript(owner, { actionDigest: ACTION_DIGEST });
+    // Sign with the attacker key but present the owner's public key + hash.
+    const proof = makeApprovalProof(attacker, transcript, owner);
+    const result = verifier.verifyPossession({ ...proof, nowMs: NOW_MS });
+    expect(result).toMatchObject({ ok: false, reason: "signature_mismatch" });
+  });
+});

--- a/test/unit/api/auth/friday-auth-service-device-login.test.ts
+++ b/test/unit/api/auth/friday-auth-service-device-login.test.ts
@@ -27,6 +27,8 @@ import { createFridayAuthService, FridayAuthError } from "#api";
 import type { FridayAuthService } from "#api";
 import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
 import { NATIVE_IPC_ATTESTATION_AVAILABLE } from "../../../../src/security/friday-device-owner-authority-precondition.js";
+import type { NativeOwnerClaimContextResolver } from "../../../../src/security/attestation/friday-verified-native-owner-claim-context.js";
+import { createTestNativeOwnerResolver } from "../../../adversarial/_native-owner-capability.helpers.js";
 import {
   generateTestDeviceKey,
   makeTranscript,
@@ -53,8 +55,19 @@ function makeIdGen(): () => string {
 
 function makeService(
   db: FridaySqliteLayer,
-  opts: { authorityEnabled?: boolean; failMintAtRegister?: boolean } = {},
+  opts: {
+    authorityEnabled?: boolean;
+    resolver?: NativeOwnerClaimContextResolver;
+    failMintAtRegister?: boolean;
+    releaseNativeOnly?: boolean;
+  } = {},
 ): FridayAuthService {
+  // Option C: the enabled branch injects a resolver that runs the REAL capability
+  // mint over injected native-evidence doubles (NEVER flips
+  // NATIVE_IPC_ATTESTATION_AVAILABLE, NEVER forges a capability — the brand makes
+  // that impossible). An explicit `resolver` override drives the negative matrix.
+  const resolver =
+    opts.resolver ?? (opts.authorityEnabled === true ? createTestNativeOwnerResolver() : undefined);
   return createFridayAuthService({
     db,
     idGenerator: makeIdGen(),
@@ -64,11 +77,12 @@ function makeService(
     refreshTokenTtlSec: 604_800,
     hubId: "test-hub",
     bootstrapNonceTtlSec: 300,
-    // Inject the authority seam ONLY when a test needs the enabled branch. This
-    // NEVER flips NATIVE_IPC_ATTESTATION_AVAILABLE — it is the same override a
-    // signed-release/native slice supplies once the OS attestation bridge lands.
+    ...(resolver ? { resolveNativeOwnerClaimContext: resolver } : {}),
     ...(opts.authorityEnabled !== undefined
-      ? { deviceOwnerAuthorityEnabled: () => opts.authorityEnabled === true }
+      ? { nativeOwnerClaimSurfaceAvailable: () => opts.authorityEnabled === true }
+      : {}),
+    ...(opts.releaseNativeOnly !== undefined
+      ? { releaseProfileNativeOnly: () => opts.releaseNativeOnly === true }
       : {}),
     // Simulate a crash mid-mint: throw INSIDE the mint transaction AFTER the
     // login-challenge CAS-consume + session insert, so the whole unit must roll back.
@@ -91,7 +105,9 @@ function clearOwnerPassphrase(db: FridaySqliteLayer): void {
 
 /** Issue a challenge + atomically claim the owner slot with `key`. */
 function claimOwner(db: FridaySqliteLayer, key: TestDeviceKey): void {
-  const svc = makeService(db);
+  // Option C: seizing the owner slot for a device key is authority-bearing and
+  // REQUIRES a per-claim native capability (the resolver). No resolver → refused.
+  const svc = makeService(db, { authorityEnabled: true });
   const challenge = svc.issueBootstrapChallenge(
     { installId: "install-1", osUser: "jarvis", origin: ORIGIN },
     LOOPBACK,
@@ -124,7 +140,9 @@ function claimOwner(db: FridaySqliteLayer, key: TestDeviceKey): void {
   );
   expect(res.claimed).toBe(true);
   // Authoritative durable binding lives on users.password_hash (the sentinel).
-  expect(res.deviceAuthorityEnabled).toBe(false); // real precondition still off
+  // A release-trusted native capability was consumed → authority granted for this
+  // claim (Option C: authority is the per-claim capability, not a global boolean).
+  expect(res.deviceAuthorityEnabled).toBe(true);
 }
 
 /**
@@ -564,5 +582,29 @@ describe("FridayAuthService — CR-1 device-key login mint", () => {
     expect(res.accessToken.length).toBeGreaterThan(0);
     expect(sessionCount(db)).toBe(1);
     expect(loginChallengeConsumedAt(db, nonce)).not.toBeNull();
+  });
+
+  // ── (6) OLD-ROUTE RETIREMENT: fresh RELEASE is device-native only ──
+
+  it("dev/CI profile: passphrase bootstrap is OFFERED (legacy dev seam)", () => {
+    const svc = makeService(db); // default → releaseProfileNativeOnly false
+    const res = svc.bootstrapLocalPassphrase({ passphrase: "correct horse battery" }, LOOPBACK);
+    expect(res.initialized).toBe(true);
+  });
+
+  it("fresh RELEASE profile: passphrase bootstrap is NOT offered (no silent fallback), owner slot untouched", () => {
+    const svc = makeService(db, { releaseNativeOnly: true });
+    let code = "";
+    try {
+      svc.bootstrapLocalPassphrase({ passphrase: "correct horse battery" }, LOOPBACK);
+    } catch (err) {
+      code = (err as { code?: string }).code ?? "";
+    }
+    expect(code).toBe("AUTH_BOOTSTRAP_PASSPHRASE_RETIRED");
+    // The owner slot is untouched — no fresh passphrase owner created.
+    const hash = db.withReadConnection((conn) =>
+      (conn.prepare("SELECT password_hash AS h FROM users WHERE id = 'test-user'").get() as { h: string | null }).h,
+    );
+    expect(hash).toBeNull();
   });
 });

--- a/test/unit/api/auth/friday-auth-service-device-login.test.ts
+++ b/test/unit/api/auth/friday-auth-service-device-login.test.ts
@@ -1,0 +1,333 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · CR-1 — device-key login mint (RED-FIRST) ───
+//
+// The device-claim BACKEND already writes a non-scrypt device-owner sentinel to
+// users.password_hash, but before CR-1 there was NO device-key login path — a
+// device-claimed owner could not obtain a session at all. These tests drive the
+// REAL production auth service (real migrations, real P-256 crypto, the REAL S2a
+// PoP verifier) through:
+//   (1) claim the owner slot with a device key, then log in by proving possession
+//       of the bound private key over a fresh `owner-login` transcript,
+//   (2) the HONEST native-IPC gate: with attestation disabled (the real build)
+//       a cryptographically VALID PoP still mints NOTHING (fall back to passphrase),
+//   (3) no cross-path confusion: the device sentinel can NEVER satisfy passphrase
+//       login, and a passphrase owner can NEVER be logged in via the device path,
+//   (4) negatives: invalid PoP, wrong intent (owner-claim proof replayed as login),
+//       wrong presented key, expired/over-TTL transcript — each denied.
+//
+// TRUTH LABEL: every keypair here is a SOFTWARE dev/test key (see the s2a helper).
+// The honesty constant NATIVE_IPC_ATTESTATION_AVAILABLE is asserted false — this
+// suite NEVER flips it; it exercises the enabled branch ONLY via the injectable
+// authority seam, exactly as a signed-release/native slice would enable it.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import { createFridayAuthService, FridayAuthError } from "#api";
+import type { FridayAuthService } from "#api";
+import { createTestDb } from "../../satellites/_helpers/create-test-db.helper.js";
+import { NATIVE_IPC_ATTESTATION_AVAILABLE } from "../../../../src/security/friday-device-owner-authority-precondition.js";
+import {
+  generateTestDeviceKey,
+  makeTranscript,
+  signTranscriptLowS,
+  type TestDeviceKey,
+} from "../../../adversarial/_secsetup-s2a.helpers.js";
+
+const NOW = "2026-07-13T00:00:00.000Z";
+const LOGIN_EXP = "2026-07-13T00:01:00.000Z"; // NOW + 60s (within the 300s login TTL clamp)
+const FAR_FUTURE = "2999-01-01T00:00:00.000Z";
+const LOOPBACK = "127.0.0.1";
+const ORIGIN = "https://friday.localhost";
+const DEVICE_ID = "device-login-001";
+const OWNER_HASH_PREFIX = "device-owner$v1$";
+const TOKEN_SECRET = "test-secret-key-for-device-login-0001"; // pragma: allowlist secret
+
+function makeIdGen(): () => string {
+  let n = 0;
+  return () => `id-${String(++n).padStart(4, "0")}`;
+}
+
+function makeService(
+  db: FridaySqliteLayer,
+  opts: { authorityEnabled?: boolean } = {},
+): FridayAuthService {
+  return createFridayAuthService({
+    db,
+    idGenerator: makeIdGen(),
+    nowIso: () => NOW,
+    tokenSecret: TOKEN_SECRET,
+    accessTokenTtlSec: 900,
+    refreshTokenTtlSec: 604_800,
+    hubId: "test-hub",
+    bootstrapNonceTtlSec: 300,
+    // Inject the authority seam ONLY when a test needs the enabled branch. This
+    // NEVER flips NATIVE_IPC_ATTESTATION_AVAILABLE — it is the same override a
+    // signed-release/native slice supplies once the OS attestation bridge lands.
+    ...(opts.authorityEnabled !== undefined
+      ? { deviceOwnerAuthorityEnabled: () => opts.authorityEnabled === true }
+      : {}),
+  });
+}
+
+/** Clear the seeded passphrase so the owner slot is a fresh first-boot NULL. */
+function clearOwnerPassphrase(db: FridaySqliteLayer): void {
+  db.withWriteTransaction((conn) => {
+    conn.prepare("UPDATE users SET password_hash = NULL WHERE id = 'test-user'").run();
+  });
+}
+
+/** Issue a challenge + atomically claim the owner slot with `key`. */
+function claimOwner(db: FridaySqliteLayer, key: TestDeviceKey): void {
+  const svc = makeService(db);
+  const challenge = svc.issueBootstrapChallenge(
+    { installId: "install-1", osUser: "jarvis", origin: ORIGIN },
+    LOOPBACK,
+  );
+  const transcript = makeTranscript(key, {
+    action: "owner-claim",
+    nonce: challenge.nonce,
+    origin: ORIGIN,
+    deviceId: DEVICE_ID,
+    hubId: "test-hub",
+    installId: "install-1",
+    osUser: "jarvis",
+    expiresAt: challenge.expiresAt,
+  });
+  const signature = {
+    encoding: "ieee-p1363-base64" as const,
+    value: signTranscriptLowS(key, transcript),
+  };
+  const res = svc.claimOwnerWithDeviceKey(
+    {
+      nonce: challenge.nonce,
+      devicePublicKey: key.spkiDerBase64,
+      deviceId: DEVICE_ID,
+      origin: ORIGIN,
+      installId: "install-1",
+      osUser: "jarvis",
+      deviceClaimProof: { transcript, signature },
+    },
+    LOOPBACK,
+  );
+  expect(res.claimed).toBe(true);
+  // Authoritative durable binding lives on users.password_hash (the sentinel).
+  expect(res.deviceAuthorityEnabled).toBe(false); // real precondition still off
+}
+
+/** Build a signed device-key LOGIN request for `key`, with optional overrides. */
+function loginReq(
+  key: TestDeviceKey,
+  over: Partial<{
+    action: string;
+    origin: string;
+    deviceId: string;
+    devicePublicKey: string;
+    expiresAt: string;
+    signWith: TestDeviceKey;
+  }> = {},
+) {
+  const action = over.action ?? "owner-login";
+  const origin = over.origin ?? ORIGIN;
+  const deviceId = over.deviceId ?? DEVICE_ID;
+  const expiresAt = over.expiresAt ?? LOGIN_EXP;
+  const signKey = over.signWith ?? key;
+  const transcript = makeTranscript(key, {
+    action,
+    origin,
+    deviceId,
+    hubId: "test-hub",
+    installId: "install-1",
+    osUser: "jarvis",
+    nonce: "login-nonce-0001",
+    expiresAt,
+  });
+  const signature = {
+    encoding: "ieee-p1363-base64" as const,
+    value: signTranscriptLowS(signKey, transcript),
+  };
+  return {
+    devicePublicKey: over.devicePublicKey ?? key.spkiDerBase64,
+    deviceId,
+    origin,
+    deviceLoginProof: { transcript, signature },
+  };
+}
+
+describe("FridayAuthService — CR-1 device-key login mint", () => {
+  let db: FridaySqliteLayer;
+
+  beforeEach(() => {
+    db = createTestDb();
+    clearOwnerPassphrase(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  // ── Honesty invariant: the native gate is genuinely off on this build. ──
+
+  it("HONESTY: NATIVE_IPC_ATTESTATION_AVAILABLE is false (native gate not faked)", () => {
+    expect(NATIVE_IPC_ATTESTATION_AVAILABLE).toBe(false);
+  });
+
+  it("getBootstrapStatus().deviceClaimAvailable is FALSE with the real precondition", () => {
+    const svc = makeService(db); // no seam override → real isDeviceOwnerAuthorityEnabled
+    expect(svc.getBootstrapStatus().deviceClaimAvailable).toBe(false);
+  });
+
+  it("getBootstrapStatus().deviceClaimAvailable is TRUE only when authority is enabled (test seam)", () => {
+    const svc = makeService(db, { authorityEnabled: true });
+    expect(svc.getBootstrapStatus().deviceClaimAvailable).toBe(true);
+  });
+
+  // ── (2) HONEST native-IPC gate: valid PoP, authority OFF → no session. ──
+
+  it("device login with a VALID PoP still fails closed while attestation is disabled", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    const svc = makeService(db); // real precondition → authority disabled
+    let code = "";
+    try {
+      svc.login(loginReq(key), LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("DEVICE_AUTHORITY_DISABLED");
+  });
+
+  // ── (1) enabled branch (test-only seam): valid PoP → real session. ──
+
+  it("device login mints a real session when authority is enabled AND PoP is valid", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    const svc = makeService(db, { authorityEnabled: true });
+    const res = svc.login(loginReq(key), LOOPBACK);
+
+    expect(res.accessToken.length).toBeGreaterThan(0);
+    expect(res.refreshToken.length).toBeGreaterThan(0);
+    expect(res.user.id).toBe("test-user");
+    expect(res.user.role).toBe("admin");
+  });
+
+  // ── (3) no cross-path confusion (both directions). ──
+
+  it("the device sentinel can NEVER satisfy passphrase login", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    // Sanity: the owner hash really is the non-scrypt device sentinel.
+    const hash = db.withReadConnection((conn) =>
+      (conn.prepare("SELECT password_hash AS h FROM users WHERE id = 'test-user'").get() as { h: string }).h,
+    );
+    expect(hash.startsWith(OWNER_HASH_PREFIX)).toBe(true);
+
+    // Even with authority enabled, the passphrase path rejects the sentinel: it is
+    // not a valid scrypt/legacy hash, so verifyPassword falls through to reject.
+    const svc = makeService(db, { authorityEnabled: true });
+    for (const attempt of [hash, `${OWNER_HASH_PREFIX}${"0".repeat(64)}`, "any", "correct horse battery"]) {
+      let code = "";
+      try {
+        svc.login({ localPassphrase: attempt }, LOOPBACK);
+      } catch (err) {
+        code = (err as FridayAuthError).code;
+      }
+      expect(code).toBe("INVALID_CREDENTIALS");
+    }
+  });
+
+  it("a passphrase owner can NEVER be logged in via the device path", () => {
+    // Re-seed a real scrypt passphrase owner (undo the first-boot NULL).
+    const svc0 = makeService(db);
+    svc0.bootstrapLocalPassphrase({ passphrase: "correct horse battery" }, LOOPBACK);
+
+    const key = generateTestDeviceKey();
+    const svc = makeService(db, { authorityEnabled: true });
+    let code = "";
+    try {
+      svc.login(loginReq(key), LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    // Rejected at the sentinel-prefix cross-path guard (not a device owner).
+    expect(code).toBe("INVALID_CREDENTIALS");
+  });
+
+  // ── (4) negatives (authority ENABLED so the gate is not what's rejecting). ──
+
+  it("rejects a device login whose PoP is signed by the WRONG key", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+    const attacker = generateTestDeviceKey();
+
+    const svc = makeService(db, { authorityEnabled: true });
+    // Present the bound key but sign the transcript with a different private key.
+    let code = "";
+    try {
+      svc.login(loginReq(key, { signWith: attacker }), LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("INVALID_CREDENTIALS");
+  });
+
+  it("rejects a proof minted for owner-claim replayed into the login leg", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    const svc = makeService(db, { authorityEnabled: true });
+    let code = "";
+    try {
+      svc.login(loginReq(key, { action: "owner-claim" }), LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("INVALID_CREDENTIALS");
+  });
+
+  it("rejects a device login presenting a key that is NOT the bound owner key", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+    const other = generateTestDeviceKey();
+
+    const svc = makeService(db, { authorityEnabled: true });
+    // Present + sign with `other` (internally consistent PoP), but `other` is not
+    // the bound owner key → sentinel-hash mismatch.
+    let code = "";
+    try {
+      svc.login(loginReq(other), LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("INVALID_CREDENTIALS");
+  });
+
+  it("rejects a device login transcript whose expiry exceeds the max TTL", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    const svc = makeService(db, { authorityEnabled: true });
+    let code = "";
+    try {
+      svc.login(loginReq(key, { expiresAt: FAR_FUTURE }), LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("INVALID_CREDENTIALS");
+  });
+
+  it("rejects a device login from a non-loopback caller", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    const svc = makeService(db, { authorityEnabled: true });
+    let code = "";
+    try {
+      svc.login(loginReq(key), "203.0.113.7");
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("INVALID_CREDENTIALS");
+  });
+});

--- a/test/unit/api/auth/friday-auth-service-device-login.test.ts
+++ b/test/unit/api/auth/friday-auth-service-device-login.test.ts
@@ -19,6 +19,8 @@
 // suite NEVER flips it; it exercises the enabled branch ONLY via the injectable
 // authority seam, exactly as a signed-release/native slice would enable it.
 
+import { createHash } from "node:crypto";
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { FridaySqliteLayer } from "#state";
 import { createFridayAuthService, FridayAuthError } from "#api";
@@ -41,14 +43,17 @@ const DEVICE_ID = "device-login-001";
 const OWNER_HASH_PREFIX = "device-owner$v1$";
 const TOKEN_SECRET = "test-secret-key-for-device-login-0001"; // pragma: allowlist secret
 
+// Monotonic across the WHOLE file so ids minted by DISTINCT service instances
+// (bootstrap challenge, login challenge, session) never collide on the
+// friday_setup_bootstrap_nonces PRIMARY KEY (id) within a single test's db.
+let idCounter = 0;
 function makeIdGen(): () => string {
-  let n = 0;
-  return () => `id-${String(++n).padStart(4, "0")}`;
+  return () => `id-${String(++idCounter).padStart(6, "0")}`;
 }
 
 function makeService(
   db: FridaySqliteLayer,
-  opts: { authorityEnabled?: boolean } = {},
+  opts: { authorityEnabled?: boolean; failMintAtRegister?: boolean } = {},
 ): FridayAuthService {
   return createFridayAuthService({
     db,
@@ -64,6 +69,15 @@ function makeService(
     // signed-release/native slice supplies once the OS attestation bridge lands.
     ...(opts.authorityEnabled !== undefined
       ? { deviceOwnerAuthorityEnabled: () => opts.authorityEnabled === true }
+      : {}),
+    // Simulate a crash mid-mint: throw INSIDE the mint transaction AFTER the
+    // login-challenge CAS-consume + session insert, so the whole unit must roll back.
+    ...(opts.failMintAtRegister
+      ? {
+        registerIssuedAccessToken: () => {
+          throw new Error("simulated crash mid-mint");
+        },
+      }
       : {}),
   });
 }
@@ -113,8 +127,37 @@ function claimOwner(db: FridaySqliteLayer, key: TestDeviceKey): void {
   expect(res.deviceAuthorityEnabled).toBe(false); // real precondition still off
 }
 
-/** Build a signed device-key LOGIN request for `key`, with optional overrides. */
+/**
+ * Issue a SERVER-ISSUED single-use login challenge bound to `key` + device +
+ * origin, returning the raw nonce. Issuing does not require device authority.
+ */
+function issueLoginNonce(
+  db: FridaySqliteLayer,
+  over: { deviceId?: string; origin?: string; key: TestDeviceKey },
+): string {
+  const challenge = makeService(db).issueLoginChallenge(
+    {
+      installId: "install-1",
+      osUser: "jarvis",
+      origin: over.origin ?? ORIGIN,
+      deviceId: over.deviceId ?? DEVICE_ID,
+      devicePublicKey: over.key.spkiDerBase64,
+    },
+    LOOPBACK,
+  );
+  return challenge.nonce;
+}
+
+/**
+ * Build a signed device-key LOGIN request for `key`, with optional overrides. By
+ * default it FIRST mints a real server-issued login challenge (bound to key +
+ * deviceId + origin) and signs the returned nonce into the transcript — the login
+ * is only replay-safe because that nonce is single-use. Pass `over.nonce` to inject
+ * a foreign / blank / already-used nonce for the negative paths (no challenge is
+ * minted in that case).
+ */
 function loginReq(
+  db: FridaySqliteLayer,
   key: TestDeviceKey,
   over: Partial<{
     action: string;
@@ -123,6 +166,7 @@ function loginReq(
     devicePublicKey: string;
     expiresAt: string;
     signWith: TestDeviceKey;
+    nonce: string;
   }> = {},
 ) {
   const action = over.action ?? "owner-login";
@@ -130,6 +174,8 @@ function loginReq(
   const deviceId = over.deviceId ?? DEVICE_ID;
   const expiresAt = over.expiresAt ?? LOGIN_EXP;
   const signKey = over.signWith ?? key;
+  const nonce =
+    over.nonce ?? issueLoginNonce(db, { deviceId, origin, key });
   const transcript = makeTranscript(key, {
     action,
     origin,
@@ -137,7 +183,7 @@ function loginReq(
     hubId: "test-hub",
     installId: "install-1",
     osUser: "jarvis",
-    nonce: "login-nonce-0001",
+    nonce,
     expiresAt,
   });
   const signature = {
@@ -150,6 +196,26 @@ function loginReq(
     origin,
     deviceLoginProof: { transcript, signature },
   };
+}
+
+/** Count minted sessions (token pairs) for the local owner. */
+function sessionCount(db: FridaySqliteLayer): number {
+  return db.withReadConnection((conn) =>
+    (conn.prepare("SELECT COUNT(*) AS c FROM auth_sessions").get() as { c: number }).c,
+  );
+}
+
+/** Read the consumed_at of the login-challenge row for a raw nonce (via its hash). */
+function loginChallengeConsumedAt(db: FridaySqliteLayer, nonce: string): string | null {
+  const hash = createHash("sha256").update(nonce).digest("hex");
+  return db.withReadConnection((conn) => {
+    const row = conn
+      .prepare(
+        "SELECT consumed_at AS c FROM friday_setup_bootstrap_nonces WHERE nonce_hash = ? AND kind = 'device_login_challenge'",
+      )
+      .get(hash) as { c: string | null } | undefined;
+    return row?.c ?? null;
+  });
 }
 
 describe("FridayAuthService — CR-1 device-key login mint", () => {
@@ -189,7 +255,7 @@ describe("FridayAuthService — CR-1 device-key login mint", () => {
     const svc = makeService(db); // real precondition → authority disabled
     let code = "";
     try {
-      svc.login(loginReq(key), LOOPBACK);
+      svc.login(loginReq(db, key), LOOPBACK);
     } catch (err) {
       code = (err as FridayAuthError).code;
     }
@@ -203,7 +269,7 @@ describe("FridayAuthService — CR-1 device-key login mint", () => {
     claimOwner(db, key);
 
     const svc = makeService(db, { authorityEnabled: true });
-    const res = svc.login(loginReq(key), LOOPBACK);
+    const res = svc.login(loginReq(db, key), LOOPBACK);
 
     expect(res.accessToken.length).toBeGreaterThan(0);
     expect(res.refreshToken.length).toBeGreaterThan(0);
@@ -246,7 +312,7 @@ describe("FridayAuthService — CR-1 device-key login mint", () => {
     const svc = makeService(db, { authorityEnabled: true });
     let code = "";
     try {
-      svc.login(loginReq(key), LOOPBACK);
+      svc.login(loginReq(db, key), LOOPBACK);
     } catch (err) {
       code = (err as FridayAuthError).code;
     }
@@ -265,7 +331,7 @@ describe("FridayAuthService — CR-1 device-key login mint", () => {
     // Present the bound key but sign the transcript with a different private key.
     let code = "";
     try {
-      svc.login(loginReq(key, { signWith: attacker }), LOOPBACK);
+      svc.login(loginReq(db, key, { signWith: attacker }), LOOPBACK);
     } catch (err) {
       code = (err as FridayAuthError).code;
     }
@@ -279,7 +345,7 @@ describe("FridayAuthService — CR-1 device-key login mint", () => {
     const svc = makeService(db, { authorityEnabled: true });
     let code = "";
     try {
-      svc.login(loginReq(key, { action: "owner-claim" }), LOOPBACK);
+      svc.login(loginReq(db, key, { action: "owner-claim" }), LOOPBACK);
     } catch (err) {
       code = (err as FridayAuthError).code;
     }
@@ -296,7 +362,7 @@ describe("FridayAuthService — CR-1 device-key login mint", () => {
     // the bound owner key → sentinel-hash mismatch.
     let code = "";
     try {
-      svc.login(loginReq(other), LOOPBACK);
+      svc.login(loginReq(db, other), LOOPBACK);
     } catch (err) {
       code = (err as FridayAuthError).code;
     }
@@ -310,7 +376,7 @@ describe("FridayAuthService — CR-1 device-key login mint", () => {
     const svc = makeService(db, { authorityEnabled: true });
     let code = "";
     try {
-      svc.login(loginReq(key, { expiresAt: FAR_FUTURE }), LOOPBACK);
+      svc.login(loginReq(db, key, { expiresAt: FAR_FUTURE }), LOOPBACK);
     } catch (err) {
       code = (err as FridayAuthError).code;
     }
@@ -324,10 +390,179 @@ describe("FridayAuthService — CR-1 device-key login mint", () => {
     const svc = makeService(db, { authorityEnabled: true });
     let code = "";
     try {
-      svc.login(loginReq(key), "203.0.113.7");
+      svc.login(loginReq(db, key), "203.0.113.7");
     } catch (err) {
       code = (err as FridayAuthError).code;
     }
     expect(code).toBe("INVALID_CREDENTIALS");
+  });
+
+  // ── (5) SERVER-ISSUED SINGLE-USE NONCE — Advisor #1628 finding #2 anti-replay ──
+
+  it("REPLAY REPRO: one challenge, same signed transcript twice → 1st mints, 2nd mints NOTHING", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    const svc = makeService(db, { authorityEnabled: true });
+    // ONE challenge → ONE signed owner-login transcript, submitted TWICE.
+    const req = loginReq(db, key);
+    const nonce = req.deviceLoginProof.transcript.nonce;
+
+    expect(sessionCount(db)).toBe(0);
+    expect(loginChallengeConsumedAt(db, nonce)).toBeNull();
+
+    // 1st call: mints a real token pair, consumes the challenge.
+    const first = svc.login(req, LOOPBACK);
+    expect(first.accessToken.length).toBeGreaterThan(0);
+    expect(first.refreshToken.length).toBeGreaterThan(0);
+    expect(sessionCount(db)).toBe(1);
+    expect(loginChallengeConsumedAt(db, nonce)).not.toBeNull();
+
+    // 2nd call (the exact Advisor repro): the challenge is already consumed →
+    // consume changes=0 → refused, ZERO new token / ZERO state change. BEFORE the
+    // fix this minted a 2nd token pair (sessionCount would be 2); AFTER, it stays 1.
+    let code = "";
+    try {
+      svc.login(req, LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("INVALID_CREDENTIALS");
+    expect(sessionCount(db)).toBe(1); // still ONE — no second token pair minted
+  });
+
+  it("refuses a device login with a BLANK challenge nonce", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    const svc = makeService(db, { authorityEnabled: true });
+    let code = "";
+    try {
+      svc.login(loginReq(db, key, { nonce: "" }), LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("INVALID_CREDENTIALS");
+    expect(sessionCount(db)).toBe(0);
+  });
+
+  it("refuses a challenge nonce minted for a DIFFERENT device", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    // Challenge bound to a different deviceId; login presents the real bound device.
+    const foreignNonce = issueLoginNonce(db, { deviceId: "some-other-device", key });
+    const svc = makeService(db, { authorityEnabled: true });
+    let code = "";
+    try {
+      svc.login(loginReq(db, key, { nonce: foreignNonce }), LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("INVALID_CREDENTIALS");
+    expect(sessionCount(db)).toBe(0);
+  });
+
+  it("refuses a challenge nonce minted for a DIFFERENT origin", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    // Challenge bound to a different origin; login presents the canonical origin.
+    const foreignNonce = issueLoginNonce(db, { origin: "https://evil.localhost", key });
+    const svc = makeService(db, { authorityEnabled: true });
+    let code = "";
+    try {
+      svc.login(loginReq(db, key, { nonce: foreignNonce }), LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("INVALID_CREDENTIALS");
+    expect(sessionCount(db)).toBe(0);
+  });
+
+  it("ATTESTATION INDEPENDENCE: valid PoP + valid single-use nonce, authority OFF → DEVICE_AUTHORITY_DISABLED, nonce NOT burned", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    // Build a fully valid login (real challenge, valid PoP) but run it against the
+    // REAL (attestation-disabled) build: it must fail closed at the native gate and
+    // must NOT consume the nonce (the replay fix does not open the native gate).
+    const req = loginReq(db, key);
+    const nonce = req.deviceLoginProof.transcript.nonce;
+
+    const disabled = makeService(db); // real precondition → authority disabled
+    let code = "";
+    try {
+      disabled.login(req, LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("DEVICE_AUTHORITY_DISABLED");
+    expect(sessionCount(db)).toBe(0);
+    // Fail-closed BEFORE the mint transaction → the challenge is still LIVE.
+    expect(loginChallengeConsumedAt(db, nonce)).toBeNull();
+
+    // And with authority enabled, that still-live nonce logs in exactly once.
+    const enabled = makeService(db, { authorityEnabled: true });
+    const res = enabled.login(req, LOOPBACK);
+    expect(res.accessToken.length).toBeGreaterThan(0);
+    expect(sessionCount(db)).toBe(1);
+    expect(loginChallengeConsumedAt(db, nonce)).not.toBeNull();
+  });
+
+  it("CONCURRENCY: two DISTINCT valid proofs race ONE challenge → exactly one wins", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    const svc = makeService(db, { authorityEnabled: true });
+    // One challenge (nonce N). Build TWO distinct valid proofs over N (different
+    // transcript expiry → different signature bytes) — both are legitimate PoPs; the
+    // single-use CAS must let exactly ONE mint. (better-sqlite3 serializes writes, so
+    // "racing" resolves to sequential CAS: winner changes=1, loser changes=0.)
+    const reqA = loginReq(db, key);
+    const nonce = reqA.deviceLoginProof.transcript.nonce;
+    const reqB = loginReq(db, key, { nonce, expiresAt: "2026-07-13T00:02:00.000Z" });
+    expect(reqB.deviceLoginProof.transcript.nonce).toBe(nonce);
+    expect(reqB.deviceLoginProof.signature.value).not.toBe(reqA.deviceLoginProof.signature.value);
+
+    const winner = svc.login(reqA, LOOPBACK);
+    expect(winner.accessToken.length).toBeGreaterThan(0);
+
+    let code = "";
+    try {
+      svc.login(reqB, LOOPBACK);
+    } catch (err) {
+      code = (err as FridayAuthError).code;
+    }
+    expect(code).toBe("INVALID_CREDENTIALS");
+    expect(sessionCount(db)).toBe(1); // exactly one token pair minted
+  });
+
+  it("CRASH ATOMICITY: a throw mid-mint rolls back the challenge consume AND the session (retry succeeds once)", () => {
+    const key = generateTestDeviceKey();
+    claimOwner(db, key);
+
+    const req = loginReq(db, key);
+    const nonce = req.deviceLoginProof.transcript.nonce;
+
+    // Crash injected AFTER the CAS-consume + session insert, INSIDE the txn.
+    const crashing = makeService(db, { authorityEnabled: true, failMintAtRegister: true });
+    let threw = false;
+    try {
+      crashing.login(req, LOOPBACK);
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+    // The whole unit rolled back: no session AND the challenge is still LIVE.
+    expect(sessionCount(db)).toBe(0);
+    expect(loginChallengeConsumedAt(db, nonce)).toBeNull();
+
+    // Retry with the still-live nonce succeeds exactly once.
+    const svc = makeService(db, { authorityEnabled: true });
+    const res = svc.login(req, LOOPBACK);
+    expect(res.accessToken.length).toBeGreaterThan(0);
+    expect(sessionCount(db)).toBe(1);
+    expect(loginChallengeConsumedAt(db, nonce)).not.toBeNull();
   });
 });

--- a/test/unit/api/http/persistence/friday-provider-approval-consumption-repository.test.ts
+++ b/test/unit/api/http/persistence/friday-provider-approval-consumption-repository.test.ts
@@ -1,0 +1,357 @@
+// SEC-APPROVAL-AUTHORITY-001 · CORE-A round-3 Lane B (Advisor round-2 finding #3) —
+// durable single-use ledger for canonical mutating-action approvals.
+//
+// Ground truth being closed: provider-approval single-use lived ONLY in the gate's
+// process-local in-memory `Set` (`consumedCanonicalApprovalKeys`). On restart the Set was
+// gone, so a fresh process re-admitted the SAME confirmed approval. This suite proves the
+// durable ledger refuses a replay across (a) new store/gate instances on the same db, and
+// (b) a REAL sqlite file closed and reopened.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { FridaySqliteLayer } from "#state";
+import { FRIDAY_SQLITE_MIGRATIONS, runFridayMigrations } from "#state";
+import {
+  FridayInMemoryApprovalConsumptionStore,
+  FridaySqliteApprovalConsumptionStore,
+  type FridayApprovalConsumptionReservation,
+} from "../../../../../src/api/http/persistence/friday-provider-approval-consumption-repository.js";
+import {
+  createFridayMutatingActionDigest,
+  createFridayMutatingActionGate,
+  type FridayCanonicalApprovalResolution,
+  type FridayMutatingActionRequest,
+} from "../../../../../src/security/friday-mutating-action-gate.js";
+import { createTestDb } from "../../../../helpers/friday-test-db.helper.js";
+
+const NOW = "2026-05-04T12:00:00.000Z";
+
+function reservation(
+  overrides: Partial<FridayApprovalConsumptionReservation> = {},
+): FridayApprovalConsumptionReservation {
+  return {
+    useKey: "approval-1:digest-abc::: ",
+    actionDigest: "digest-abc",
+    idempotencyKey: "idem-1",
+    mutationOperationId: "providers.create",
+    ...overrides,
+  };
+}
+
+function createFileDbLayer(path: string): FridaySqliteLayer {
+  const db = new Database(path);
+  runFridayMigrations({ db, migrations: FRIDAY_SQLITE_MIGRATIONS });
+  return {
+    dbPath: path,
+    writer: db,
+    reads: {
+      size: 1,
+      withReadConnection: <T>(fn: (c: Database.Database) => T): T => fn(db),
+      close() {},
+    },
+    withWriteTransaction: <T>(fn: (c: Database.Database) => T): T => db.transaction(() => fn(db))(),
+    withReadConnection: <T>(fn: (c: Database.Database) => T): T => fn(db),
+    checkpoint() {},
+    optimize() {},
+    close() {
+      db.close();
+    },
+  };
+}
+
+describe("v108 provider_mutation_approval_consumption migration", () => {
+  const layers: FridaySqliteLayer[] = [];
+  afterEach(() => {
+    while (layers.length) layers.pop()!.close();
+  });
+
+  it("creates the ledger table with the use key as PRIMARY KEY", () => {
+    const db = createTestDb();
+    layers.push(db);
+    const columns = db.withReadConnection((c) =>
+      c.prepare("PRAGMA table_info(provider_mutation_approval_consumption)").all() as Array<{
+        name: string;
+        pk: number;
+      }>,
+    );
+    const names = columns.map((c) => c.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "use_key",
+        "action_digest",
+        "idempotency_key",
+        "mutation_operation_id",
+        "status",
+        "consumed_at_ms",
+        "created_at_ms",
+      ]),
+    );
+    // use_key is the sole PRIMARY KEY.
+    expect(columns.filter((c) => c.pk > 0).map((c) => c.name)).toEqual(["use_key"]);
+  });
+});
+
+describe("FridayApprovalConsumptionStore (in-memory + sqlite parity)", () => {
+  const layers: FridaySqliteLayer[] = [];
+  afterEach(() => {
+    while (layers.length) layers.pop()!.close();
+  });
+
+  function stores(): Array<{ label: string; make: () => { db?: FridaySqliteLayer; store: FridaySqliteApprovalConsumptionStore | FridayInMemoryApprovalConsumptionStore } }> {
+    return [
+      {
+        label: "in-memory",
+        make: () => ({ store: new FridayInMemoryApprovalConsumptionStore() }),
+      },
+      {
+        label: "sqlite",
+        make: () => {
+          const db = createTestDb();
+          layers.push(db);
+          return { db, store: new FridaySqliteApprovalConsumptionStore(db) };
+        },
+      },
+    ];
+  }
+
+  for (const { label, make } of stores()) {
+    it(`${label}: reserveConsumed is single-use (a replay of the same key is refused)`, () => {
+      const { store } = make();
+      expect(store.reserveConsumed(reservation())).toEqual({ ok: true });
+      expect(store.reserveConsumed(reservation())).toEqual({
+        ok: false,
+        reason: "canonical_approval_already_used",
+      });
+      expect(store.hasConsumption(reservation().useKey)).toBe(true);
+    });
+
+    it(`${label}: reserveInFlight then completeConsumptionInTransaction, replay refused`, () => {
+      const built = make();
+      const { store } = built;
+      expect(store.reserveInFlight(reservation())).toEqual({ ok: true });
+      // A replay while in_flight already collides (single-use enforced at the reserve).
+      expect(store.reserveInFlight(reservation())).toEqual({
+        ok: false,
+        reason: "canonical_approval_already_used",
+      });
+      // Finalize in the "mutation" transaction.
+      if (built.db) {
+        built.db.withWriteTransaction((c) => store.completeConsumptionInTransaction(c, reservation().useKey));
+      } else {
+        store.completeConsumptionInTransaction({} as never, reservation().useKey);
+      }
+      expect(store.hasConsumption(reservation().useKey)).toBe(true);
+    });
+
+    it(`${label}: releaseReservation frees an in_flight reservation but never a consumed one`, () => {
+      const built = make();
+      const { store } = built;
+      store.reserveInFlight(reservation());
+      store.releaseReservation(reservation().useKey);
+      // Released → the owner may retry the same approval.
+      expect(store.hasConsumption(reservation().useKey)).toBe(false);
+      expect(store.reserveConsumed(reservation())).toEqual({ ok: true });
+      // Now consumed: release is a no-op (scoped to in_flight), so single-use still holds.
+      store.releaseReservation(reservation().useKey);
+      expect(store.hasConsumption(reservation().useKey)).toBe(true);
+    });
+
+    it(`${label}: reconcileOrphanedReservations keeps an in_flight orphan single-use (fail-closed)`, () => {
+      const { store } = make();
+      store.reserveInFlight(reservation());
+      store.reconcileOrphanedReservations();
+      // Still present → a replay is still refused after reconcile.
+      expect(store.hasConsumption(reservation().useKey)).toBe(true);
+      expect(store.reserveConsumed(reservation())).toEqual({
+        ok: false,
+        reason: "canonical_approval_already_used",
+      });
+    });
+  }
+
+  it("sqlite: a throw AFTER completeConsumptionInTransaction rolls the completion BACK (atomicity)", () => {
+    // Models a crash between the consume-complete and the mutation-commit: because both run
+    // in ONE write transaction, the throw unwinds the completion too — the row stays
+    // in_flight (never a consumed row without its paired effect). Boot reconcile then marks
+    // the orphan indeterminate (fail-closed), so a replay is still refused.
+    const db = createTestDb();
+    layers.push(db);
+    const store = new FridaySqliteApprovalConsumptionStore(db);
+    store.reserveInFlight(reservation());
+
+    expect(() =>
+      db.withWriteTransaction((c) => {
+        store.completeConsumptionInTransaction(c, reservation().useKey);
+        throw new Error("simulated crash before mutation commit");
+      }),
+    ).toThrow("simulated crash");
+
+    // The completion rolled back → the row is STILL in_flight (no consumed-without-effect).
+    const statusAfter = db.withReadConnection((c) =>
+      (c
+        .prepare("SELECT status FROM provider_mutation_approval_consumption WHERE use_key = ?")
+        .get(reservation().useKey) as { status: string }).status,
+    );
+    expect(statusAfter).toBe("in_flight");
+
+    // Boot reconcile marks the orphan indeterminate — fail-closed; a replay is still refused.
+    store.reconcileOrphanedReservations();
+    const statusReconciled = db.withReadConnection((c) =>
+      (c
+        .prepare("SELECT status FROM provider_mutation_approval_consumption WHERE use_key = ?")
+        .get(reservation().useKey) as { status: string }).status,
+    );
+    expect(statusReconciled).toBe("indeterminate");
+    expect(store.reserveConsumed(reservation())).toEqual({
+      ok: false,
+      reason: "canonical_approval_already_used",
+    });
+  });
+
+  it("sqlite: a NEW store instance on the SAME db refuses a replay (restart durability)", () => {
+    const db = createTestDb();
+    layers.push(db);
+    const first = new FridaySqliteApprovalConsumptionStore(db);
+    expect(first.reserveConsumed(reservation())).toEqual({ ok: true });
+
+    // Simulate a process restart: a brand-new store object with NO in-memory carryover.
+    const afterRestart = new FridaySqliteApprovalConsumptionStore(db);
+    expect(afterRestart.reserveConsumed(reservation())).toEqual({
+      ok: false,
+      reason: "canonical_approval_already_used",
+    });
+  });
+
+  it("sqlite FILE closed + reopened refuses a replay (authoritative durable-sink readback)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "friday-approval-consumption-"));
+    const path = join(dir, "consumption.db");
+    try {
+      const before = createFileDbLayer(path);
+      expect(new FridaySqliteApprovalConsumptionStore(before).reserveConsumed(reservation())).toEqual({
+        ok: true,
+      });
+      before.close();
+
+      // Reopen the SAME file — the consumption survived the close.
+      const after = createFileDbLayer(path);
+      try {
+        expect(new FridaySqliteApprovalConsumptionStore(after).reserveConsumed(reservation())).toEqual({
+          ok: false,
+          reason: "canonical_approval_already_used",
+        });
+      } finally {
+        after.close();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Gate-level durability (the seam the Advisor probed) ───
+
+function makeApprovedRequest(): {
+  request: FridayMutatingActionRequest;
+  canonicalApproval: FridayCanonicalApprovalResolution;
+} {
+  const request: FridayMutatingActionRequest = {
+    action: "providers.create",
+    actor: { kind: "api", id: "api:req-1", principalId: "user-1" },
+    surface: "api:/v1/providers/create",
+    resource: { type: "provider", id: "p-1" },
+    mutating: true,
+    risk: "high",
+    idempotencyKey: "idem-1",
+  };
+  const actionDigest = createFridayMutatingActionDigest(request);
+  return {
+    request,
+    canonicalApproval: {
+      decision: "approved",
+      approvalId: "approval-1",
+      decidedByPrincipalId: "user-1",
+      actionDigest,
+      expiresAt: "2026-05-04T13:00:00.000Z",
+    },
+  };
+}
+
+describe("mutating-action gate: durable approval single-use", () => {
+  const layers: FridaySqliteLayer[] = [];
+  afterEach(() => {
+    while (layers.length) layers.pop()!.close();
+  });
+
+  it("RED (pre-fix behaviour): two gate instances with SEPARATE in-memory stores BOTH admit", () => {
+    // This documents exactly the finding-#3 vulnerability: process-local single-use means a
+    // fresh process (a NEW gate + a NEW in-memory store) re-admits the identical approval.
+    const { request, canonicalApproval } = makeApprovedRequest();
+    const gateA = createFridayMutatingActionGate({ nowIso: () => NOW });
+    const gateB = createFridayMutatingActionGate({ nowIso: () => NOW });
+    expect(gateA.evaluate({ ...request, canonicalApproval }).decision).toBe("allow");
+    // Double-admit — the second (restarted) process has no memory of the first consumption.
+    expect(gateB.evaluate({ ...request, canonicalApproval }).decision).toBe("allow");
+  });
+
+  it("GREEN: two gate instances SHARING a durable sqlite store refuse the replay across restart", () => {
+    const db = createTestDb();
+    layers.push(db);
+    const store = new FridaySqliteApprovalConsumptionStore(db);
+    const { request, canonicalApproval } = makeApprovedRequest();
+
+    const gateBeforeRestart = createFridayMutatingActionGate({
+      nowIso: () => NOW,
+      approvalConsumptionStore: store,
+    });
+    expect(gateBeforeRestart.evaluate({ ...request, canonicalApproval }).decision).toBe("allow");
+
+    // Fresh gate instance backed by the SAME durable store (== the same db after restart).
+    const gateAfterRestart = createFridayMutatingActionGate({
+      nowIso: () => NOW,
+      approvalConsumptionStore: new FridaySqliteApprovalConsumptionStore(db),
+    });
+    const replay = gateAfterRestart.evaluate({ ...request, canonicalApproval });
+    expect(replay.decision).toBe("deny");
+    expect(replay.reason).toBe("canonical_approval_already_used");
+    expect(replay.ticket).toBeUndefined();
+  });
+
+  it("deferred consumption returns the use key on the ticket and reserves in_flight (replay refused)", () => {
+    const db = createTestDb();
+    layers.push(db);
+    const store = new FridaySqliteApprovalConsumptionStore(db);
+    const gate = createFridayMutatingActionGate({ nowIso: () => NOW, approvalConsumptionStore: store });
+    const { request, canonicalApproval } = makeApprovedRequest();
+
+    const result = gate.evaluate({ ...request, canonicalApproval }, { deferApprovalConsumption: true });
+    expect(result.decision).toBe("allow");
+    const useKey = result.ticket?.canonicalApprovalUseKey;
+    expect(useKey).toBeTruthy();
+    // The reservation is already durable (in_flight): a concurrent/replayed evaluate is refused.
+    const replay = gate.evaluate({ ...request, canonicalApproval }, { deferApprovalConsumption: true });
+    expect(replay.decision).toBe("deny");
+    expect(replay.reason).toBe("canonical_approval_already_used");
+
+    // The caller finalizes it inside its mutation transaction.
+    db.withWriteTransaction((c) => store.completeConsumptionInTransaction(c, useKey!));
+    expect(store.hasConsumption(useKey!)).toBe(true);
+  });
+
+  it("inline (non-deferred) consumption does NOT expose a use key on the ticket", () => {
+    const db = createTestDb();
+    layers.push(db);
+    const gate = createFridayMutatingActionGate({
+      nowIso: () => NOW,
+      approvalConsumptionStore: new FridaySqliteApprovalConsumptionStore(db),
+    });
+    const { request, canonicalApproval } = makeApprovedRequest();
+    const result = gate.evaluate({ ...request, canonicalApproval });
+    expect(result.decision).toBe("allow");
+    expect(result.ticket?.canonicalApprovalUseKey).toBeUndefined();
+  });
+});

--- a/test/unit/api/http/routes/friday-auth-routes.test.ts
+++ b/test/unit/api/http/routes/friday-auth-routes.test.ts
@@ -70,8 +70,8 @@ describe("FridayAuthRoutes", () => {
 
   // ─── Route registration ───
 
-  it("registers 12 auth routes", () => {
-    expect(routes).toHaveLength(12);
+  it("registers 13 auth routes", () => {
+    expect(routes).toHaveLength(13);
   });
 
   it("has correct operation IDs", () => {
@@ -87,6 +87,8 @@ describe("FridayAuthRoutes", () => {
     // the owner-gated binding-state read seam.
     expect(opIds).toContain("auth.migrate.device.readback");
     expect(opIds).toContain("auth.migrate.device.binding.read");
+    // SEC-SETUP-BOOTSTRAP-001 (CR-1): server-issued device-key login challenge.
+    expect(opIds).toContain("auth.login.challenge");
     expect(opIds).toContain("auth.login");
     expect(opIds).toContain("auth.refresh");
     expect(opIds).toContain("auth.logout");
@@ -148,6 +150,52 @@ describe("FridayAuthRoutes", () => {
     expect(route.path).toBe("/v1/auth/bootstrap/device-claim");
     expect(route.auth).toEqual({ public: true, allowUnauthenticatedMutation: true });
     expect(route.rateLimitPolicyId).toBe("auth.login");
+  });
+
+  it("POST /v1/auth/login/challenge is public, rate-limited, loopback-only (CR-1)", () => {
+    const route = findRoute("auth.login.challenge");
+    expect(route.method).toBe("POST");
+    expect(route.path).toBe("/v1/auth/login/challenge");
+    expect(route.auth).toEqual({ public: true, allowUnauthenticatedMutation: true });
+    expect(route.rateLimitPolicyId).toBe("auth.login");
+  });
+
+  it("login-challenge route mints a device_login_challenge nonce over the route layer", async () => {
+    const route = findRoute("auth.login.challenge");
+    const res = (await route.handler(
+      makeCtx({
+        ip: "127.0.0.1",
+        body: {
+          installId: "i-1",
+          osUser: "u",
+          origin: "https://friday.localhost",
+          deviceId: "dev-1",
+          devicePublicKey: "pubkey-b64",
+        },
+      }),
+    )) as { kind: string; nonce: string; deviceId: string; devicePublicKeyHash: string };
+    expect(res.kind).toBe("device_login_challenge");
+    expect(res.nonce.length).toBeGreaterThan(0);
+    expect(res.deviceId).toBe("dev-1");
+    expect(res.devicePublicKeyHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("login-challenge route rejects non-localhost callers (loopback-only)", async () => {
+    const route = findRoute("auth.login.challenge");
+    await expect(
+      route.handler(
+        makeCtx({
+          ip: "10.0.0.2",
+          body: {
+            installId: "i-1",
+            osUser: "u",
+            origin: "https://friday.localhost",
+            deviceId: "dev-1",
+            devicePublicKey: "pubkey-b64",
+          },
+        }),
+      ),
+    ).rejects.toThrow("only allowed from localhost");
   });
 
   it("challenge route rejects non-localhost callers (loopback-only)", async () => {

--- a/test/unit/api/http/routes/friday-auth-routes.test.ts
+++ b/test/unit/api/http/routes/friday-auth-routes.test.ts
@@ -6,6 +6,7 @@ import type { FridayAuthService } from "#api";
 import type { FridayRouteDefinition, FridayHttpContext } from "#api";
 // SEC-SETUP-BOOTSTRAP-001 Slice 3: device-claim now requires proof-of-possession.
 import { generateTestDeviceKey, makeTranscript, signTranscriptLowS } from "../../../../adversarial/_secsetup-s2a.helpers.js";
+import { createTestNativeOwnerResolver } from "../../../../adversarial/_native-owner-capability.helpers.js";
 
 const ROUTE_DEVICE_KEY = generateTestDeviceKey();
 /** Build a device-claim body carrying a valid PoP bound to (nonce, origin, deviceId). */
@@ -60,6 +61,10 @@ describe("FridayAuthRoutes", () => {
       tokenSecret: TOKEN_SECRET,
       accessTokenTtlSec: 900,
       refreshTokenTtlSec: 604800,
+      // Option C: the device-claim route flips ownership only with a per-claim
+      // native capability. Inject a resolver that runs the REAL mint over injected
+      // native-evidence doubles so the route-layer flow is exercised end to end.
+      resolveNativeOwnerClaimContext: createTestNativeOwnerResolver(),
     });
     routes = createFridayAuthRoutes({ authService });
   });

--- a/test/unit/api/http/routes/friday-provider-mutation-plan-confirm.test.ts
+++ b/test/unit/api/http/routes/friday-provider-mutation-plan-confirm.test.ts
@@ -21,12 +21,12 @@ import {
  */
 describe("provider mutation plan → owner confirm → gated mutation", () => {
   const NOW = "2026-02-17T10:00:00.000Z";
-  const APPROVAL_SIGNATURE_SECRET = "test-hub-token-secret";
+  const APPROVAL_SIGNATURE_SECRET = "test-hub-token-secret"; // pragma: allowlist secret
   /**
    * A key-SHAPED value. Every "no secret leaks" assertion below searches the full
    * serialized plan/confirm response for this exact string.
    */
-  const SECRET_API_KEY = "sk-live-CR2SECRET0000000000000000000000000000";
+  const SECRET_API_KEY = "sk-live-CR2SECRET0000000000000000000000000000"; // pragma: allowlist secret
 
   const sampleProfile: FridayProviderProfile = {
     id: "prov-001",

--- a/test/unit/api/http/routes/friday-provider-mutation-plan-confirm.test.ts
+++ b/test/unit/api/http/routes/friday-provider-mutation-plan-confirm.test.ts
@@ -254,7 +254,9 @@ describe("provider mutation plan → DEVICE confirm → gated mutation", () => {
     const result = await harness.route("providers.create").handler(makeCtx({
       body: { ...CREATE_PARAMS, planDigest: planned.planDigest, canonicalApproval: approval },
     }));
-    expect(harness.service.createProvider).toHaveBeenCalledWith(CREATE_PARAMS);
+    // Second arg is the optional provider-mutation options (approval consume hook);
+    // undefined here because this fixture injects no durable approval-consumption store.
+    expect(harness.service.createProvider).toHaveBeenCalledWith(CREATE_PARAMS, undefined);
     expect(result).toHaveProperty("canonicalGate.ticketId", "ticket-1");
   });
 

--- a/test/unit/api/http/routes/friday-provider-mutation-plan-confirm.test.ts
+++ b/test/unit/api/http/routes/friday-provider-mutation-plan-confirm.test.ts
@@ -1,0 +1,537 @@
+import { describe, it, expect, vi } from "vitest";
+
+import type { FridayHttpContext, FridayRouteDefinition } from "#api";
+import { createFridayProviderRoutes } from "#api";
+import type { FridayProviderProfile, FridayProviderService } from "#providers";
+import {
+  createFridayMutatingActionDigest,
+  createFridayMutatingActionGate,
+  signFridayCanonicalApproval,
+  type FridayCanonicalApprovalResolution,
+  type FridayMutatingActionRequest,
+} from "../../../../../src/security/friday-mutating-action-gate.js";
+
+/**
+ * CORE-A CR-2 — provider setup owner-confirm handshake.
+ *
+ * These are integration tests against the REAL provider routes (plan / plan.confirm /
+ * the gated mutation routes) with the REAL canonical mutating-action gate wired with a
+ * signature secret. Nothing here is a mock of the gate: every negative below is the
+ * production fail-closed path.
+ */
+describe("provider mutation plan → owner confirm → gated mutation", () => {
+  const NOW = "2026-02-17T10:00:00.000Z";
+  const APPROVAL_SIGNATURE_SECRET = "test-hub-token-secret";
+  /**
+   * A key-SHAPED value. Every "no secret leaks" assertion below searches the full
+   * serialized plan/confirm response for this exact string.
+   */
+  const SECRET_API_KEY = "sk-live-CR2SECRET0000000000000000000000000000";
+
+  const sampleProfile: FridayProviderProfile = {
+    id: "prov-001",
+    kind: "openai",
+    name: "OpenAI",
+    baseUrl: "https://api.openai.com",
+    enabled: true,
+    defaultModel: "gpt-4o",
+    config: {
+      api: "openai-completions",
+      authMode: "api-key",
+      keySource: { kind: "env-ref", envVar: "OPENAI_API_KEY" },
+      supportedModels: ["gpt-4o"],
+      validation: { status: "ok", checkedAt: NOW },
+    },
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+
+  function makeMockService(): FridayProviderService {
+    return {
+      listProviders: vi.fn(async () => [sampleProfile]),
+      getProvider: vi.fn(async () => sampleProfile),
+      createProvider: vi.fn(async () => sampleProfile),
+      updateProvider: vi.fn(async () => sampleProfile),
+      deleteProvider: vi.fn(async () => undefined),
+      activateAuthProfile: vi.fn(async () => ({ id: "auth-default" })),
+      getRoutingConfig: vi.fn(async () => ({ defaultProviderId: "prov-001", fallbackProviderIds: [] })),
+      setRoutingConfig: vi.fn(async (input: unknown) => input),
+    } as unknown as FridayProviderService;
+  }
+
+  interface Harness {
+    routes: FridayRouteDefinition<unknown, unknown, unknown, unknown>[];
+    service: FridayProviderService;
+    route: (operationId: string) => FridayRouteDefinition<unknown, unknown, unknown, unknown>;
+    setNow: (iso: string) => void;
+    signCalls: () => number;
+  }
+
+  function makeHarness(options: { withSigner?: boolean } = {}): Harness {
+    const service = makeMockService();
+    let now = NOW;
+    let signCalls = 0;
+
+    // The REAL production signing seam (identical to friday-api-runtime's
+    // signCanonicalApprovalForRequest): HMAC over the server-derived action digest,
+    // with a ~10 minute expiry.
+    const signCanonicalApproval = (
+      request: FridayMutatingActionRequest,
+      input: { approvalIdPrefix: string },
+    ): FridayCanonicalApprovalResolution => {
+      signCalls += 1;
+      const expiresAt = new Date(Date.parse(now) + 10 * 60 * 1000).toISOString();
+      return signFridayCanonicalApproval({
+        decision: "approved",
+        approvalId: `${input.approvalIdPrefix}-${String(signCalls)}`,
+        decidedByPrincipalId: request.actor.principalId ?? request.actor.id,
+        actionDigest: createFridayMutatingActionDigest(request),
+        expiresAt,
+      }, APPROVAL_SIGNATURE_SECRET);
+    };
+
+    const routes = createFridayProviderRoutes({
+      providerService: service,
+      providerMutationGateRequired: true,
+      canonicalMutationGate: createFridayMutatingActionGate({
+        nowIso: () => now,
+        ticketIdGenerator: () => "ticket-1",
+        approvalSignatureSecret: APPROVAL_SIGNATURE_SECRET,
+      }),
+      allowTestOnlyProviderProbeExecution: true,
+      allowTestOnlyProviderRoutingControlsExecution: true,
+      nowIso: () => now,
+      ...(options.withSigner === false ? {} : { signCanonicalApproval }),
+    });
+
+    return {
+      routes,
+      service,
+      route: (operationId: string) => {
+        const found = routes.find((entry) => entry.operationId === operationId);
+        if (!found) {
+          throw new Error(`route not found: ${operationId}`);
+        }
+        return found;
+      },
+      setNow: (iso: string) => {
+        now = iso;
+      },
+      signCalls: () => signCalls,
+    };
+  }
+
+  function makeCtx(input: {
+    body?: unknown;
+    params?: Record<string, string>;
+    principalId?: string;
+    requestId?: string;
+  }): FridayHttpContext<unknown, unknown, unknown> {
+    const principalId = input.principalId ?? "user-1";
+    return {
+      requestId: input.requestId ?? "req-1",
+      receivedAt: NOW,
+      params: input.params ?? {},
+      query: {},
+      body: input.body ?? {},
+      headers: {},
+      principal: {
+        principalType: "user",
+        principalId,
+        userId: principalId,
+        role: "admin",
+        scopes: ["hub.admin"],
+        tokenId: "tok-1",
+        tokenKind: "access",
+        issuedAt: NOW,
+      },
+    } as unknown as FridayHttpContext<unknown, unknown, unknown>;
+  }
+
+  const CREATE_PARAMS = {
+    kind: "openai" as const,
+    name: "Test",
+    baseUrl: "https://test.com",
+    authMode: "api-key" as const,
+    api: "openai-completions" as const,
+    supportedModels: ["gpt-4o"],
+    apiKey: SECRET_API_KEY,
+  };
+
+  async function plan(
+    harness: Harness,
+    body: Record<string, unknown>,
+    principalId = "user-1",
+  ): Promise<{ plan: { planDigest: string; humanReadableSummary: string[] } }> {
+    return await harness.route("providers.plan").handler(
+      makeCtx({ body, principalId }),
+    ) as { plan: { planDigest: string; humanReadableSummary: string[] } };
+  }
+
+  async function confirm(
+    harness: Harness,
+    planDigest: string,
+    principalId = "user-1",
+  ): Promise<{ approval: { canonicalApproval: unknown; planDigest: string } }> {
+    return await harness.route("providers.plan.confirm").handler(
+      makeCtx({ body: { planDigest, confirm: true }, principalId }),
+    ) as { approval: { canonicalApproval: unknown; planDigest: string } };
+  }
+
+  // ─── Happy path ───
+
+  it("plan → confirm → create passes the canonical gate for a NORMAL owner", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    expect(planned.plan.planDigest).toMatch(/^fpmp_[0-9a-f]{64}$/);
+
+    const confirmed = await confirm(harness, planned.plan.planDigest);
+    const result = await harness.route("providers.create").handler(makeCtx({
+      body: {
+        ...CREATE_PARAMS,
+        planDigest: planned.plan.planDigest,
+        canonicalApproval: confirmed.approval.canonicalApproval,
+      },
+    }));
+
+    expect(harness.service.createProvider).toHaveBeenCalledWith(CREATE_PARAMS);
+    expect(result).toHaveProperty("canonicalGate.ticketId", "ticket-1");
+    expect(result).toHaveProperty("canonicalGate.planDigest", planned.plan.planDigest);
+  });
+
+  it("plan → confirm → routing.set (a second gated surface) passes the gate", async () => {
+    const harness = makeHarness();
+    const routingParams = { defaultProviderId: "prov-001", fallbackProviderIds: ["prov-001"] };
+    const planned = await plan(harness, { action: "providers.routing.set", params: routingParams });
+    const confirmed = await confirm(harness, planned.plan.planDigest);
+
+    const result = await harness.route("providers.routing.set").handler(makeCtx({
+      body: {
+        ...routingParams,
+        planDigest: planned.plan.planDigest,
+        canonicalApproval: confirmed.approval.canonicalApproval,
+      },
+    }));
+    expect(result).toHaveProperty("canonicalGate.ticketId", "ticket-1");
+  });
+
+  it("plan → confirm → delete (a param-free target-id surface) passes the gate", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.delete", providerId: "prov-001" });
+    const confirmed = await confirm(harness, planned.plan.planDigest);
+
+    const result = await harness.route("providers.delete").handler(makeCtx({
+      params: { providerId: "prov-001" },
+      body: {
+        planDigest: planned.plan.planDigest,
+        canonicalApproval: confirmed.approval.canonicalApproval,
+      },
+    }));
+    expect(harness.service.deleteProvider).toHaveBeenCalledWith("prov-001");
+    expect(result).toHaveProperty("canonicalGate.ticketId", "ticket-1");
+  });
+
+  // ─── Fail-closed negatives ───
+
+  it("missing planDigest is refused with PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED", async () => {
+    const harness = makeHarness();
+    await expect(harness.route("providers.create").handler(makeCtx({ body: CREATE_PARAMS })))
+      .rejects.toMatchObject({
+        code: "PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED",
+        httpStatus: 403,
+      });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("a plan digest alone (no approval) never authorizes a mutation", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+
+    await expect(harness.route("providers.create").handler(makeCtx({
+      body: { ...CREATE_PARAMS, planDigest: planned.plan.planDigest },
+    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_REQUIRED" });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("an unknown / stale plan digest cannot be confirmed", async () => {
+    const harness = makeHarness();
+    await expect(confirm(harness, "fpmp_deadbeef")).rejects.toMatchObject({
+      code: "PROVIDER_MUTATION_PLAN_NOT_FOUND",
+      httpStatus: 404,
+    });
+  });
+
+  it("replaying a valid approval under a DIFFERENT plan digest fails closed on digest mismatch", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    const confirmed = await confirm(harness, planned.plan.planDigest);
+
+    await expect(harness.route("providers.create").handler(makeCtx({
+      body: {
+        ...CREATE_PARAMS,
+        planDigest: "fpmp_someone-elses-digest",
+        canonicalApproval: confirmed.approval.canonicalApproval,
+      },
+    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_DENIED" });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("parameter drift between the reviewed plan and the replayed body fails closed", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    const confirmed = await confirm(harness, planned.plan.planDigest);
+
+    // Same owner, same planDigest, same signed approval — but the body that actually
+    // arrives points at a different endpoint. The gate recomputes the action digest
+    // from THIS request, so the approval no longer binds.
+    await expect(harness.route("providers.create").handler(makeCtx({
+      body: {
+        ...CREATE_PARAMS,
+        baseUrl: "https://attacker.example",
+        planDigest: planned.plan.planDigest,
+        canonicalApproval: confirmed.approval.canonicalApproval,
+      },
+    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_DENIED" });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("a tampered approval signature fails closed", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    const confirmed = await confirm(harness, planned.plan.planDigest);
+    const tampered = {
+      ...(confirmed.approval.canonicalApproval as Record<string, unknown>),
+      signature: "00".repeat(32),
+    };
+
+    await expect(harness.route("providers.create").handler(makeCtx({
+      body: { ...CREATE_PARAMS, planDigest: planned.plan.planDigest, canonicalApproval: tampered },
+    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_DENIED" });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("a plan can only be confirmed by the principal that created it", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS }, "user-1");
+
+    await expect(confirm(harness, planned.plan.planDigest, "user-2")).rejects.toMatchObject({
+      code: "PROVIDER_MUTATION_PLAN_OWNER_MISMATCH",
+      httpStatus: 403,
+    });
+    expect(harness.signCalls()).toBe(0);
+  });
+
+  it("a plan is single-use at the confirm layer", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    await confirm(harness, planned.plan.planDigest);
+
+    await expect(confirm(harness, planned.plan.planDigest)).rejects.toMatchObject({
+      code: "PROVIDER_MUTATION_PLAN_ALREADY_CONFIRMED",
+      httpStatus: 409,
+    });
+    expect(harness.signCalls()).toBe(1);
+  });
+
+  it("a minted approval is single-use at the gate layer (replay is denied)", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    const confirmed = await confirm(harness, planned.plan.planDigest);
+    const body = {
+      ...CREATE_PARAMS,
+      planDigest: planned.plan.planDigest,
+      canonicalApproval: confirmed.approval.canonicalApproval,
+    };
+
+    await harness.route("providers.create").handler(makeCtx({ body }));
+    await expect(harness.route("providers.create").handler(makeCtx({ body })))
+      .rejects.toMatchObject({ code: "CANONICAL_APPROVAL_DENIED" });
+    expect(harness.service.createProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it("an expired plan cannot be confirmed", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+
+    harness.setNow("2026-02-17T10:11:00.000Z"); // > 10 minute plan TTL
+    await expect(confirm(harness, planned.plan.planDigest)).rejects.toMatchObject({
+      code: "PROVIDER_MUTATION_PLAN_NOT_FOUND",
+    });
+    expect(harness.signCalls()).toBe(0);
+  });
+
+  it("an expired approval is refused by the gate", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    const confirmed = await confirm(harness, planned.plan.planDigest);
+
+    harness.setNow("2026-02-17T10:20:00.000Z"); // past the ~10 minute approval expiry
+    await expect(harness.route("providers.create").handler(makeCtx({
+      body: {
+        ...CREATE_PARAMS,
+        planDigest: planned.plan.planDigest,
+        canonicalApproval: confirmed.approval.canonicalApproval,
+      },
+    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_DENIED" });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("confirm requires an explicit `confirm: true` and never defaults it", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+
+    await expect(harness.route("providers.plan.confirm").handler(makeCtx({
+      body: { planDigest: planned.plan.planDigest },
+    }))).rejects.toMatchObject({ code: "PROVIDER_MUTATION_CONFIRMATION_REQUIRED" });
+    expect(harness.signCalls()).toBe(0);
+  });
+
+  it("confirm fails closed (503) when no approval signer is wired", async () => {
+    const harness = makeHarness({ withSigner: false });
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+
+    await expect(confirm(harness, planned.plan.planDigest)).rejects.toMatchObject({
+      code: "PROVIDER_MUTATION_APPROVAL_SIGNER_UNAVAILABLE",
+      httpStatus: 503,
+    });
+  });
+
+  it("plan and confirm refuse the unauthenticated public principal", async () => {
+    const harness = makeHarness();
+    const publicCtx = {
+      requestId: "req-1",
+      receivedAt: NOW,
+      params: {},
+      query: {},
+      body: { action: "providers.create", params: CREATE_PARAMS },
+      headers: {},
+      principal: null,
+    } as unknown as FridayHttpContext<unknown, unknown, unknown>;
+
+    await expect(harness.route("providers.plan").handler(publicCtx)).rejects.toMatchObject({
+      code: "OWNER_SESSION_CHANNEL_PRINCIPAL_REQUIRED",
+      httpStatus: 401,
+    });
+  });
+
+  // ─── Secret-freedom of the review artifact ───
+
+  it("the plan response never echoes an API key (presence only)", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    const serialized = JSON.stringify(planned);
+
+    expect(serialized).not.toContain(SECRET_API_KEY);
+    expect(serialized).not.toContain("CR2SECRET");
+    expect(planned.plan.humanReadableSummary.join("\n")).toContain("never shown or echoed back");
+  });
+
+  it("the confirm response never echoes an API key", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    const confirmed = await confirm(harness, planned.plan.planDigest);
+
+    expect(JSON.stringify(confirmed)).not.toContain(SECRET_API_KEY);
+    expect(JSON.stringify(confirmed)).not.toContain("CR2SECRET");
+  });
+
+  it("a secret smuggled into a custom header value never reaches the plan summary", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, {
+      action: "providers.update",
+      providerId: "prov-001",
+      params: { headers: { "X-Api-Token": SECRET_API_KEY } },
+    });
+
+    expect(JSON.stringify(planned)).not.toContain(SECRET_API_KEY);
+    expect(planned.plan.humanReadableSummary.join("\n")).toContain("1 header value(s)");
+  });
+
+  it("the OAuth device-complete plan never echoes the device code", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, {
+      action: "providers.oauth.openai_codex.device.complete",
+      params: { providerId: "codex-001", deviceCodeId: SECRET_API_KEY },
+    });
+
+    expect(JSON.stringify(planned)).not.toContain(SECRET_API_KEY);
+    expect(planned.plan.humanReadableSummary.join("\n")).toContain("never shown here");
+  });
+
+  // ─── Plannability coverage of every gated action ───
+
+  it("every gated provider action is plannable", async () => {
+    const harness = makeHarness();
+    const cases: Array<Record<string, unknown>> = [
+      { action: "providers.create", params: CREATE_PARAMS },
+      { action: "providers.update", providerId: "prov-001", params: { name: "Renamed" } },
+      { action: "providers.delete", providerId: "prov-001" },
+      { action: "providers.validate", providerId: "prov-001" },
+      { action: "providers.routing.set", params: { defaultProviderId: "prov-001", fallbackProviderIds: [] } },
+      {
+        action: "providers.routing.pin",
+        params: { providerId: "prov-001", model: "gpt-4o", backendKind: "http" },
+      },
+      {
+        action: "providers.routing.penalty.clear",
+        params: { providerId: "prov-001", model: "gpt-4o", backendKind: "http" },
+      },
+      { action: "providers.auth.profiles.activate", providerId: "prov-001", profileKey: "default" },
+      { action: "providers.oauth.openai_codex.device.initiate", params: { providerId: "codex-001" } },
+      {
+        action: "providers.oauth.openai_codex.device.complete",
+        params: { providerId: "codex-001", deviceCodeId: "device-1" },
+      },
+      { action: "capabilities.doctor", params: { providerIds: ["prov-001"] } },
+    ];
+
+    for (const body of cases) {
+      const planned = await plan(harness, body);
+      expect(planned.plan.planDigest, String(body.action)).toMatch(/^fpmp_/);
+      expect(planned.plan.humanReadableSummary.length, String(body.action)).toBeGreaterThan(0);
+    }
+  });
+
+  it("an unknown action is refused before any plan is minted", async () => {
+    const harness = makeHarness();
+    await expect(plan(harness, { action: "providers.exfiltrate" })).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+  });
+
+  it("a plan whose parameters are invalid is refused up front", async () => {
+    const harness = makeHarness();
+    await expect(plan(harness, { action: "providers.create", params: { kind: "openai" } }))
+      .rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    await expect(plan(harness, { action: "providers.delete" }))
+      .rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  // ─── The plan/confirm routes grant no authority of their own ───
+
+  it("planning performs no provider mutation", async () => {
+    const harness = makeHarness();
+    await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    await plan(harness, { action: "providers.delete", providerId: "prov-001" });
+
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+    expect(harness.service.deleteProvider).not.toHaveBeenCalled();
+    expect(harness.signCalls()).toBe(0);
+  });
+
+  it("re-planning the same change replaces the record and revokes an unspent confirmation slot", async () => {
+    const harness = makeHarness();
+    const first = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    await confirm(harness, first.plan.planDigest);
+
+    // Deterministic digest: re-planning yields the SAME digest, and the fresh record
+    // is unconfirmed — but that is safe because the gate refuses the already-minted
+    // approval on replay (single-use), proven above.
+    const second = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    expect(second.plan.planDigest).toBe(first.plan.planDigest);
+
+    const confirmed = await confirm(harness, second.plan.planDigest);
+    expect(harness.signCalls()).toBe(2);
+    expect(confirmed.approval.planDigest).toBe(first.plan.planDigest);
+  });
+});

--- a/test/unit/api/http/routes/friday-provider-mutation-plan-confirm.test.ts
+++ b/test/unit/api/http/routes/friday-provider-mutation-plan-confirm.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { describe, it, expect, vi } from "vitest";
 
 import type { FridayHttpContext, FridayRouteDefinition } from "#api";
@@ -117,6 +119,13 @@ describe("provider mutation plan → DEVICE confirm → gated mutation", () => {
       allowTestOnlyProviderProbeExecution: true,
       allowTestOnlyProviderRoutingControlsExecution: true,
       nowIso: () => now,
+      // Option B*: resolve the authenticated owner's durable device binding
+      // server-side. The harness's owner session has `userId: "owner-user"` and its
+      // registered device is `OWNER`; a passphrase / unknown user resolves to null.
+      resolveBoundDeviceOwnerSentinelHash: (userId: string) =>
+        userId === "owner-user"
+          ? createHash("sha256").update(OWNER.spkiDerBase64).digest("hex")
+          : null,
       ...(options.withVerifier === false ? {} : { providerApprovalVerifier }),
     });
 

--- a/test/unit/api/http/routes/friday-provider-mutation-plan-confirm.test.ts
+++ b/test/unit/api/http/routes/friday-provider-mutation-plan-confirm.test.ts
@@ -4,28 +4,35 @@ import type { FridayHttpContext, FridayRouteDefinition } from "#api";
 import { createFridayProviderRoutes } from "#api";
 import type { FridayProviderProfile, FridayProviderService } from "#providers";
 import {
-  createFridayMutatingActionDigest,
   createFridayMutatingActionGate,
   signFridayCanonicalApproval,
   type FridayCanonicalApprovalResolution,
-  type FridayMutatingActionRequest,
+  type FridayDeviceApprovalVerifyResult,
 } from "../../../../../src/security/friday-mutating-action-gate.js";
+import { createFridayProviderApprovalPoPVerifier } from "../../../../../src/api/auth/device-attest/index.js";
+import type { ProviderApprovalDeviceProof } from "../../../../../src/api/auth/device-attest/index.js";
+import {
+  deviceOwnerPrincipalIdFor,
+  generateTestDeviceKey,
+  makeApprovalProof,
+  makeApprovalTranscript,
+  type TestDeviceKey,
+} from "../../../../helpers/friday-provider-approval-test-kit.js";
 
 /**
- * CORE-A CR-2 — provider setup owner-confirm handshake.
+ * SEC-APPROVAL-AUTHORITY-001 · CORE-A CR-2 — device-authored provider approval.
  *
- * These are integration tests against the REAL provider routes (plan / plan.confirm /
- * the gated mutation routes) with the REAL canonical mutating-action gate wired with a
- * signature secret. Nothing here is a mock of the gate: every negative below is the
- * production fail-closed path.
+ * Integration tests against the REAL provider routes (plan / plan.confirm / the
+ * gated mutation routes) with the REAL canonical mutating-action gate + the REAL
+ * asymmetric device-approval verifier. Nothing here mocks the gate or the crypto:
+ * every negative is the production fail-closed path. The Hub holds NO signing key —
+ * the owner DEVICE signs each approval; the Hub only verifies it.
  */
-describe("provider mutation plan → owner confirm → gated mutation", () => {
+describe("provider mutation plan → DEVICE confirm → gated mutation", () => {
   const NOW = "2026-02-17T10:00:00.000Z";
+  /** The shared HMAC secret the LEGACY plugin-lifecycle path uses — a provider
+   * mutation must REFUSE any approval carrying it (the Hub-self-sign negative). */
   const APPROVAL_SIGNATURE_SECRET = "test-hub-token-secret"; // pragma: allowlist secret
-  /**
-   * A key-SHAPED value. Every "no secret leaks" assertion below searches the full
-   * serialized plan/confirm response for this exact string.
-   */
   const SECRET_API_KEY = "sk-live-CR2SECRET0000000000000000000000000000"; // pragma: allowlist secret
 
   const sampleProfile: FridayProviderProfile = {
@@ -59,67 +66,76 @@ describe("provider mutation plan → owner confirm → gated mutation", () => {
     } as unknown as FridayProviderService;
   }
 
+  interface Plan {
+    planDigest: string;
+    actionDigest: string;
+    humanReadableSummary: string[];
+  }
+
   interface Harness {
-    routes: FridayRouteDefinition<unknown, unknown, unknown, unknown>[];
     service: FridayProviderService;
     route: (operationId: string) => FridayRouteDefinition<unknown, unknown, unknown, unknown>;
     setNow: (iso: string) => void;
-    signCalls: () => number;
   }
 
-  function makeHarness(options: { withSigner?: boolean } = {}): Harness {
+  function makeHarness(options: { withVerifier?: boolean } = {}): Harness {
     const service = makeMockService();
     let now = NOW;
-    let signCalls = 0;
 
-    // The REAL production signing seam (identical to friday-api-runtime's
-    // signCanonicalApprovalForRequest): HMAC over the server-derived action digest,
-    // with a ~10 minute expiry.
-    const signCanonicalApproval = (
-      request: FridayMutatingActionRequest,
-      input: { approvalIdPrefix: string },
-    ): FridayCanonicalApprovalResolution => {
-      signCalls += 1;
-      const expiresAt = new Date(Date.parse(now) + 10 * 60 * 1000).toISOString();
-      return signFridayCanonicalApproval({
-        decision: "approved",
-        approvalId: `${input.approvalIdPrefix}-${String(signCalls)}`,
-        decidedByPrincipalId: request.actor.principalId ?? request.actor.id,
-        actionDigest: createFridayMutatingActionDigest(request),
-        expiresAt,
-      }, APPROVAL_SIGNATURE_SECRET);
-    };
+    const providerApprovalVerifier = createFridayProviderApprovalPoPVerifier();
+    // Wire the gate EXACTLY like the runtime: legacy HMAC secret (plugin path) PLUS
+    // the asymmetric device verifier (provider path). Providers reject HMAC issuers.
+    const canonicalMutationGate = createFridayMutatingActionGate({
+      nowIso: () => now,
+      ticketIdGenerator: () => "ticket-1",
+      approvalSignatureSecret: APPROVAL_SIGNATURE_SECRET,
+      requireApprovalSignature: true,
+      deviceApprovalVerifier: (proof, nowMs): FridayDeviceApprovalVerifyResult => {
+        const r = providerApprovalVerifier.verifyPossession({
+          transcript: proof.transcript,
+          devicePublicKey: proof.devicePublicKey,
+          signature: proof.signature,
+          nowMs,
+        });
+        return r.ok
+          ? {
+              ok: true,
+              devicePublicKeyHash: r.devicePublicKeyHash,
+              approvalId: r.approvalId,
+              actionDigest: r.actionDigest,
+              decidedByPrincipalId: r.decidedByPrincipalId,
+              expiresAt: r.expiresAt,
+            }
+          : { ok: false, reason: r.reason };
+      },
+    });
 
     const routes = createFridayProviderRoutes({
       providerService: service,
       providerMutationGateRequired: true,
-      canonicalMutationGate: createFridayMutatingActionGate({
-        nowIso: () => now,
-        ticketIdGenerator: () => "ticket-1",
-        approvalSignatureSecret: APPROVAL_SIGNATURE_SECRET,
-      }),
+      canonicalMutationGate,
       allowTestOnlyProviderProbeExecution: true,
       allowTestOnlyProviderRoutingControlsExecution: true,
       nowIso: () => now,
-      ...(options.withSigner === false ? {} : { signCanonicalApproval }),
+      ...(options.withVerifier === false ? {} : { providerApprovalVerifier }),
     });
 
     return {
-      routes,
       service,
       route: (operationId: string) => {
         const found = routes.find((entry) => entry.operationId === operationId);
-        if (!found) {
-          throw new Error(`route not found: ${operationId}`);
-        }
+        if (!found) throw new Error(`route not found: ${operationId}`);
         return found;
       },
       setNow: (iso: string) => {
         now = iso;
       },
-      signCalls: () => signCalls,
     };
   }
+
+  // The single owner device for the harness (device-owner principal binds to it).
+  const OWNER = generateTestDeviceKey();
+  const OWNER_PRINCIPAL = deviceOwnerPrincipalIdFor(OWNER);
 
   function makeCtx(input: {
     body?: unknown;
@@ -127,7 +143,7 @@ describe("provider mutation plan → owner confirm → gated mutation", () => {
     principalId?: string;
     requestId?: string;
   }): FridayHttpContext<unknown, unknown, unknown> {
-    const principalId = input.principalId ?? "user-1";
+    const principalId = input.principalId ?? OWNER_PRINCIPAL;
     return {
       requestId: input.requestId ?? "req-1",
       receivedAt: NOW,
@@ -135,11 +151,20 @@ describe("provider mutation plan → owner confirm → gated mutation", () => {
       query: {},
       body: input.body ?? {},
       headers: {},
+      // The owner principal is BOUND to the device (its principalId IS the
+      // device-owner id `device-owner:<keyHash>`). We set `principalType: "user"`
+      // rather than "device" ON PURPOSE: a "device"-typed principal is release
+      // DISABLED today (`isReleaseDisabledDevicePrincipal` — the NATIVE_IPC
+      // attestation operator leaf we must NOT touch), so a "device" principal is
+      // refused before any device-verification logic runs. This fixture stands in
+      // for that principal AFTER it clears the attestation gate, so the tests
+      // exercise the device-authored approval LOGIC (which binds on the principalId).
+      // The real "device"-typed end-to-end admit remains the attestation operator leaf.
       principal: {
         principalType: "user",
         principalId,
-        userId: principalId,
-        role: "admin",
+        userId: "owner-user",
+        role: "owner",
         scopes: ["hub.admin"],
         tokenId: "tok-1",
         tokenKind: "access",
@@ -161,110 +186,153 @@ describe("provider mutation plan → owner confirm → gated mutation", () => {
   async function plan(
     harness: Harness,
     body: Record<string, unknown>,
-    principalId = "user-1",
-  ): Promise<{ plan: { planDigest: string; humanReadableSummary: string[] } }> {
-    return await harness.route("providers.plan").handler(
-      makeCtx({ body, principalId }),
-    ) as { plan: { planDigest: string; humanReadableSummary: string[] } };
+    principalId = OWNER_PRINCIPAL,
+  ): Promise<Plan> {
+    const result = await harness.route("providers.plan").handler(makeCtx({ body, principalId })) as {
+      plan: Plan;
+    };
+    return result.plan;
+  }
+
+  /** Author a device proof for `planned` (defaults: owner key + a fresh expiry). */
+  function deviceProofFor(
+    planned: Plan,
+    opts: { key?: TestDeviceKey; decidedByPrincipalId?: string; expiresAt?: string } = {},
+  ): ProviderApprovalDeviceProof {
+    const key = opts.key ?? OWNER;
+    const transcript = makeApprovalTranscript(key, {
+      actionDigest: planned.actionDigest,
+      decidedByPrincipalId: opts.decidedByPrincipalId ?? deviceOwnerPrincipalIdFor(key),
+      expiresAt: opts.expiresAt ?? "2026-02-17T10:09:00.000Z",
+    });
+    return makeApprovalProof(key, transcript);
   }
 
   async function confirm(
     harness: Harness,
-    planDigest: string,
-    principalId = "user-1",
-  ): Promise<{ approval: { canonicalApproval: unknown; planDigest: string } }> {
+    planned: Plan,
+    opts: {
+      principalId?: string;
+      deviceApproval?: ProviderApprovalDeviceProof;
+    } = {},
+  ): Promise<{ approval: { canonicalApproval: unknown; planDigest: string; expiresAt: string } }> {
     return await harness.route("providers.plan.confirm").handler(
-      makeCtx({ body: { planDigest, confirm: true }, principalId }),
-    ) as { approval: { canonicalApproval: unknown; planDigest: string } };
+      makeCtx({
+        body: {
+          planDigest: planned.planDigest,
+          confirm: true,
+          deviceApproval: opts.deviceApproval ?? deviceProofFor(planned),
+        },
+        principalId: opts.principalId ?? OWNER_PRINCIPAL,
+      }),
+    ) as { approval: { canonicalApproval: unknown; planDigest: string; expiresAt: string } };
   }
 
-  // ─── Happy path ───
+  // ─── Happy path: the Hub VERIFIES a device approval and admits ───
 
-  it("plan → confirm → create passes the canonical gate for a NORMAL owner", async () => {
+  it("plan → DEVICE confirm → create passes the canonical gate", async () => {
     const harness = makeHarness();
     const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-    expect(planned.plan.planDigest).toMatch(/^fpmp_[0-9a-f]{64}$/);
+    expect(planned.planDigest).toMatch(/^fpmp_[0-9a-f]{64}$/);
 
-    const confirmed = await confirm(harness, planned.plan.planDigest);
+    const confirmed = await confirm(harness, planned);
+    // The Hub added NO signature; it returned the device-authored approval verbatim.
+    const approval = confirmed.approval.canonicalApproval as FridayCanonicalApprovalResolution;
+    expect(approval.issuer).toBe("friday_device_owner");
+    expect(approval.signature).toBeUndefined();
+    expect(approval.deviceProof).toBeDefined();
+
     const result = await harness.route("providers.create").handler(makeCtx({
-      body: {
-        ...CREATE_PARAMS,
-        planDigest: planned.plan.planDigest,
-        canonicalApproval: confirmed.approval.canonicalApproval,
-      },
+      body: { ...CREATE_PARAMS, planDigest: planned.planDigest, canonicalApproval: approval },
     }));
-
     expect(harness.service.createProvider).toHaveBeenCalledWith(CREATE_PARAMS);
     expect(result).toHaveProperty("canonicalGate.ticketId", "ticket-1");
-    expect(result).toHaveProperty("canonicalGate.planDigest", planned.plan.planDigest);
   });
 
-  it("plan → confirm → routing.set (a second gated surface) passes the gate", async () => {
+  it("plan → DEVICE confirm → routing.set (a second gated surface) passes the gate", async () => {
     const harness = makeHarness();
     const routingParams = { defaultProviderId: "prov-001", fallbackProviderIds: ["prov-001"] };
     const planned = await plan(harness, { action: "providers.routing.set", params: routingParams });
-    const confirmed = await confirm(harness, planned.plan.planDigest);
+    const confirmed = await confirm(harness, planned);
 
     const result = await harness.route("providers.routing.set").handler(makeCtx({
-      body: {
-        ...routingParams,
-        planDigest: planned.plan.planDigest,
-        canonicalApproval: confirmed.approval.canonicalApproval,
-      },
+      body: { ...routingParams, planDigest: planned.planDigest, canonicalApproval: confirmed.approval.canonicalApproval },
     }));
     expect(result).toHaveProperty("canonicalGate.ticketId", "ticket-1");
   });
 
-  it("plan → confirm → delete (a param-free target-id surface) passes the gate", async () => {
-    const harness = makeHarness();
-    const planned = await plan(harness, { action: "providers.delete", providerId: "prov-001" });
-    const confirmed = await confirm(harness, planned.plan.planDigest);
+  // ─── SEC-APPROVAL-AUTHORITY-001 negative controls ───
 
-    const result = await harness.route("providers.delete").handler(makeCtx({
-      params: { providerId: "prov-001" },
-      body: {
-        planDigest: planned.plan.planDigest,
-        canonicalApproval: confirmed.approval.canonicalApproval,
-      },
-    }));
-    expect(harness.service.deleteProvider).toHaveBeenCalledWith("prov-001");
-    expect(result).toHaveProperty("canonicalGate.ticketId", "ticket-1");
-  });
-
-  // ─── Fail-closed negatives ───
-
-  it("missing planDigest is refused with PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED", async () => {
-    const harness = makeHarness();
-    await expect(harness.route("providers.create").handler(makeCtx({ body: CREATE_PARAMS })))
-      .rejects.toMatchObject({
-        code: "PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED",
-        httpStatus: 403,
-      });
-    expect(harness.service.createProvider).not.toHaveBeenCalled();
-  });
-
-  it("a plan digest alone (no approval) never authorizes a mutation", async () => {
+  it("HUB SELF-SIGN: a Hub-minted HMAC approval is REFUSED on a provider mutation", async () => {
     const harness = makeHarness();
     const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
 
+    // The exact forbidden primitive: a symmetric HMAC the Hub both mints AND holds
+    // the secret for, bound to the correct action digest. It MUST NOT admit.
+    const hubSelfSigned = signFridayCanonicalApproval(
+      {
+        decision: "approved",
+        approvalId: "hub-self-signed-1",
+        decidedByPrincipalId: OWNER_PRINCIPAL,
+        actionDigest: planned.actionDigest,
+        expiresAt: "2026-02-17T10:09:00.000Z",
+      },
+      APPROVAL_SIGNATURE_SECRET,
+    );
+
     await expect(harness.route("providers.create").handler(makeCtx({
-      body: { ...CREATE_PARAMS, planDigest: planned.plan.planDigest },
-    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_REQUIRED" });
+      body: { ...CREATE_PARAMS, planDigest: planned.planDigest, canonicalApproval: hubSelfSigned },
+    }))).rejects.toMatchObject({ code: "PROVIDER_MUTATION_APPROVAL_NOT_DEVICE_AUTHORED", httpStatus: 403 });
     expect(harness.service.createProvider).not.toHaveBeenCalled();
   });
 
-  it("an unknown / stale plan digest cannot be confirmed", async () => {
+  it("WEB-SESSION confirm:true with NO device proof FAILS (no Hub self-mint)", async () => {
     const harness = makeHarness();
-    await expect(confirm(harness, "fpmp_deadbeef")).rejects.toMatchObject({
-      code: "PROVIDER_MUTATION_PLAN_NOT_FOUND",
-      httpStatus: 404,
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+
+    await expect(harness.route("providers.plan.confirm").handler(makeCtx({
+      body: { planDigest: planned.planDigest, confirm: true },
+    }))).rejects.toMatchObject({ code: "PROVIDER_MUTATION_APPROVAL_PROOF_REQUIRED", httpStatus: 400 });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("WRONG DEVICE: an approval whose signing key is not the owner's bound device is refused at confirm", async () => {
+    const harness = makeHarness();
+    const attacker = generateTestDeviceKey();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+
+    // The attacker signs with its OWN key but claims the owner's principal id. The
+    // signing key hash no longer maps to the owner principal → refused.
+    const proof = deviceProofFor(planned, { key: attacker, decidedByPrincipalId: OWNER_PRINCIPAL });
+    await expect(confirm(harness, planned, { deviceApproval: proof })).rejects.toMatchObject({
+      code: "PROVIDER_MUTATION_APPROVAL_DEVICE_NOT_BOUND",
+      httpStatus: 403,
     });
   });
 
-  it("replaying a valid approval under a DIFFERENT plan digest fails closed on digest mismatch", async () => {
+  it("DIGEST MUTATION between preview and dispatch yields zero sink", async () => {
     const harness = makeHarness();
     const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-    const confirmed = await confirm(harness, planned.plan.planDigest);
+    const confirmed = await confirm(harness, planned);
+
+    // Same owner, same planDigest, same device approval — but the body that arrives
+    // points at a different endpoint. The gate recomputes the digest from THIS
+    // request, so the device signature no longer covers it.
+    await expect(harness.route("providers.create").handler(makeCtx({
+      body: {
+        ...CREATE_PARAMS,
+        baseUrl: "https://attacker.example",
+        planDigest: planned.planDigest,
+        canonicalApproval: confirmed.approval.canonicalApproval,
+      },
+    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_DENIED" });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("replaying a valid approval under a DIFFERENT plan digest fails closed", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    const confirmed = await confirm(harness, planned);
 
     await expect(harness.route("providers.create").handler(makeCtx({
       body: {
@@ -276,70 +344,32 @@ describe("provider mutation plan → owner confirm → gated mutation", () => {
     expect(harness.service.createProvider).not.toHaveBeenCalled();
   });
 
-  it("parameter drift between the reviewed plan and the replayed body fails closed", async () => {
+  it("a tampered device signature fails closed at the gate", async () => {
     const harness = makeHarness();
     const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-    const confirmed = await confirm(harness, planned.plan.planDigest);
-
-    // Same owner, same planDigest, same signed approval — but the body that actually
-    // arrives points at a different endpoint. The gate recomputes the action digest
-    // from THIS request, so the approval no longer binds.
-    await expect(harness.route("providers.create").handler(makeCtx({
-      body: {
-        ...CREATE_PARAMS,
-        baseUrl: "https://attacker.example",
-        planDigest: planned.plan.planDigest,
-        canonicalApproval: confirmed.approval.canonicalApproval,
-      },
-    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_DENIED" });
-    expect(harness.service.createProvider).not.toHaveBeenCalled();
-  });
-
-  it("a tampered approval signature fails closed", async () => {
-    const harness = makeHarness();
-    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-    const confirmed = await confirm(harness, planned.plan.planDigest);
+    const confirmed = await confirm(harness, planned);
+    const approval = confirmed.approval.canonicalApproval as FridayCanonicalApprovalResolution;
     const tampered = {
-      ...(confirmed.approval.canonicalApproval as Record<string, unknown>),
-      signature: "00".repeat(32),
+      ...approval,
+      deviceProof: {
+        ...approval.deviceProof!,
+        signature: { encoding: "ieee-p1363-base64" as const, value: Buffer.alloc(64, 7).toString("base64") },
+      },
     };
 
     await expect(harness.route("providers.create").handler(makeCtx({
-      body: { ...CREATE_PARAMS, planDigest: planned.plan.planDigest, canonicalApproval: tampered },
+      body: { ...CREATE_PARAMS, planDigest: planned.planDigest, canonicalApproval: tampered },
     }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_DENIED" });
     expect(harness.service.createProvider).not.toHaveBeenCalled();
   });
 
-  it("a plan can only be confirmed by the principal that created it", async () => {
-    const harness = makeHarness();
-    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS }, "user-1");
-
-    await expect(confirm(harness, planned.plan.planDigest, "user-2")).rejects.toMatchObject({
-      code: "PROVIDER_MUTATION_PLAN_OWNER_MISMATCH",
-      httpStatus: 403,
-    });
-    expect(harness.signCalls()).toBe(0);
-  });
-
-  it("a plan is single-use at the confirm layer", async () => {
+  it("a device approval is single-use at the gate (replay is denied)", async () => {
     const harness = makeHarness();
     const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-    await confirm(harness, planned.plan.planDigest);
-
-    await expect(confirm(harness, planned.plan.planDigest)).rejects.toMatchObject({
-      code: "PROVIDER_MUTATION_PLAN_ALREADY_CONFIRMED",
-      httpStatus: 409,
-    });
-    expect(harness.signCalls()).toBe(1);
-  });
-
-  it("a minted approval is single-use at the gate layer (replay is denied)", async () => {
-    const harness = makeHarness();
-    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-    const confirmed = await confirm(harness, planned.plan.planDigest);
+    const confirmed = await confirm(harness, planned);
     const body = {
       ...CREATE_PARAMS,
-      planDigest: planned.plan.planDigest,
+      planDigest: planned.planDigest,
       canonicalApproval: confirmed.approval.canonicalApproval,
     };
 
@@ -349,49 +379,95 @@ describe("provider mutation plan → owner confirm → gated mutation", () => {
     expect(harness.service.createProvider).toHaveBeenCalledTimes(1);
   });
 
+  it("an EXPIRED device approval is refused by the gate", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    const confirmed = await confirm(harness, planned, {
+      deviceApproval: deviceProofFor(planned, { expiresAt: "2026-02-17T10:05:00.000Z" }),
+    });
+
+    harness.setNow("2026-02-17T10:06:00.000Z"); // past the signed approval expiry
+    await expect(harness.route("providers.create").handler(makeCtx({
+      body: { ...CREATE_PARAMS, planDigest: planned.planDigest, canonicalApproval: confirmed.approval.canonicalApproval },
+    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_DENIED" });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("a device approval with an over-long lifetime is refused at confirm", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    // 30 minutes > the Hub's 10-minute max device-approval lifetime.
+    await expect(confirm(harness, planned, {
+      deviceApproval: deviceProofFor(planned, { expiresAt: "2026-02-17T10:30:00.000Z" }),
+    })).rejects.toMatchObject({ code: "PROVIDER_MUTATION_APPROVAL_EXPIRY_INVALID", httpStatus: 403 });
+  });
+
+  // ─── Plan-layer fail-closed negatives (unchanged semantics) ───
+
+  it("missing planDigest is refused with PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED", async () => {
+    const harness = makeHarness();
+    await expect(harness.route("providers.create").handler(makeCtx({ body: CREATE_PARAMS })))
+      .rejects.toMatchObject({ code: "PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED", httpStatus: 403 });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("a plan digest alone (no approval) never authorizes a mutation", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    await expect(harness.route("providers.create").handler(makeCtx({
+      body: { ...CREATE_PARAMS, planDigest: planned.planDigest },
+    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_REQUIRED" });
+    expect(harness.service.createProvider).not.toHaveBeenCalled();
+  });
+
+  it("an unknown / stale plan digest cannot be confirmed", async () => {
+    const harness = makeHarness();
+    await expect(confirm(harness, { planDigest: "fpmp_deadbeef", actionDigest: "d".repeat(64), humanReadableSummary: [] }))
+      .rejects.toMatchObject({ code: "PROVIDER_MUTATION_PLAN_NOT_FOUND", httpStatus: 404 });
+  });
+
+  it("a plan can only be confirmed by the principal that created it", async () => {
+    const harness = makeHarness();
+    const otherOwner = generateTestDeviceKey();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS }, OWNER_PRINCIPAL);
+
+    // A different owner device presents a structurally valid proof for itself.
+    await expect(confirm(harness, planned, {
+      principalId: deviceOwnerPrincipalIdFor(otherOwner),
+      deviceApproval: deviceProofFor(planned, { key: otherOwner }),
+    })).rejects.toMatchObject({ code: "PROVIDER_MUTATION_PLAN_OWNER_MISMATCH", httpStatus: 403 });
+  });
+
+  it("a plan is single-use at the confirm layer", async () => {
+    const harness = makeHarness();
+    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
+    await confirm(harness, planned);
+    await expect(confirm(harness, planned)).rejects.toMatchObject({
+      code: "PROVIDER_MUTATION_PLAN_ALREADY_CONFIRMED",
+      httpStatus: 409,
+    });
+  });
+
   it("an expired plan cannot be confirmed", async () => {
     const harness = makeHarness();
     const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-
     harness.setNow("2026-02-17T10:11:00.000Z"); // > 10 minute plan TTL
-    await expect(confirm(harness, planned.plan.planDigest)).rejects.toMatchObject({
-      code: "PROVIDER_MUTATION_PLAN_NOT_FOUND",
-    });
-    expect(harness.signCalls()).toBe(0);
-  });
-
-  it("an expired approval is refused by the gate", async () => {
-    const harness = makeHarness();
-    const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-    const confirmed = await confirm(harness, planned.plan.planDigest);
-
-    harness.setNow("2026-02-17T10:20:00.000Z"); // past the ~10 minute approval expiry
-    await expect(harness.route("providers.create").handler(makeCtx({
-      body: {
-        ...CREATE_PARAMS,
-        planDigest: planned.plan.planDigest,
-        canonicalApproval: confirmed.approval.canonicalApproval,
-      },
-    }))).rejects.toMatchObject({ code: "CANONICAL_APPROVAL_DENIED" });
-    expect(harness.service.createProvider).not.toHaveBeenCalled();
+    await expect(confirm(harness, planned)).rejects.toMatchObject({ code: "PROVIDER_MUTATION_PLAN_NOT_FOUND" });
   });
 
   it("confirm requires an explicit `confirm: true` and never defaults it", async () => {
     const harness = makeHarness();
     const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-
     await expect(harness.route("providers.plan.confirm").handler(makeCtx({
-      body: { planDigest: planned.plan.planDigest },
+      body: { planDigest: planned.planDigest },
     }))).rejects.toMatchObject({ code: "PROVIDER_MUTATION_CONFIRMATION_REQUIRED" });
-    expect(harness.signCalls()).toBe(0);
   });
 
-  it("confirm fails closed (503) when no approval signer is wired", async () => {
-    const harness = makeHarness({ withSigner: false });
+  it("confirm fails closed (503) when no device-approval verifier is wired", async () => {
+    const harness = makeHarness({ withVerifier: false });
     const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-
-    await expect(confirm(harness, planned.plan.planDigest)).rejects.toMatchObject({
-      code: "PROVIDER_MUTATION_APPROVAL_SIGNER_UNAVAILABLE",
+    await expect(confirm(harness, planned)).rejects.toMatchObject({
+      code: "PROVIDER_MUTATION_APPROVAL_VERIFIER_UNAVAILABLE",
       httpStatus: 503,
     });
   });
@@ -414,23 +490,21 @@ describe("provider mutation plan → owner confirm → gated mutation", () => {
     });
   });
 
-  // ─── Secret-freedom of the review artifact ───
+  // ─── Secret-freedom of the review + approval artifacts ───
 
   it("the plan response never echoes an API key (presence only)", async () => {
     const harness = makeHarness();
     const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
     const serialized = JSON.stringify(planned);
-
     expect(serialized).not.toContain(SECRET_API_KEY);
     expect(serialized).not.toContain("CR2SECRET");
-    expect(planned.plan.humanReadableSummary.join("\n")).toContain("never shown or echoed back");
+    expect(planned.humanReadableSummary.join("\n")).toContain("never shown or echoed back");
   });
 
   it("the confirm response never echoes an API key", async () => {
     const harness = makeHarness();
     const planned = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-    const confirmed = await confirm(harness, planned.plan.planDigest);
-
+    const confirmed = await confirm(harness, planned);
     expect(JSON.stringify(confirmed)).not.toContain(SECRET_API_KEY);
     expect(JSON.stringify(confirmed)).not.toContain("CR2SECRET");
   });
@@ -442,20 +516,8 @@ describe("provider mutation plan → owner confirm → gated mutation", () => {
       providerId: "prov-001",
       params: { headers: { "X-Api-Token": SECRET_API_KEY } },
     });
-
     expect(JSON.stringify(planned)).not.toContain(SECRET_API_KEY);
-    expect(planned.plan.humanReadableSummary.join("\n")).toContain("1 header value(s)");
-  });
-
-  it("the OAuth device-complete plan never echoes the device code", async () => {
-    const harness = makeHarness();
-    const planned = await plan(harness, {
-      action: "providers.oauth.openai_codex.device.complete",
-      params: { providerId: "codex-001", deviceCodeId: SECRET_API_KEY },
-    });
-
-    expect(JSON.stringify(planned)).not.toContain(SECRET_API_KEY);
-    expect(planned.plan.humanReadableSummary.join("\n")).toContain("never shown here");
+    expect(planned.humanReadableSummary.join("\n")).toContain("1 header value(s)");
   });
 
   // ─── Plannability coverage of every gated action ───
@@ -468,70 +530,25 @@ describe("provider mutation plan → owner confirm → gated mutation", () => {
       { action: "providers.delete", providerId: "prov-001" },
       { action: "providers.validate", providerId: "prov-001" },
       { action: "providers.routing.set", params: { defaultProviderId: "prov-001", fallbackProviderIds: [] } },
-      {
-        action: "providers.routing.pin",
-        params: { providerId: "prov-001", model: "gpt-4o", backendKind: "http" },
-      },
-      {
-        action: "providers.routing.penalty.clear",
-        params: { providerId: "prov-001", model: "gpt-4o", backendKind: "http" },
-      },
+      { action: "providers.routing.pin", params: { providerId: "prov-001", model: "gpt-4o", backendKind: "http" } },
+      { action: "providers.routing.penalty.clear", params: { providerId: "prov-001", model: "gpt-4o", backendKind: "http" } },
       { action: "providers.auth.profiles.activate", providerId: "prov-001", profileKey: "default" },
       { action: "providers.oauth.openai_codex.device.initiate", params: { providerId: "codex-001" } },
-      {
-        action: "providers.oauth.openai_codex.device.complete",
-        params: { providerId: "codex-001", deviceCodeId: "device-1" },
-      },
+      { action: "providers.oauth.openai_codex.device.complete", params: { providerId: "codex-001", deviceCodeId: "device-1" } },
       { action: "capabilities.doctor", params: { providerIds: ["prov-001"] } },
     ];
-
     for (const body of cases) {
       const planned = await plan(harness, body);
-      expect(planned.plan.planDigest, String(body.action)).toMatch(/^fpmp_/);
-      expect(planned.plan.humanReadableSummary.length, String(body.action)).toBeGreaterThan(0);
+      expect(planned.planDigest, String(body.action)).toMatch(/^fpmp_/);
+      expect(planned.humanReadableSummary.length, String(body.action)).toBeGreaterThan(0);
     }
   });
-
-  it("an unknown action is refused before any plan is minted", async () => {
-    const harness = makeHarness();
-    await expect(plan(harness, { action: "providers.exfiltrate" })).rejects.toMatchObject({
-      code: "VALIDATION_ERROR",
-    });
-  });
-
-  it("a plan whose parameters are invalid is refused up front", async () => {
-    const harness = makeHarness();
-    await expect(plan(harness, { action: "providers.create", params: { kind: "openai" } }))
-      .rejects.toMatchObject({ code: "VALIDATION_ERROR" });
-    await expect(plan(harness, { action: "providers.delete" }))
-      .rejects.toMatchObject({ code: "VALIDATION_ERROR" });
-  });
-
-  // ─── The plan/confirm routes grant no authority of their own ───
 
   it("planning performs no provider mutation", async () => {
     const harness = makeHarness();
     await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
     await plan(harness, { action: "providers.delete", providerId: "prov-001" });
-
     expect(harness.service.createProvider).not.toHaveBeenCalled();
     expect(harness.service.deleteProvider).not.toHaveBeenCalled();
-    expect(harness.signCalls()).toBe(0);
-  });
-
-  it("re-planning the same change replaces the record and revokes an unspent confirmation slot", async () => {
-    const harness = makeHarness();
-    const first = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-    await confirm(harness, first.plan.planDigest);
-
-    // Deterministic digest: re-planning yields the SAME digest, and the fresh record
-    // is unconfirmed — but that is safe because the gate refuses the already-minted
-    // approval on replay (single-use), proven above.
-    const second = await plan(harness, { action: "providers.create", params: CREATE_PARAMS });
-    expect(second.plan.planDigest).toBe(first.plan.planDigest);
-
-    const confirmed = await confirm(harness, second.plan.planDigest);
-    expect(harness.signCalls()).toBe(2);
-    expect(confirmed.approval.planDigest).toBe(first.plan.planDigest);
   });
 });

--- a/test/unit/api/http/routes/friday-session-routes.test.ts
+++ b/test/unit/api/http/routes/friday-session-routes.test.ts
@@ -4,6 +4,9 @@ import { createFridaySessionRoutes } from "#api";
 import { FRIDAY_SESSION_ERROR_CODES, FRIDAY_SESSION_MEMORY_EXTRACTION_ERROR_CODES } from "#sessions";
 import type { FridaySessionService, FridaySessionMemoryExtractionService } from "#sessions";
 import type { FridaySessionRecord, FridaySessionMessageRecord } from "#sessions";
+import { createFridayRustHubSessionLifecycleDispatchAdapter } from "../../../../../src/api/mission-spine/friday-rust-hub-session-lifecycle-dispatch-adapter.js";
+import type { FridayRustHubAgentRunSealedClient } from "../../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+import type { FridayRustHubRunAnswerReadbackService } from "../../../../../src/api/mission-spine/friday-rust-hub-run-answer-readback-service.js";
 
 function makeMockSession(overrides: Partial<FridaySessionRecord> = {}): FridaySessionRecord {
   return {
@@ -2756,5 +2759,197 @@ describe("Rust session lifecycle bridge", () => {
       "OWNER_SESSION_CHANNEL_AUTHORITY_REQUIRED",
     );
     expect(rustSessionLifecycleBridge.appendMessage).not.toHaveBeenCalled();
+  });
+});
+
+// (CORE-RUNNABLE-001 / CORE-A CR-3) The REAL production session bridge adapter — NOT a mock — driven
+// over a TEST TRANSPORT (a fake low-level sealed client + a fake owner-gated readback, exactly the
+// seams the agent-run + mission-spine adapters use in their tests). Proves the session run Rust route
+// is reachable-and-real when routeSessionsViaRust is on, and byte-identical fail-closed when off.
+describe("Rust session run route (REAL adapter over a test transport)", () => {
+  function makeRealBridgeWithTestTransport(
+    overrides: Partial<Parameters<typeof createFridayRustHubSessionLifecycleDispatchAdapter>[0]> = {},
+  ) {
+    const dispatchRun = vi.fn().mockResolvedValue({
+      truthLabel: "rust_wired",
+      runId: "rust-session-run-1",
+      status: "finished",
+      answerSha256: "sha-answer",
+      answerLen: 32,
+      turns: 1,
+      executedTools: 2,
+      promptTokens: 11,
+      completionTokens: 4,
+    });
+    const readAnswer = vi.fn().mockResolvedValue({
+      truthLabel: "rust_wired_dev",
+      proofOnly: true,
+      outcome: "delivered",
+      runId: "rust-session-run-1",
+      status: "finished",
+      answer: "hello from the rust session loop",
+      answerSha256: "sha-answer",
+      answerLen: 32,
+    });
+    const bridge = createFridayRustHubSessionLifecycleDispatchAdapter({
+      port: 0,
+      // A fixture 32-byte secret; the fake createClient ignores it (no socket). NEVER a real key.
+      secretResolver: () => new Uint8Array(32),
+      idGenerator: () => "rust-session-run-1",
+      hubDbPath: "/tmp/friday-rust-session-test.db",
+      // Test transport: a fake low-level sealed client. The REAL service adapter wraps it.
+      createClient: () => ({ dispatchRun } as unknown as FridayRustHubAgentRunSealedClient),
+      // Test transport: a fake owner-gated readback returning a delivered body.
+      readback: { readAnswer } as unknown as FridayRustHubRunAnswerReadbackService,
+      ...overrides,
+    });
+    return { bridge, dispatchRun, readAnswer };
+  }
+
+  it("dispatches sessions.run to the Rust-backed bridge (not 503) when routeSessionsViaRust is on", async () => {
+    const { bridge, dispatchRun, readAnswer } = makeRealBridgeWithTestTransport();
+    const routes = createFridaySessionRoutes({
+      sessionService: createMockService(),
+      // Must be present so the route does not 501; NOT called (the Rust branch returns first).
+      runSession: vi.fn(),
+      routeSessionsViaRust: true,
+      rustSessionLifecycleBridge: bridge,
+      // The legacy TS run oracle is OFF — proving the Rust path (not the TS oracle) served the run.
+      allowTestOnlySessionRunExecution: false,
+    });
+
+    const run = routes.find((r) => r.operationId === "sessions.run")!;
+    const result = (await run.handler(
+      makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        body: { task: "summarize my day" },
+        principal: makeBoundPrincipal(),
+      }) as never,
+    )) as {
+      run: {
+        runId: string;
+        status: string;
+        response: string;
+        toolCallCount: number;
+        usageInput: number;
+        usageOutput: number;
+      };
+      messages: Array<{ role: string; content: string }>;
+    };
+
+    expect(result.run.status).toBe("completed");
+    expect(result.run.response).toBe("hello from the rust session loop");
+    expect(result.run.toolCallCount).toBe(2);
+    expect(result.run.usageInput).toBe(11);
+    expect(result.run.usageOutput).toBe(4);
+    expect(result.messages).toEqual([
+      { role: "user", content: "summarize my day" },
+      { role: "assistant", content: "hello from the rust session loop" },
+    ]);
+    // Proves the REAL adapter drove the sealed transport + owner-gated readback (not a mock bridge).
+    expect(dispatchRun).toHaveBeenCalledTimes(1);
+    expect(dispatchRun.mock.calls[0][0]).toMatchObject({
+      task: "summarize my day",
+      sessionKey: "discord:default:user1",
+      forwardedPrincipal: "user:bound-1",
+      constraints: { readOnly: true },
+    });
+    expect(readAnswer).toHaveBeenCalledTimes(1);
+    expect(readAnswer.mock.calls[0][0]).toMatchObject({
+      runId: "rust-session-run-1",
+      callerPrincipal: "user:bound-1",
+    });
+  });
+
+  it("still fails closed with TS_RUNTIME_SESSION_RUN_RETIRED when routeSessionsViaRust is OFF (unchanged default)", async () => {
+    const { bridge, dispatchRun } = makeRealBridgeWithTestTransport();
+    const routes = createFridaySessionRoutes({
+      sessionService: createMockService(),
+      runSession: vi.fn(),
+      // Flag OFF (omitted) + TS oracle off ⇒ today's fail-closed 503, bridge never consulted.
+      rustSessionLifecycleBridge: bridge,
+      allowTestOnlySessionRunExecution: false,
+    });
+
+    const run = routes.find((r) => r.operationId === "sessions.run")!;
+    await expectRouteError(
+      run.handler(
+        makeMockCtx({
+          params: { sessionKey: "discord:default:user1" },
+          body: { task: "summarize my day" },
+          principal: makeBoundPrincipal(),
+        }) as never,
+      ),
+      "TS_RUNTIME_SESSION_RUN_RETIRED",
+    );
+    expect(dispatchRun).not.toHaveBeenCalled();
+  });
+
+  it("rejects a Rust session run without a bound session.write principal", async () => {
+    const { bridge, dispatchRun } = makeRealBridgeWithTestTransport();
+    const routes = createFridaySessionRoutes({
+      sessionService: createMockService(),
+      runSession: vi.fn(),
+      routeSessionsViaRust: true,
+      rustSessionLifecycleBridge: bridge,
+      allowTestOnlySessionRunExecution: false,
+    });
+
+    const run = routes.find((r) => r.operationId === "sessions.run")!;
+    await expectRouteError(
+      run.handler(
+        makeMockCtx({
+          params: { sessionKey: "discord:default:user1" },
+          body: { task: "summarize my day" },
+          principal: makeBoundPrincipal({ scopes: ["session.read"], role: "viewer" }),
+        }) as never,
+      ),
+      "OWNER_SESSION_CHANNEL_AUTHORITY_REQUIRED",
+    );
+    expect(dispatchRun).not.toHaveBeenCalled();
+  });
+
+  it("fails closed (never a fake success) for the storage lifecycle ops that have no Rust protocol yet", async () => {
+    const { bridge } = makeRealBridgeWithTestTransport();
+    await expectRouteError(
+      bridge.createSession({
+        channel: "discord",
+        chatId: "user1",
+        principal: makeBoundPrincipal() as never,
+      }),
+      "RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE",
+    );
+    await expectRouteError(
+      bridge.appendMessage({
+        sessionKey: "discord:default:user1",
+        role: "user",
+        content: "hi",
+        principal: makeBoundPrincipal() as never,
+      }),
+      "RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE",
+    );
+    await expectRouteError(
+      bridge.getMemoryNamespace({
+        sessionKey: "discord:default:user1",
+        principal: makeBoundPrincipal() as never,
+      }),
+      "RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE",
+    );
+  });
+
+  it("fails closed when the sealed-WS client secret cannot be resolved (no socket, no fake body)", async () => {
+    const { bridge, dispatchRun, readAnswer } = makeRealBridgeWithTestTransport({
+      secretResolver: () => null,
+    });
+    await expectRouteError(
+      bridge.runSession!({
+        sessionKey: "discord:default:user1",
+        task: "summarize my day",
+        principalId: "user:bound-1",
+      }),
+      "RUST_SESSION_LIFECYCLE_DISPATCH_UNAVAILABLE",
+    );
+    expect(dispatchRun).not.toHaveBeenCalled();
+    expect(readAnswer).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/api/http/routes/friday-session-routes.test.ts
+++ b/test/unit/api/http/routes/friday-session-routes.test.ts
@@ -2791,6 +2791,23 @@ describe("Rust session run route (REAL adapter over a test transport)", () => {
       answerSha256: "sha-answer",
       answerLen: 32,
     });
+    // (CR-3) The fake low-level sealed client ALSO answers the session create/append round-trips —
+    // the SAME `createSession` / `appendSessionMessage` methods the Rust arms serve. These echo a
+    // refs-only receipt (id + seq + timestamps) WITHOUT a socket, exactly like the Rust store's
+    // refs-only reply, so the REAL adapter's create/append mapping is exercised end-to-end.
+    const createSession = vi.fn().mockResolvedValue({
+      truthLabel: "rust_wired",
+      sessionId: "discord:default:user1",
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+    const appendSessionMessage = vi.fn().mockResolvedValue({
+      truthLabel: "rust_wired",
+      messageId: "discord:default:user1:m0",
+      seq: 0,
+      createdAt: 1_700_000_000_500,
+      updatedAt: 1_700_000_000_500,
+    });
     const bridge = createFridayRustHubSessionLifecycleDispatchAdapter({
       port: 0,
       // A fixture 32-byte secret; the fake createClient ignores it (no socket). NEVER a real key.
@@ -2798,12 +2815,17 @@ describe("Rust session run route (REAL adapter over a test transport)", () => {
       idGenerator: () => "rust-session-run-1",
       hubDbPath: "/tmp/friday-rust-session-test.db",
       // Test transport: a fake low-level sealed client. The REAL service adapter wraps it.
-      createClient: () => ({ dispatchRun } as unknown as FridayRustHubAgentRunSealedClient),
+      createClient: () =>
+        ({
+          dispatchRun,
+          createSession,
+          appendSessionMessage,
+        } as unknown as FridayRustHubAgentRunSealedClient),
       // Test transport: a fake owner-gated readback returning a delivered body.
       readback: { readAnswer } as unknown as FridayRustHubRunAnswerReadbackService,
       ...overrides,
     });
-    return { bridge, dispatchRun, readAnswer };
+    return { bridge, dispatchRun, readAnswer, createSession, appendSessionMessage };
   }
 
   it("dispatches sessions.run to the Rust-backed bridge (not 503) when routeSessionsViaRust is on", async () => {
@@ -2909,15 +2931,97 @@ describe("Rust session run route (REAL adapter over a test transport)", () => {
     expect(dispatchRun).not.toHaveBeenCalled();
   });
 
-  it("fails closed (never a fake success) for the storage lifecycle ops that have no Rust protocol yet", async () => {
+  it("dispatches the FULL create → append → run public seam to the Rust bridge (not 503) when routeSessionsViaRust is on", async () => {
+    const { bridge, createSession, appendSessionMessage, dispatchRun } =
+      makeRealBridgeWithTestTransport();
+    const routes = createFridaySessionRoutes({
+      sessionService: createMockService(),
+      runSession: vi.fn(),
+      routeSessionsViaRust: true,
+      rustSessionLifecycleBridge: bridge,
+      // Every legacy TS oracle OFF — proving the Rust path (not the TS oracle) served the seam.
+      allowTestOnlySessionExecution: false,
+      allowTestOnlySessionRunExecution: false,
+    });
+
+    // POST /v1/sessions → bridge.createSession → SessionCreateRequest → refs-only session.
+    const create = routes.find((r) => r.operationId === "sessions.create")!;
+    const created = (await create.handler(
+      makeMockCtx({
+        body: { channel: "discord", chatId: "user1", metadata: { source: "cr3" } },
+        principal: makeBoundPrincipal(),
+      }) as never,
+    )) as { session: { key: string; channel: string; status: string; messageCount: number } };
+    expect(created.session.key).toBe("discord:default:user1");
+    expect(created.session.channel).toBe("discord");
+    expect(created.session.status).toBe("active");
+    expect(created.session.messageCount).toBe(0);
+    // The REAL adapter drove the sealed transport: the derived canonical key rode the wire, and the
+    // forwarded owner is the AUTHENTICATED principal (never a client-asserted owner).
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(createSession.mock.calls[0][0]).toMatchObject({
+      sessionId: "discord:default:user1",
+      userId: "user:bound-1",
+      metadataJson: JSON.stringify({ source: "cr3" }),
+    });
+
+    // POST /v1/sessions/:key/messages → bridge.appendMessage → SessionMessageAppendRequest → refs.
+    const message = routes.find((r) => r.operationId === "sessions.messages.create")!;
+    const appended = (await message.handler(
+      makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        body: { role: "user", content: "summarize my day", idempotencyKey: "idem-cr3" },
+        principal: makeBoundPrincipal(),
+      }) as never,
+    )) as { message: { id: string; sequence: number; role: string; contentText: string } };
+    expect(appended.message.id).toBe("discord:default:user1:m0");
+    expect(appended.message.sequence).toBe(0);
+    expect(appended.message.role).toBe("user");
+    expect(appended.message.contentText).toBe("summarize my day");
+    expect(appendSessionMessage).toHaveBeenCalledTimes(1);
+    expect(appendSessionMessage.mock.calls[0][0]).toMatchObject({
+      sessionId: "discord:default:user1",
+      role: "user",
+      content: "summarize my day",
+      refs: "idem-cr3",
+    });
+
+    // POST /v1/sessions/:key/run → bridge.runSession → dispatchRun (already proven) → answer.
+    const run = routes.find((r) => r.operationId === "sessions.run")!;
+    const ran = (await run.handler(
+      makeMockCtx({
+        params: { sessionKey: "discord:default:user1" },
+        body: { task: "summarize my day" },
+        principal: makeBoundPrincipal(),
+      }) as never,
+    )) as { run: { status: string; response: string } };
+    expect(ran.run.status).toBe("completed");
+    expect(ran.run.response).toBe("hello from the rust session loop");
+    expect(dispatchRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("getMemoryNamespace remains an HONEST 503 (deferred Rust owner-gated read; never a faked namespace)", async () => {
     const { bridge } = makeRealBridgeWithTestTransport();
+    await expectRouteError(
+      bridge.getMemoryNamespace({
+        sessionKey: "discord:default:user1",
+        principal: makeBoundPrincipal() as never,
+      }),
+      "RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE",
+    );
+  });
+
+  it("create/append fail closed when the sealed-WS client secret cannot be resolved (no socket, no fake row)", async () => {
+    const { bridge, createSession, appendSessionMessage } = makeRealBridgeWithTestTransport({
+      secretResolver: () => null,
+    });
     await expectRouteError(
       bridge.createSession({
         channel: "discord",
         chatId: "user1",
         principal: makeBoundPrincipal() as never,
       }),
-      "RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE",
+      "RUST_SESSION_LIFECYCLE_DISPATCH_UNAVAILABLE",
     );
     await expectRouteError(
       bridge.appendMessage({
@@ -2926,15 +3030,39 @@ describe("Rust session run route (REAL adapter over a test transport)", () => {
         content: "hi",
         principal: makeBoundPrincipal() as never,
       }),
-      "RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE",
+      "RUST_SESSION_LIFECYCLE_DISPATCH_UNAVAILABLE",
     );
-    await expectRouteError(
-      bridge.getMemoryNamespace({
-        sessionKey: "discord:default:user1",
+    // Fail-closed BEFORE any socket: the underlying client round-trips were never constructed/called.
+    expect(createSession).not.toHaveBeenCalled();
+    expect(appendSessionMessage).not.toHaveBeenCalled();
+  });
+
+  it("a foreign-owner append surfaces the Rust owner-gate refusal as a fail-closed 503 (never a silent success)", async () => {
+    // The Rust arm refuses a non-owner append with an `Error` → the sealed client fails closed (503).
+    // Model that with a fake client whose `appendSessionMessage` rejects with the domain 503.
+    const denial = new FridayDomainError(
+      "MISSION_SPINE_RUST_AGENT_RUN_SEALED_WS_CLIENT_UNAVAILABLE",
+      "owner-gate refusal (Error inbound)",
+      { httpStatus: 503 },
+    );
+    const appendSessionMessage = vi.fn().mockRejectedValue(denial);
+    const bridge = createFridayRustHubSessionLifecycleDispatchAdapter({
+      port: 0,
+      secretResolver: () => new Uint8Array(32),
+      idGenerator: () => "run-x",
+      hubDbPath: "/tmp/friday-rust-session-test.db",
+      createClient: () =>
+        ({ appendSessionMessage } as unknown as FridayRustHubAgentRunSealedClient),
+    });
+    await expect(
+      bridge.appendMessage({
+        sessionKey: "discord:default:someone-elses",
+        role: "user",
+        content: "sneaky",
         principal: makeBoundPrincipal() as never,
       }),
-      "RUST_SESSION_LIFECYCLE_PROTOCOL_UNAVAILABLE",
-    );
+    ).rejects.toMatchObject({ httpStatus: 503 });
+    expect(appendSessionMessage).toHaveBeenCalledTimes(1);
   });
 
   it("fails closed when the sealed-WS client secret cannot be resolved (no socket, no fake body)", async () => {

--- a/test/unit/api/mission-spine/friday-rust-hub-session-lifecycle-wire.test.ts
+++ b/test/unit/api/mission-spine/friday-rust-hub-session-lifecycle-wire.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSessionCreateEnvelope,
+  buildSessionMessageAppendEnvelope,
+  parseSessionCreateResult,
+  parseSessionMessageAppendResult,
+  type FridayRustHubSessionCreateRequest,
+  type FridayRustHubSessionMessageAppendRequest,
+} from "../../../../src/api/mission-spine/friday-rust-hub-agent-run-ws-sealed-client.js";
+
+// (CORE-A CR-3) The session create/append wire builders map the TS request onto the EXACT snake_case
+// `friday-protocol` `SessionCreateRequestWire` / `SessionMessageAppendRequestWire` shapes. Like the
+// sibling MemoryDecision wire, `Message::SessionCreateRequest` is a SINGLE-FIELD WRAPPER
+// (`{ request: SessionCreateRequestWire }`) on an internally-tagged (`#[serde(tag = "kind")]`)
+// `Message`, so serde NESTS the inner fields under a `request` key (NOT flat under `message`). A flat
+// shape 503s server-side on `Envelope::decode`. The golden fixtures below pin the byte-exact
+// `{kind,request}` nesting against the Rust round-trip test
+// (friday-protocol/src/lib.rs `session_lifecycle_wire_round_trips_and_uses_the_request_result_wrapper`).
+
+describe("buildSessionCreateEnvelope (SessionCreateRequestWire wire mapping)", () => {
+  it("emits EXACTLY the golden {kind, request:{...snake_case}} envelope (all axes present)", () => {
+    const request: FridayRustHubSessionCreateRequest = {
+      sessionId: "discord:default:chat-1",
+      channel: "discord",
+      chatId: "chat-1",
+      userId: "owner-1",
+      accountId: "default",
+      chatKind: "dm",
+      metadataJson: '{"source":"cr3"}',
+    };
+    const env = buildSessionCreateEnvelope(request);
+    expect(env.msg_id).toBe("session-create-discord:default:chat-1");
+    const message = env.message as Record<string, unknown>;
+    expect(message).toEqual({
+      kind: "SessionCreateRequest",
+      request: {
+        session_id: "discord:default:chat-1",
+        channel: "discord",
+        chat_id: "chat-1",
+        user_id: "owner-1",
+        account_id: "default",
+        chat_kind: "dm",
+        metadata_json: '{"source":"cr3"}',
+      },
+    });
+    // The wrapper key is `request` (flat-shape 503 regression guard) + NO camelCase leak.
+    expect(Object.keys(message).sort()).toEqual(["kind", "request"]);
+    const inner = message.request as Record<string, unknown>;
+    expect("sessionId" in inner).toBe(false);
+    expect("chatKind" in inner).toBe(false);
+  });
+
+  it("OMITS absent optional axes (byte-clean; round-trips to None Rust-side)", () => {
+    const env = buildSessionCreateEnvelope({ sessionId: "system:default:heartbeat" });
+    const inner = (env.message as Record<string, unknown>).request as Record<string, unknown>;
+    // Only the required session_id rides the wire; no null-valued keys.
+    expect(Object.keys(inner)).toEqual(["session_id"]);
+    expect("channel" in inner).toBe(false);
+    expect("metadata_json" in inner).toBe(false);
+  });
+});
+
+describe("buildSessionMessageAppendEnvelope (SessionMessageAppendRequestWire wire mapping)", () => {
+  it("emits EXACTLY the golden {kind, request:{session_id, role, content, refs}} envelope", () => {
+    const request: FridayRustHubSessionMessageAppendRequest = {
+      sessionId: "discord:default:chat-1",
+      role: "user",
+      content: "remember teal",
+      refs: "run-7",
+    };
+    const message = buildSessionMessageAppendEnvelope(request).message as Record<string, unknown>;
+    expect(message).toEqual({
+      kind: "SessionMessageAppendRequest",
+      request: {
+        session_id: "discord:default:chat-1",
+        role: "user",
+        content: "remember teal",
+        refs: "run-7",
+      },
+    });
+    expect(Object.keys(message).sort()).toEqual(["kind", "request"]);
+  });
+
+  it("OMITS refs when absent (conditional-spread; byte-clean)", () => {
+    const inner = (
+      buildSessionMessageAppendEnvelope({
+        sessionId: "discord:default:chat-1",
+        role: "assistant",
+        content: "ok",
+      }).message as Record<string, unknown>
+    ).request as Record<string, unknown>;
+    expect(Object.keys(inner).sort()).toEqual(["content", "role", "session_id"]);
+    expect("refs" in inner).toBe(false);
+  });
+});
+
+describe("parseSessionCreateResult (SessionCreateResultWire wire mapping)", () => {
+  it("unwraps the nested `result` and surfaces the refs-only receipt with the rust_wired label", () => {
+    const parsed = parseSessionCreateResult({
+      kind: "SessionCreateResult",
+      result: { session_id: "discord:default:chat-1", created_at: 900, updated_at: 1000 },
+    });
+    expect(parsed).toEqual({
+      truthLabel: "rust_wired",
+      sessionId: "discord:default:chat-1",
+      createdAt: 900,
+      updatedAt: 1000,
+    });
+  });
+
+  it("fails closed (undefined) on a missing wrapper / id / timestamp (never a fake receipt)", () => {
+    expect(parseSessionCreateResult({ kind: "SessionCreateResult" })).toBeUndefined();
+    expect(
+      parseSessionCreateResult({ result: { created_at: 900, updated_at: 1000 } }),
+    ).toBeUndefined();
+    // created_at ill-typed (string) → fail closed.
+    expect(
+      parseSessionCreateResult({ result: { session_id: "s", created_at: "900", updated_at: 1000 } }),
+    ).toBeUndefined();
+  });
+});
+
+describe("parseSessionMessageAppendResult (SessionMessageAppendResultWire wire mapping)", () => {
+  it("surfaces the refs-only receipt (seq=0 is a VALID ordinal, not falsy-rejected)", () => {
+    const parsed = parseSessionMessageAppendResult({
+      kind: "SessionMessageAppendResult",
+      result: {
+        message_id: "discord:default:chat-1:m0",
+        seq: 0,
+        created_at: 1002,
+        updated_at: 1002,
+      },
+    });
+    expect(parsed).toEqual({
+      truthLabel: "rust_wired",
+      messageId: "discord:default:chat-1:m0",
+      seq: 0,
+      createdAt: 1002,
+      updatedAt: 1002,
+    });
+  });
+
+  it("fails closed (undefined) on a missing wrapper / message id / seq", () => {
+    expect(parseSessionMessageAppendResult({ kind: "SessionMessageAppendResult" })).toBeUndefined();
+    expect(
+      parseSessionMessageAppendResult({ result: { seq: 0, created_at: 1, updated_at: 1 } }),
+    ).toBeUndefined();
+    // seq ill-typed (string) → fail closed.
+    expect(
+      parseSessionMessageAppendResult({
+        result: { message_id: "m", seq: "0", created_at: 1, updated_at: 1 },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -1141,7 +1141,9 @@ describe("API Runtime — Extended Route Registration", () => {
       principal: makePrincipal({ role: "admin", scopes: ["hub.admin"] }),
     });
 
-    expect(providerService.createProvider).toHaveBeenCalledWith(providerBody);
+    // No canonical gate in this runtime → no deferred reservation → the optional
+    // provider-mutation options second arg is undefined.
+    expect(providerService.createProvider).toHaveBeenCalledWith(providerBody, undefined);
   });
 
   it("requires signed provider setup canonical approval when runtime canonical gate profile is on", async () => {
@@ -1208,7 +1210,12 @@ describe("API Runtime — Extended Route Registration", () => {
       },
     });
 
-    expect(providerService.createProvider).toHaveBeenCalledWith(providerBody);
+    // Gate-required runtime injects the durable approval-consumption store, so the deferred
+    // ticket threads a consume-in-transaction hook as the second arg (finalized atomically
+    // with the mutation's write).
+    expect(providerService.createProvider).toHaveBeenCalledWith(providerBody, {
+      consumeApprovalInTransaction: expect.any(Function),
+    });
     expect(result).toHaveProperty("canonicalGate.ticketId");
   });
 

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -26,7 +26,39 @@ import type { FridayProviderProfile } from "#providers";
 import type { FridaySqliteLayer } from "#state";
 import type { FridayWorkflowRuntime } from "#workflows";
 import { signFridayCanonicalApproval } from "../../../../src/security/friday-mutating-action-gate.js";
+import type { FridayCanonicalApprovalResolution } from "../../../../src/security/friday-mutating-action-gate.js";
+import {
+  deviceOwnerPrincipalIdFor,
+  generateTestDeviceKey,
+  makeApprovalProof,
+  makeApprovalTranscript,
+} from "../../../helpers/friday-provider-approval-test-kit.js";
 import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
+
+// SEC-APPROVAL-AUTHORITY-001: a single owner device for the runtime provider-gate
+// tests. The Hub verifies its P-256 proof; no Hub signing key is on the approval path.
+const RUNTIME_OWNER_KEY = generateTestDeviceKey();
+const RUNTIME_OWNER_PRINCIPAL = deviceOwnerPrincipalIdFor(RUNTIME_OWNER_KEY);
+
+/** A DEVICE-AUTHORED provider approval bound to `actionDigest` + the owner device. */
+function runtimeDeviceApproval(actionDigest: string, approvalId: string): FridayCanonicalApprovalResolution {
+  const expiresAt = "2026-02-27T01:00:00.000Z";
+  const transcript = makeApprovalTranscript(RUNTIME_OWNER_KEY, {
+    actionDigest,
+    decidedByPrincipalId: RUNTIME_OWNER_PRINCIPAL,
+    approvalId,
+    expiresAt,
+  });
+  return {
+    decision: "approved",
+    approvalId,
+    decidedByPrincipalId: RUNTIME_OWNER_PRINCIPAL,
+    actionDigest,
+    expiresAt,
+    issuer: "friday_device_owner",
+    deviceProof: makeApprovalProof(RUNTIME_OWNER_KEY, transcript),
+  };
+}
 
 const NOW = "2026-02-27T00:00:00.000Z";
 const allocatedDbs: FridaySqliteLayer[] = [];
@@ -1109,7 +1141,12 @@ describe("API Runtime — Extended Route Registration", () => {
         planDigest: "provider-runtime-plan-1",
       },
       headers: {},
-      principal: makePrincipal({ role: "admin", scopes: ["hub.admin"] }),
+      // Owner principal BOUND to the device (principalId = device-owner:<keyHash>).
+      principal: makePrincipal({
+        role: "admin",
+        scopes: ["hub.admin"],
+        principalId: RUNTIME_OWNER_PRINCIPAL,
+      }),
     };
 
     let actionDigest = "";
@@ -1123,17 +1160,28 @@ describe("API Runtime — Extended Route Registration", () => {
     expect(actionDigest).toBeTruthy();
     expect(providerService.createProvider).not.toHaveBeenCalled();
 
-    const result = await route.handler({
+    // A Hub-minted HMAC approval must be REFUSED on the provider path (Hub self-sign).
+    await expect(route.handler({
       ...baseCtx,
       body: {
         ...baseCtx.body,
         canonicalApproval: signFridayCanonicalApproval({
           decision: "approved",
-          approvalId: "provider-runtime-approval",
-          decidedByPrincipalId: "tenant-a",
+          approvalId: "provider-runtime-hmac",
+          decidedByPrincipalId: RUNTIME_OWNER_PRINCIPAL,
           actionDigest,
           expiresAt: "2026-02-27T01:00:00.000Z",
         }, "test-secret"),
+      },
+    })).rejects.toMatchObject({ code: "PROVIDER_MUTATION_APPROVAL_NOT_DEVICE_AUTHORED" });
+    expect(providerService.createProvider).not.toHaveBeenCalled();
+
+    // A DEVICE-AUTHORED approval admits — the Hub verified it with the public key.
+    const result = await route.handler({
+      ...baseCtx,
+      body: {
+        ...baseCtx.body,
+        canonicalApproval: runtimeDeviceApproval(actionDigest, "provider-runtime-approval"),
       },
     });
 
@@ -1269,7 +1317,11 @@ describe("API Runtime — Extended Route Registration", () => {
         planDigest: "provider-routing-plan-1",
       },
       headers: {},
-      principal: makePrincipal({ role: "admin", scopes: ["hub.admin"] }),
+      principal: makePrincipal({
+        role: "admin",
+        scopes: ["hub.admin"],
+        principalId: RUNTIME_OWNER_PRINCIPAL,
+      }),
     };
 
     let actionDigest = "";
@@ -1287,13 +1339,7 @@ describe("API Runtime — Extended Route Registration", () => {
       ...baseCtx,
       body: {
         ...baseCtx.body,
-        canonicalApproval: signFridayCanonicalApproval({
-          decision: "approved",
-          approvalId: "provider-routing-runtime-approval",
-          decidedByPrincipalId: "tenant-a",
-          actionDigest,
-          expiresAt: "2026-02-27T01:00:00.000Z",
-        }, "test-secret"),
+        canonicalApproval: runtimeDeviceApproval(actionDigest, "provider-routing-runtime-approval"),
       },
     });
 

--- a/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
+++ b/test/unit/api/runtime/friday-api-runtime-extra-route-registration.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createFridayApiRuntime } from "#api";
@@ -39,6 +41,25 @@ import { createTestDb } from "../../../helpers/friday-test-db.helper.js";
 // tests. The Hub verifies its P-256 proof; no Hub signing key is on the approval path.
 const RUNTIME_OWNER_KEY = generateTestDeviceKey();
 const RUNTIME_OWNER_PRINCIPAL = deviceOwnerPrincipalIdFor(RUNTIME_OWNER_KEY);
+
+/**
+ * Option B*: seed a device-claimed owner (`users.password_hash = device-owner$v1$<sha256Hex
+ * (SPKI-DER base64)>`) so the runtime's server-side resolver binds a device-authored
+ * provider approval to the authenticated owner's registered device. `userId` is the
+ * authenticated principal's `userId` (makePrincipal defaults to "user-1").
+ */
+function seedDeviceOwner(db: FridaySqliteLayer, userId: string): void {
+  const sentinel = `device-owner$v1$${createHash("sha256").update(RUNTIME_OWNER_KEY.spkiDerBase64).digest("hex")}`;
+  db.withWriteTransaction((conn) => {
+    conn
+      .prepare(
+        `INSERT INTO users (id, display_name, role, is_local_only, password_hash, created_at, updated_at)
+         VALUES (?, 'Owner', 'admin', 1, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET password_hash = excluded.password_hash`,
+      )
+      .run(userId, sentinel, NOW, NOW);
+  });
+}
 
 /** A DEVICE-AUTHORED provider approval bound to `actionDigest` + the owner device. */
 function runtimeDeviceApproval(actionDigest: string, approvalId: string): FridayCanonicalApprovalResolution {
@@ -1125,8 +1146,10 @@ describe("API Runtime — Extended Route Registration", () => {
 
   it("requires signed provider setup canonical approval when runtime canonical gate profile is on", async () => {
     const providerService = makeMockProviderService();
+    const deps = makeBaseDeps();
+    seedDeviceOwner(deps.db, "user-1");
     const runtime = createFridayApiRuntime({
-      ...makeBaseDeps(),
+      ...deps,
       providerService,
       canonicalMutatingActionGate: true,
     });
@@ -1300,8 +1323,10 @@ describe("API Runtime — Extended Route Registration", () => {
 
   it("requires signed model-routing canonical approval when runtime canonical gate profile is on", async () => {
     const providerService = makeMockProviderService();
+    const deps = makeBaseDeps();
+    seedDeviceOwner(deps.db, "user-1");
     const runtime = createFridayApiRuntime({
-      ...makeBaseDeps(),
+      ...deps,
       providerService,
       canonicalMutatingActionGate: true,
     });

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -405,8 +405,9 @@ describe("resolveRouteAgentRunViaRust", () => {
     expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: " true " })).toBe(true);
   });
 
-  // Fail-safe OFF: everything that is not exactly "1"/"true" → false.
-  it("treats 0, false, empty, and garbage env values as false (fail-safe off)", () => {
+  // Explicit off (0/false) forces off; empty/garbage falls to the release-default (false here, since
+  // these envs carry NO release marker → unprotected profile). See the R14 release-default block.
+  it("treats 0, false, empty, and garbage env values as false on an unprotected profile", () => {
     expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "0" })).toBe(false);
     expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "false" })).toBe(false);
     expect(resolveRouteAgentRunViaRust(undefined, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "" })).toBe(false);
@@ -445,8 +446,9 @@ describe("resolveRouteSessionsViaRust (CORE-A CR-3 session bridge flag)", () => 
     expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "  True  " })).toBe(true);
   });
 
-  // Fail-safe OFF: everything that is not exactly "1"/"true" → false (NARROWER than the canonical gate).
-  it("treats 0, false, empty, and garbage env values as false (fail-safe off)", () => {
+  // Explicit off (0/false) forces off; empty/garbage falls to the release-default (false here, since
+  // these envs carry NO release marker → unprotected profile). See the R14 release-default block.
+  it("treats 0, false, empty, and garbage env values as false on an unprotected profile", () => {
     expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "0" })).toBe(false);
     expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "false" })).toBe(false);
     expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "" })).toBe(false);
@@ -462,6 +464,43 @@ describe("resolveRouteSessionsViaRust (CORE-A CR-3 session bridge flag)", () => 
     expect(resolveRouteSessionsViaRust(false, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "1" })).toBe(false);
     expect(resolveRouteSessionsViaRust(false, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "true" })).toBe(false);
   });
+});
+
+// ─── (R14 / CORE-A CR-3) FLAGLESS release-default: a protected profile routes to Rust with NO flag ───
+describe("route-*-via-rust FLAGLESS release-default (R14 CR-3)", () => {
+  for (const [name, resolve, envKey] of [
+    ["resolveRouteSessionsViaRust", resolveRouteSessionsViaRust, "FRIDAY_ROUTE_SESSIONS_VIA_RUST"],
+    ["resolveRouteAgentRunViaRust", resolveRouteAgentRunViaRust, "FRIDAY_ROUTE_AGENT_RUN_VIA_RUST"],
+  ] as const) {
+    describe(name, () => {
+      it("routes to Rust with NO flag on a release profile (NODE_ENV=production)", () => {
+        expect(resolve(undefined, { NODE_ENV: "production" })).toBe(true);
+      });
+      it("routes to Rust with NO flag on a release profile (FRIDAY_RELEASE_TAG set)", () => {
+        expect(resolve(undefined, { FRIDAY_RELEASE_TAG: "v1.4.0" })).toBe(true);
+      });
+      it("stays OFF on a dev/test (unprotected) profile with no flag (CR-0 baseline unchanged)", () => {
+        expect(resolve(undefined, { NODE_ENV: "test" })).toBe(false);
+        expect(resolve(undefined, emptyEnv())).toBe(false);
+      });
+      it("HIGHEST-priority explicit env kill-switch (0|false) forces OFF even on a release profile", () => {
+        expect(resolve(undefined, { NODE_ENV: "production", [envKey]: "0" })).toBe(false);
+        expect(resolve(undefined, { NODE_ENV: "production", [envKey]: "false" })).toBe(false);
+        expect(resolve(undefined, { FRIDAY_RELEASE_TAG: "v1", [envKey]: "0" })).toBe(false);
+      });
+      it("explicit env ON (1|true) stays ON on a release profile", () => {
+        expect(resolve(undefined, { NODE_ENV: "production", [envKey]: "1" })).toBe(true);
+        expect(resolve(undefined, { NODE_ENV: "production", [envKey]: "true" })).toBe(true);
+      });
+      it("explicit config false beats the release-default (config is the highest priority)", () => {
+        expect(resolve(false, { NODE_ENV: "production" })).toBe(false);
+        expect(resolve(false, { FRIDAY_RELEASE_TAG: "v1" })).toBe(false);
+      });
+      it("explicit config true routes to Rust even on an unprotected profile", () => {
+        expect(resolve(true, { NODE_ENV: "test" })).toBe(true);
+      });
+    });
+  }
 });
 
 describe("resolveAgentRunControlViaRust (A3 courier pause/resume flag)", () => {

--- a/test/unit/hub/friday-hub-bootstrap-env.test.ts
+++ b/test/unit/hub/friday-hub-bootstrap-env.test.ts
@@ -5,6 +5,7 @@ import {
   resolveFridayCanonicalMutatingActionGate,
   resolveFridayHubConfig,
   resolveRouteAgentRunViaRust,
+  resolveRouteSessionsViaRust,
   resolveRouteMissionSpineViaRust,
   resolveRouteMemorySpineViaRust,
   resolveRouteRunOutcomeLearningViaRust,
@@ -428,6 +429,38 @@ describe("resolveRouteAgentRunViaRust", () => {
     expect(resolveRouteAgentRunViaRust(false, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "1" })).toBe(false);
     expect(resolveRouteAgentRunViaRust(false, { FRIDAY_ROUTE_AGENT_RUN_VIA_RUST: "true" })).toBe(false);
     expect(resolveRouteAgentRunViaRust(false, emptyEnv())).toBe(false);
+  });
+});
+
+describe("resolveRouteSessionsViaRust (CORE-A CR-3 session bridge flag)", () => {
+  // DEFAULT-OFF: env unset → false → the runtime threads no session bridge → today's fail-closed 503.
+  it("defaults to false when neither config nor env is set", () => {
+    expect(resolveRouteSessionsViaRust(undefined, emptyEnv())).toBe(false);
+  });
+
+  it("parses FRIDAY_ROUTE_SESSIONS_VIA_RUST=1 / =true (case-insensitive, trimmed) as true", () => {
+    expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "1" })).toBe(true);
+    expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "true" })).toBe(true);
+    expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "TRUE" })).toBe(true);
+    expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "  True  " })).toBe(true);
+  });
+
+  // Fail-safe OFF: everything that is not exactly "1"/"true" → false (NARROWER than the canonical gate).
+  it("treats 0, false, empty, and garbage env values as false (fail-safe off)", () => {
+    expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "0" })).toBe(false);
+    expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "false" })).toBe(false);
+    expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "" })).toBe(false);
+    expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "yes" })).toBe(false);
+    expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "on" })).toBe(false);
+    expect(resolveRouteSessionsViaRust(undefined, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "enabled" })).toBe(false);
+  });
+
+  // PRECEDENCE: an explicit config boolean ALWAYS wins over the env (the discriminating false case).
+  it("uses explicit config over the env (config true beats env false; config false beats env true)", () => {
+    expect(resolveRouteSessionsViaRust(true, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "false" })).toBe(true);
+    expect(resolveRouteSessionsViaRust(true, emptyEnv())).toBe(true);
+    expect(resolveRouteSessionsViaRust(false, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "1" })).toBe(false);
+    expect(resolveRouteSessionsViaRust(false, { FRIDAY_ROUTE_SESSIONS_VIA_RUST: "true" })).toBe(false);
   });
 });
 

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -392,11 +392,21 @@ describe("FridayProviderRoutes", () => {
     };
   }
 
-  it("creates 22 route definitions", () => {
+  it("creates 25 route definitions", () => {
     const routes = createFridayProviderRoutes({
       providerService: makeMockService(),
     });
-    expect(routes).toHaveLength(23);
+    // 23 → 25: CORE-A CR-2 added the two owner-confirm handshake routes below. The count is
+    // asserted TOGETHER with their exact identity so a future accidental route cannot slip in
+    // behind a silently bumped number.
+    expect(routes).toHaveLength(25);
+    const planRoutes = routes
+      .filter((r) => r.path === "/v1/providers/plan" || r.path === "/v1/providers/plan/confirm")
+      .map((r) => ({ path: r.path, operationId: r.operationId }));
+    expect(planRoutes).toEqual([
+      { path: "/v1/providers/plan", operationId: "providers.plan" },
+      { path: "/v1/providers/plan/confirm", operationId: "providers.plan.confirm" },
+    ]);
   });
 
   it("has correct operation ids", () => {

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -572,7 +572,9 @@ describe("FridayProviderRoutes", () => {
       };
 
       const result = await createRoute.handler(makeCtx({ body }));
-      expect(mockService.createProvider).toHaveBeenCalledWith(body);
+      // Second arg is the optional provider-mutation options (approval consume hook); it is
+      // undefined here because this fixture injects no durable approval-consumption store.
+      expect(mockService.createProvider).toHaveBeenCalledWith(body, undefined);
       expect(result).toHaveProperty("provider");
     });
 
@@ -628,7 +630,9 @@ describe("FridayProviderRoutes", () => {
 
       const result = await createRoute.handler(makeDeviceOwnerCtx({ body }));
 
-      expect(mockService.createProvider).toHaveBeenCalledWith(providerBody);
+      // Second arg is the optional provider-mutation options (approval consume hook);
+      // undefined here because this fixture injects no durable approval-consumption store.
+      expect(mockService.createProvider).toHaveBeenCalledWith(providerBody, undefined);
       expect(result).toHaveProperty("canonicalGate.ticketId", "ticket-1");
     });
 

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -10,7 +10,15 @@ import {
   createFridayMutatingActionDigest,
   createFridayMutatingActionGate,
   type FridayCanonicalApprovalResolution,
+  type FridayDeviceApprovalVerifyResult,
 } from "../../../../src/security/friday-mutating-action-gate.js";
+import { createFridayProviderApprovalPoPVerifier } from "../../../../src/api/auth/device-attest/index.js";
+import {
+  deviceOwnerPrincipalIdFor,
+  generateTestDeviceKey,
+  makeApprovalProof,
+  makeApprovalTranscript,
+} from "../../../helpers/friday-provider-approval-test-kit.js";
 
 describe("FridayProviderRoutes", () => {
   const NOW = "2026-02-17T10:00:00.000Z";
@@ -101,6 +109,11 @@ describe("FridayProviderRoutes", () => {
     });
   }
 
+  // A single owner device; the gate binds the device-authored approval to it.
+  const OWNER = generateTestDeviceKey();
+  const OWNER_PRINCIPAL = deviceOwnerPrincipalIdFor(OWNER);
+  const APPROVAL_EXPIRES_AT = "2026-02-17T10:09:00.000Z";
+
   function makeProviderMutationApproval(input: {
     action: string;
     surface: string;
@@ -112,8 +125,8 @@ describe("FridayProviderRoutes", () => {
       action: input.action,
       actor: {
         kind: "user",
-        id: "user-1",
-        principalId: "user-1",
+        id: OWNER_PRINCIPAL,
+        principalId: OWNER_PRINCIPAL,
       },
       surface: input.surface,
       resourceId: input.resourceId,
@@ -121,23 +134,72 @@ describe("FridayProviderRoutes", () => {
       planDigest: PLAN_DIGEST,
       idempotencyKey: input.idempotencyKey,
     });
+    const actionDigest = createFridayMutatingActionDigest(request);
+    const approvalId = `${input.action}-approval`;
+    // A DEVICE-AUTHORED approval (SEC-APPROVAL-AUTHORITY-001): the owner device
+    // signs it; the Hub only verifies. A Hub-minted / unsigned approval is refused.
+    const transcript = makeApprovalTranscript(OWNER, {
+      actionDigest,
+      decidedByPrincipalId: OWNER_PRINCIPAL,
+      approvalId,
+      expiresAt: APPROVAL_EXPIRES_AT,
+    });
     return {
       decision: "approved",
-      approvalId: `${input.action}-approval`,
-      decidedByPrincipalId: "user-1",
-      actionDigest: createFridayMutatingActionDigest(request),
-      expiresAt: "2026-02-17T11:00:00.000Z",
+      approvalId,
+      decidedByPrincipalId: OWNER_PRINCIPAL,
+      actionDigest,
+      expiresAt: APPROVAL_EXPIRES_AT,
+      issuer: "friday_device_owner",
+      deviceProof: makeApprovalProof(OWNER, transcript),
     };
   }
 
+  /** A ctx whose bound owner principal IS the device-owner (device-owner:<keyHash>). */
+  function makeDeviceOwnerCtx(overrides: Partial<FridayHttpContext<unknown, unknown, unknown>> = {}) {
+    return makeAdminCtx({
+      principal: {
+        principalType: "user",
+        principalId: OWNER_PRINCIPAL,
+        userId: "user-1",
+        role: "owner",
+        scopes: ["hub.admin"],
+        tokenId: "tok-1",
+        tokenKind: "access",
+        issuedAt: NOW,
+      } as FridayHttpContext<unknown, unknown, unknown>["principal"],
+      ...overrides,
+    });
+  }
+
   function createProviderRoutesWithGate(mockService: FridayProviderService) {
+    const providerApprovalVerifier = createFridayProviderApprovalPoPVerifier();
     return createFridayProviderRoutes({
       providerService: mockService,
       providerMutationGateRequired: true,
       canonicalMutationGate: createFridayMutatingActionGate({
         nowIso: () => NOW,
         ticketIdGenerator: () => "ticket-1",
+        deviceApprovalVerifier: (proof, nowMs): FridayDeviceApprovalVerifyResult => {
+          const r = providerApprovalVerifier.verifyPossession({
+            transcript: proof.transcript,
+            devicePublicKey: proof.devicePublicKey,
+            signature: proof.signature,
+            nowMs,
+          });
+          return r.ok
+            ? {
+                ok: true,
+                devicePublicKeyHash: r.devicePublicKeyHash,
+                approvalId: r.approvalId,
+                actionDigest: r.actionDigest,
+                decidedByPrincipalId: r.decidedByPrincipalId,
+                expiresAt: r.expiresAt,
+              }
+            : { ok: false, reason: r.reason };
+        },
       }),
+      providerApprovalVerifier,
       // Probe + routing-controls surfaces fail-close by default; enable the
       // test-oracle flags so these positive-path tests exercise real behavior.
       // The dedicated retirement describe block omits these flags.
@@ -555,7 +617,7 @@ describe("FridayProviderRoutes", () => {
         }),
       };
 
-      const result = await createRoute.handler(makeAdminCtx({ body }));
+      const result = await createRoute.handler(makeDeviceOwnerCtx({ body }));
 
       expect(mockService.createProvider).toHaveBeenCalledWith(providerBody);
       expect(result).toHaveProperty("canonicalGate.ticketId", "ticket-1");
@@ -664,7 +726,7 @@ describe("FridayProviderRoutes", () => {
         (r) => r.operationId === "providers.validate",
       )!;
 
-      const result = await validateRoute.handler(makeAdminCtx({
+      const result = await validateRoute.handler(makeDeviceOwnerCtx({
         params: { providerId: "prov-001" },
         body: {
           planDigest: PLAN_DIGEST,
@@ -772,7 +834,7 @@ describe("FridayProviderRoutes", () => {
         (r) => r.operationId === "capabilities.doctor",
       )!;
 
-      const result = await doctorRoute.handler(makeAdminCtx({
+      const result = await doctorRoute.handler(makeDeviceOwnerCtx({
         body: {
           providerIds: ["prov-001"],
           planDigest: PLAN_DIGEST,
@@ -1079,7 +1141,7 @@ describe("FridayProviderRoutes", () => {
         }),
       };
 
-      const result = await setRoutingRoute.handler(makeAdminCtx({ body }));
+      const result = await setRoutingRoute.handler(makeDeviceOwnerCtx({ body }));
 
       expect(mockService.setRoutingConfig).toHaveBeenCalledWith(routingBody);
       expect(result).toHaveProperty("canonicalGate.ticketId", "ticket-1");

--- a/test/unit/providers/api/friday-provider-routes.test.ts
+++ b/test/unit/providers/api/friday-provider-routes.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createFridayProviderRoutes } from "#api";
 import type { FridayProviderService } from "#providers";
@@ -200,6 +202,13 @@ describe("FridayProviderRoutes", () => {
         },
       }),
       providerApprovalVerifier,
+      // Option B*: resolve the authenticated owner's durable device binding
+      // server-side. The device-owner ctx has `userId: "user-1"` and its registered
+      // device is `OWNER`; a passphrase / unknown user resolves to null.
+      resolveBoundDeviceOwnerSentinelHash: (userId: string) =>
+        userId === "user-1"
+          ? createHash("sha256").update(OWNER.spkiDerBase64).digest("hex")
+          : null,
       // Probe + routing-controls surfaces fail-close by default; enable the
       // test-oracle flags so these positive-path tests exercise real behavior.
       // The dedicated retirement describe block omits these flags.

--- a/test/unit/scripts/friday-install-smoke-root-path.test.ts
+++ b/test/unit/scripts/friday-install-smoke-root-path.test.ts
@@ -19,7 +19,10 @@ describe("install smoke root path handling", () => {
   it("uses fileURLToPath instead of URL pathname in the install smoke script", () => {
     const source = readFileSync(join(process.cwd(), "scripts/ci/install-smoke.mjs"), "utf8");
 
-    expect(source).toContain('import { fileURLToPath } from "node:url";');
+    // `fileURLToPath` must be imported from node:url — but the script may legitimately import
+    // additional named bindings from the same module (Lane C added `pathToFileURL` for the Rust
+    // agent-run proof), so assert the named import is PRESENT rather than the SOLE import.
+    expect(source).toMatch(/import \{[^}]*\bfileURLToPath\b[^}]*\} from "node:url";/);
     expect(source).toContain('fileURLToPath(new URL("../../", import.meta.url))');
     expect(source).not.toContain(".pathname.replace");
   });

--- a/test/unit/security/friday-mutating-action-gate.test.ts
+++ b/test/unit/security/friday-mutating-action-gate.test.ts
@@ -4,8 +4,18 @@ import {
   createFridayMutatingActionGate,
   createFridaySystemIntentMutatingActionRequest,
   signFridayCanonicalApproval,
+  type FridayCanonicalApprovalResolution,
+  type FridayDeviceApprovalVerifyResult,
 } from "../../../src/security/friday-mutating-action-gate.js";
 import type { FridayMutatingActionRequest } from "../../../src/security/friday-mutating-action-gate.js";
+import { createFridayProviderApprovalPoPVerifier } from "../../../src/api/auth/device-attest/index.js";
+import {
+  deviceOwnerPrincipalIdFor,
+  generateTestDeviceKey,
+  makeApprovalProof,
+  makeApprovalTranscript,
+  type TestDeviceKey,
+} from "../../helpers/friday-provider-approval-test-kit.js";
 
 const NOW = "2026-05-04T12:00:00.000Z";
 
@@ -474,5 +484,174 @@ describe("friday mutating action gate", () => {
       windowId: "window:finder:1",
     });
     expect(createFridayMutatingActionDigest(left)).not.toBe(createFridayMutatingActionDigest(right));
+  });
+});
+
+// ─── SEC-APPROVAL-AUTHORITY-001 · device-authored (verify-only) admission ───
+
+describe("friday mutating action gate — device-authored approval", () => {
+  const popVerifier = createFridayProviderApprovalPoPVerifier();
+
+  function deviceGate(options: { withVerifier?: boolean } = {}) {
+    return createFridayMutatingActionGate({
+      nowIso: () => NOW,
+      ticketIdGenerator: () => "ticket-1",
+      // The legacy HMAC secret coexists (plugin lifecycle). The device path never
+      // uses it — the Hub holds NO signing key on the device-authored approval path.
+      approvalSignatureSecret: "legacy-hmac-secret", // pragma: allowlist secret
+      requireApprovalSignature: true,
+      ...(options.withVerifier === false
+        ? {}
+        : {
+            deviceApprovalVerifier: (proof, nowMs): FridayDeviceApprovalVerifyResult => {
+              const r = popVerifier.verifyPossession({
+                transcript: proof.transcript,
+                devicePublicKey: proof.devicePublicKey,
+                signature: proof.signature,
+                nowMs,
+              });
+              return r.ok
+                ? {
+                    ok: true,
+                    devicePublicKeyHash: r.devicePublicKeyHash,
+                    approvalId: r.approvalId,
+                    actionDigest: r.actionDigest,
+                    decidedByPrincipalId: r.decidedByPrincipalId,
+                    expiresAt: r.expiresAt,
+                  }
+                : { ok: false, reason: r.reason };
+            },
+          }),
+    });
+  }
+
+  function ownerRequest(owner: TestDeviceKey, overrides: Partial<FridayMutatingActionRequest> = {}): FridayMutatingActionRequest {
+    return makeRequest({
+      action: "providers.create",
+      actor: { kind: "user", id: deviceOwnerPrincipalIdFor(owner), principalId: deviceOwnerPrincipalIdFor(owner) },
+      surface: "provider_setup",
+      resource: { type: "provider_setup", id: "prov-x" },
+      mutating: true,
+      risk: "high",
+      ...overrides,
+    });
+  }
+
+  function deviceApprovalFor(
+    owner: TestDeviceKey,
+    request: FridayMutatingActionRequest,
+    opts: { signWith?: TestDeviceKey; decidedByPrincipalId?: string; expiresAt?: string; approvalId?: string } = {},
+  ): FridayCanonicalApprovalResolution {
+    const actionDigest = createFridayMutatingActionDigest(request);
+    const expiresAt = opts.expiresAt ?? "2026-05-04T12:09:00.000Z";
+    const approvalId = opts.approvalId ?? "approval-gate-1";
+    const decidedByPrincipalId = opts.decidedByPrincipalId ?? deviceOwnerPrincipalIdFor(owner);
+    const transcript = makeApprovalTranscript(owner, { actionDigest, decidedByPrincipalId, approvalId, expiresAt });
+    const proof = makeApprovalProof(opts.signWith ?? owner, transcript, owner);
+    return {
+      decision: "approved",
+      approvalId,
+      decidedByPrincipalId,
+      actionDigest,
+      expiresAt,
+      issuer: "friday_device_owner",
+      deviceProof: proof,
+    };
+  }
+
+  it("ADMITS a valid device-authored approval and issues a ticket (Hub verify-only)", () => {
+    const owner = generateTestDeviceKey();
+    const request = ownerRequest(owner);
+    const approval = deviceApprovalFor(owner, request);
+
+    const result = deviceGate().evaluate({ ...request, canonicalApproval: approval });
+    expect(result.decision).toBe("allow");
+    expect(result.ticket?.approvedByPrincipalId).toBe(deviceOwnerPrincipalIdFor(owner));
+  });
+
+  it("DENIES when no device verifier is wired (fail closed)", () => {
+    const owner = generateTestDeviceKey();
+    const request = ownerRequest(owner);
+    const approval = deviceApprovalFor(owner, request);
+
+    const result = deviceGate({ withVerifier: false }).evaluate({ ...request, canonicalApproval: approval });
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toBe("device_approval_verifier_unavailable");
+  });
+
+  it("DENIES a device whose key does not hash to the acting owner (wrong device)", () => {
+    const owner = generateTestDeviceKey();
+    const attacker = generateTestDeviceKey();
+    const request = ownerRequest(owner);
+    // The attacker signs with its own key but claims the owner's principal id. The
+    // presented key hashes to the attacker → not bound to the owner. Every OTHER
+    // field matches the approval object so the device binding is the sole discrepancy.
+    const attackerTranscript = makeApprovalTranscript(attacker, {
+      actionDigest: createFridayMutatingActionDigest(request),
+      decidedByPrincipalId: deviceOwnerPrincipalIdFor(owner),
+      approvalId: "approval-attacker",
+      expiresAt: "2026-05-04T12:09:00.000Z",
+    });
+    const approval: FridayCanonicalApprovalResolution = {
+      decision: "approved",
+      approvalId: "approval-attacker",
+      decidedByPrincipalId: deviceOwnerPrincipalIdFor(owner),
+      actionDigest: createFridayMutatingActionDigest(request),
+      expiresAt: "2026-05-04T12:09:00.000Z",
+      issuer: "friday_device_owner",
+      deviceProof: makeApprovalProof(attacker, attackerTranscript, attacker),
+    };
+
+    const result = deviceGate().evaluate({ ...request, canonicalApproval: approval });
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toBe("device_approval_device_not_bound_to_owner");
+  });
+
+  it("DENIES a device approval lifted onto a different action (digest mismatch)", () => {
+    const owner = generateTestDeviceKey();
+    const request = ownerRequest(owner);
+    const approval = deviceApprovalFor(owner, request);
+    // Same approval, but the request that arrives mutates a different resource.
+    const drifted = ownerRequest(owner, { resource: { type: "provider_setup", id: "prov-OTHER" } });
+
+    const result = deviceGate().evaluate({ ...drifted, canonicalApproval: approval });
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toBe("canonical_approval_digest_mismatch");
+  });
+
+  it("DENIES a replayed (already-consumed) device approval", () => {
+    const owner = generateTestDeviceKey();
+    const request = ownerRequest(owner);
+    const approval = deviceApprovalFor(owner, request);
+    const gate = deviceGate();
+
+    expect(gate.evaluate({ ...request, canonicalApproval: approval }).decision).toBe("allow");
+    const replay = gate.evaluate({ ...request, canonicalApproval: approval });
+    expect(replay.decision).toBe("deny");
+    expect(replay.reason).toBe("canonical_approval_already_used");
+  });
+
+  it("DENIES an expired device approval", () => {
+    const owner = generateTestDeviceKey();
+    const request = ownerRequest(owner);
+    const approval = deviceApprovalFor(owner, request, { expiresAt: "2026-05-04T11:00:00.000Z" });
+
+    const result = deviceGate().evaluate({ ...request, canonicalApproval: approval });
+    expect(result.decision).toBe("deny");
+    expect(result.reason).toBe("canonical_approval_expired");
+  });
+
+  it("DENIES a device approval with a tampered signed action digest", () => {
+    const owner = generateTestDeviceKey();
+    const request = ownerRequest(owner);
+    const approval = deviceApprovalFor(owner, request);
+    // Flip the approval's top-level digest to match a DIFFERENT action while the
+    // signed transcript still binds the original — the gate cross-checks both.
+    const tampered: FridayCanonicalApprovalResolution = { ...approval, actionDigest: "f".repeat(64) };
+
+    const result = deviceGate().evaluate({ ...request, canonicalApproval: tampered });
+    expect(result.decision).toBe("deny");
+    // The approval's advertised digest no longer matches the request's recomputed one.
+    expect(result.reason).toBe("canonical_approval_digest_mismatch");
   });
 });

--- a/test/unit/security/friday-mutating-action-gate.test.ts
+++ b/test/unit/security/friday-mutating-action-gate.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { describe, expect, it } from "vitest";
 import {
   createFridayMutatingActionDigest,
@@ -525,10 +527,23 @@ describe("friday mutating action gate — device-authored approval", () => {
     });
   }
 
+  // Option B*: the acting principal is the ordinary local owner `user.id` (NOT a
+  // `device-owner:` principal); the durable device binding is carried SERVER-SIDE as
+  // `boundDeviceOwnerSentinelHash = sha256Hex(owner SPKI-DER base64)` — the SAME
+  // sentinel convention `deviceKeyLogin`/`users.password_hash` use.
+  function ownerSentinelHash(owner: TestDeviceKey): string {
+    return createHash("sha256").update(owner.spkiDerBase64).digest("hex");
+  }
+
   function ownerRequest(owner: TestDeviceKey, overrides: Partial<FridayMutatingActionRequest> = {}): FridayMutatingActionRequest {
     return makeRequest({
       action: "providers.create",
-      actor: { kind: "user", id: deviceOwnerPrincipalIdFor(owner), principalId: deviceOwnerPrincipalIdFor(owner) },
+      actor: {
+        kind: "user",
+        id: "owner-user-1",
+        principalId: "owner-user-1",
+        boundDeviceOwnerSentinelHash: ownerSentinelHash(owner),
+      },
       surface: "provider_setup",
       resource: { type: "provider_setup", id: "prov-x" },
       mutating: true,
@@ -584,7 +599,8 @@ describe("friday mutating action gate — device-authored approval", () => {
     const attacker = generateTestDeviceKey();
     const request = ownerRequest(owner);
     // The attacker signs with its own key but claims the owner's principal id. The
-    // presented key hashes to the attacker → not bound to the owner. Every OTHER
+    // presented key does NOT hash (sentinel convention) to the authenticated owner's
+    // registered device → the Option B* durable-binding check refuses it. Every OTHER
     // field matches the approval object so the device binding is the sole discrepancy.
     const attackerTranscript = makeApprovalTranscript(attacker, {
       actionDigest: createFridayMutatingActionDigest(request),
@@ -604,7 +620,7 @@ describe("friday mutating action gate — device-authored approval", () => {
 
     const result = deviceGate().evaluate({ ...request, canonicalApproval: approval });
     expect(result.decision).toBe("deny");
-    expect(result.reason).toBe("device_approval_device_not_bound_to_owner");
+    expect(result.reason).toBe("device_approval_actor_mismatch");
   });
 
   it("DENIES a device approval lifted onto a different action (digest mismatch)", () => {

--- a/test/unit/security/friday-native-peer-attestation-verifier.test.ts
+++ b/test/unit/security/friday-native-peer-attestation-verifier.test.ts
@@ -1,0 +1,274 @@
+// ─── SEC-NATIVE-PEER-ATTESTATION-001 · CORE-A CR-1 (SLICE 4) — VERIFIER SEAM (RED-FIRST) ───
+//
+// A signed release proves the connecting UI peer is the genuine owner device by
+// (a) reading the AF_UNIX peer's kernel-vouched credential (LOCAL_PEERCRED) and
+// (b) verifying that peer binary's code signature equals the expected release
+// identity. This suite drives the STANDALONE verifier seam through injected test
+// doubles — the ONLY path to `attested:true`. It NEVER wires the seam into any
+// live socket path and NEVER flips the operator-locked honesty anchor
+// `NATIVE_IPC_ATTESTATION_AVAILABLE` (asserted still-false below).
+//
+// TRUTH LABEL: this dev/CI source tree has NO native LOCAL_PEERCRED addon and is
+// UNSIGNED, so the DEFAULT provider + DEFAULT codesign verifier both yield
+// nothing → the verifier is honestly `attested:false` here. The `true` branch is
+// reachable ONLY via injected doubles, exactly as a signed-release/native slice
+// would supply the real provider + a valid codesign check.
+
+import { readFileSync } from "node:fs";
+import type { Socket } from "node:net";
+
+import { describe, expect, it } from "vitest";
+
+import { NATIVE_IPC_ATTESTATION_AVAILABLE } from "../../../src/security/friday-device-owner-authority-precondition.js";
+import {
+  NATIVE_PEER_ATTESTATION_REASON,
+  createAbsentCodesignPeerVerifier,
+  createAbsentNativePeerAttestationProvider,
+  createMacosCodesignPeerVerifier,
+  verifyNativePeerAttestation,
+} from "../../../src/security/attestation/friday-native-peer-attestation-verifier.js";
+import type {
+  CodesignPeerVerifier,
+  FridayCodesignIdentity,
+  FridayPeerCredential,
+  NativePeerAttestationProvider,
+} from "../../../src/security/attestation/friday-native-peer-attestation-verifier.js";
+
+const EXPECTED_IDENTITY = "com.friday.owner-device.release";
+// A fake socket handle — the pure verifier only forwards it to the provider.
+const FAKE_SOCKET = {} as unknown as Socket;
+
+/** Inject a provider that yields a fixed peer credential (or a thrown error). */
+function providerYielding(
+  cred: FridayPeerCredential | null,
+  opts: { throwErr?: boolean } = {},
+): NativePeerAttestationProvider {
+  return {
+    readPeerCredential(): FridayPeerCredential | null {
+      if (opts.throwErr) {
+        throw new Error("simulated native provider read failure");
+      }
+      return cred;
+    },
+  };
+}
+
+/** Inject a codesign verifier that returns a fixed result (or throws). */
+function codesignYielding(
+  result: FridayCodesignIdentity | null,
+  opts: { throwErr?: boolean } = {},
+): CodesignPeerVerifier {
+  return (_pid: number): FridayCodesignIdentity | null => {
+    if (opts.throwErr) {
+      throw new Error("simulated codesign verify failure");
+    }
+    return result;
+  };
+}
+
+const GOOD_CRED: FridayPeerCredential = { pid: 4242, uid: 501, gid: 20 };
+
+describe("FridayNativePeerAttestationVerifier", () => {
+  // ── HONESTY ANCHOR (read-only; NEVER flipped) ─────────────────────────────
+  it("HONESTY: NATIVE_IPC_ATTESTATION_AVAILABLE remains false (anchor untouched)", () => {
+    expect(NATIVE_IPC_ATTESTATION_AVAILABLE).toBe(false);
+  });
+
+  // ── DEFAULTS on this source/dev/CI tree are honestly empty ────────────────
+  it("DEFAULT native provider returns null (no LOCAL_PEERCRED addon installed)", () => {
+    const provider = createAbsentNativePeerAttestationProvider();
+    expect(provider.readPeerCredential(FAKE_SOCKET)).toBeNull();
+  });
+
+  it("DEFAULT codesign verifier returns null (unsigned dev/CI build)", () => {
+    const verifier = createAbsentCodesignPeerVerifier();
+    expect(verifier(GOOD_CRED.pid)).toBeNull();
+  });
+
+  it("DEFAULTS composed → attested:false NATIVE_PROVIDER_ABSENT (honest-false here)", () => {
+    const result = verifyNativePeerAttestation({
+      provider: createAbsentNativePeerAttestationProvider(),
+      codesignVerifier: createAbsentCodesignPeerVerifier(),
+      expectedReleaseIdentity: EXPECTED_IDENTITY,
+      socket: FAKE_SOCKET,
+    });
+    expect(result.attested).toBe(false);
+    expect(result.reason).toBe(NATIVE_PEER_ATTESTATION_REASON.NATIVE_PROVIDER_ABSENT);
+  });
+
+  // ── NEGATIVE MATRIX ───────────────────────────────────────────────────────
+  it("native provider absent → attested:false NATIVE_PROVIDER_ABSENT", () => {
+    const result = verifyNativePeerAttestation({
+      provider: providerYielding(null),
+      codesignVerifier: codesignYielding({ identity: EXPECTED_IDENTITY, valid: true }),
+      expectedReleaseIdentity: EXPECTED_IDENTITY,
+      socket: FAKE_SOCKET,
+    });
+    expect(result.attested).toBe(false);
+    expect(result.reason).toBe(NATIVE_PEER_ATTESTATION_REASON.NATIVE_PROVIDER_ABSENT);
+    expect(result.codesignIdentity).toBeUndefined();
+  });
+
+  it("peer credential present but codesign UNVERIFIED (null) → attested:false CODESIGN_UNVERIFIED", () => {
+    const result = verifyNativePeerAttestation({
+      provider: providerYielding(GOOD_CRED),
+      codesignVerifier: codesignYielding(null),
+      expectedReleaseIdentity: EXPECTED_IDENTITY,
+      socket: FAKE_SOCKET,
+    });
+    expect(result.attested).toBe(false);
+    expect(result.reason).toBe(NATIVE_PEER_ATTESTATION_REASON.CODESIGN_UNVERIFIED);
+    expect(result.peerCredential).toEqual(GOOD_CRED);
+  });
+
+  it("peer credential present but codesign INVALID → attested:false CODESIGN_INVALID", () => {
+    const result = verifyNativePeerAttestation({
+      provider: providerYielding(GOOD_CRED),
+      codesignVerifier: codesignYielding({ identity: EXPECTED_IDENTITY, valid: false }),
+      expectedReleaseIdentity: EXPECTED_IDENTITY,
+      socket: FAKE_SOCKET,
+    });
+    expect(result.attested).toBe(false);
+    expect(result.reason).toBe(NATIVE_PEER_ATTESTATION_REASON.CODESIGN_INVALID);
+  });
+
+  it("codesign valid but identity ≠ expected → attested:false CODESIGN_IDENTITY_MISMATCH", () => {
+    const result = verifyNativePeerAttestation({
+      provider: providerYielding(GOOD_CRED),
+      codesignVerifier: codesignYielding({ identity: "com.someone.else.debug", valid: true }),
+      expectedReleaseIdentity: EXPECTED_IDENTITY,
+      socket: FAKE_SOCKET,
+    });
+    expect(result.attested).toBe(false);
+    expect(result.reason).toBe(NATIVE_PEER_ATTESTATION_REASON.CODESIGN_IDENTITY_MISMATCH);
+  });
+
+  it("blank expectedReleaseIdentity fails closed → attested:false EXPECTED_IDENTITY_MISSING", () => {
+    const result = verifyNativePeerAttestation({
+      provider: providerYielding(GOOD_CRED),
+      codesignVerifier: codesignYielding({ identity: "", valid: true }),
+      expectedReleaseIdentity: "   ",
+      socket: FAKE_SOCKET,
+    });
+    expect(result.attested).toBe(false);
+    expect(result.reason).toBe(NATIVE_PEER_ATTESTATION_REASON.EXPECTED_IDENTITY_MISSING);
+  });
+
+  // Malformed / partial peer-credential payloads must be REJECTED, never throw,
+  // never coerced into a `true`.
+  const MALFORMED: ReadonlyArray<{ label: string; cred: unknown }> = [
+    { label: "missing uid", cred: { pid: 4242, gid: 20 } },
+    { label: "missing gid", cred: { pid: 4242, uid: 501 } },
+    { label: "missing pid", cred: { uid: 501, gid: 20 } },
+    { label: "NaN pid", cred: { pid: Number.NaN, uid: 501, gid: 20 } },
+    { label: "negative uid", cred: { pid: 4242, uid: -1, gid: 20 } },
+    { label: "non-integer pid", cred: { pid: 42.5, uid: 501, gid: 20 } },
+    { label: "string pid", cred: { pid: "4242", uid: 501, gid: 20 } },
+    { label: "empty object", cred: {} },
+  ];
+  for (const { label, cred } of MALFORMED) {
+    it(`malformed peer credential (${label}) → attested:false MALFORMED_PEER_CREDENTIAL (no throw)`, () => {
+      let result!: ReturnType<typeof verifyNativePeerAttestation>;
+      expect(() => {
+        result = verifyNativePeerAttestation({
+          provider: providerYielding(cred as FridayPeerCredential),
+          codesignVerifier: codesignYielding({ identity: EXPECTED_IDENTITY, valid: true }),
+          expectedReleaseIdentity: EXPECTED_IDENTITY,
+          socket: FAKE_SOCKET,
+        });
+      }).not.toThrow();
+      expect(result.attested).toBe(false);
+      expect(result.reason).toBe(NATIVE_PEER_ATTESTATION_REASON.MALFORMED_PEER_CREDENTIAL);
+    });
+  }
+
+  it("provider read throws → attested:false PROVIDER_READ_ERROR (never throws)", () => {
+    let result!: ReturnType<typeof verifyNativePeerAttestation>;
+    expect(() => {
+      result = verifyNativePeerAttestation({
+        provider: providerYielding(null, { throwErr: true }),
+        codesignVerifier: codesignYielding({ identity: EXPECTED_IDENTITY, valid: true }),
+        expectedReleaseIdentity: EXPECTED_IDENTITY,
+        socket: FAKE_SOCKET,
+      });
+    }).not.toThrow();
+    expect(result.attested).toBe(false);
+    expect(result.reason).toBe(NATIVE_PEER_ATTESTATION_REASON.PROVIDER_READ_ERROR);
+  });
+
+  it("codesign verifier throws → attested:false CODESIGN_VERIFY_ERROR (never throws)", () => {
+    let result!: ReturnType<typeof verifyNativePeerAttestation>;
+    expect(() => {
+      result = verifyNativePeerAttestation({
+        provider: providerYielding(GOOD_CRED),
+        codesignVerifier: codesignYielding(null, { throwErr: true }),
+        expectedReleaseIdentity: EXPECTED_IDENTITY,
+        socket: FAKE_SOCKET,
+      });
+    }).not.toThrow();
+    expect(result.attested).toBe(false);
+    expect(result.reason).toBe(NATIVE_PEER_ATTESTATION_REASON.CODESIGN_VERIFY_ERROR);
+  });
+
+  // ── THE ONLY PATH TO true — real peercred + valid codesign + matching id ──
+  it("ONLY real peercred + valid codesign + matching identity (injected) → attested:true", () => {
+    const result = verifyNativePeerAttestation({
+      provider: providerYielding(GOOD_CRED),
+      codesignVerifier: codesignYielding({ identity: EXPECTED_IDENTITY, valid: true }),
+      expectedReleaseIdentity: EXPECTED_IDENTITY,
+      socket: FAKE_SOCKET,
+    });
+    expect(result.attested).toBe(true);
+    expect(result.reason).toBe(NATIVE_PEER_ATTESTATION_REASON.ATTESTED);
+    expect(result.peerCredential).toEqual(GOOD_CRED);
+    expect(result.codesignIdentity).toBe(EXPECTED_IDENTITY);
+  });
+
+  // ── VERIFY-ONLY: the module holds NO signing key and NO secret ─────────────
+  it("holds no key/secret — module source imports no node:crypto and has no signing primitive", () => {
+    const source = readFileSync(
+      new URL(
+        "../../../src/security/attestation/friday-native-peer-attestation-verifier.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    // No secret/key custody: verify-only. (Note: "codesign" intentionally allowed.)
+    expect(source).not.toMatch(/["']node:crypto["']/);
+    expect(source).not.toMatch(/\bcreateHmac\b/);
+    expect(source).not.toMatch(/\bcreateSign\b/);
+    expect(source).not.toMatch(/\bcreateHash\b/);
+    expect(source).not.toMatch(/\bprivateKey\b/);
+    expect(source).not.toMatch(/\btokenSecret\b/);
+    expect(source).not.toMatch(/\bKeyObject\b/);
+  });
+
+  // ── LIVE honest-false proof on this real, unsigned dev machine (darwin) ────
+  // The macOS codesign verifier is REAL (shells to codesign) but is NOT wired to
+  // any socket path and is NOT the default. Against the current process with a
+  // bogus expected identity, the composed verifier MUST stay attested:false —
+  // proving it can never fabricate a pass on an unsigned/foreign-identity peer.
+  it.skipIf(process.platform !== "darwin")(
+    "LIVE (darwin): macOS codesign verifier never fabricates a pass on this build",
+    () => {
+      const livePid = process.pid;
+      const macosCodesign = createMacosCodesignPeerVerifier();
+      const liveProvider: NativePeerAttestationProvider = {
+        readPeerCredential(): FridayPeerCredential {
+          return {
+            pid: livePid,
+            uid: typeof process.getuid === "function" ? process.getuid() : 0,
+            gid: typeof process.getgid === "function" ? process.getgid() : 0,
+          };
+        },
+      };
+      const result = verifyNativePeerAttestation({
+        provider: liveProvider,
+        codesignVerifier: macosCodesign,
+        expectedReleaseIdentity: "com.friday.owner-device.release.BOGUS-NEVER-MATCHES",
+        socket: FAKE_SOCKET,
+      });
+      expect(result.attested).toBe(false);
+    },
+  );
+});

--- a/test/unit/security/friday-verified-native-owner-claim-context.test.ts
+++ b/test/unit/security/friday-verified-native-owner-claim-context.test.ts
@@ -1,0 +1,321 @@
+// ─── SEC-NATIVE-OWNER-CLAIM-CAPABILITY-001 · CR-1 Option C — NEGATIVE MATRIX ───
+//
+// Module-level negative matrix for the OPAQUE per-claim capability that REPLACES
+// the retired global boolean authority. Every mint requires a REAL `attested:true`
+// result (produced here by the REAL CR-4 verifier over injected doubles — the ONLY
+// path to `true`), release-trusted native custody, a pinned policy, and a complete
+// request binding. Every consume EXACT-matches the live request, is single-use,
+// expiry-bound, and connection-bound. The Advisor negative matrix maps as follows:
+//   absent provider / unsupported platform / unsigned-adhoc-dev binary / wrong
+//   Team-bundle-DR-entitlement-path-hash / stale-revoked sig / missing-malformed
+//   peer creds  → attestation not attested            → mint refused
+//   wrong UID / PID reuse / exec-fork / FD-socket sub  → peer-evidence-inconsistent → mint refused
+//   WebCrypto / software / unverified custody          → key-protection not trusted → mint refused
+//   wrong artifact role (helper vs app)                → artifact-role-mismatch     → mint refused
+//   forged header/body/cookie/env/UA/bundle/test lit   → not a capability (brand)   → consume refused
+//   direct HTTP/TCP/browser (no capability)            → no-capability              → consume refused
+//   disconnect/reconnect / accept-verify race / conn sub → connection-substituted   → consume refused
+//   ONE attested peer authorizing a DIFFERENT request  → binding-drift              → consume refused
+//   wrong/cross hub/install/owner/origin/channel/nonce → binding-drift              → consume refused
+//   replay (same capability twice)                     → already-consumed           → consume refused
+//   expiry / restart                                   → expired                    → consume refused
+//   emergency kill switch                              → kill-switch-engaged        → mint + consume refused
+// Every refusal returns `{ ok: false }`, so the caller performs ZERO state change.
+
+import type { Socket } from "node:net";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  verifyNativePeerAttestation,
+} from "../../../src/security/attestation/friday-native-peer-attestation-verifier.js";
+import type {
+  FridayPeerCredential,
+  NativePeerAttestationResult,
+} from "../../../src/security/attestation/friday-native-peer-attestation-verifier.js";
+import {
+  consumeVerifiedNativeOwnerClaimContext,
+  deriveNativeOwnerExchangeConnectionId,
+  isVerifiedNativeOwnerClaimContext,
+  mintVerifiedNativeOwnerClaimContext,
+  createAbsentNativeOwnerClaimResolver,
+  type MintVerifiedNativeOwnerClaimContextInput,
+  type NativeOwnerClaimBinding,
+  type NativeOwnerPeerEvidence,
+  type PinnedNativeOwnerPolicy,
+} from "../../../src/security/attestation/friday-verified-native-owner-claim-context.js";
+import { deriveDeviceKeyProtection } from "../../../src/security/friday-device-owner-authority-precondition.js";
+
+const IDENTITY = "com.friday.owner-device.release";
+const ROLE = "friday.owner-device.app";
+const UID = 501;
+const PID = 4242;
+const NOW = 1_700_000_000_000;
+const FAKE_SOCKET = {} as unknown as Socket;
+const KILL_ENV: NodeJS.ProcessEnv = { FRIDAY_DEVICE_OWNER_AUTHORITY_KILL_SWITCH: "1" };
+
+function attestedResult(over: { uid?: number; pid?: number; identity?: string } = {}): NativePeerAttestationResult {
+  const uid = over.uid ?? UID;
+  const pid = over.pid ?? PID;
+  const identity = over.identity ?? IDENTITY;
+  return verifyNativePeerAttestation({
+    provider: { readPeerCredential: (): FridayPeerCredential => ({ pid, uid, gid: 20 }) },
+    codesignVerifier: () => ({ identity, valid: true }),
+    expectedReleaseIdentity: identity,
+    socket: FAKE_SOCKET,
+  });
+}
+
+function notAttestedResult(): NativePeerAttestationResult {
+  // Absent native provider → attested:false (the honest state on this tree).
+  return verifyNativePeerAttestation({
+    provider: { readPeerCredential: (): FridayPeerCredential | null => null },
+    codesignVerifier: () => ({ identity: IDENTITY, valid: true }),
+    expectedReleaseIdentity: IDENTITY,
+    socket: FAKE_SOCKET,
+  });
+}
+
+const BINDING: NativeOwnerClaimBinding = {
+  hubId: "test-hub",
+  installId: "install-1",
+  osUser: "jarvis",
+  origin: "https://friday.localhost",
+  channel: "install-ipc",
+  action: "owner-claim",
+  nonce: "nonce-abc",
+  expiresAtMs: NOW + 60_000,
+  deviceId: "device-1",
+  devicePublicKeyHash: "a".repeat(64),
+  artifactRole: ROLE,
+};
+
+function evidenceFor(binding: NativeOwnerClaimBinding, over: Partial<NativeOwnerPeerEvidence> = {}): NativeOwnerPeerEvidence {
+  return {
+    osUid: UID,
+    peerPid: PID,
+    acceptedConnectionId: deriveNativeOwnerExchangeConnectionId(binding),
+    auditTokenIdentity: "audit-token-4242",
+    codesignIdentity: IDENTITY,
+    ...over,
+  };
+}
+
+const POLICY: PinnedNativeOwnerPolicy = {
+  expectedReleaseIdentity: IDENTITY,
+  expectedArtifactRole: ROLE,
+};
+
+function mintInput(
+  over: Partial<MintVerifiedNativeOwnerClaimContextInput> = {},
+): MintVerifiedNativeOwnerClaimContextInput {
+  const binding = over.binding ?? BINDING;
+  return {
+    attestation: over.attestation ?? attestedResult(),
+    keyProtection:
+      over.keyProtection ?? deriveDeviceKeyProtection({ custody: "secure_enclave", osVerified: true }),
+    binding,
+    evidence: over.evidence ?? evidenceFor(binding),
+    policy: over.policy ?? POLICY,
+    env: over.env,
+  };
+}
+
+/** A valid capability for the canonical binding. */
+function mintOk() {
+  const result = mintVerifiedNativeOwnerClaimContext(mintInput());
+  if (!result.ok) throw new Error(`expected mint ok, got ${result.reason}`);
+  return result.capability;
+}
+
+function consumeExpect(binding: NativeOwnerClaimBinding = BINDING, over: { connectionId?: string; nowMs?: number; env?: NodeJS.ProcessEnv } = {}) {
+  return {
+    binding,
+    expectedConnectionId: over.connectionId ?? deriveNativeOwnerExchangeConnectionId(binding),
+    nowMs: over.nowMs ?? NOW,
+    env: over.env,
+  };
+}
+
+describe("VerifiedNativeOwnerClaimContext — mint negative matrix", () => {
+  it("POSITIVE: real attestation + release-trusted custody + pinned policy + complete binding → mint ok", () => {
+    const result = mintVerifiedNativeOwnerClaimContext(mintInput());
+    expect(result.ok).toBe(true);
+  });
+
+  it("kill switch engaged → mint refused (no capability minted)", () => {
+    const result = mintVerifiedNativeOwnerClaimContext(mintInput({ env: KILL_ENV }));
+    expect(result).toEqual({ ok: false, reason: "kill-switch-engaged" });
+  });
+
+  it("attestation NOT attested (absent provider / unsigned / malformed peercred) → mint refused", () => {
+    const result = mintVerifiedNativeOwnerClaimContext(mintInput({ attestation: notAttestedResult() }));
+    expect(result).toEqual({ ok: false, reason: "attestation-not-attested" });
+  });
+
+  it("codesign identity ≠ pinned policy identity → mint refused", () => {
+    const result = mintVerifiedNativeOwnerClaimContext(
+      mintInput({ policy: { expectedReleaseIdentity: "com.someone.else", expectedArtifactRole: ROLE } }),
+    );
+    expect(result).toEqual({ ok: false, reason: "codesign-identity-mismatch" });
+  });
+
+  it("WebCrypto / software / unverified custody → mint refused (never release-trusted)", () => {
+    for (const kp of [
+      deriveDeviceKeyProtection({ custody: "webcrypto_software", osVerified: false }),
+      deriveDeviceKeyProtection(null),
+      deriveDeviceKeyProtection({ custody: "secure_enclave", osVerified: false }),
+    ]) {
+      const result = mintVerifiedNativeOwnerClaimContext(mintInput({ keyProtection: kp }));
+      expect(result).toEqual({ ok: false, reason: "key-protection-not-release-trusted" });
+    }
+  });
+
+  it("wrong artifact role (validly signed helper, not the main app) → mint refused", () => {
+    const binding: NativeOwnerClaimBinding = { ...BINDING, artifactRole: "friday.owner-device.helper" };
+    const result = mintVerifiedNativeOwnerClaimContext(
+      mintInput({ binding, evidence: evidenceFor(binding) }),
+    );
+    expect(result).toEqual({ ok: false, reason: "artifact-role-mismatch" });
+  });
+
+  it("peer evidence inconsistent with verified peercred (wrong UID / PID reuse / FD sub) → mint refused", () => {
+    for (const over of [{ osUid: UID + 1 }, { peerPid: PID + 1 }, { codesignIdentity: "mismatch" }]) {
+      const result = mintVerifiedNativeOwnerClaimContext(
+        mintInput({ evidence: evidenceFor(BINDING, over) }),
+      );
+      expect(result).toEqual({ ok: false, reason: "peer-evidence-inconsistent" });
+    }
+  });
+
+  it("incomplete binding (any blank / non-finite field) → mint refused", () => {
+    const bads: Partial<NativeOwnerClaimBinding>[] = [
+      { hubId: "" },
+      { installId: "  " },
+      { osUser: "" },
+      { origin: "" },
+      { channel: "" },
+      { action: "" },
+      { nonce: "" },
+      { deviceId: "" },
+      { devicePublicKeyHash: "" },
+      { artifactRole: "" },
+      { expiresAtMs: 0 },
+      { expiresAtMs: Number.NaN },
+    ];
+    for (const bad of bads) {
+      const binding = { ...BINDING, ...bad };
+      // artifactRole blank must still fail as binding-incomplete BEFORE role compare.
+      const result = mintVerifiedNativeOwnerClaimContext(
+        mintInput({ binding, evidence: evidenceFor(binding) }),
+      );
+      expect(result.ok).toBe(false);
+    }
+  });
+
+  it("incomplete evidence (blank connection / audit token / codesign id) → mint refused", () => {
+    for (const over of [
+      { acceptedConnectionId: "" },
+      { auditTokenIdentity: "" },
+      { codesignIdentity: "" },
+      { peerPid: 0 },
+    ]) {
+      const result = mintVerifiedNativeOwnerClaimContext(
+        mintInput({ evidence: evidenceFor(BINDING, over) }),
+      );
+      expect(result.ok).toBe(false);
+    }
+  });
+});
+
+describe("VerifiedNativeOwnerClaimContext — consume negative matrix (single-use, exact-match)", () => {
+  it("POSITIVE: valid capability + exact request match → consume ok with the release-trusted keyProtection", () => {
+    const cap = mintOk();
+    const res = consumeVerifiedNativeOwnerClaimContext(cap, consumeExpect());
+    expect(res).toEqual({ ok: true, keyProtection: "secure_enclave_os_verified" });
+  });
+
+  it("no capability (direct HTTP/TCP/browser — resolver returns null) → refused", () => {
+    const resolver = createAbsentNativeOwnerClaimResolver();
+    const res = consumeVerifiedNativeOwnerClaimContext(resolver(BINDING), consumeExpect());
+    expect(res).toEqual({ ok: false, reason: "no-capability" });
+  });
+
+  it("forged object literal (request/env/header/test injection) is NOT a capability (brand)", () => {
+    const forged = {
+      binding: BINDING,
+      evidence: evidenceFor(BINDING),
+      keyProtection: "secure_enclave_os_verified",
+    };
+    expect(isVerifiedNativeOwnerClaimContext(forged)).toBe(false);
+    const res = consumeVerifiedNativeOwnerClaimContext(forged, consumeExpect());
+    expect(res).toEqual({ ok: false, reason: "no-capability" });
+  });
+
+  it("kill switch engaged at consume → refused (emergency force-off)", () => {
+    const cap = mintOk();
+    const res = consumeVerifiedNativeOwnerClaimContext(cap, consumeExpect(BINDING, { env: KILL_ENV }));
+    expect(res).toEqual({ ok: false, reason: "kill-switch-engaged" });
+  });
+
+  it("single-use: the SAME capability cannot be consumed twice (replay) → already-consumed", () => {
+    const cap = mintOk();
+    expect(consumeVerifiedNativeOwnerClaimContext(cap, consumeExpect()).ok).toBe(true);
+    const res = consumeVerifiedNativeOwnerClaimContext(cap, consumeExpect());
+    expect(res).toEqual({ ok: false, reason: "already-consumed" });
+  });
+
+  it("expired / restart (nowMs at or past expiry) → refused", () => {
+    const cap = mintOk();
+    const res = consumeVerifiedNativeOwnerClaimContext(cap, consumeExpect(BINDING, { nowMs: BINDING.expiresAtMs }));
+    expect(res).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("binding drift on ANY field (wrong hub/install/owner/origin/channel/action/nonce/device/key/role/expiry) → refused", () => {
+    const drifts: Partial<NativeOwnerClaimBinding>[] = [
+      { hubId: "other-hub" },
+      { installId: "install-2" },
+      { osUser: "mallory" },
+      { origin: "https://evil.localhost" },
+      { channel: "other-channel" },
+      { action: "owner-login" },
+      { nonce: "nonce-xyz" },
+      { deviceId: "device-2" },
+      { devicePublicKeyHash: "b".repeat(64) },
+      { artifactRole: "friday.owner-device.helper" },
+      { expiresAtMs: NOW + 120_000 },
+    ];
+    for (const drift of drifts) {
+      const cap = mintOk(); // fresh capability for the CANONICAL binding
+      const res = consumeVerifiedNativeOwnerClaimContext(cap, consumeExpect({ ...BINDING, ...drift }));
+      expect(res, `drift=${JSON.stringify(drift)}`).toEqual({ ok: false, reason: "binding-drift" });
+    }
+  });
+
+  it("ONE attested peer authorizing a DIFFERENT request → refused (capability minted for B1, consumed for B2)", () => {
+    // Mint a capability for a DIFFERENT request (a login for another device).
+    const otherBinding: NativeOwnerClaimBinding = {
+      ...BINDING,
+      action: "owner-login",
+      nonce: "some-other-nonce",
+      deviceId: "device-99",
+    };
+    const capForOther = mintVerifiedNativeOwnerClaimContext(
+      mintInput({ binding: otherBinding, evidence: evidenceFor(otherBinding) }),
+    );
+    expect(capForOther.ok).toBe(true);
+    if (!capForOther.ok) return;
+    // Try to consume it for the CANONICAL claim request → refused.
+    const res = consumeVerifiedNativeOwnerClaimContext(capForOther.capability, consumeExpect());
+    expect(res).toEqual({ ok: false, reason: "binding-drift" });
+  });
+
+  it("connection substitution (disconnect/reconnect / accept-verify race) → refused", () => {
+    const cap = mintOk();
+    const res = consumeVerifiedNativeOwnerClaimContext(
+      cap,
+      consumeExpect(BINDING, { connectionId: "a-different-connection" }),
+    );
+    expect(res).toEqual({ ok: false, reason: "connection-substituted" });
+  });
+});

--- a/test/unit/state/migrations/v107-setup-bootstrap-login-challenge.test.ts
+++ b/test/unit/state/migrations/v107-setup-bootstrap-login-challenge.test.ts
@@ -1,0 +1,127 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+
+import { V103_SETUP_BOOTSTRAP_DEVICE_CLAIM_MIGRATION } from "../../../../src/state/sqlite/migrations/v103-setup-bootstrap-device-claim.js";
+import { V104_SETUP_BOOTSTRAP_MIGRATION_STATE_MIGRATION } from "../../../../src/state/sqlite/migrations/v104-setup-bootstrap-migration-state.js";
+import { V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION } from "../../../../src/state/sqlite/migrations/v107-setup-bootstrap-login-challenge.js";
+
+/** Build the nonce-ledger table exactly as it exists at the v104 boundary. */
+function makeV104Db(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(V103_SETUP_BOOTSTRAP_DEVICE_CLAIM_MIGRATION.sql);
+  db.exec(V104_SETUP_BOOTSTRAP_MIGRATION_STATE_MIGRATION.sql);
+  return db;
+}
+
+let seq = 0;
+function insertNonce(
+  db: Database.Database,
+  over: Partial<{
+    id: string;
+    kind: string;
+    origin: string;
+    deviceId: string | null;
+    devicePublicKeyHash: string | null;
+    consumedAt: string | null;
+    expiresAt: string;
+  }> = {},
+): string {
+  const id = over.id ?? `nonce-${++seq}`;
+  db.prepare(
+    `INSERT INTO friday_setup_bootstrap_nonces (
+       id, nonce_hash, kind, hub_id, install_id, os_user, origin, action,
+       device_id, device_public_key, device_public_key_hash, claimed_user_id,
+       created_at, expires_at, consumed_at
+     ) VALUES (?, ?, ?, 'hub', 'install', 'os', ?, 'action', ?, NULL, ?, NULL, ?, ?, ?)`,
+  ).run(
+    id,
+    `hash-${id}`,
+    over.kind ?? "install_owner_claim",
+    over.origin ?? "https://friday.localhost",
+    over.deviceId ?? null,
+    over.devicePublicKeyHash ?? null,
+    "2026-05-31T00:00:00.000Z",
+    over.expiresAt ?? "2999-01-01T00:00:00.000Z",
+    over.consumedAt ?? null,
+  );
+  return id;
+}
+
+describe("v107 setup-bootstrap login-challenge migration", () => {
+  it("preserves live install/migration nonce rows, accepts the new login kind, and re-scopes the single-owner index", () => {
+    const db = makeV104Db();
+    try {
+      // Seed rows that exist BEFORE the migration: one CONSUMED owner-claim binding,
+      // one CONSUMED migration binding, and one LIVE unconsumed challenge.
+      insertNonce(db, { id: "claim-consumed", kind: "install_owner_claim", consumedAt: "2026-06-01T00:00:00.000Z" });
+      insertNonce(db, { id: "migrate-consumed", kind: "device_migration_claim", consumedAt: "2026-06-02T00:00:00.000Z" });
+      insertNonce(db, { id: "claim-live", kind: "install_owner_claim", consumedAt: null });
+
+      // Sanity: the pre-v107 CHECK rejects the login kind.
+      expect(() =>
+        insertNonce(db, { id: "reject", kind: "device_login_challenge" }),
+      ).toThrow(/CHECK|constraint/i);
+
+      // Apply the migration.
+      db.exec(V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION.sql);
+
+      // (1) All pre-existing rows are preserved verbatim.
+      const rows = db
+        .prepare("SELECT id, kind, consumed_at FROM friday_setup_bootstrap_nonces ORDER BY id")
+        .all() as Array<{ id: string; kind: string; consumed_at: string | null }>;
+      expect(rows).toEqual([
+        { id: "claim-consumed", kind: "install_owner_claim", consumed_at: "2026-06-01T00:00:00.000Z" },
+        { id: "claim-live", kind: "install_owner_claim", consumed_at: null },
+        { id: "migrate-consumed", kind: "device_migration_claim", consumed_at: "2026-06-02T00:00:00.000Z" },
+      ]);
+
+      // (2) The new device_login_challenge kind is now accepted by the widened CHECK.
+      insertNonce(db, {
+        id: "login-1",
+        kind: "device_login_challenge",
+        deviceId: "dev-1",
+        devicePublicKeyHash: "keyhash-1",
+        consumedAt: "2026-06-03T00:00:00.000Z",
+      });
+
+      // (3) A SECOND CONSUMED device_login_challenge row does NOT hit the single-owner
+      // UNIQUE index (it was re-scoped to EXCLUDE the login kind) — logins accumulate.
+      expect(() =>
+        insertNonce(db, {
+          id: "login-2",
+          kind: "device_login_challenge",
+          deviceId: "dev-1",
+          devicePublicKeyHash: "keyhash-1",
+          consumedAt: "2026-06-04T00:00:00.000Z",
+        }),
+      ).not.toThrow();
+      const consumedLogins = db
+        .prepare(
+          "SELECT COUNT(*) AS c FROM friday_setup_bootstrap_nonces WHERE kind = 'device_login_challenge' AND consumed_at IS NOT NULL",
+        )
+        .get() as { c: number };
+      expect(consumedLogins.c).toBe(2);
+
+      // (4) The single-owner belt STILL holds for the two single-shot kinds: a 2nd
+      // consumed install_owner_claim is a UNIQUE violation (single owner preserved).
+      expect(() =>
+        insertNonce(db, { id: "claim-consumed-2", kind: "install_owner_claim", consumedAt: "2026-06-05T00:00:00.000Z" }),
+      ).toThrow(/UNIQUE|constraint/i);
+      // ...and likewise for a 2nd consumed device_migration_claim.
+      expect(() =>
+        insertNonce(db, { id: "migrate-consumed-2", kind: "device_migration_claim", consumedAt: "2026-06-06T00:00:00.000Z" }),
+      ).toThrow(/UNIQUE|constraint/i);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("migration metadata is well-formed", () => {
+    expect(V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION.version).toBe(107);
+    expect(V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION.name).toBe(
+      "v107-setup-bootstrap-login-challenge",
+    );
+    expect(V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION.checksum).toMatch(/^[0-9a-f]{64}$/);
+    expect(V107_SETUP_BOOTSTRAP_LOGIN_CHALLENGE_MIGRATION.sql).toMatch(/device_login_challenge/);
+  });
+});

--- a/test/unit/ui/device-key-durable.test.ts
+++ b/test/unit/ui/device-key-durable.test.ts
@@ -1,0 +1,165 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · CR-1 — durable browser device key (Advisor #1628 #2) ───
+//
+// Advisor #1628 finding #2 (second half): the browser owner key was in-memory only,
+// so it did NOT survive a reload — the device-bound owner could not be recovered.
+// CR-1 persists the non-extractable P-256 CryptoKey in IndexedDB. IndexedDB stores
+// the key via the STRUCTURED CLONE algorithm; a structured-cloned CryptoKey keeps
+// `extractable === false` (raw bytes are never materialised), so the key is durable
+// WITHOUT becoming extractable.
+//
+// This suite runs the REAL provider. IndexedDB is a browser API (absent in Node),
+// so the durable-store contract is exercised with an in-memory store that runs the
+// record through the SAME `structuredClone` algorithm IndexedDB uses — a faithful
+// stand-in for the persistence mechanism (the IndexedDB glue itself is thin
+// browser wiring). A direct structuredClone(CryptoKey) proof pins the crux: the
+// non-extractable flag survives the clone and the key still signs. TRUTH LABEL:
+// every key here is a SOFTWARE WebCrypto key; nothing claims hardware backing.
+
+import { describe, it, expect } from "vitest";
+
+import {
+  createWebCryptoDeviceKeyProvider,
+  type DeviceClaimTranscript,
+  type DeviceKeyStore,
+  type DurableDeviceKeyRecord,
+} from "../../../ui/src/lib/auth/device-key.js";
+import { createFridayOwnerClaimPoPVerifier } from "../../../src/api/auth/device-attest/index.js";
+import type { OwnerClaimTranscript } from "../../../src/api/auth/device-attest/index.js";
+
+const NOW = "2026-07-13T00:00:00.000Z";
+
+function sampleTranscript(hash: string): DeviceClaimTranscript {
+  return {
+    transcriptVersion: "friday-owner-claim-v1",
+    algorithm: "ECDSA_P256_SHA256",
+    kind: "install_owner_claim",
+    hubId: "test-hub",
+    installId: "install-1",
+    osUser: "ui",
+    deviceId: "device-durable",
+    action: "owner-login",
+    origin: "https://friday.localhost",
+    channel: "ui-loopback",
+    nonce: "server-issued-nonce",
+    expiresAt: "2026-07-13T00:02:00.000Z",
+    devicePublicKeyHash: hash,
+  };
+}
+
+/**
+ * In-memory DeviceKeyStore that persists the record through `structuredClone` — the
+ * SAME algorithm IndexedDB applies on put/get. This faithfully reproduces IndexedDB
+ * persistence of a non-extractable CryptoKey (double-clone: once on save, once on
+ * load, exactly as a real write-then-read round-trip does).
+ */
+function createStructuredCloneStore(): DeviceKeyStore & {
+  peek(): DurableDeviceKeyRecord | null;
+  saveCalls(): number;
+} {
+  let slot: DurableDeviceKeyRecord | null = null;
+  let saves = 0;
+  return {
+    async load() {
+      return slot ? structuredClone(slot) : null;
+    },
+    async save(record) {
+      saves += 1;
+      slot = structuredClone(record); // IndexedDB clones on write
+    },
+    peek() {
+      return slot ? structuredClone(slot) : null;
+    },
+    saveCalls() {
+      return saves;
+    },
+  };
+}
+
+describe("CR-1 durable browser device key (IndexedDB structured-clone persistence)", () => {
+  it("PROOF (crux): structuredClone of a non-extractable CryptoKey preserves extractable=false and can still sign", async () => {
+    const { subtle } = globalThis.crypto;
+    const keyPair = (await subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign", "verify"],
+    )) as CryptoKeyPair;
+    expect(keyPair.privateKey.extractable).toBe(false);
+
+    // The exact operation IndexedDB performs when persisting the key object.
+    const cloned = structuredClone({ publicKey: keyPair.publicKey, privateKey: keyPair.privateKey });
+    expect(cloned.privateKey.extractable).toBe(false);
+
+    const bytes = new TextEncoder().encode("possession proof");
+    const sig = await subtle.sign({ name: "ECDSA", hash: "SHA-256" }, cloned.privateKey, bytes);
+    const ok = await subtle.verify({ name: "ECDSA", hash: "SHA-256" }, cloned.publicKey, sig, bytes);
+    expect(ok).toBe(true);
+
+    // And the cloned private key still cannot be exported (raw bytes never exposed).
+    await expect(subtle.exportKey("pkcs8", cloned.privateKey)).rejects.toBeInstanceOf(Error);
+  });
+
+  it("survives a reload: a fresh provider over the SAME store recovers the SAME key (hash + deviceId) and still signs", async () => {
+    const store = createStructuredCloneStore();
+
+    // Session 1: generate + persist.
+    const provider1 = createWebCryptoDeviceKeyProvider(store);
+    const first = await provider1.getOrCreateDeviceKey();
+    expect(store.saveCalls()).toBe(1);
+    expect(first.devicePublicKeyHash).toMatch(/^[0-9a-f]{64}$/);
+
+    // Session 2 (simulated reload): a BRAND-NEW provider instance reads the persisted
+    // key back — same public key hash AND same stable deviceId, no new key minted.
+    const provider2 = createWebCryptoDeviceKeyProvider(store);
+    const recovered = await provider2.getOrCreateDeviceKey();
+    expect(recovered.devicePublicKeyHash).toBe(first.devicePublicKeyHash);
+    expect(recovered.deviceId).toBe(first.deviceId);
+    expect(recovered.devicePublicKeySpkiBase64).toBe(first.devicePublicKeySpkiBase64);
+    expect(store.saveCalls()).toBe(1); // recovery did NOT persist a new key
+
+    // The recovered key produces a real PoP that the REAL server verifier accepts.
+    const transcript = sampleTranscript(recovered.devicePublicKeyHash);
+    const signature = await provider2.signTranscript(transcript);
+    const verifier = createFridayOwnerClaimPoPVerifier();
+    const result = verifier.verifyPossession({
+      transcript: transcript as unknown as OwnerClaimTranscript,
+      devicePublicKey: { encoding: "spki-der-base64", value: recovered.devicePublicKeySpkiBase64 },
+      signature,
+      nowMs: Date.parse(NOW),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("the persisted (reloaded) private key stays NON-EXTRACTABLE", async () => {
+    const store = createStructuredCloneStore();
+    const provider = createWebCryptoDeviceKeyProvider(store);
+    await provider.getOrCreateDeviceKey();
+
+    const record = store.peek();
+    expect(record).not.toBeNull();
+    expect(record!.keyPair.privateKey.extractable).toBe(false);
+    // Raw private-key bytes can never be exported from the persisted key.
+    await expect(
+      globalThis.crypto.subtle.exportKey("pkcs8", record!.keyPair.privateKey),
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it("in-memory ONLY (no store): a fresh provider mints a DIFFERENT key — recovery is impossible without persistence", async () => {
+    const a = await createWebCryptoDeviceKeyProvider().getOrCreateDeviceKey();
+    const b = await createWebCryptoDeviceKeyProvider().getOrCreateDeviceKey();
+    expect(b.devicePublicKeyHash).not.toBe(a.devicePublicKeyHash);
+    expect(b.deviceId).not.toBe(a.deviceId);
+  });
+
+  it("fails closed when the store SAVE fails (does not silently continue with a non-durable key)", async () => {
+    const failingStore: DeviceKeyStore = {
+      async load() {
+        return null;
+      },
+      async save() {
+        throw new Error("indexedDB quota exceeded");
+      },
+    };
+    const provider = createWebCryptoDeviceKeyProvider(failingStore);
+    await expect(provider.getOrCreateDeviceKey()).rejects.toThrow(/quota exceeded/);
+  });
+});

--- a/test/unit/ui/device-owner-bootstrap.test.ts
+++ b/test/unit/ui/device-owner-bootstrap.test.ts
@@ -1,0 +1,180 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · CR-1 — UI device-key seam ⇄ server proof ───
+//
+// Cross-correctness for the UI device-key wiring. The UI signs a transcript with
+// WebCrypto; the SERVER verifier must accept it. These tests prove:
+//   (A) the UI canonical encoder is BYTE-IDENTICAL to the server encoder,
+//   (B) a WebCrypto (software) signature verifies against the REAL server S2a PoP
+//       verifier (incl. low-S normalization), and
+//   (C) the full UI orchestrator (challenge → claim → device-key login) mints a
+//       real session against the REAL auth service when authority is enabled — and
+//       fails closed when the device-key capability is unavailable.
+//
+// TRUTH LABEL: the WebCrypto keypair is a SOFTWARE dev key; it fabricates no
+// attestation. The enabled branch is reached ONLY via the injectable authority
+// seam (never by flipping the native constant).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { FridaySqliteLayer } from "#state";
+import { createFridayAuthService } from "#api";
+import type { FridayAuthService } from "#api";
+import { createFridayOwnerClaimPoPVerifier } from "../../../src/api/auth/device-attest/index.js";
+import { encodeOwnerClaimTranscript as serverEncode } from "../../../src/api/auth/device-attest/index.js";
+import type { OwnerClaimTranscript } from "../../../src/api/auth/device-attest/index.js";
+import { createTestDb } from "../satellites/_helpers/create-test-db.helper.js";
+import {
+  createWebCryptoDeviceKeyProvider,
+  encodeOwnerClaimTranscript as uiEncode,
+  DeviceKeyUnavailableError,
+  type DeviceClaimTranscript,
+  type DeviceKeyProvider,
+} from "../../../ui/src/lib/auth/device-key.js";
+import { runDeviceOwnerBootstrap } from "../../../ui/src/lib/auth/device-owner-bootstrap.js";
+
+const NOW = "2026-07-13T00:00:00.000Z";
+const LOOPBACK = "127.0.0.1";
+const ORIGIN = "https://friday.localhost";
+const TOKEN_SECRET = "test-secret-key-for-ui-device-bootstrap-01"; // pragma: allowlist secret
+
+function sampleTranscript(hash: string): DeviceClaimTranscript {
+  return {
+    transcriptVersion: "friday-owner-claim-v1",
+    algorithm: "ECDSA_P256_SHA256",
+    kind: "install_owner_claim",
+    hubId: "test-hub",
+    installId: "install-1",
+    osUser: "ui",
+    deviceId: "device-xyz",
+    action: "owner-login",
+    origin: ORIGIN,
+    channel: "ui-loopback",
+    nonce: "login-nonce-1",
+    expiresAt: "2026-07-13T00:02:00.000Z",
+    devicePublicKeyHash: hash,
+  };
+}
+
+describe("CR-1 UI device-key seam ⇄ server verifier", () => {
+  // ── (A) encoder byte-match ──
+
+  it("the UI canonical encoder is byte-identical to the server encoder", () => {
+    const t = sampleTranscript("a".repeat(64));
+    const ui = Buffer.from(uiEncode(t));
+    const server = serverEncode(t as unknown as OwnerClaimTranscript);
+    expect(ui.equals(server)).toBe(true);
+  });
+
+  // ── (B) WebCrypto signature verifies against the real server PoP verifier ──
+
+  it("a WebCrypto software signature verifies against the real S2a PoP verifier", async () => {
+    const provider = createWebCryptoDeviceKeyProvider();
+    expect(provider.isAvailable()).toBe(true);
+    const key = await provider.getOrCreateDeviceKey();
+
+    const transcript = sampleTranscript(key.devicePublicKeyHash);
+    const signature = await provider.signTranscript(transcript);
+
+    const verifier = createFridayOwnerClaimPoPVerifier();
+    const result = verifier.verifyPossession({
+      transcript: transcript as unknown as OwnerClaimTranscript,
+      devicePublicKey: { encoding: "spki-der-base64", value: key.devicePublicKeySpkiBase64 },
+      signature,
+      nowMs: Date.parse(NOW),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("signTranscript fails closed before a key has been created", async () => {
+    const provider = createWebCryptoDeviceKeyProvider();
+    await expect(
+      provider.signTranscript(sampleTranscript("b".repeat(64))),
+    ).rejects.toBeInstanceOf(DeviceKeyUnavailableError);
+  });
+
+  // ── (C) full orchestrator end-to-end against the REAL auth service ──
+
+  describe("full device-owner bootstrap against the real auth service", () => {
+    let db: FridaySqliteLayer;
+
+    function makeService(authorityEnabled: boolean): FridayAuthService {
+      let n = 0;
+      return createFridayAuthService({
+        db,
+        idGenerator: () => `id-${String(++n).padStart(4, "0")}`,
+        nowIso: () => NOW,
+        tokenSecret: TOKEN_SECRET,
+        accessTokenTtlSec: 900,
+        refreshTokenTtlSec: 604_800,
+        hubId: "test-hub",
+        bootstrapNonceTtlSec: 300,
+        deviceOwnerAuthorityEnabled: () => authorityEnabled,
+      });
+    }
+
+    function apiFor(svc: FridayAuthService) {
+      return {
+        issueChallenge: (input: { installId: string; osUser: string; origin: string }) =>
+          Promise.resolve(svc.issueBootstrapChallenge(input, LOOPBACK) as never),
+        claim: (input: Parameters<FridayAuthService["claimOwnerWithDeviceKey"]>[0]) =>
+          Promise.resolve(svc.claimOwnerWithDeviceKey(input, LOOPBACK) as never),
+        login: (input: Parameters<FridayAuthService["login"]>[0]) =>
+          Promise.resolve(svc.login(input, LOOPBACK) as never),
+      };
+    }
+
+    beforeEach(() => {
+      db = createTestDb();
+      db.withWriteTransaction((conn) => {
+        conn.prepare("UPDATE users SET password_hash = NULL WHERE id = 'test-user'").run();
+      });
+    });
+
+    afterEach(() => {
+      db.close();
+    });
+
+    it("mints a real session end-to-end when device authority is enabled", async () => {
+      const provider = createWebCryptoDeviceKeyProvider();
+      const svc = makeService(true);
+      const response = await runDeviceOwnerBootstrap(provider, apiFor(svc), {
+        origin: ORIGIN,
+        installId: "install-1",
+        osUser: "ui",
+        nowMs: () => Date.parse(NOW),
+        loginTranscriptTtlMs: 120_000,
+      });
+      expect(response.accessToken.length).toBeGreaterThan(0);
+      expect(response.refreshToken.length).toBeGreaterThan(0);
+      expect(response.user.id).toBe("test-user");
+    });
+
+    it("fails closed at the login leg when device authority is disabled", async () => {
+      const provider = createWebCryptoDeviceKeyProvider();
+      const svc = makeService(false); // real-build honest state
+      await expect(
+        runDeviceOwnerBootstrap(provider, apiFor(svc), {
+          origin: ORIGIN,
+          installId: "install-1",
+          osUser: "ui",
+          nowMs: () => Date.parse(NOW),
+          loginTranscriptTtlMs: 120_000,
+        }),
+      ).rejects.toThrow(/DEVICE_AUTHORITY_DISABLED|disabled/i);
+    });
+
+    it("orchestrator fails closed when the device-key capability is unavailable", async () => {
+      const unavailable: DeviceKeyProvider = {
+        isAvailable: () => false,
+        getOrCreateDeviceKey: () => Promise.reject(new DeviceKeyUnavailableError()),
+        signTranscript: () => Promise.reject(new DeviceKeyUnavailableError()),
+      };
+      const svc = makeService(true);
+      await expect(
+        runDeviceOwnerBootstrap(unavailable, apiFor(svc), {
+          origin: ORIGIN,
+          installId: "install-1",
+          osUser: "ui",
+        }),
+      ).rejects.toBeInstanceOf(DeviceKeyUnavailableError);
+    });
+  });
+});

--- a/test/unit/ui/device-owner-bootstrap.test.ts
+++ b/test/unit/ui/device-owner-bootstrap.test.ts
@@ -21,6 +21,7 @@ import { createFridayOwnerClaimPoPVerifier } from "../../../src/api/auth/device-
 import { encodeOwnerClaimTranscript as serverEncode } from "../../../src/api/auth/device-attest/index.js";
 import type { OwnerClaimTranscript } from "../../../src/api/auth/device-attest/index.js";
 import { createTestDb } from "../satellites/_helpers/create-test-db.helper.js";
+import { createTestNativeOwnerResolver } from "../../adversarial/_native-owner-capability.helpers.js";
 import {
   createWebCryptoDeviceKeyProvider,
   encodeOwnerClaimTranscript as uiEncode,
@@ -106,7 +107,15 @@ describe("CR-1 UI device-key seam ⇄ server verifier", () => {
         refreshTokenTtlSec: 604_800,
         hubId: "test-hub",
         bootstrapNonceTtlSec: 300,
-        deviceOwnerAuthorityEnabled: () => authorityEnabled,
+        // Option C: the enabled branch injects a resolver that runs the REAL
+        // capability mint over injected native-evidence doubles (never flips the
+        // native constant, never forges). Disabled → no resolver → fails closed.
+        ...(authorityEnabled
+          ? {
+            resolveNativeOwnerClaimContext: createTestNativeOwnerResolver(),
+            nativeOwnerClaimSurfaceAvailable: () => true,
+          }
+          : {}),
       });
     }
 
@@ -147,16 +156,19 @@ describe("CR-1 UI device-key seam ⇄ server verifier", () => {
       expect(response.user.id).toBe("test-user");
     });
 
-    it("fails closed at the login leg when device authority is disabled", async () => {
+    it("fails closed when no native-owner capability is present (real-build honest state)", async () => {
       const provider = createWebCryptoDeviceKeyProvider();
-      const svc = makeService(false); // real-build honest state
+      const svc = makeService(false); // real-build honest state — no resolver
+      // Option C: without a per-claim native capability the CLAIM leg itself fails
+      // closed (the fresh owner slot can never be seized by a software key alone) —
+      // a strictly stronger guarantee than the prior login-leg-only gate.
       await expect(
         runDeviceOwnerBootstrap(provider, apiFor(svc), {
           origin: ORIGIN,
           installId: "install-1",
           osUser: "ui",
         }),
-      ).rejects.toThrow(/DEVICE_AUTHORITY_DISABLED|disabled/i);
+      ).rejects.toThrow(/DEVICE_AUTHORITY|native-owner capability|no state change/i);
     });
 
     it("orchestrator fails closed when the device-key capability is unavailable", async () => {

--- a/test/unit/ui/device-owner-bootstrap.test.ts
+++ b/test/unit/ui/device-owner-bootstrap.test.ts
@@ -116,6 +116,8 @@ describe("CR-1 UI device-key seam ⇄ server verifier", () => {
           Promise.resolve(svc.issueBootstrapChallenge(input, LOOPBACK) as never),
         claim: (input: Parameters<FridayAuthService["claimOwnerWithDeviceKey"]>[0]) =>
           Promise.resolve(svc.claimOwnerWithDeviceKey(input, LOOPBACK) as never),
+        issueLoginChallenge: (input: Parameters<FridayAuthService["issueLoginChallenge"]>[0]) =>
+          Promise.resolve(svc.issueLoginChallenge(input, LOOPBACK) as never),
         login: (input: Parameters<FridayAuthService["login"]>[0]) =>
           Promise.resolve(svc.login(input, LOOPBACK) as never),
       };
@@ -139,8 +141,6 @@ describe("CR-1 UI device-key seam ⇄ server verifier", () => {
         origin: ORIGIN,
         installId: "install-1",
         osUser: "ui",
-        nowMs: () => Date.parse(NOW),
-        loginTranscriptTtlMs: 120_000,
       });
       expect(response.accessToken.length).toBeGreaterThan(0);
       expect(response.refreshToken.length).toBeGreaterThan(0);
@@ -155,8 +155,6 @@ describe("CR-1 UI device-key seam ⇄ server verifier", () => {
           origin: ORIGIN,
           installId: "install-1",
           osUser: "ui",
-          nowMs: () => Date.parse(NOW),
-          loginTranscriptTtlMs: 120_000,
         }),
       ).rejects.toThrow(/DEVICE_AUTHORITY_DISABLED|disabled/i);
     });

--- a/test/unit/ui/first-run-device-claim-gate.test.ts
+++ b/test/unit/ui/first-run-device-claim-gate.test.ts
@@ -1,0 +1,53 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · CR-1 — first-run device-claim gate wiring ───
+//
+// Source-level wiring assertions (mirrors local-bootstrap-auth-gate.test.ts style):
+// the router routes first-run to the DEVICE-CLAIM gate ONLY when the backend
+// reports device-owner authority is enabled (deviceClaimAvailable), else keeps the
+// passphrase gate; the gate is HONEST (real device-key seam, fail-closed, no
+// silent passphrase fallback as authoritative, no browser-storage token seeding).
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("CR-1 first-run device-claim gate wiring", () => {
+  it("router routes first-run to the device-claim gate ONLY when deviceClaimAvailable, else passphrase", () => {
+    const src = readFileSync("ui/src/router.tsx", "utf8");
+    // Both gates are wired.
+    expect(src).toContain("FirstRunDeviceClaimGate");
+    expect(src).toContain("FirstRunPassphraseGate");
+    // Device gate is gated on the server-derived deviceClaimAvailable flag.
+    expect(src).toContain("bootstrapStatusQuery.data.deviceClaimAvailable === true");
+    // The passphrase gate remains the fallback branch (not removed).
+    expect(src).toContain("bootstrapStatusQuery.data?.bootstrapRequired");
+  });
+
+  it("device-claim gate uses the real device-key seam, fails closed, and never seeds tokens", () => {
+    const src = readFileSync("ui/src/routes/first-run-device-claim-gate.tsx", "utf8");
+    // Runs the device-owner login (challenge → claim → device-key login) via auth.
+    expect(src).toContain("deviceOwnerLogin");
+    // Fail-closed on missing capability — no fabricated attestation / passphrase.
+    expect(src).toContain("deviceKeyAvailable");
+    expect(src).not.toContain("localStorage.setItem");
+    expect(src).not.toContain("postBootstrapLocalPassphrase");
+    // Re-evaluates bootstrap status after success (same signal as the passphrase gate).
+    expect(src).toContain('queryKey: ["auth", "bootstrap", "status"]');
+  });
+
+  it("auth client exposes the three device-claim legs", () => {
+    const src = readFileSync("ui/src/lib/api/auth.ts", "utf8");
+    expect(src).toContain("postBootstrapChallenge");
+    expect(src).toContain("postDeviceClaim");
+    expect(src).toContain("deviceKeyLogin");
+  });
+
+  it("device-key seam is a real WebCrypto provider, not a mock, and fails closed", () => {
+    const src = readFileSync("ui/src/lib/auth/device-key.ts", "utf8");
+    // Real crypto: WebCrypto keygen + ECDSA P-256 + low-S normalization.
+    expect(src).toContain("globalThis.crypto.subtle.generateKey");
+    expect(src).toContain("ECDSA");
+    expect(src).toContain("normalizeLowS");
+    // Fail-closed capability guard (no fabricated attestation).
+    expect(src).toContain("DeviceKeyUnavailableError");
+    expect(src).toContain("isAvailable");
+  });
+});

--- a/test/unit/ui/providers-validate-before-persist.test.ts
+++ b/test/unit/ui/providers-validate-before-persist.test.ts
@@ -1,11 +1,18 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
+  ProviderMutationDeclinedError,
   saveProviderWithValidation,
+  type ProviderPlanConfirmer,
   type ProviderValidateSaveClient,
   type ProviderSaveResult,
 } from "@/lib/providers";
-import type { CreateProviderInput } from "@/lib/api/providers";
+import type {
+  CreateProviderInput,
+  FridayProviderMutationApproval,
+  FridayProviderMutationPlan,
+  PlanProviderMutationInput,
+} from "@/lib/api/providers";
 import type { FridayProviderProfile } from "@/lib/api/types";
 
 /**
@@ -14,8 +21,13 @@ import type { FridayProviderProfile } from "@/lib/api/types";
  * (providersApi.create/update with validateOnSave:true), NOT the retired
  * POST /v1/providers/detect route (fail-closed 503 in the default runtime).
  *
- * These tests drive the shared client helper (the re-point target) and also
- * assert the wizard no longer depends on the detect route. No real key / call.
+ * CORE-RUNNABLE-001 / CORE-A CR-2 — in a release profile the canonical
+ * mutating-action gate REQUIRES a server-derived plan digest plus a signed
+ * canonical approval (absent ⇒ 403 PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED).
+ * The helper must therefore run the full plan → owner-confirm → mint → replay
+ * handshake, and must NOT mutate anything when the owner declines.
+ *
+ * These tests drive the shared client helper. No real key / call.
  */
 
 function fakeProvider(id: string): FridayProviderProfile {
@@ -37,8 +49,28 @@ function makeDraft(): CreateProviderInput {
   };
 }
 
+function fakePlan(overrides?: Partial<FridayProviderMutationPlan>): FridayProviderMutationPlan {
+  return {
+    planDigest: "plan-digest-1",
+    actionDigest: "action-digest-1",
+    action: "providers.create",
+    surface: "providers",
+    humanReadableSummary: ["Add provider openai", "Base URL https://api.openai.com"],
+    approvalRequired: true,
+    createdAt: "2026-07-19T00:00:00.000Z",
+    expiresAt: "2026-07-19T00:05:00.000Z",
+    ...overrides,
+  };
+}
+
+/** Owner ALWAYS confirms — used by the pre-existing behavioural assertions. */
+const alwaysConfirm: ProviderPlanConfirmer = async () => true;
+/** Owner reviews and DECLINES. */
+const alwaysDecline: ProviderPlanConfirmer = async () => false;
+
 function makeClient(overrides?: {
   create?: (input: CreateProviderInput) => Promise<ProviderSaveResult>;
+  plan?: FridayProviderMutationPlan;
 }) {
   const create = vi.fn(
     overrides?.create ??
@@ -53,15 +85,29 @@ function makeClient(overrides?: {
       validation: { status: "ok" },
     }),
   );
-  const client: ProviderValidateSaveClient = { create, update };
-  return { client, create, update };
+  const planMutation = vi.fn(
+    async (_input: PlanProviderMutationInput): Promise<FridayProviderMutationPlan> =>
+      overrides?.plan ?? fakePlan(),
+  );
+  const confirmMutation = vi.fn(
+    async (planDigest: string): Promise<FridayProviderMutationApproval> => ({
+      planDigest,
+      actionDigest: "action-digest-1",
+      action: "providers.create",
+      confirmedAt: "2026-07-19T00:01:00.000Z",
+      expiresAt: "2026-07-19T00:06:00.000Z",
+      canonicalApproval: { signature: "signed-by-server" },
+    }),
+  );
+  const client: ProviderValidateSaveClient = { planMutation, confirmMutation, create, update };
+  return { client, create, update, planMutation, confirmMutation };
 }
 
 describe("onboarding validate-before-persist (Task 1 re-point)", () => {
   it("hits the live create route with validateOnSave:true when no provider of that kind exists", async () => {
     const { client, create, update } = makeClient();
 
-    await saveProviderWithValidation(client, undefined, makeDraft());
+    await saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm);
 
     expect(create).toHaveBeenCalledTimes(1);
     expect(update).not.toHaveBeenCalled();
@@ -73,7 +119,7 @@ describe("onboarding validate-before-persist (Task 1 re-point)", () => {
   it("updates the existing same-kind provider instead of creating a duplicate", async () => {
     const { client, create, update } = makeClient();
 
-    await saveProviderWithValidation(client, { id: "existing-openai" }, makeDraft());
+    await saveProviderWithValidation(client, { id: "existing-openai" }, makeDraft(), alwaysConfirm);
 
     expect(update).toHaveBeenCalledTimes(1);
     expect(create).not.toHaveBeenCalled();
@@ -87,11 +133,11 @@ describe("onboarding validate-before-persist (Task 1 re-point)", () => {
     const draft = makeDraft();
 
     // First submit: nothing exists yet → create.
-    await saveProviderWithValidation(client, undefined, draft);
+    await saveProviderWithValidation(client, undefined, draft, alwaysConfirm);
     // Replay of the same submit: the provider now exists (same kind) → update,
     // NOT a second create. So the credential is not persisted twice, and the
     // re-check still runs (validateOnSave stays true).
-    await saveProviderWithValidation(client, { id: "created-1" }, draft);
+    await saveProviderWithValidation(client, { id: "created-1" }, draft, alwaysConfirm);
 
     expect(create).toHaveBeenCalledTimes(1); // exactly one persist, no duplicate
     expect(update).toHaveBeenCalledTimes(1);
@@ -109,7 +155,7 @@ describe("onboarding validate-before-persist (Task 1 re-point)", () => {
     });
 
     await expect(
-      saveProviderWithValidation(client, undefined, makeDraft()),
+      saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm),
     ).rejects.toMatchObject({ code: "PROVIDER_AUTH_INVALID" });
   });
 
@@ -122,5 +168,94 @@ describe("onboarding validate-before-persist (Task 1 re-point)", () => {
     expect(setupSource).toContain("saveProviderWithValidation");
     // …with validate-before-persist explicitly requested.
     expect(setupSource).toContain("validateOnSave: true");
+  });
+});
+
+describe("CORE-A CR-2 — provider owner-confirm handshake (release canonical gate)", () => {
+  it("runs plan → confirm → mutate and replays the SERVER digest + approval on the mutation", async () => {
+    const { client, create, planMutation, confirmMutation } = makeClient();
+
+    await saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm);
+
+    // 1) the server derived the plan from the EXACT body the mutation will send
+    expect(planMutation).toHaveBeenCalledTimes(1);
+    const planReq = planMutation.mock.calls[0][0];
+    expect(planReq.action).toBe("providers.create");
+    expect(planReq.providerId).toBeUndefined();
+    expect(planReq.params).toMatchObject({ kind: "openai", validateOnSave: true });
+
+    // 2) the owner's confirmation was bound to THAT plan digest
+    expect(confirmMutation).toHaveBeenCalledWith("plan-digest-1");
+
+    // 3) the mutation replays the server-minted controls so the gate can
+    //    recompute the action digest server-side (absent ⇒ 403 fail-closed)
+    const body = create.mock.calls[0][0];
+    expect(body.planDigest).toBe("plan-digest-1");
+    expect(body.canonicalApproval).toEqual({ signature: "signed-by-server" });
+  });
+
+  it("update path plans against the existing provider id and replays the approval", async () => {
+    const { client, update, planMutation } = makeClient({
+      plan: fakePlan({ action: "providers.update" }),
+    });
+
+    await saveProviderWithValidation(client, { id: "existing-openai" }, makeDraft(), alwaysConfirm);
+
+    const planReq = planMutation.mock.calls[0][0];
+    expect(planReq.action).toBe("providers.update");
+    expect(planReq.providerId).toBe("existing-openai");
+    // an update patch carries no immutable `kind`
+    expect(planReq.params).not.toHaveProperty("kind");
+
+    const [, patch] = update.mock.calls[0];
+    expect(patch.planDigest).toBe("plan-digest-1");
+    expect(patch.canonicalApproval).toEqual({ signature: "signed-by-server" });
+  });
+
+  it("NEGATIVE: owner declines → nothing is minted and nothing is mutated", async () => {
+    const { client, create, update, planMutation, confirmMutation } = makeClient();
+
+    await expect(
+      saveProviderWithValidation(client, undefined, makeDraft(), alwaysDecline),
+    ).rejects.toBeInstanceOf(ProviderMutationDeclinedError);
+
+    expect(planMutation).toHaveBeenCalledTimes(1); // the owner did see a plan
+    expect(confirmMutation).not.toHaveBeenCalled(); // …but no approval was minted
+    expect(create).not.toHaveBeenCalled(); // …and nothing was persisted
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("NEGATIVE: confirmation is never defaulted — a non-true resolution aborts", async () => {
+    const { client, create, confirmMutation } = makeClient();
+    // A confirmer that resolves a falsy non-boolean must NOT be treated as consent.
+    const ambiguous = (async () => undefined) as unknown as ProviderPlanConfirmer;
+
+    await expect(
+      saveProviderWithValidation(client, undefined, makeDraft(), ambiguous),
+    ).rejects.toBeInstanceOf(ProviderMutationDeclinedError);
+
+    expect(confirmMutation).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("the client never derives the digest itself — it only replays what the server returned", async () => {
+    const { client, create } = makeClient({
+      plan: fakePlan({ planDigest: "server-only-digest" }),
+    });
+
+    await saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm);
+
+    // the replayed digest is exactly the server's, never recomputed client-side
+    expect(create.mock.calls[0][0].planDigest).toBe("server-only-digest");
+  });
+
+  it("the setup wizard wires the owner-confirm handshake (not a blind save)", () => {
+    const setupSource = readFileSync("ui/src/routes/setup-page.tsx", "utf8");
+
+    // the owner must be shown the server-derived summary and confirm explicitly
+    expect(setupSource).toContain("humanReadableSummary");
+    expect(setupSource).toContain("pendingProviderPlan");
+    // a decline is handled as a deliberate cancel, not a validation failure
+    expect(setupSource).toContain("ProviderMutationDeclinedError");
   });
 });

--- a/test/unit/ui/providers-validate-before-persist.test.ts
+++ b/test/unit/ui/providers-validate-before-persist.test.ts
@@ -2,8 +2,11 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import {
   ProviderMutationDeclinedError,
+  ProviderRoutingAfterSaveError,
+  saveProviderWithRouting,
   saveProviderWithValidation,
   type ProviderPlanConfirmer,
+  type ProviderRoutingSaveClient,
   type ProviderValidateSaveClient,
   type ProviderSaveResult,
 } from "@/lib/providers";
@@ -12,27 +15,22 @@ import type {
   FridayProviderMutationApproval,
   FridayProviderMutationPlan,
   PlanProviderMutationInput,
+  SetRoutingInput,
 } from "@/lib/api/providers";
-import type { FridayProviderProfile } from "@/lib/api/types";
+import type { ProviderApprovalAuthor, ProviderApprovalDeviceProof } from "@/lib/auth/device-key";
+import type { FridayModelRoutingConfig, FridayProviderProfile } from "@/lib/api/types";
 
 /**
- * Task 1 — the onboarding setup wizard's validate/save action must go through
- * the SAME live create validate-before-persist path the Settings page uses
- * (providersApi.create/update with validateOnSave:true), NOT the retired
- * POST /v1/providers/detect route (fail-closed 503 in the default runtime).
- *
- * CORE-RUNNABLE-001 / CORE-A CR-2 — in a release profile the canonical
- * mutating-action gate REQUIRES a server-derived plan digest plus a signed
- * canonical approval (absent ⇒ 403 PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED).
- * The helper must therefore run the full plan → owner-confirm → mint → replay
- * handshake, and must NOT mutate anything when the owner declines.
- *
- * These tests drive the shared client helper. No real key / call.
+ * The onboarding setup wizard's validate/save action goes through the SAME live
+ * create validate-before-persist path the Settings page uses, and — in a release
+ * profile — through the DEVICE-AUTHORED owner-confirm handshake (SEC-APPROVAL-
+ * AUTHORITY-001 / CORE-A CR-2): plan → owner-review → DEVICE-sign → confirm →
+ * replay. The Hub holds no signing key. These tests drive the shared client
+ * helpers with mocks. No real key / call / device.
  */
 
-function fakeProvider(id: string): FridayProviderProfile {
-  // The helper never inspects the provider body, so a minimal stub is fine.
-  return { id } as unknown as FridayProviderProfile;
+function fakeProvider(id: string, name = id): FridayProviderProfile {
+  return { id, name } as unknown as FridayProviderProfile;
 }
 
 function makeDraft(): CreateProviderInput {
@@ -63,19 +61,38 @@ function fakePlan(overrides?: Partial<FridayProviderMutationPlan>): FridayProvid
   };
 }
 
-/** Owner ALWAYS confirms — used by the pre-existing behavioural assertions. */
+/** A device proof stub — the client helpers pass it through opaquely. */
+function fakeDeviceProof(actionDigest: string): ProviderApprovalDeviceProof {
+  return {
+    transcript: {
+      transcriptVersion: "friday-provider-approval-v1",
+      algorithm: "ECDSA_P256_SHA256",
+      kind: "provider_mutation_approval",
+      approvalId: "approval-stub",
+      actionDigest,
+      decidedByPrincipalId: "device-owner:hash",
+      expiresAt: "2026-07-19T00:09:00.000Z",
+      devicePublicKeyHash: "hash",
+    },
+    devicePublicKey: { encoding: "spki-der-base64", value: "spki" },
+    signature: { encoding: "ieee-p1363-base64", value: "sig" },
+  };
+}
+
+/** Owner ALWAYS confirms. */
 const alwaysConfirm: ProviderPlanConfirmer = async () => true;
 /** Owner reviews and DECLINES. */
 const alwaysDecline: ProviderPlanConfirmer = async () => false;
 
 function makeClient(overrides?: {
   create?: (input: CreateProviderInput) => Promise<ProviderSaveResult>;
+  setRouting?: (input: SetRoutingInput) => Promise<FridayModelRoutingConfig>;
   plan?: FridayProviderMutationPlan;
 }) {
   const create = vi.fn(
     overrides?.create ??
       (async (_input: CreateProviderInput): Promise<ProviderSaveResult> => ({
-        provider: fakeProvider("created-1"),
+        provider: fakeProvider("created-1", "OpenAI Provider"),
         validation: { status: "ok" },
       })),
   );
@@ -86,41 +103,59 @@ function makeClient(overrides?: {
     }),
   );
   const planMutation = vi.fn(
-    async (_input: PlanProviderMutationInput): Promise<FridayProviderMutationPlan> =>
-      overrides?.plan ?? fakePlan(),
+    async (input: PlanProviderMutationInput): Promise<FridayProviderMutationPlan> =>
+      overrides?.plan
+        ?? fakePlan(input.action === "providers.routing.set"
+          ? { action: "providers.routing.set", planDigest: "routing-digest-1", actionDigest: "routing-action-1" }
+          : {}),
   );
+  // The device-authored approval is the SECOND argument now — the Hub verifies it.
   const confirmMutation = vi.fn(
-    async (planDigest: string): Promise<FridayProviderMutationApproval> => ({
+    async (planDigest: string, deviceApproval: ProviderApprovalDeviceProof): Promise<FridayProviderMutationApproval> => ({
       planDigest,
-      actionDigest: "action-digest-1",
+      actionDigest: deviceApproval.transcript.actionDigest,
       action: "providers.create",
       confirmedAt: "2026-07-19T00:01:00.000Z",
       expiresAt: "2026-07-19T00:06:00.000Z",
-      canonicalApproval: { signature: "signed-by-server" },
+      canonicalApproval: { issuer: "friday_device_owner", deviceProof: deviceApproval },
     }),
   );
-  const client: ProviderValidateSaveClient = { planMutation, confirmMutation, create, update };
-  return { client, create, update, planMutation, confirmMutation };
+  const setRouting = vi.fn(
+    overrides?.setRouting ??
+      (async (input: SetRoutingInput): Promise<FridayModelRoutingConfig> => ({
+        defaultProviderId: input.defaultProviderId,
+        fallbackProviderIds: input.fallbackProviderIds,
+      } as FridayModelRoutingConfig)),
+  );
+  const client: ProviderRoutingSaveClient = { planMutation, confirmMutation, create, update, setRouting };
+  return { client, create, update, planMutation, confirmMutation, setRouting };
 }
 
-describe("onboarding validate-before-persist (Task 1 re-point)", () => {
+/** A device-approval author stub that records the digests it was asked to sign. */
+function makeAuthor(): ProviderApprovalAuthor & { calls: string[] } {
+  const calls: string[] = [];
+  const author = (async ({ actionDigest }: { actionDigest: string }) => {
+    calls.push(actionDigest);
+    return fakeDeviceProof(actionDigest);
+  }) as ProviderApprovalAuthor & { calls: string[] };
+  author.calls = calls;
+  return author;
+}
+
+describe("onboarding validate-before-persist", () => {
   it("hits the live create route with validateOnSave:true when no provider of that kind exists", async () => {
     const { client, create, update } = makeClient();
-
-    await saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm);
-
+    await saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm, makeAuthor());
     expect(create).toHaveBeenCalledTimes(1);
     expect(update).not.toHaveBeenCalled();
     const arg = create.mock.calls[0][0];
-    expect(arg.validateOnSave).toBe(true); // validate-before-persist, not blind save
-    expect(arg.kind).toBe("openai"); // saves the selected kind
+    expect(arg.validateOnSave).toBe(true);
+    expect(arg.kind).toBe("openai");
   });
 
   it("updates the existing same-kind provider instead of creating a duplicate", async () => {
     const { client, create, update } = makeClient();
-
-    await saveProviderWithValidation(client, { id: "existing-openai" }, makeDraft(), alwaysConfirm);
-
+    await saveProviderWithValidation(client, { id: "existing-openai" }, makeDraft(), alwaysConfirm, makeAuthor());
     expect(update).toHaveBeenCalledTimes(1);
     expect(create).not.toHaveBeenCalled();
     const [id, patch] = update.mock.calls[0];
@@ -128,134 +163,184 @@ describe("onboarding validate-before-persist (Task 1 re-point)", () => {
     expect(patch.validateOnSave).toBe(true);
   });
 
-  it("replay: a replayed save is idempotent — create once, then update (no double-persist, no validate bypass)", async () => {
-    const { client, create, update } = makeClient();
-    const draft = makeDraft();
-
-    // First submit: nothing exists yet → create.
-    await saveProviderWithValidation(client, undefined, draft, alwaysConfirm);
-    // Replay of the same submit: the provider now exists (same kind) → update,
-    // NOT a second create. So the credential is not persisted twice, and the
-    // re-check still runs (validateOnSave stays true).
-    await saveProviderWithValidation(client, { id: "created-1" }, draft, alwaysConfirm);
-
-    expect(create).toHaveBeenCalledTimes(1); // exactly one persist, no duplicate
-    expect(update).toHaveBeenCalledTimes(1);
-    expect(create.mock.calls[0][0].validateOnSave).toBe(true);
-    expect(update.mock.calls[0][1].validateOnSave).toBe(true); // no bypass on replay
-  });
-
   it("propagates a validate-before-persist rejection (invalid key is surfaced, not swallowed)", async () => {
     const { client } = makeClient({
       create: async () => {
-        throw Object.assign(new Error("Authentication failed"), {
-          code: "PROVIDER_AUTH_INVALID",
-        });
+        throw Object.assign(new Error("Authentication failed"), { code: "PROVIDER_AUTH_INVALID" });
       },
     });
-
     await expect(
-      saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm),
+      saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm, makeAuthor()),
     ).rejects.toMatchObject({ code: "PROVIDER_AUTH_INVALID" });
   });
 
   it("the setup wizard no longer depends on the retired /v1/providers/detect route", () => {
     const setupSource = readFileSync("ui/src/routes/setup-page.tsx", "utf8");
-
-    // The validate/save action must not call the retired detect endpoint.
     expect(setupSource).not.toContain("setupApi.detectProvider");
-    // It must route through the shared validate-before-persist helper…
-    expect(setupSource).toContain("saveProviderWithValidation");
-    // …with validate-before-persist explicitly requested.
-    expect(setupSource).toContain("validateOnSave: true");
+    // It routes through the shared confirmed-save + confirmed-routing helper.
+    expect(setupSource).toContain("saveProviderWithRouting");
   });
 });
 
-describe("CORE-A CR-2 — provider owner-confirm handshake (release canonical gate)", () => {
-  it("runs plan → confirm → mutate and replays the SERVER digest + approval on the mutation", async () => {
+describe("CORE-A CR-2 — DEVICE-authored owner-confirm handshake", () => {
+  it("runs plan → DEVICE-sign → confirm → mutate and replays the SERVER digest + device approval", async () => {
     const { client, create, planMutation, confirmMutation } = makeClient();
+    const author = makeAuthor();
 
-    await saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm);
+    await saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm, author);
 
-    // 1) the server derived the plan from the EXACT body the mutation will send
-    expect(planMutation).toHaveBeenCalledTimes(1);
+    // 1) plan derived from the EXACT mutation body
     const planReq = planMutation.mock.calls[0][0];
     expect(planReq.action).toBe("providers.create");
-    expect(planReq.providerId).toBeUndefined();
     expect(planReq.params).toMatchObject({ kind: "openai", validateOnSave: true });
 
-    // 2) the owner's confirmation was bound to THAT plan digest
-    expect(confirmMutation).toHaveBeenCalledWith("plan-digest-1");
+    // 2) the DEVICE signed over the SERVER-computed action digest…
+    expect(author.calls).toEqual(["action-digest-1"]);
+    // 3) …and confirm carried that device proof (2-arg confirm; Hub verifies it)
+    expect(confirmMutation).toHaveBeenCalledTimes(1);
+    const [confirmDigest, confirmProof] = confirmMutation.mock.calls[0];
+    expect(confirmDigest).toBe("plan-digest-1");
+    expect((confirmProof as ProviderApprovalDeviceProof).transcript.actionDigest).toBe("action-digest-1");
 
-    // 3) the mutation replays the server-minted controls so the gate can
-    //    recompute the action digest server-side (absent ⇒ 403 fail-closed)
+    // 4) the mutation replays the device-authored controls
     const body = create.mock.calls[0][0];
     expect(body.planDigest).toBe("plan-digest-1");
-    expect(body.canonicalApproval).toEqual({ signature: "signed-by-server" });
+    expect((body.canonicalApproval as { issuer?: string }).issuer).toBe("friday_device_owner");
   });
 
-  it("update path plans against the existing provider id and replays the approval", async () => {
-    const { client, update, planMutation } = makeClient({
-      plan: fakePlan({ action: "providers.update" }),
-    });
-
-    await saveProviderWithValidation(client, { id: "existing-openai" }, makeDraft(), alwaysConfirm);
-
-    const planReq = planMutation.mock.calls[0][0];
-    expect(planReq.action).toBe("providers.update");
-    expect(planReq.providerId).toBe("existing-openai");
-    // an update patch carries no immutable `kind`
-    expect(planReq.params).not.toHaveProperty("kind");
-
-    const [, patch] = update.mock.calls[0];
-    expect(patch.planDigest).toBe("plan-digest-1");
-    expect(patch.canonicalApproval).toEqual({ signature: "signed-by-server" });
-  });
-
-  it("NEGATIVE: owner declines → nothing is minted and nothing is mutated", async () => {
+  it("NEGATIVE: owner declines → no device approval authored, nothing mutated", async () => {
     const { client, create, update, planMutation, confirmMutation } = makeClient();
+    const author = makeAuthor();
 
     await expect(
-      saveProviderWithValidation(client, undefined, makeDraft(), alwaysDecline),
+      saveProviderWithValidation(client, undefined, makeDraft(), alwaysDecline, author),
     ).rejects.toBeInstanceOf(ProviderMutationDeclinedError);
 
-    expect(planMutation).toHaveBeenCalledTimes(1); // the owner did see a plan
-    expect(confirmMutation).not.toHaveBeenCalled(); // …but no approval was minted
-    expect(create).not.toHaveBeenCalled(); // …and nothing was persisted
+    expect(planMutation).toHaveBeenCalledTimes(1);
+    expect(author.calls).toEqual([]); // no device signature authored
+    expect(confirmMutation).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
     expect(update).not.toHaveBeenCalled();
   });
 
-  it("NEGATIVE: confirmation is never defaulted — a non-true resolution aborts", async () => {
+  it("NEGATIVE: a non-true confirmation is never treated as consent", async () => {
     const { client, create, confirmMutation } = makeClient();
-    // A confirmer that resolves a falsy non-boolean must NOT be treated as consent.
     const ambiguous = (async () => undefined) as unknown as ProviderPlanConfirmer;
 
     await expect(
-      saveProviderWithValidation(client, undefined, makeDraft(), ambiguous),
+      saveProviderWithValidation(client, undefined, makeDraft(), ambiguous, makeAuthor()),
     ).rejects.toBeInstanceOf(ProviderMutationDeclinedError);
 
     expect(confirmMutation).not.toHaveBeenCalled();
     expect(create).not.toHaveBeenCalled();
   });
 
-  it("the client never derives the digest itself — it only replays what the server returned", async () => {
-    const { client, create } = makeClient({
-      plan: fakePlan({ planDigest: "server-only-digest" }),
+  it("the client never derives the digest itself — the DEVICE signs the SERVER digest", async () => {
+    const { client, create } = makeClient({ plan: fakePlan({ planDigest: "server-only-digest" }) });
+    const author = makeAuthor();
+    await saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm, author);
+    expect(create.mock.calls[0][0].planDigest).toBe("server-only-digest");
+    expect(author.calls).toEqual(["action-digest-1"]); // whatever the server derived
+  });
+});
+
+// ─── Advisor #1628 finding #3 — partial Setup state (SAFE-ROLLBACK-PRECONDITION-001) ───
+
+describe("CORE-A CR-2 — provider save + routing cannot leave a partial provider", () => {
+  it("RED-FIRST (the defect): a BARE setRouting with no approval 403s in a release profile", async () => {
+    // This reproduces the OLD setup path: create succeeds, then `providersApi.setRouting`
+    // is called WITHOUT a planDigest/approval → the release gate 403s AFTER the provider
+    // is already persisted, stranding a created-but-unrouted provider.
+    const { client } = makeClient({
+      setRouting: async (input) => {
+        if (!input.planDigest || !input.canonicalApproval) {
+          throw Object.assign(new Error("plan digest required"), {
+            code: "PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED",
+            httpStatus: 403,
+          });
+        }
+        return { defaultProviderId: input.defaultProviderId, fallbackProviderIds: [] } as FridayModelRoutingConfig;
+      },
     });
 
-    await saveProviderWithValidation(client, undefined, makeDraft(), alwaysConfirm);
-
-    // the replayed digest is exactly the server's, never recomputed client-side
-    expect(create.mock.calls[0][0].planDigest).toBe("server-only-digest");
+    await expect(
+      client.setRouting({ defaultProviderId: "created-1", fallbackProviderIds: [] }),
+    ).rejects.toMatchObject({ code: "PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED", httpStatus: 403 });
   });
 
-  it("the setup wizard wires the owner-confirm handshake (not a blind save)", () => {
-    const setupSource = readFileSync("ui/src/routes/setup-page.tsx", "utf8");
+  it("FIXED: saveProviderWithRouting routes setRouting THROUGH plan/confirm (carries a device approval)", async () => {
+    // Same release gate as the red-first, but now routing flows through the confirmed,
+    // device-authored handshake, so it carries the controls and never 403s-after-persist.
+    const { client, create, setRouting, planMutation, confirmMutation } = makeClient({
+      setRouting: async (input) => {
+        if (!input.planDigest || !input.canonicalApproval) {
+          throw Object.assign(new Error("plan digest required"), { code: "PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED" });
+        }
+        return { defaultProviderId: input.defaultProviderId, fallbackProviderIds: [] } as FridayModelRoutingConfig;
+      },
+    });
+    const author = makeAuthor();
 
-    // the owner must be shown the server-derived summary and confirm explicitly
-    expect(setupSource).toContain("humanReadableSummary");
-    expect(setupSource).toContain("pendingProviderPlan");
-    // a decline is handled as a deliberate cancel, not a validation failure
-    expect(setupSource).toContain("ProviderMutationDeclinedError");
+    const result = await saveProviderWithRouting(
+      client,
+      undefined,
+      makeDraft(),
+      (provider) => ({ defaultProviderId: provider.id, fallbackProviderIds: [] }),
+      alwaysConfirm,
+      author,
+    );
+
+    expect(create).toHaveBeenCalledTimes(1);
+    // TWO gated mutations, TWO confirmed device approvals (create + routing).
+    expect(planMutation).toHaveBeenCalledTimes(2);
+    expect(confirmMutation).toHaveBeenCalledTimes(2);
+    // routing carried the confirmed controls → no 403-after-persist.
+    const routingArg = setRouting.mock.calls[0][0];
+    expect(routingArg.defaultProviderId).toBe("created-1");
+    expect(routingArg.planDigest).toBe("routing-digest-1");
+    expect(routingArg.canonicalApproval).toBeDefined();
+    expect(result.routing.defaultProviderId).toBe("created-1");
+  });
+
+  it("routing failure AFTER a save is reported TRUTHFULLY (provider named), never hidden", async () => {
+    const { client } = makeClient({
+      setRouting: async () => {
+        throw Object.assign(new Error("routing service unavailable"), { code: "ROUTING_UNAVAILABLE" });
+      },
+    });
+
+    const err = await saveProviderWithRouting(
+      client,
+      undefined,
+      makeDraft(),
+      (provider) => ({ defaultProviderId: provider.id, fallbackProviderIds: [] }),
+      alwaysConfirm,
+      makeAuthor(),
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ProviderRoutingAfterSaveError);
+    expect((err as ProviderRoutingAfterSaveError).provider.id).toBe("created-1");
+    // the provider was saved (reported), not swallowed behind a generic save failure
+    expect((err as ProviderRoutingAfterSaveError).provider.name).toBe("OpenAI Provider");
+  });
+
+  it("declining the routing plan propagates the decline (the save's first step stands)", async () => {
+    const { client } = makeClient();
+    let call = 0;
+    const confirmThenDecline: ProviderPlanConfirmer = async () => {
+      call += 1;
+      return call === 1; // confirm the create, decline the routing
+    };
+
+    await expect(
+      saveProviderWithRouting(
+        client,
+        undefined,
+        makeDraft(),
+        (provider) => ({ defaultProviderId: provider.id, fallbackProviderIds: [] }),
+        confirmThenDecline,
+        makeAuthor(),
+      ),
+    ).rejects.toBeInstanceOf(ProviderMutationDeclinedError);
   });
 });

--- a/test/unit/ui/setup-provider-regressions.test.ts
+++ b/test/unit/ui/setup-provider-regressions.test.ts
@@ -16,13 +16,12 @@ describe("setup provider regressions", () => {
   it("saves the detected provider kind instead of overwriting the first existing provider", () => {
     const setupSource = readFileSync("ui/src/routes/setup-page.tsx", "utf8");
 
-    // The setup save now routes through the shared validate-before-persist
-    // helper, resolving an existing provider by kind (not overwriting the first).
-    // Same axis as before (the helper is called with `providersApi` and the
-    // same-KIND lookup, in that order) but tolerant of argument wrapping: the
-    // call gained a 4th argument (the CORE-A CR-2 owner-confirm callback) and is
-    // now formatted multi-line.
-    expect(setupSource).toMatch(/saveProviderWithValidation\(\s*providersApi,\s*existingSameKind,/);
+    // The setup save now routes through the shared confirmed save+routing helper
+    // (SEC-APPROVAL-AUTHORITY-001 / CR-2 finding #3), resolving an existing provider
+    // by kind (not overwriting the first). Same axis as before (the helper is called
+    // with `providersApi` and the same-KIND lookup, in that order) but tolerant of
+    // argument wrapping: create + routing are now ONE owner-reviewed operation.
+    expect(setupSource).toMatch(/saveProviderWithRouting\(\s*providersApi,\s*existingSameKind,/);
     expect(setupSource).toContain("existingProviders.find((provider) => provider.kind === draft.kind)");
     expect(setupSource).toContain("saveProviderMutation.mutate(buildCurrentProviderSaveDraft()");
     expect(setupSource).not.toContain("const existing = existingProviders[0]");

--- a/test/unit/ui/setup-provider-regressions.test.ts
+++ b/test/unit/ui/setup-provider-regressions.test.ts
@@ -18,7 +18,11 @@ describe("setup provider regressions", () => {
 
     // The setup save now routes through the shared validate-before-persist
     // helper, resolving an existing provider by kind (not overwriting the first).
-    expect(setupSource).toContain("saveProviderWithValidation(providersApi, existingSameKind,");
+    // Same axis as before (the helper is called with `providersApi` and the
+    // same-KIND lookup, in that order) but tolerant of argument wrapping: the
+    // call gained a 4th argument (the CORE-A CR-2 owner-confirm callback) and is
+    // now formatted multi-line.
+    expect(setupSource).toMatch(/saveProviderWithValidation\(\s*providersApi,\s*existingSameKind,/);
     expect(setupSource).toContain("existingProviders.find((provider) => provider.kind === draft.kind)");
     expect(setupSource).toContain("saveProviderMutation.mutate(buildCurrentProviderSaveDraft()");
     expect(setupSource).not.toContain("const existing = existingProviders[0]");

--- a/ui/src/lib/api/auth.ts
+++ b/ui/src/lib/api/auth.ts
@@ -6,6 +6,7 @@ import type {
   AuthBootstrapResponse,
   AuthBootstrapStatusResponse,
   AuthDeviceClaimResponse,
+  AuthLoginChallengeResponse,
   LoginResponse,
   MeResponse,
 } from "./types";
@@ -46,12 +47,35 @@ export interface DeviceKeyLoginInput {
   deviceLoginProof: DeviceClaimProof;
 }
 
+export interface LoginChallengeInput {
+  installId: string;
+  osUser: string;
+  origin: string;
+  deviceId: string;
+  devicePublicKey: string;
+  action?: string;
+}
+
 /** Mint a single-use install nonce (challenge) for a device-bound owner claim. */
 export async function postBootstrapChallenge(
   input: BootstrapChallengeInput,
 ): Promise<AuthBootstrapChallengeResponse> {
   return apiClient.post<BootstrapChallengeInput, AuthBootstrapChallengeResponse>(
     "/v1/auth/bootstrap/challenge",
+    input,
+  );
+}
+
+/**
+ * SEC-SETUP-BOOTSTRAP-001 (CR-1): mint a single-use device-key LOGIN challenge
+ * bound to this device + key + origin. The device signs the returned nonce into a
+ * fresh owner-login transcript so the login proof-of-possession is not replayable.
+ */
+export async function postLoginChallenge(
+  input: LoginChallengeInput,
+): Promise<AuthLoginChallengeResponse> {
+  return apiClient.post<LoginChallengeInput, AuthLoginChallengeResponse>(
+    "/v1/auth/login/challenge",
     input,
   );
 }

--- a/ui/src/lib/api/auth.ts
+++ b/ui/src/lib/api/auth.ts
@@ -1,8 +1,11 @@
 import { apiClient } from "./client";
 import { authStorage } from "@/lib/storage/auth-storage";
+import type { DeviceClaimProof } from "@/lib/auth/device-key";
 import type {
+  AuthBootstrapChallengeResponse,
   AuthBootstrapResponse,
   AuthBootstrapStatusResponse,
+  AuthDeviceClaimResponse,
   LoginResponse,
   MeResponse,
 } from "./types";
@@ -15,6 +18,72 @@ export interface LoginInput {
   localPassphrase?: string;
   email?: string;
   password?: string;
+}
+
+// ─── SEC-SETUP-BOOTSTRAP-001 (CR-1): device-bound owner claim client fns ───
+
+export interface BootstrapChallengeInput {
+  installId: string;
+  osUser: string;
+  origin: string;
+  action?: string;
+}
+
+export interface DeviceClaimInput {
+  nonce: string;
+  devicePublicKey: string;
+  deviceId: string;
+  origin: string;
+  installId: string;
+  osUser: string;
+  deviceClaimProof: DeviceClaimProof;
+}
+
+export interface DeviceKeyLoginInput {
+  devicePublicKey: string;
+  deviceId: string;
+  origin: string;
+  deviceLoginProof: DeviceClaimProof;
+}
+
+/** Mint a single-use install nonce (challenge) for a device-bound owner claim. */
+export async function postBootstrapChallenge(
+  input: BootstrapChallengeInput,
+): Promise<AuthBootstrapChallengeResponse> {
+  return apiClient.post<BootstrapChallengeInput, AuthBootstrapChallengeResponse>(
+    "/v1/auth/bootstrap/challenge",
+    input,
+  );
+}
+
+/**
+ * Atomically claim the local owner slot with a device public key + proof-of-
+ * possession. The backend is loopback-only, origin-bound, replay-protected.
+ */
+export async function postDeviceClaim(
+  input: DeviceClaimInput,
+): Promise<AuthDeviceClaimResponse> {
+  return apiClient.post<DeviceClaimInput, AuthDeviceClaimResponse>(
+    "/v1/auth/bootstrap/device-claim",
+    input,
+  );
+}
+
+/**
+ * Log in with a device-key proof-of-possession (a fresh `owner-login` transcript
+ * signed by the bound device key). On success stores the session, mirroring
+ * `login()`. NOTE: the backend mints a session ONLY when device-owner authority is
+ * enabled (native-IPC attestation) — otherwise it fails closed and the caller
+ * falls back to the passphrase path.
+ */
+export async function deviceKeyLogin(input: DeviceKeyLoginInput): Promise<LoginResponse> {
+  const data = await apiClient.post<DeviceKeyLoginInput, LoginResponse>(
+    "/v1/auth/login",
+    input,
+  );
+  authStorage.setTokens(data.accessToken, data.refreshToken, data.expiresInSec);
+  authStorage.setUser(data.user);
+  return data;
 }
 
 export async function login(input: LoginInput): Promise<LoginResponse> {

--- a/ui/src/lib/api/providers.ts
+++ b/ui/src/lib/api/providers.ts
@@ -39,6 +39,15 @@ export interface CreateProviderInput {
   runtimeCapabilities?: FridayProviderRuntimeCapabilityDeclaration[];
   enabled?: boolean;
   validateOnSave?: boolean;
+  /**
+   * Owner-confirm control fields (CORE-RUNNABLE-001 / CORE-A CR-2). Replayed
+   * verbatim from the plan → confirm handshake so the canonical mutating-action
+   * gate can recompute the action digest server-side from the request that
+   * actually arrived. Never carries a secret. Absent ⇒ the gate fails closed
+   * with `PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED`.
+   */
+  planDigest?: string;
+  canonicalApproval?: unknown;
 }
 
 export interface UpdateProviderInput {
@@ -57,6 +66,67 @@ export interface UpdateProviderInput {
   runtimeCapabilities?: FridayProviderRuntimeCapabilityDeclaration[];
   enabled?: boolean;
   validateOnSave?: boolean;
+  /** Owner-confirm control fields — see {@link CreateProviderInput.planDigest}. */
+  planDigest?: string;
+  canonicalApproval?: unknown;
+}
+
+// ─── Provider mutation plan / owner-confirm handshake (CORE-A CR-2) ───
+
+export type FridayProviderPlannableAction =
+  | "providers.create"
+  | "providers.update"
+  | "providers.delete"
+  | "providers.validate"
+  | "providers.routing.set"
+  | "providers.routing.pin"
+  | "providers.routing.penalty.clear"
+  | "providers.auth.profiles.activate"
+  | "providers.oauth.openai_codex.device.initiate"
+  | "providers.oauth.openai_codex.device.complete"
+  | "capabilities.doctor";
+
+export interface PlanProviderMutationInput {
+  action: FridayProviderPlannableAction;
+  providerId?: string;
+  profileKey?: string;
+  /** The exact body the follow-up mutation will send (control fields ignored). */
+  params?: Record<string, unknown> | null;
+  idempotencyKey?: string;
+}
+
+export interface FridayProviderMutationPlan {
+  planDigest: string;
+  actionDigest: string;
+  action: FridayProviderPlannableAction;
+  surface: string;
+  resourceId?: string;
+  idempotencyKey?: string;
+  /** Secret-free review lines shown to the owner BEFORE they confirm. */
+  humanReadableSummary: string[];
+  approvalRequired: boolean;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface FridayProviderMutationApproval {
+  planDigest: string;
+  actionDigest: string;
+  action: FridayProviderPlannableAction;
+  resourceId?: string;
+  idempotencyKey?: string;
+  confirmedAt: string;
+  expiresAt: string;
+  /** Signed, single-use canonical approval to replay on the mutation request. */
+  canonicalApproval: unknown;
+}
+
+interface PlanProviderMutationResponse {
+  plan: FridayProviderMutationPlan;
+}
+
+interface ConfirmProviderMutationResponse {
+  approval: FridayProviderMutationApproval;
 }
 
 export interface SetRoutingInput {
@@ -253,6 +323,34 @@ export const providersApi = {
       "/v1/capabilities/doctor",
       {},
     );
+  },
+
+  /**
+   * Step 1 of the owner-confirm handshake (CORE-A CR-2): ask the SERVER to
+   * sanitize the intended parameters and derive the plan + action digests
+   * itself, returning a secret-free summary for the owner to review. The client
+   * never computes a digest — drift can only fail closed, never be forged.
+   */
+  async planMutation(input: PlanProviderMutationInput): Promise<FridayProviderMutationPlan> {
+    const data = await apiClient.post<PlanProviderMutationInput, PlanProviderMutationResponse>(
+      "/v1/providers/plan",
+      input,
+    );
+    return data.plan;
+  },
+
+  /**
+   * Step 2: the SAME authenticated owner explicitly confirms that exact plan
+   * digest; only then does the server mint a signed, short-lived, single-use
+   * canonical approval bound to the server-computed action digest. `confirm` is
+   * always literal `true` — never defaulted, never inferred.
+   */
+  async confirmMutation(planDigest: string): Promise<FridayProviderMutationApproval> {
+    const data = await apiClient.post<
+      { planDigest: string; confirm: true },
+      ConfirmProviderMutationResponse
+    >("/v1/providers/plan/confirm", { planDigest, confirm: true });
+    return data.approval;
   },
 
   async create(input: CreateProviderInput): Promise<CreateProviderResponse> {

--- a/ui/src/lib/api/providers.ts
+++ b/ui/src/lib/api/providers.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "./client";
+import type { ProviderApprovalDeviceProof } from "@/lib/auth/device-key";
 import type {
   FridayProviderProfile,
   FridayProviderValidationState,
@@ -135,6 +136,16 @@ export interface SetRoutingInput {
   fallbackProviderIds: string[];
   costMode?: FridayModelRoutingConfig["costMode"];
   enforceRequestedModel?: boolean;
+  /**
+   * Owner-confirm control fields (SEC-APPROVAL-AUTHORITY-001 / CORE-A CR-2 finding
+   * #3). `providers.routing.set` is a GATED mutation: in a release profile it
+   * requires an approved plan digest + a device-authored approval, exactly like
+   * create/update. Routing setup MUST flow through plan → confirm so it can never
+   * 403-after-persist and strand a created-but-unrouted provider. Absent ⇒ the gate
+   * fails closed with `PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED`.
+   */
+  planDigest?: string;
+  canonicalApproval?: unknown;
 }
 
 // ─── Response wrappers ───
@@ -341,15 +352,20 @@ export const providersApi = {
 
   /**
    * Step 2: the SAME authenticated owner explicitly confirms that exact plan
-   * digest; only then does the server mint a signed, short-lived, single-use
-   * canonical approval bound to the server-computed action digest. `confirm` is
-   * always literal `true` — never defaulted, never inferred.
+   * digest by presenting a DEVICE-AUTHORED approval proof (SEC-APPROVAL-AUTHORITY-001).
+   * The Hub holds NO signing key — it only VERIFIES the owner device's P-256
+   * proof-of-possession over the reviewed action digest and returns the
+   * device-authored, single-use canonical approval. `confirm` is always literal
+   * `true` — never defaulted, never inferred.
    */
-  async confirmMutation(planDigest: string): Promise<FridayProviderMutationApproval> {
+  async confirmMutation(
+    planDigest: string,
+    deviceApproval: ProviderApprovalDeviceProof,
+  ): Promise<FridayProviderMutationApproval> {
     const data = await apiClient.post<
-      { planDigest: string; confirm: true },
+      { planDigest: string; confirm: true; deviceApproval: ProviderApprovalDeviceProof },
       ConfirmProviderMutationResponse
-    >("/v1/providers/plan/confirm", { planDigest, confirm: true });
+    >("/v1/providers/plan/confirm", { planDigest, confirm: true, deviceApproval });
     return data.approval;
   },
 

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -49,12 +49,51 @@ export interface MeResponse {
 
 export interface AuthBootstrapStatusResponse {
   bootstrapRequired: boolean;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 (CR-1): server-derived, fail-closed flag for whether
+   * device-bound owner claim is the AUTHORITATIVE first-run path. `true` ONLY when
+   * device-owner authority is enabled (requires native-IPC attestation). On the
+   * current build it is `false`, so first-run honestly stays on the passphrase
+   * gate. When `true`, RequireAuth routes first-run to the device-claim gate and
+   * the passphrase gate is not offered as the authoritative path.
+   *
+   * Optional in the client type so an older backend (pre-CR-1) that omits the
+   * field is treated as `false` (fail-closed → passphrase), never as available.
+   */
+  deviceClaimAvailable?: boolean;
 }
 
 export interface AuthBootstrapResponse {
   initialized: true;
   initializedAt: string;
   userId: string;
+}
+
+// ─── SEC-SETUP-BOOTSTRAP-001 (CR-1): device-bound owner claim ───
+
+export interface AuthBootstrapChallengeResponse {
+  challengeId: string;
+  /** Raw single-use nonce — returned exactly once. */
+  nonce: string;
+  kind: "install_owner_claim";
+  hubId: string;
+  installId: string;
+  osUser: string;
+  origin: string;
+  action: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface AuthDeviceClaimResponse {
+  claimed: true;
+  claimedAt: string;
+  userId: string;
+  deviceId: string;
+  devicePublicKeyHash: string;
+  keyProtection: "secure_enclave_os_verified" | "keychain_acl_verified" | "software_dev_only" | "unverified";
+  /** Always false in the release/default profile until native-IPC attestation lands. */
+  deviceAuthorityEnabled: boolean;
 }
 
 // ─── Agent types ───

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -85,6 +85,28 @@ export interface AuthBootstrapChallengeResponse {
   expiresAt: string;
 }
 
+/**
+ * SEC-SETUP-BOOTSTRAP-001 (CR-1): server-issued single-use device-key LOGIN
+ * challenge. The device signs `nonce` into a fresh owner-login transcript; the
+ * backend CAS-consumes it atomically with the session mint, so the login proof is
+ * not replayable.
+ */
+export interface AuthLoginChallengeResponse {
+  challengeId: string;
+  /** Raw single-use nonce — returned exactly once. */
+  nonce: string;
+  kind: "device_login_challenge";
+  hubId: string;
+  installId: string;
+  osUser: string;
+  origin: string;
+  action: string;
+  deviceId: string;
+  devicePublicKeyHash: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
 export interface AuthDeviceClaimResponse {
   claimed: true;
   claimedAt: string;

--- a/ui/src/lib/auth/device-key.ts
+++ b/ui/src/lib/auth/device-key.ts
@@ -1,0 +1,252 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · CR-1 — device keypair seam (UI) ───
+//
+// A REAL device-key provider abstraction for the device-bound owner flow. It is
+// NOT a mock and it NEVER fabricates attestation:
+//   - `WebCryptoDeviceKeyProvider` generates a genuine non-extractable P-256
+//     keypair via WebCrypto and produces genuine ECDSA proofs-of-possession over
+//     the SAME canonical transcript bytes the server verifier reconstructs, so a
+//     signature here is a real possession proof there.
+//   - Key PROTECTION / OS attestation is derived SERVER-SIDE and stays
+//     "unverified" until a native attestation bridge lands; this seam asserts
+//     nothing about hardware backing. Minting a device-owner session additionally
+//     requires the server's native-IPC precondition, so a software key here can
+//     never masquerade as a hardware-attested one.
+//   - When WebCrypto is unavailable (e.g. an insecure context), the provider is
+//     `isAvailable() === false` and every operation FAILS CLOSED — the caller must
+//     NOT silently fall back to a fabricated key.
+//
+// NATIVE/OPERATOR LEAF (flagged, not faked): hardware-backed (Secure Enclave /
+// TPM) key generation, OS attestation, and durable cross-restart key storage are
+// the native bridge's responsibility. This WebCrypto provider is the software-dev
+// seam that proves the wiring; its keypair lives in memory for the session only.
+
+/** Canonical owner-claim/login transcript (mirrors the server S2a shape). */
+export interface DeviceClaimTranscript {
+  transcriptVersion: "friday-owner-claim-v1";
+  algorithm: "ECDSA_P256_SHA256";
+  kind: "install_owner_claim";
+  hubId: string;
+  installId: string;
+  osUser: string;
+  deviceId: string;
+  action: string;
+  origin: string;
+  channel: string;
+  nonce: string;
+  expiresAt: string;
+  /** SHA-256 hex of the canonical SPKI DER of the device public key. */
+  devicePublicKeyHash: string;
+}
+
+export interface DeviceClaimProof {
+  transcript: DeviceClaimTranscript;
+  /** IEEE P-1363 raw (r‖s, 64 bytes) ECDSA signature, base64 (canonical low-S). */
+  signature: { encoding: "ieee-p1363-base64"; value: string };
+}
+
+export interface DeviceKeyMaterial {
+  /** Device public key, SPKI DER, standard base64. */
+  devicePublicKeySpkiBase64: string;
+  /** SHA-256 hex of the canonical SPKI DER (the transcript-bound key hash). */
+  devicePublicKeyHash: string;
+  /** Stable-per-session device identifier. */
+  deviceId: string;
+}
+
+/**
+ * The device-key seam. A native bridge implementation (Secure Enclave / TPM) would
+ * satisfy this SAME interface; the WebCrypto implementation below is the software
+ * fallback. All operations reject when `isAvailable()` is false (fail-closed).
+ */
+export interface DeviceKeyProvider {
+  isAvailable(): boolean;
+  /** Generate (or return the session-cached) device key material. */
+  getOrCreateDeviceKey(): Promise<DeviceKeyMaterial>;
+  /**
+   * Sign a canonical transcript, returning a canonical low-S IEEE P-1363 raw
+   * signature as base64. Rejects if no key has been created yet.
+   */
+  signTranscript(transcript: DeviceClaimTranscript): Promise<DeviceClaimProof["signature"]>;
+}
+
+/** Thrown when the device-key capability is unavailable — the caller fails closed. */
+export class DeviceKeyUnavailableError extends Error {
+  constructor(message = "Device key capability is unavailable in this context.") {
+    super(message);
+    this.name = "DeviceKeyUnavailableError";
+  }
+}
+
+// ─── Canonical transcript encoding (byte-identical to the server encoder) ───
+
+const TRANSCRIPT_DOMAIN = "friday.owner-claim.transcript";
+
+// NIST P-256 order (n) and n/2 for low-S malleability normalization.
+const P256_ORDER_N = BigInt(
+  "0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551",
+);
+const P256_HALF_ORDER = P256_ORDER_N >> 1n;
+
+function lengthPrefixed(value: string): Uint8Array {
+  const body = new TextEncoder().encode(value);
+  const out = new Uint8Array(4 + body.length);
+  new DataView(out.buffer).setUint32(0, body.length, false); // u32 big-endian
+  out.set(body, 4);
+  return out;
+}
+
+/**
+ * Deterministically encode a transcript to `LP(domain) ‖ LP(field_0) ‖ …` where
+ * LP(x) = u32be(len) ‖ utf8(x). Field order + domain MUST match the server's
+ * `encodeOwnerClaimTranscript` exactly (asserted by a cross-encoder test).
+ */
+export function encodeOwnerClaimTranscript(t: DeviceClaimTranscript): Uint8Array {
+  const parts = [
+    lengthPrefixed(TRANSCRIPT_DOMAIN),
+    lengthPrefixed(t.transcriptVersion),
+    lengthPrefixed(t.algorithm),
+    lengthPrefixed(t.kind),
+    lengthPrefixed(t.hubId),
+    lengthPrefixed(t.installId),
+    lengthPrefixed(t.osUser),
+    lengthPrefixed(t.deviceId),
+    lengthPrefixed(t.action),
+    lengthPrefixed(t.origin),
+    lengthPrefixed(t.channel),
+    lengthPrefixed(t.nonce),
+    lengthPrefixed(t.expiresAt),
+    lengthPrefixed(t.devicePublicKeyHash),
+  ];
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+// ─── byte / bigint helpers ───
+
+function toBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i += 1) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+function toHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (let i = 0; i < bytes.length; i += 1) hex += bytes[i].toString(16).padStart(2, "0");
+  return hex;
+}
+
+function bytesToBigInt(bytes: Uint8Array): bigint {
+  return bytes.length === 0 ? 0n : BigInt("0x" + toHex(bytes));
+}
+
+function bigIntTo32(value: bigint): Uint8Array {
+  const hex = value.toString(16).padStart(64, "0");
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i += 1) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+/**
+ * Normalize a raw P-1363 signature to canonical low-S (s ≤ n/2). WebCrypto does
+ * not guarantee low-S, and the server verifier REJECTS the high-S twin, so this
+ * normalization is required for interop.
+ */
+export function normalizeLowS(raw: Uint8Array): Uint8Array {
+  const r = raw.slice(0, 32);
+  let s = bytesToBigInt(raw.slice(32, 64));
+  if (s > P256_HALF_ORDER) s = P256_ORDER_N - s;
+  const out = new Uint8Array(64);
+  out.set(r, 0);
+  out.set(bigIntTo32(s), 32);
+  return out;
+}
+
+// ─── WebCrypto software provider ───
+
+function subtleAvailable(): boolean {
+  return (
+    typeof globalThis.crypto !== "undefined" &&
+    typeof globalThis.crypto.subtle !== "undefined" &&
+    typeof globalThis.crypto.subtle.generateKey === "function"
+  );
+}
+
+function randomDeviceId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") return `wc-${c.randomUUID()}`;
+  // Fallback random id (still non-fabricated — just a session identifier).
+  const rnd = new Uint8Array(16);
+  if (c && typeof c.getRandomValues === "function") c.getRandomValues(rnd);
+  return `wc-${toHex(rnd)}`;
+}
+
+/**
+ * Create a WebCrypto-backed device-key provider. The private key is
+ * non-extractable and cached in memory for the session. Durable, hardware-backed
+ * storage is the native/operator leaf (see file header).
+ */
+export function createWebCryptoDeviceKeyProvider(): DeviceKeyProvider {
+  let cached: { keyPair: CryptoKeyPair; material: DeviceKeyMaterial } | null = null;
+
+  return {
+    isAvailable: subtleAvailable,
+
+    async getOrCreateDeviceKey(): Promise<DeviceKeyMaterial> {
+      if (!subtleAvailable()) throw new DeviceKeyUnavailableError();
+      if (cached) return cached.material;
+
+      const keyPair = (await globalThis.crypto.subtle.generateKey(
+        { name: "ECDSA", namedCurve: "P-256" },
+        false, // private key non-extractable; public key stays exportable
+        ["sign", "verify"],
+      )) as CryptoKeyPair;
+
+      const spki = new Uint8Array(
+        await globalThis.crypto.subtle.exportKey("spki", keyPair.publicKey),
+      );
+      const digest = new Uint8Array(await globalThis.crypto.subtle.digest("SHA-256", spki));
+
+      const material: DeviceKeyMaterial = {
+        devicePublicKeySpkiBase64: toBase64(spki),
+        devicePublicKeyHash: toHex(digest),
+        deviceId: randomDeviceId(),
+      };
+      cached = { keyPair, material };
+      return material;
+    },
+
+    async signTranscript(
+      transcript: DeviceClaimTranscript,
+    ): Promise<DeviceClaimProof["signature"]> {
+      if (!subtleAvailable()) throw new DeviceKeyUnavailableError();
+      if (!cached) {
+        throw new DeviceKeyUnavailableError("Device key has not been created yet.");
+      }
+      const bytes = encodeOwnerClaimTranscript(transcript);
+      const raw = new Uint8Array(
+        await globalThis.crypto.subtle.sign(
+          { name: "ECDSA", hash: "SHA-256" },
+          cached.keyPair.privateKey,
+          // Copy into a fresh ArrayBuffer-backed view for BufferSource typing.
+          bytes.slice(),
+        ),
+      );
+      return { encoding: "ieee-p1363-base64", value: toBase64(normalizeLowS(raw)) };
+    },
+  };
+}
+
+// Default provider singleton (native bridge would replace this at wire time).
+let defaultProvider: DeviceKeyProvider | null = null;
+
+/** The process/tab default device-key provider (WebCrypto software seam). */
+export function getDeviceKeyProvider(): DeviceKeyProvider {
+  if (!defaultProvider) defaultProvider = createWebCryptoDeviceKeyProvider();
+  return defaultProvider;
+}

--- a/ui/src/lib/auth/device-key.ts
+++ b/ui/src/lib/auth/device-key.ts
@@ -14,11 +14,19 @@
 //   - When WebCrypto is unavailable (e.g. an insecure context), the provider is
 //     `isAvailable() === false` and every operation FAILS CLOSED — the caller must
 //     NOT silently fall back to a fabricated key.
+//   - DURABLE ACROSS RELOAD (CR-1 · Advisor #1628 finding #2): the non-extractable
+//     private key is persisted in IndexedDB as a structured-cloneable CryptoKey.
+//     IndexedDB stores the live key OBJECT (never raw key bytes — a non-extractable
+//     key cannot be exported), and structured clone PRESERVES `extractable=false`,
+//     so the key survives a page reload WITHOUT ever becoming extractable. This is
+//     what makes the device-owner claim + login recoverable across restart rather
+//     than minting a fresh (unbound) key on every load.
 //
 // NATIVE/OPERATOR LEAF (flagged, not faked): hardware-backed (Secure Enclave /
-// TPM) key generation, OS attestation, and durable cross-restart key storage are
-// the native bridge's responsibility. This WebCrypto provider is the software-dev
-// seam that proves the wiring; its keypair lives in memory for the session only.
+// TPM) key generation and OS attestation remain the native bridge's responsibility
+// — this WebCrypto provider is the software-dev seam that proves the wiring and its
+// key protection stays server-derived "unverified". Durable browser-key storage
+// (IndexedDB) is implemented here; hardware backing is NOT claimed.
 
 /** Canonical owner-claim/login transcript (mirrors the server S2a shape). */
 export interface DeviceClaimTranscript {
@@ -167,6 +175,98 @@ export function normalizeLowS(raw: Uint8Array): Uint8Array {
   return out;
 }
 
+// ─── Durable key store (IndexedDB) ───
+
+/**
+ * The durable device-key record persisted across page reloads. `keyPair` is the
+ * LIVE non-extractable CryptoKeyPair — IndexedDB persists it via the structured
+ * clone algorithm, which keeps `privateKey.extractable === false` (raw key bytes
+ * are never materialised). `deviceId` is persisted alongside so the stable device
+ * identity the claim bound to survives a reload too.
+ */
+export interface DurableDeviceKeyRecord {
+  keyPair: CryptoKeyPair;
+  deviceId: string;
+}
+
+/**
+ * Persistence seam for the device key. The default browser implementation is
+ * IndexedDB (`createIndexedDbDeviceKeyStore`); tests inject an in-memory store that
+ * runs the record through the SAME structured-clone algorithm IndexedDB uses.
+ */
+export interface DeviceKeyStore {
+  /** Return the persisted record, or null if none / unreadable. */
+  load(): Promise<DurableDeviceKeyRecord | null>;
+  /** Persist (overwrite) the record. Rejects if the write fails (fail closed). */
+  save(record: DurableDeviceKeyRecord): Promise<void>;
+}
+
+const DEVICE_KEY_DB_NAME = "friday-device-key";
+const DEVICE_KEY_STORE_NAME = "device-owner-keys";
+const DEVICE_KEY_RECORD_ID = "primary";
+
+/** True when the IndexedDB API is present (browser secure context). */
+export function indexedDbDeviceKeyStorageAvailable(): boolean {
+  return typeof indexedDB !== "undefined";
+}
+
+/**
+ * IndexedDB-backed device-key store. Stores the CryptoKeyPair OBJECT (not raw
+ * bytes) under a single fixed key. Because the private key is non-extractable and
+ * structured clone preserves that flag, the reloaded key can sign but can never be
+ * exported. All operations reject on IndexedDB error (the provider fails closed on
+ * a save failure rather than silently continuing with a non-durable key).
+ */
+export function createIndexedDbDeviceKeyStore(): DeviceKeyStore {
+  function openDb(): Promise<IDBDatabase> {
+    return new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(DEVICE_KEY_DB_NAME, 1);
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains(DEVICE_KEY_STORE_NAME)) {
+          database.createObjectStore(DEVICE_KEY_STORE_NAME);
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error ?? new Error("indexedDB open failed"));
+    });
+  }
+
+  return {
+    async load(): Promise<DurableDeviceKeyRecord | null> {
+      const database = await openDb();
+      try {
+        return await new Promise<DurableDeviceKeyRecord | null>((resolve, reject) => {
+          const tx = database.transaction(DEVICE_KEY_STORE_NAME, "readonly");
+          const req = tx.objectStore(DEVICE_KEY_STORE_NAME).get(DEVICE_KEY_RECORD_ID);
+          req.onsuccess = () => {
+            const value = req.result as DurableDeviceKeyRecord | undefined;
+            resolve(value && value.keyPair ? value : null);
+          };
+          req.onerror = () => reject(req.error ?? new Error("indexedDB get failed"));
+        });
+      } finally {
+        database.close();
+      }
+    },
+
+    async save(record: DurableDeviceKeyRecord): Promise<void> {
+      const database = await openDb();
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const tx = database.transaction(DEVICE_KEY_STORE_NAME, "readwrite");
+          tx.objectStore(DEVICE_KEY_STORE_NAME).put(record, DEVICE_KEY_RECORD_ID);
+          tx.oncomplete = () => resolve();
+          tx.onerror = () => reject(tx.error ?? new Error("indexedDB put failed"));
+          tx.onabort = () => reject(tx.error ?? new Error("indexedDB put aborted"));
+        });
+      } finally {
+        database.close();
+      }
+    },
+  };
+}
+
 // ─── WebCrypto software provider ───
 
 function subtleAvailable(): boolean {
@@ -175,6 +275,20 @@ function subtleAvailable(): boolean {
     typeof globalThis.crypto.subtle !== "undefined" &&
     typeof globalThis.crypto.subtle.generateKey === "function"
   );
+}
+
+/** Derive the public key material (SPKI base64 + hash) for a keypair + deviceId. */
+async function deriveDeviceKeyMaterial(
+  publicKey: CryptoKey,
+  deviceId: string,
+): Promise<DeviceKeyMaterial> {
+  const spki = new Uint8Array(await globalThis.crypto.subtle.exportKey("spki", publicKey));
+  const digest = new Uint8Array(await globalThis.crypto.subtle.digest("SHA-256", spki));
+  return {
+    devicePublicKeySpkiBase64: toBase64(spki),
+    devicePublicKeyHash: toHex(digest),
+    deviceId,
+  };
 }
 
 function randomDeviceId(): string {
@@ -188,10 +302,14 @@ function randomDeviceId(): string {
 
 /**
  * Create a WebCrypto-backed device-key provider. The private key is
- * non-extractable and cached in memory for the session. Durable, hardware-backed
- * storage is the native/operator leaf (see file header).
+ * non-extractable and cached in memory for the session. When a `store` is supplied
+ * (the browser default is IndexedDB), the key is DURABLE across page reloads: on
+ * first use it is generated + persisted; on a later load it is read back from the
+ * store (still non-extractable). WITHOUT a store the key is in-memory only (the old
+ * behaviour) — used by cross-encoder / signature unit tests. Hardware backing is
+ * the native/operator leaf (see file header); this seam never claims it.
  */
-export function createWebCryptoDeviceKeyProvider(): DeviceKeyProvider {
+export function createWebCryptoDeviceKeyProvider(store?: DeviceKeyStore): DeviceKeyProvider {
   let cached: { keyPair: CryptoKeyPair; material: DeviceKeyMaterial } | null = null;
 
   return {
@@ -201,22 +319,36 @@ export function createWebCryptoDeviceKeyProvider(): DeviceKeyProvider {
       if (!subtleAvailable()) throw new DeviceKeyUnavailableError();
       if (cached) return cached.material;
 
+      // Durable recovery: reload a previously-persisted non-extractable keypair so
+      // the owner binding survives a reload. A corrupt/unreadable record is treated
+      // as "none" (regenerate); a genuine key just rehydrates and signs.
+      if (store) {
+        let record: DurableDeviceKeyRecord | null = null;
+        try {
+          record = await store.load();
+        } catch {
+          record = null;
+        }
+        if (record) {
+          const material = await deriveDeviceKeyMaterial(record.keyPair.publicKey, record.deviceId);
+          cached = { keyPair: record.keyPair, material };
+          return material;
+        }
+      }
+
       const keyPair = (await globalThis.crypto.subtle.generateKey(
         { name: "ECDSA", namedCurve: "P-256" },
         false, // private key non-extractable; public key stays exportable
         ["sign", "verify"],
       )) as CryptoKeyPair;
 
-      const spki = new Uint8Array(
-        await globalThis.crypto.subtle.exportKey("spki", keyPair.publicKey),
-      );
-      const digest = new Uint8Array(await globalThis.crypto.subtle.digest("SHA-256", spki));
-
-      const material: DeviceKeyMaterial = {
-        devicePublicKeySpkiBase64: toBase64(spki),
-        devicePublicKeyHash: toHex(digest),
-        deviceId: randomDeviceId(),
-      };
+      const deviceId = randomDeviceId();
+      const material = await deriveDeviceKeyMaterial(keyPair.publicKey, deviceId);
+      // Persist BEFORE returning so the key is durable from first use. A save failure
+      // fails closed (rejects) rather than silently continuing with a non-durable key.
+      if (store) {
+        await store.save({ keyPair, deviceId });
+      }
       cached = { keyPair, material };
       return material;
     },
@@ -245,8 +377,16 @@ export function createWebCryptoDeviceKeyProvider(): DeviceKeyProvider {
 // Default provider singleton (native bridge would replace this at wire time).
 let defaultProvider: DeviceKeyProvider | null = null;
 
-/** The process/tab default device-key provider (WebCrypto software seam). */
+/**
+ * The process/tab default device-key provider (WebCrypto software seam). When
+ * IndexedDB is available (browser secure context) the provider is DURABLE — its
+ * non-extractable key survives reload; otherwise it is in-memory only.
+ */
 export function getDeviceKeyProvider(): DeviceKeyProvider {
-  if (!defaultProvider) defaultProvider = createWebCryptoDeviceKeyProvider();
+  if (!defaultProvider) {
+    defaultProvider = createWebCryptoDeviceKeyProvider(
+      indexedDbDeviceKeyStorageAvailable() ? createIndexedDbDeviceKeyStore() : undefined,
+    );
+  }
   return defaultProvider;
 }

--- a/ui/src/lib/auth/device-key.ts
+++ b/ui/src/lib/auth/device-key.ts
@@ -52,6 +52,47 @@ export interface DeviceClaimProof {
   signature: { encoding: "ieee-p1363-base64"; value: string };
 }
 
+// ─── SEC-APPROVAL-AUTHORITY-001 · CR-2 — device-authored provider approval ───
+//
+// The owner device AUTHORS a provider-mutation approval by signing this canonical
+// transcript with the SAME non-extractable P-256 key. The Hub holds NO signing key
+// — it only VERIFIES this proof with the presented PUBLIC key. The encoding mirrors
+// the server `encodeProviderApprovalTranscript` byte-for-byte (cross-encoder test).
+
+/** Canonical provider-approval transcript (mirrors the server shape). */
+export interface ProviderApprovalTranscript {
+  transcriptVersion: "friday-provider-approval-v1";
+  algorithm: "ECDSA_P256_SHA256";
+  kind: "provider_mutation_approval";
+  /** Unique id the device assigns to this single approval. */
+  approvalId: string;
+  /** The EXACT reviewed mutating-action digest (from the server plan). */
+  actionDigest: string;
+  /** The owner principal authoring the approval (device-owner:<devicePublicKeyHash>). */
+  decidedByPrincipalId: string;
+  /** Absolute expiry (ISO-8601); the Hub bounds this to a short lifetime. */
+  expiresAt: string;
+  /** SHA-256 hex of the canonical SPKI DER of the device public key. */
+  devicePublicKeyHash: string;
+}
+
+/** The self-describing device proof the client sends to plan/confirm. */
+export interface ProviderApprovalDeviceProof {
+  transcript: ProviderApprovalTranscript;
+  /** Device public key, SPKI DER, standard base64. */
+  devicePublicKey: { encoding: "spki-der-base64"; value: string };
+  /** IEEE P-1363 raw (r‖s, 64 bytes) ECDSA signature, base64 (canonical low-S). */
+  signature: { encoding: "ieee-p1363-base64"; value: string };
+}
+
+/** Stable prefix binding a device-owner principal id to its device public key hash. */
+export const DEVICE_OWNER_PRINCIPAL_ID_PREFIX = "device-owner:";
+
+/** Derive the device-owner principal id from a canonical device public key hash. */
+export function deviceOwnerPrincipalId(devicePublicKeyHash: string): string {
+  return `${DEVICE_OWNER_PRINCIPAL_ID_PREFIX}${devicePublicKeyHash}`;
+}
+
 export interface DeviceKeyMaterial {
   /** Device public key, SPKI DER, standard base64. */
   devicePublicKeySpkiBase64: string;
@@ -75,6 +116,14 @@ export interface DeviceKeyProvider {
    * signature as base64. Rejects if no key has been created yet.
    */
   signTranscript(transcript: DeviceClaimTranscript): Promise<DeviceClaimProof["signature"]>;
+  /**
+   * Sign a canonical PROVIDER-APPROVAL transcript (SEC-APPROVAL-AUTHORITY-001).
+   * Returns a canonical low-S IEEE P-1363 raw signature as base64. Rejects if no
+   * key has been created yet.
+   */
+  signApprovalTranscript(
+    transcript: ProviderApprovalTranscript,
+  ): Promise<ProviderApprovalDeviceProof["signature"]>;
 }
 
 /** Thrown when the device-key capability is unavailable — the caller fails closed. */
@@ -122,6 +171,35 @@ export function encodeOwnerClaimTranscript(t: DeviceClaimTranscript): Uint8Array
     lengthPrefixed(t.origin),
     lengthPrefixed(t.channel),
     lengthPrefixed(t.nonce),
+    lengthPrefixed(t.expiresAt),
+    lengthPrefixed(t.devicePublicKeyHash),
+  ];
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+const PROVIDER_APPROVAL_TRANSCRIPT_DOMAIN = "friday.provider-approval.transcript";
+
+/**
+ * Deterministically encode a provider-approval transcript to
+ * `LP(domain) ‖ LP(field_0) ‖ …`. Field order + domain MUST match the server's
+ * `encodeProviderApprovalTranscript` exactly (asserted by a cross-encoder test).
+ */
+export function encodeProviderApprovalTranscript(t: ProviderApprovalTranscript): Uint8Array {
+  const parts = [
+    lengthPrefixed(PROVIDER_APPROVAL_TRANSCRIPT_DOMAIN),
+    lengthPrefixed(t.transcriptVersion),
+    lengthPrefixed(t.algorithm),
+    lengthPrefixed(t.kind),
+    lengthPrefixed(t.approvalId),
+    lengthPrefixed(t.actionDigest),
+    lengthPrefixed(t.decidedByPrincipalId),
     lengthPrefixed(t.expiresAt),
     lengthPrefixed(t.devicePublicKeyHash),
   ];
@@ -312,6 +390,25 @@ function randomDeviceId(): string {
 export function createWebCryptoDeviceKeyProvider(store?: DeviceKeyStore): DeviceKeyProvider {
   let cached: { keyPair: CryptoKeyPair; material: DeviceKeyMaterial } | null = null;
 
+  /** Sign canonical transcript bytes with the cached non-extractable key (low-S). */
+  async function signCanonicalBytes(
+    bytes: Uint8Array,
+  ): Promise<{ encoding: "ieee-p1363-base64"; value: string }> {
+    if (!subtleAvailable()) throw new DeviceKeyUnavailableError();
+    if (!cached) {
+      throw new DeviceKeyUnavailableError("Device key has not been created yet.");
+    }
+    const raw = new Uint8Array(
+      await globalThis.crypto.subtle.sign(
+        { name: "ECDSA", hash: "SHA-256" },
+        cached.keyPair.privateKey,
+        // Copy into a fresh ArrayBuffer-backed view for BufferSource typing.
+        bytes.slice(),
+      ),
+    );
+    return { encoding: "ieee-p1363-base64", value: toBase64(normalizeLowS(raw)) };
+  }
+
   return {
     isAvailable: subtleAvailable,
 
@@ -356,21 +453,67 @@ export function createWebCryptoDeviceKeyProvider(store?: DeviceKeyStore): Device
     async signTranscript(
       transcript: DeviceClaimTranscript,
     ): Promise<DeviceClaimProof["signature"]> {
-      if (!subtleAvailable()) throw new DeviceKeyUnavailableError();
-      if (!cached) {
-        throw new DeviceKeyUnavailableError("Device key has not been created yet.");
-      }
-      const bytes = encodeOwnerClaimTranscript(transcript);
-      const raw = new Uint8Array(
-        await globalThis.crypto.subtle.sign(
-          { name: "ECDSA", hash: "SHA-256" },
-          cached.keyPair.privateKey,
-          // Copy into a fresh ArrayBuffer-backed view for BufferSource typing.
-          bytes.slice(),
-        ),
-      );
-      return { encoding: "ieee-p1363-base64", value: toBase64(normalizeLowS(raw)) };
+      return signCanonicalBytes(encodeOwnerClaimTranscript(transcript));
     },
+
+    async signApprovalTranscript(
+      transcript: ProviderApprovalTranscript,
+    ): Promise<ProviderApprovalDeviceProof["signature"]> {
+      return signCanonicalBytes(encodeProviderApprovalTranscript(transcript));
+    },
+  };
+}
+
+// ─── Provider-approval authoring (SEC-APPROVAL-AUTHORITY-001 · CR-2) ───
+
+/** Authors a device-signed provider-approval proof binding an exact action digest. */
+export type ProviderApprovalAuthor = (
+  input: { actionDigest: string },
+) => Promise<ProviderApprovalDeviceProof>;
+
+/** Device-chosen approval lifetime. Kept below the Hub's max (10 min) with buffer. */
+const DEFAULT_APPROVAL_LIFETIME_MS = 9 * 60 * 1000;
+
+function randomApprovalId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") return `approval-${c.randomUUID()}`;
+  const rnd = new Uint8Array(16);
+  if (c && typeof c.getRandomValues === "function") c.getRandomValues(rnd);
+  return `approval-${toHex(rnd)}`;
+}
+
+/**
+ * Build a {@link ProviderApprovalAuthor} backed by a device-key provider. The
+ * returned author signs a canonical approval transcript over the reviewed action
+ * digest, binding `decidedByPrincipalId` to the device (device-owner:<keyHash>) so
+ * the Hub verifies the approving owner IS the signing device. It NEVER holds or
+ * exposes a signing secret — the Hub only ever sees the PUBLIC key + signature.
+ */
+export function createProviderApprovalAuthor(
+  provider: DeviceKeyProvider,
+  opts: { now?: () => number; lifetimeMs?: number; approvalId?: () => string } = {},
+): ProviderApprovalAuthor {
+  return async ({ actionDigest }) => {
+    if (!provider.isAvailable()) throw new DeviceKeyUnavailableError();
+    const key = await provider.getOrCreateDeviceKey();
+    const nowMs = opts.now?.() ?? Date.now();
+    const lifetime = opts.lifetimeMs ?? DEFAULT_APPROVAL_LIFETIME_MS;
+    const transcript: ProviderApprovalTranscript = {
+      transcriptVersion: "friday-provider-approval-v1",
+      algorithm: "ECDSA_P256_SHA256",
+      kind: "provider_mutation_approval",
+      approvalId: opts.approvalId?.() ?? randomApprovalId(),
+      actionDigest,
+      decidedByPrincipalId: deviceOwnerPrincipalId(key.devicePublicKeyHash),
+      expiresAt: new Date(nowMs + lifetime).toISOString(),
+      devicePublicKeyHash: key.devicePublicKeyHash,
+    };
+    const signature = await provider.signApprovalTranscript(transcript);
+    return {
+      transcript,
+      devicePublicKey: { encoding: "spki-der-base64", value: key.devicePublicKeySpkiBase64 },
+      signature,
+    };
   };
 }
 

--- a/ui/src/lib/auth/device-owner-bootstrap.ts
+++ b/ui/src/lib/auth/device-owner-bootstrap.ts
@@ -19,6 +19,7 @@ import {
 import type {
   AuthBootstrapChallengeResponse,
   AuthDeviceClaimResponse,
+  AuthLoginChallengeResponse,
   LoginResponse,
 } from "../api/types";
 
@@ -38,6 +39,19 @@ export interface DeviceOwnerBootstrapApi {
     osUser: string;
     deviceClaimProof: DeviceClaimProof;
   }): Promise<AuthDeviceClaimResponse>;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 (CR-1 · Advisor #1628 finding #2): mint a server-issued
+   * single-use login challenge bound to this device + key + origin. Its nonce is the
+   * ONLY value the backend accepts in the owner-login transcript, which makes the
+   * login proof non-replayable.
+   */
+  issueLoginChallenge(input: {
+    installId: string;
+    osUser: string;
+    origin: string;
+    deviceId: string;
+    devicePublicKey: string;
+  }): Promise<AuthLoginChallengeResponse>;
   login(input: {
     devicePublicKey: string;
     deviceId: string;
@@ -57,26 +71,9 @@ export interface DeviceOwnerBootstrapContext {
    * only echoed into the (signed, but not server-cross-checked) transcript.
    */
   osUser: string;
-  /** Deterministic clock override (tests). Defaults to Date.now. */
-  nowMs?: () => number;
-  /** Deterministic login-nonce override (tests). Defaults to a random value. */
-  randomNonce?: () => string;
-  /** Login transcript TTL (ms); MUST be <= the server login TTL clamp (300s). */
-  loginTranscriptTtlMs?: number;
 }
 
 const TRANSCRIPT_CHANNEL = "ui-loopback";
-const DEFAULT_LOGIN_TTL_MS = 120_000;
-
-function defaultRandomNonce(): string {
-  const c = globalThis.crypto;
-  if (c && typeof c.randomUUID === "function") return `login-${c.randomUUID()}`;
-  const rnd = new Uint8Array(16);
-  if (c && typeof c.getRandomValues === "function") c.getRandomValues(rnd);
-  let hex = "";
-  for (let i = 0; i < rnd.length; i += 1) hex += rnd[i].toString(16).padStart(2, "0");
-  return `login-${hex}`;
-}
 
 /**
  * Run the full device-owner first-run: generate/get the device key, claim the
@@ -128,29 +125,41 @@ export async function runDeviceOwnerBootstrap(
     deviceClaimProof: { transcript: claimTranscript, signature: claimSignature },
   });
 
-  // 3) Sign a FRESH owner-login transcript and mint a session by proving possession.
-  const nowMs = (ctx.nowMs ?? (() => Date.now()))();
-  const ttlMs = ctx.loginTranscriptTtlMs ?? DEFAULT_LOGIN_TTL_MS;
+  // 3) Mint a SERVER-ISSUED single-use login challenge (Advisor #1628 finding #2):
+  //    the login nonce is chosen by the SERVER, not the client, so a captured
+  //    owner-login transcript cannot be replayed to mint a second session. The
+  //    challenge is bound to this device + key + origin; its nonce + expiry govern
+  //    the login transcript (the client no longer self-generates either).
+  const loginChallenge = await api.issueLoginChallenge({
+    installId: ctx.installId,
+    osUser: ctx.osUser,
+    origin: ctx.origin,
+    deviceId: key.deviceId,
+    devicePublicKey: key.devicePublicKeySpkiBase64,
+  });
+
+  // 4) Sign a FRESH owner-login transcript over the server nonce and mint a session
+  //    by proving possession.
   const loginTranscript: DeviceClaimTranscript = {
     transcriptVersion: "friday-owner-claim-v1",
     algorithm: "ECDSA_P256_SHA256",
     kind: "install_owner_claim",
-    hubId: challenge.hubId,
-    installId: challenge.installId,
-    osUser: challenge.osUser,
+    hubId: loginChallenge.hubId,
+    installId: loginChallenge.installId,
+    osUser: loginChallenge.osUser,
     deviceId: key.deviceId,
     action: "owner-login",
-    origin: ctx.origin,
+    origin: loginChallenge.origin,
     channel: TRANSCRIPT_CHANNEL,
-    nonce: (ctx.randomNonce ?? defaultRandomNonce)(),
-    expiresAt: new Date(nowMs + ttlMs).toISOString(),
+    nonce: loginChallenge.nonce,
+    expiresAt: loginChallenge.expiresAt,
     devicePublicKeyHash: key.devicePublicKeyHash,
   };
   const loginSignature = await provider.signTranscript(loginTranscript);
   return api.login({
     devicePublicKey: key.devicePublicKeySpkiBase64,
     deviceId: key.deviceId,
-    origin: ctx.origin,
+    origin: loginChallenge.origin,
     deviceLoginProof: { transcript: loginTranscript, signature: loginSignature },
   });
 }

--- a/ui/src/lib/auth/device-owner-bootstrap.ts
+++ b/ui/src/lib/auth/device-owner-bootstrap.ts
@@ -1,0 +1,156 @@
+// ─── SEC-SETUP-BOOTSTRAP-001 · CR-1 — device-owner bootstrap orchestration (UI) ───
+//
+// Ties the device-key seam to the three backend legs for a first-run device-bound
+// owner: challenge → device-claim → device-key login. Pure orchestration with
+// INJECTED api callables + device-key provider so it is unit-testable end-to-end
+// against the real server verifier (see test/unit/ui/device-owner-bootstrap.test.ts).
+//
+// It fabricates NOTHING: the transcripts are signed by a real device key, and the
+// final login mints a session ONLY if the backend's native-IPC attestation
+// precondition is enabled (else the login call fails closed and this rejects — the
+// caller must then fall back to the passphrase path, NOT to a fabricated identity).
+
+import {
+  DeviceKeyUnavailableError,
+  type DeviceClaimProof,
+  type DeviceClaimTranscript,
+  type DeviceKeyProvider,
+} from "./device-key";
+import type {
+  AuthBootstrapChallengeResponse,
+  AuthDeviceClaimResponse,
+  LoginResponse,
+} from "../api/types";
+
+/** The transport leg — real implementations are the `@/lib/api/auth` client fns. */
+export interface DeviceOwnerBootstrapApi {
+  issueChallenge(input: {
+    installId: string;
+    osUser: string;
+    origin: string;
+  }): Promise<AuthBootstrapChallengeResponse>;
+  claim(input: {
+    nonce: string;
+    devicePublicKey: string;
+    deviceId: string;
+    origin: string;
+    installId: string;
+    osUser: string;
+    deviceClaimProof: DeviceClaimProof;
+  }): Promise<AuthDeviceClaimResponse>;
+  login(input: {
+    devicePublicKey: string;
+    deviceId: string;
+    origin: string;
+    deviceLoginProof: DeviceClaimProof;
+  }): Promise<LoginResponse>;
+}
+
+export interface DeviceOwnerBootstrapContext {
+  /** Loopback origin (window.location.origin in the browser). */
+  origin: string;
+  /** Best-effort install id (stable per install). */
+  installId: string;
+  /**
+   * Best-effort OS user LABEL. The browser cannot authoritatively know the OS
+   * user — the trusted caller-identity binding is the native-IPC leaf — so this is
+   * only echoed into the (signed, but not server-cross-checked) transcript.
+   */
+  osUser: string;
+  /** Deterministic clock override (tests). Defaults to Date.now. */
+  nowMs?: () => number;
+  /** Deterministic login-nonce override (tests). Defaults to a random value. */
+  randomNonce?: () => string;
+  /** Login transcript TTL (ms); MUST be <= the server login TTL clamp (300s). */
+  loginTranscriptTtlMs?: number;
+}
+
+const TRANSCRIPT_CHANNEL = "ui-loopback";
+const DEFAULT_LOGIN_TTL_MS = 120_000;
+
+function defaultRandomNonce(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") return `login-${c.randomUUID()}`;
+  const rnd = new Uint8Array(16);
+  if (c && typeof c.getRandomValues === "function") c.getRandomValues(rnd);
+  let hex = "";
+  for (let i = 0; i < rnd.length; i += 1) hex += rnd[i].toString(16).padStart(2, "0");
+  return `login-${hex}`;
+}
+
+/**
+ * Run the full device-owner first-run: generate/get the device key, claim the
+ * owner slot, then log in with a device-key proof-of-possession. Returns the
+ * minted session. Fails closed (throws) when the device-key capability is
+ * unavailable OR when the backend refuses to mint (device authority disabled).
+ */
+export async function runDeviceOwnerBootstrap(
+  provider: DeviceKeyProvider,
+  api: DeviceOwnerBootstrapApi,
+  ctx: DeviceOwnerBootstrapContext,
+): Promise<LoginResponse> {
+  if (!provider.isAvailable()) {
+    throw new DeviceKeyUnavailableError();
+  }
+  const key = await provider.getOrCreateDeviceKey();
+
+  // 1) Mint a single-use install challenge.
+  const challenge = await api.issueChallenge({
+    installId: ctx.installId,
+    osUser: ctx.osUser,
+    origin: ctx.origin,
+  });
+
+  // 2) Sign the canonical owner-claim transcript bound to the challenge + claim it.
+  const claimTranscript: DeviceClaimTranscript = {
+    transcriptVersion: "friday-owner-claim-v1",
+    algorithm: "ECDSA_P256_SHA256",
+    kind: "install_owner_claim",
+    hubId: challenge.hubId,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    deviceId: key.deviceId,
+    action: challenge.action,
+    origin: challenge.origin,
+    channel: TRANSCRIPT_CHANNEL,
+    nonce: challenge.nonce,
+    expiresAt: challenge.expiresAt,
+    devicePublicKeyHash: key.devicePublicKeyHash,
+  };
+  const claimSignature = await provider.signTranscript(claimTranscript);
+  await api.claim({
+    nonce: challenge.nonce,
+    devicePublicKey: key.devicePublicKeySpkiBase64,
+    deviceId: key.deviceId,
+    origin: challenge.origin,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    deviceClaimProof: { transcript: claimTranscript, signature: claimSignature },
+  });
+
+  // 3) Sign a FRESH owner-login transcript and mint a session by proving possession.
+  const nowMs = (ctx.nowMs ?? (() => Date.now()))();
+  const ttlMs = ctx.loginTranscriptTtlMs ?? DEFAULT_LOGIN_TTL_MS;
+  const loginTranscript: DeviceClaimTranscript = {
+    transcriptVersion: "friday-owner-claim-v1",
+    algorithm: "ECDSA_P256_SHA256",
+    kind: "install_owner_claim",
+    hubId: challenge.hubId,
+    installId: challenge.installId,
+    osUser: challenge.osUser,
+    deviceId: key.deviceId,
+    action: "owner-login",
+    origin: ctx.origin,
+    channel: TRANSCRIPT_CHANNEL,
+    nonce: (ctx.randomNonce ?? defaultRandomNonce)(),
+    expiresAt: new Date(nowMs + ttlMs).toISOString(),
+    devicePublicKeyHash: key.devicePublicKeyHash,
+  };
+  const loginSignature = await provider.signTranscript(loginTranscript);
+  return api.login({
+    devicePublicKey: key.devicePublicKeySpkiBase64,
+    deviceId: key.deviceId,
+    origin: ctx.origin,
+    deviceLoginProof: { transcript: loginTranscript, signature: loginSignature },
+  });
+}

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -1,4 +1,10 @@
-import type { CreateProviderInput, UpdateProviderInput } from "@/lib/api/providers";
+import type {
+  CreateProviderInput,
+  FridayProviderMutationApproval,
+  FridayProviderMutationPlan,
+  PlanProviderMutationInput,
+  UpdateProviderInput,
+} from "@/lib/api/providers";
 import type {
   FridayProviderProfile,
   FridayProviderValidationState,
@@ -15,6 +21,27 @@ import type {
  * The onboarding setup wizard routes its validate/save button through this
  * helper instead of the retired `POST /v1/providers/detect` route (which is
  * fail-closed 503 in the default production runtime).
+ *
+ * ## Owner-confirm handshake (CORE-RUNNABLE-001 / CORE-A CR-2)
+ *
+ * In a release profile the canonical mutating-action gate REQUIRES a plan digest
+ * plus a signed canonical approval; without them the mutation fails closed with
+ * `PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED` (403). This helper therefore performs
+ * the full three-step protocol rather than posting the mutation blind:
+ *
+ *   1. `providers.plan` — the SERVER sanitizes the intended parameters and
+ *      derives the plan + action digests itself, returning a secret-free
+ *      human-readable summary. The client never computes a digest, so parameter
+ *      drift can only fail closed — it can never be forged client-side.
+ *   2. the owner REVIEWS that summary and explicitly confirms (`confirmPlan`).
+ *      Declining aborts before anything is minted or mutated.
+ *   3. `providers.plan/confirm` mints a short-lived single-use canonical
+ *      approval bound to the server-computed action digest, which is then
+ *      replayed on the real mutation.
+ *
+ * The gate recomputes the action digest server-side from the request that
+ * actually arrives, so a changed parameter between plan and mutation fails
+ * closed. No step of this handshake weakens the gate.
  */
 
 export interface ProviderSaveResult {
@@ -28,29 +55,80 @@ export interface ProviderSaveResult {
  * satisfy it without an extra adapter.
  */
 export interface ProviderValidateSaveClient {
+  planMutation(input: PlanProviderMutationInput): Promise<FridayProviderMutationPlan>;
+  confirmMutation(planDigest: string): Promise<FridayProviderMutationApproval>;
   create(input: CreateProviderInput): Promise<ProviderSaveResult>;
   update(providerId: string, patch: UpdateProviderInput): Promise<ProviderSaveResult>;
 }
 
 /**
- * Persist a provider only after the backend validates its credential.
+ * Owner review + explicit confirmation of a server-produced plan.
+ *
+ * MUST resolve `true` only on a deliberate owner confirmation of THIS plan —
+ * never defaulted, never auto-accepted. Resolving `false` aborts the save before
+ * any approval is minted and before any mutation is sent.
+ */
+export type ProviderPlanConfirmer = (plan: FridayProviderMutationPlan) => Promise<boolean>;
+
+/** Thrown when the owner reviewed the plan and declined it. Nothing was mutated. */
+export class ProviderMutationDeclinedError extends Error {
+  readonly planDigest: string;
+
+  constructor(planDigest: string) {
+    super("Provider change was not confirmed by the owner; nothing was saved.");
+    this.name = "ProviderMutationDeclinedError";
+    this.planDigest = planDigest;
+  }
+}
+
+/**
+ * Persist a provider only after the backend validates its credential AND the
+ * owner has confirmed the server-derived plan.
  *
  * - When a provider of the same kind already exists, this updates it (so a
  *   re-submit / replay is idempotent — no duplicate provider, no double-persist
  *   of the credential) rather than creating a second one.
  * - `validateOnSave: true` is always set, so validation is never bypassed.
+ * - The plan is derived by the server from the EXACT body the mutation will
+ *   send, so the replayed approval cannot cover different parameters.
  */
 export async function saveProviderWithValidation(
   client: ProviderValidateSaveClient,
   existing: { id: string } | undefined,
   input: CreateProviderInput,
+  confirmPlan: ProviderPlanConfirmer,
 ): Promise<ProviderSaveResult> {
-  if (!existing) {
-    return client.create({ ...input, validateOnSave: true });
+  // Build the exact mutation body FIRST so the plan the owner reviews is derived
+  // from the same parameters the mutation will actually carry.
+  let body: CreateProviderInput | UpdateProviderInput;
+  if (existing) {
+    // An update patch carries no `kind` (the provider's kind is immutable).
+    const { kind, ...rest } = input;
+    void kind;
+    body = { ...rest, validateOnSave: true };
+  } else {
+    body = { ...input, validateOnSave: true };
   }
-  // An update patch carries no `kind` (the provider's kind is immutable).
-  const { kind, ...rest } = input;
-  void kind;
-  const patch: UpdateProviderInput = { ...rest, validateOnSave: true };
-  return client.update(existing.id, patch);
+
+  const plan = await client.planMutation({
+    action: existing ? "providers.update" : "providers.create",
+    providerId: existing?.id,
+    params: body as unknown as Record<string, unknown>,
+  });
+
+  const confirmed = await confirmPlan(plan);
+  if (confirmed !== true) {
+    throw new ProviderMutationDeclinedError(plan.planDigest);
+  }
+
+  const approval = await client.confirmMutation(plan.planDigest);
+  const controls = {
+    planDigest: approval.planDigest,
+    canonicalApproval: approval.canonicalApproval,
+  };
+
+  if (existing) {
+    return client.update(existing.id, { ...(body as UpdateProviderInput), ...controls });
+  }
+  return client.create({ ...(body as CreateProviderInput), ...controls });
 }

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -3,9 +3,12 @@ import type {
   FridayProviderMutationApproval,
   FridayProviderMutationPlan,
   PlanProviderMutationInput,
+  SetRoutingInput,
   UpdateProviderInput,
 } from "@/lib/api/providers";
+import type { ProviderApprovalAuthor, ProviderApprovalDeviceProof } from "@/lib/auth/device-key";
 import type {
+  FridayModelRoutingConfig,
   FridayProviderProfile,
   FridayProviderValidationState,
 } from "@/lib/api/types";
@@ -22,26 +25,28 @@ import type {
  * helper instead of the retired `POST /v1/providers/detect` route (which is
  * fail-closed 503 in the default production runtime).
  *
- * ## Owner-confirm handshake (CORE-RUNNABLE-001 / CORE-A CR-2)
+ * ## Owner-confirm handshake (SEC-APPROVAL-AUTHORITY-001 / CORE-A CR-2)
  *
  * In a release profile the canonical mutating-action gate REQUIRES a plan digest
- * plus a signed canonical approval; without them the mutation fails closed with
+ * plus a DEVICE-AUTHORED approval; without them the mutation fails closed with
  * `PROVIDER_MUTATION_PLAN_DIGEST_REQUIRED` (403). This helper therefore performs
- * the full three-step protocol rather than posting the mutation blind:
+ * the full four-step protocol rather than posting the mutation blind:
  *
- *   1. `providers.plan` — the SERVER sanitizes the intended parameters and
- *      derives the plan + action digests itself, returning a secret-free
- *      human-readable summary. The client never computes a digest, so parameter
- *      drift can only fail closed — it can never be forged client-side.
+ *   1. `providers.plan` — the SERVER sanitizes the intended parameters and derives
+ *      the plan + action digests itself, returning a secret-free human-readable
+ *      summary. The client never computes a digest, so parameter drift can only
+ *      fail closed — it can never be forged client-side.
  *   2. the owner REVIEWS that summary and explicitly confirms (`confirmPlan`).
- *      Declining aborts before anything is minted or mutated.
- *   3. `providers.plan/confirm` mints a short-lived single-use canonical
- *      approval bound to the server-computed action digest, which is then
+ *      Declining aborts before anything is signed or mutated.
+ *   3. the owner DEVICE signs an approval transcript binding the SERVER-computed
+ *      action digest (`authorApproval`). The Hub holds NO signing key.
+ *   4. `providers.plan/confirm` VERIFIES that device proof (asymmetric P-256) and
+ *      returns the device-authored, single-use canonical approval, which is then
  *      replayed on the real mutation.
  *
- * The gate recomputes the action digest server-side from the request that
- * actually arrives, so a changed parameter between plan and mutation fails
- * closed. No step of this handshake weakens the gate.
+ * The gate recomputes the action digest server-side from the request that actually
+ * arrives AND re-verifies the device proof, so a changed parameter between plan and
+ * mutation fails closed. No step of this handshake weakens the gate.
  */
 
 export interface ProviderSaveResult {
@@ -50,23 +55,31 @@ export interface ProviderSaveResult {
 }
 
 /**
- * The subset of `providersApi` this helper needs. Declaring it structurally
- * keeps the helper unit-testable with a mock and lets the real `providersApi`
- * satisfy it without an extra adapter.
+ * The subset of `providersApi` these helpers need. Declaring it structurally keeps
+ * the helpers unit-testable with a mock and lets the real `providersApi` satisfy it
+ * without an extra adapter.
  */
 export interface ProviderValidateSaveClient {
   planMutation(input: PlanProviderMutationInput): Promise<FridayProviderMutationPlan>;
-  confirmMutation(planDigest: string): Promise<FridayProviderMutationApproval>;
+  confirmMutation(
+    planDigest: string,
+    deviceApproval: ProviderApprovalDeviceProof,
+  ): Promise<FridayProviderMutationApproval>;
   create(input: CreateProviderInput): Promise<ProviderSaveResult>;
   update(providerId: string, patch: UpdateProviderInput): Promise<ProviderSaveResult>;
+}
+
+/** The routing seam, needed by {@link saveProviderWithRouting}. */
+export interface ProviderRoutingSaveClient extends ProviderValidateSaveClient {
+  setRouting(input: SetRoutingInput): Promise<FridayModelRoutingConfig>;
 }
 
 /**
  * Owner review + explicit confirmation of a server-produced plan.
  *
  * MUST resolve `true` only on a deliberate owner confirmation of THIS plan —
- * never defaulted, never auto-accepted. Resolving `false` aborts the save before
- * any approval is minted and before any mutation is sent.
+ * never defaulted, never auto-accepted. Resolving `false` aborts before any
+ * approval is authored and before any mutation is sent.
  */
 export type ProviderPlanConfirmer = (plan: FridayProviderMutationPlan) => Promise<boolean>;
 
@@ -82,21 +95,71 @@ export class ProviderMutationDeclinedError extends Error {
 }
 
 /**
- * Persist a provider only after the backend validates its credential AND the
- * owner has confirmed the server-derived plan.
+ * Thrown when a provider was created/updated (and its credential persisted) but the
+ * follow-up routing step failed. This surfaces the partial state TRUTHFULLY — naming
+ * the persisted provider — instead of masquerading as a total save failure that
+ * hides the created provider (SAFE-ROLLBACK-PRECONDITION-001 / Advisor #1628 #3).
+ */
+export class ProviderRoutingAfterSaveError extends Error {
+  readonly provider: FridayProviderProfile;
+  readonly cause: unknown;
+
+  constructor(provider: FridayProviderProfile, cause: unknown) {
+    super(
+      "The provider was saved but its default-routing could not be set. "
+        + "The provider exists; set it as the default from the provider list to finish.",
+    );
+    this.name = "ProviderRoutingAfterSaveError";
+    this.provider = provider;
+    this.cause = cause;
+  }
+}
+
+/**
+ * Run ONE gated provider mutation through the full owner-confirm handshake and
+ * return the control fields (`planDigest` + device-authored `canonicalApproval`)
+ * to replay on the real mutation. Shared by create/update AND routing so NO gated
+ * provider mutation is ever posted without a confirmed, device-authored approval.
+ */
+async function confirmProviderMutationPlan(
+  client: ProviderValidateSaveClient,
+  planInput: PlanProviderMutationInput,
+  confirmPlan: ProviderPlanConfirmer,
+  authorApproval: ProviderApprovalAuthor,
+): Promise<{ planDigest: string; canonicalApproval: unknown }> {
+  const plan = await client.planMutation(planInput);
+
+  const confirmed = await confirmPlan(plan);
+  if (confirmed !== true) {
+    throw new ProviderMutationDeclinedError(plan.planDigest);
+  }
+
+  // The owner DEVICE authors the approval over the SERVER-computed action digest.
+  const deviceApproval = await authorApproval({ actionDigest: plan.actionDigest });
+  const approval = await client.confirmMutation(plan.planDigest, deviceApproval);
+  return {
+    planDigest: approval.planDigest,
+    canonicalApproval: approval.canonicalApproval,
+  };
+}
+
+/**
+ * Persist a provider only after the backend validates its credential AND the owner
+ * has confirmed the server-derived plan with a device-authored approval.
  *
  * - When a provider of the same kind already exists, this updates it (so a
- *   re-submit / replay is idempotent — no duplicate provider, no double-persist
- *   of the credential) rather than creating a second one.
+ *   re-submit / replay is idempotent — no duplicate provider, no double-persist of
+ *   the credential) rather than creating a second one.
  * - `validateOnSave: true` is always set, so validation is never bypassed.
- * - The plan is derived by the server from the EXACT body the mutation will
- *   send, so the replayed approval cannot cover different parameters.
+ * - The plan is derived by the server from the EXACT body the mutation will send,
+ *   so the replayed approval cannot cover different parameters.
  */
 export async function saveProviderWithValidation(
   client: ProviderValidateSaveClient,
   existing: { id: string } | undefined,
   input: CreateProviderInput,
   confirmPlan: ProviderPlanConfirmer,
+  authorApproval: ProviderApprovalAuthor,
 ): Promise<ProviderSaveResult> {
   // Build the exact mutation body FIRST so the plan the owner reviews is derived
   // from the same parameters the mutation will actually carry.
@@ -110,25 +173,82 @@ export async function saveProviderWithValidation(
     body = { ...input, validateOnSave: true };
   }
 
-  const plan = await client.planMutation({
-    action: existing ? "providers.update" : "providers.create",
-    providerId: existing?.id,
-    params: body as unknown as Record<string, unknown>,
-  });
-
-  const confirmed = await confirmPlan(plan);
-  if (confirmed !== true) {
-    throw new ProviderMutationDeclinedError(plan.planDigest);
-  }
-
-  const approval = await client.confirmMutation(plan.planDigest);
-  const controls = {
-    planDigest: approval.planDigest,
-    canonicalApproval: approval.canonicalApproval,
-  };
+  const controls = await confirmProviderMutationPlan(
+    client,
+    {
+      action: existing ? "providers.update" : "providers.create",
+      providerId: existing?.id,
+      params: body as unknown as Record<string, unknown>,
+    },
+    confirmPlan,
+    authorApproval,
+  );
 
   if (existing) {
     return client.update(existing.id, { ...(body as UpdateProviderInput), ...controls });
   }
   return client.create({ ...(body as CreateProviderInput), ...controls });
+}
+
+/**
+ * Set the model routing config through the SAME owner-confirm + device-authored
+ * handshake as create/update. `providers.routing.set` is a GATED mutation, so a
+ * bare `setRouting` fails closed (403) in a release profile — every routing change
+ * must carry a confirmed, device-authored approval.
+ */
+export async function setRoutingWithConfirmation(
+  client: ProviderRoutingSaveClient,
+  routingBody: Omit<SetRoutingInput, "planDigest" | "canonicalApproval">,
+  confirmPlan: ProviderPlanConfirmer,
+  authorApproval: ProviderApprovalAuthor,
+): Promise<FridayModelRoutingConfig> {
+  const controls = await confirmProviderMutationPlan(
+    client,
+    { action: "providers.routing.set", params: routingBody as unknown as Record<string, unknown> },
+    confirmPlan,
+    authorApproval,
+  );
+  return client.setRouting({ ...routingBody, ...controls });
+}
+
+/**
+ * Persist a provider AND set it as the default route as ONE owner-reviewed
+ * operation — each gated mutation flowing through its OWN confirmed, device-authored
+ * plan (SAFE-ROLLBACK-PRECONDITION-001 / Advisor #1628 #3).
+ *
+ * The previous setup path called `providersApi.setRouting` WITHOUT a plan/approval
+ * right after a successful create; in a release profile that guarantees a 403 AFTER
+ * the provider is persisted, leaving a created-but-unrouted provider surfaced as a
+ * total save failure. Here routing is a first-class confirmed mutation, so it can
+ * never 403-after-persist; and if it fails for any OTHER reason, the partial state
+ * is reported truthfully (the provider is named) instead of hidden.
+ */
+export async function saveProviderWithRouting(
+  client: ProviderRoutingSaveClient,
+  existing: { id: string } | undefined,
+  input: CreateProviderInput,
+  buildRouting: (provider: FridayProviderProfile) => Omit<SetRoutingInput, "planDigest" | "canonicalApproval">,
+  confirmPlan: ProviderPlanConfirmer,
+  authorApproval: ProviderApprovalAuthor,
+): Promise<ProviderSaveResult & { routing: FridayModelRoutingConfig }> {
+  const saved = await saveProviderWithValidation(client, existing, input, confirmPlan, authorApproval);
+
+  try {
+    const routing = await setRoutingWithConfirmation(
+      client,
+      buildRouting(saved.provider),
+      confirmPlan,
+      authorApproval,
+    );
+    return { ...saved, routing };
+  } catch (error) {
+    // The owner declined the routing plan → propagate the decline unchanged (the
+    // provider is saved, which is the reviewed-and-confirmed first step).
+    if (error instanceof ProviderMutationDeclinedError) {
+      throw error;
+    }
+    // Any other routing failure AFTER a successful save is reported truthfully so
+    // the created provider is never hidden behind a generic save error.
+    throw new ProviderRoutingAfterSaveError(saved.provider, error);
+  }
 }

--- a/ui/src/providers/auth-provider.tsx
+++ b/ui/src/providers/auth-provider.tsx
@@ -1,6 +1,16 @@
 import * as React from "react";
 import { authStorage } from "@/lib/storage/auth-storage";
-import { fetchMe, login as loginRequest, logout, type LoginInput } from "@/lib/api/auth";
+import {
+  deviceKeyLogin,
+  fetchMe,
+  login as loginRequest,
+  logout,
+  postBootstrapChallenge,
+  postDeviceClaim,
+  type LoginInput,
+} from "@/lib/api/auth";
+import { getDeviceKeyProvider } from "@/lib/auth/device-key";
+import { runDeviceOwnerBootstrap } from "@/lib/auth/device-owner-bootstrap";
 import type { FridayUser } from "@/lib/api/types";
 
 // ─── Context shape ───
@@ -11,8 +21,35 @@ interface AuthContextValue {
   isLoading: boolean;
   authError: Error | null;
   login: (input: LoginInput) => Promise<void>;
+  /**
+   * SEC-SETUP-BOOTSTRAP-001 (CR-1): device-bound owner first-run. Generates a real
+   * device key, claims the owner slot, and logs in by proving key possession.
+   * Rejects (fails closed) if the device-key capability is unavailable OR if the
+   * backend refuses to mint (device authority disabled) — the caller must NOT
+   * silently fall back to a fabricated identity.
+   */
+  deviceOwnerLogin: () => Promise<void>;
+  /** Whether the device-key capability is available in this context (fail-closed). */
+  deviceKeyAvailable: boolean;
   logout: () => Promise<void>;
   retryLocalSession: () => Promise<void>;
+}
+
+/** Stable per-install id used to bind device-claim challenge context. */
+function resolveInstallId(): string {
+  const KEY = "friday.device.install-id";
+  try {
+    const existing = window.localStorage.getItem(KEY);
+    if (existing) return existing;
+    const generated =
+      typeof window.crypto?.randomUUID === "function"
+        ? window.crypto.randomUUID()
+        : `install-${String(Date.now())}`;
+    window.localStorage.setItem(KEY, generated);
+    return generated;
+  } catch {
+    return "install-local";
+  }
 }
 
 const AuthContext = React.createContext<AuthContextValue | null>(null);
@@ -103,6 +140,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setAuthError(null);
   }, []);
 
+  const handleDeviceOwnerLogin = React.useCallback(async () => {
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const response = await runDeviceOwnerBootstrap(
+      getDeviceKeyProvider(),
+      { issueChallenge: postBootstrapChallenge, claim: postDeviceClaim, login: deviceKeyLogin },
+      { origin, installId: resolveInstallId(), osUser: "ui" },
+    );
+    setUser(response.user);
+    setAuthError(null);
+  }, []);
+
   const handleLogout = React.useCallback(async () => {
     await logout();
     setUser(null);
@@ -116,10 +164,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       isLoading,
       authError,
       login: handleLogin,
+      deviceOwnerLogin: handleDeviceOwnerLogin,
+      deviceKeyAvailable: getDeviceKeyProvider().isAvailable(),
       logout: handleLogout,
       retryLocalSession,
     }),
-    [user, isLoading, authError, handleLogin, handleLogout, retryLocalSession],
+    [user, isLoading, authError, handleLogin, handleDeviceOwnerLogin, handleLogout, retryLocalSession],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/ui/src/providers/auth-provider.tsx
+++ b/ui/src/providers/auth-provider.tsx
@@ -7,6 +7,7 @@ import {
   logout,
   postBootstrapChallenge,
   postDeviceClaim,
+  postLoginChallenge,
   type LoginInput,
 } from "@/lib/api/auth";
 import { getDeviceKeyProvider } from "@/lib/auth/device-key";
@@ -144,7 +145,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const origin = typeof window !== "undefined" ? window.location.origin : "";
     const response = await runDeviceOwnerBootstrap(
       getDeviceKeyProvider(),
-      { issueChallenge: postBootstrapChallenge, claim: postDeviceClaim, login: deviceKeyLogin },
+      {
+        issueChallenge: postBootstrapChallenge,
+        claim: postDeviceClaim,
+        issueLoginChallenge: postLoginChallenge,
+        login: deviceKeyLogin,
+      },
       { origin, installId: resolveInstallId(), osUser: "ui" },
     );
     setUser(response.user);

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -35,6 +35,7 @@ const ReflexPage = lazy(async () => import("@/routes/reflex-page").then((module)
 const SettingsPage = lazy(async () => import("@/routes/settings-page").then((module) => ({ default: module.SettingsPage })));
 const SetupPage = lazy(async () => import("@/routes/setup-page").then((module) => ({ default: module.SetupPage })));
 const FirstRunPassphraseGate = lazy(async () => import("@/routes/first-run-passphrase-gate").then((module) => ({ default: module.FirstRunPassphraseGate })));
+const FirstRunDeviceClaimGate = lazy(async () => import("@/routes/first-run-device-claim-gate").then((module) => ({ default: module.FirstRunDeviceClaimGate })));
 const SkillsPage = lazy(async () => import("@/routes/skills-page").then((module) => ({ default: module.SkillsPage })));
 const SkillGeneratorPage = lazy(async () => import("@/routes/skill-generator-page").then((module) => ({ default: module.SkillGeneratorPage })));
 const WorkflowBuilderPage = lazy(async () => import("@/routes/workflow-builder-page").then((module) => ({ default: module.WorkflowBuilderPage })));
@@ -211,7 +212,25 @@ function RequireAuth({ children }: { children: ReactNode }) {
     }
     if (bootstrapStatusQuery.data?.bootstrapRequired) {
       // Backend is reachable and reports a fresh machine → offer the first-run local
-      // security gate (create passphrase), NOT a misleading "connecting" screen.
+      // security gate, NOT a misleading "connecting" screen.
+      //
+      // SEC-SETUP-BOOTSTRAP-001 (CR-1): when the backend reports device-owner
+      // authority is enabled (deviceClaimAvailable — server-derived, requires the
+      // native-IPC attestation precondition), route to the DEVICE-CLAIM gate as the
+      // authoritative first-run path. Otherwise (the current release build, where
+      // attestation is honestly unavailable) keep the passphrase gate. The
+      // passphrase gate is NOT offered as the authoritative path when device-claim
+      // is available.
+      if (bootstrapStatusQuery.data.deviceClaimAvailable === true) {
+        return (
+          <RouteSuspense
+            title={localizedText("绑定本机设备", "Bind this device")}
+            detail={localizedText("Friday 正在准备本机设备安全设置。", "Friday is preparing device-bound security setup.")}
+          >
+            <FirstRunDeviceClaimGate />
+          </RouteSuspense>
+        );
+      }
       return (
         <RouteSuspense
           title={localizedText("创建本机口令", "Create local passphrase")}

--- a/ui/src/routes/first-run-device-claim-gate.tsx
+++ b/ui/src/routes/first-run-device-claim-gate.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/hooks/use-auth";
+import { localize } from "@/lib/i18n/localized-text";
+import { useAppLocale } from "@/providers/locale-provider";
+
+/**
+ * SEC-SETUP-BOOTSTRAP-001 (CR-1) — first-run DEVICE-BOUND owner gate.
+ *
+ * Shown when the backend reports `bootstrapRequired: true` AND
+ * `deviceClaimAvailable: true` (device-owner authority is enabled — which requires
+ * the native-IPC attestation precondition). It binds THIS machine's owner slot to a
+ * device key and logs in by proving possession of that key — no passphrase.
+ *
+ * HONESTY: this gate NEVER fabricates attestation. If the device-key capability is
+ * unavailable in this context it FAILS CLOSED with a clear message and does NOT
+ * silently fall back to the passphrase path as the authoritative one. Minting a
+ * session still requires the backend's native-IPC precondition; if the backend
+ * refuses, the error is surfaced (not papered over).
+ *
+ * Never logs any key material or token.
+ */
+export function FirstRunDeviceClaimGate() {
+  const { locale } = useAppLocale();
+  const { deviceOwnerLogin, deviceKeyAvailable } = useAuth();
+  const queryClient = useQueryClient();
+
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleClaim() {
+    setError(null);
+    if (!deviceKeyAvailable) {
+      // Fail closed — do NOT fabricate a device key or silently use passphrase.
+      setError(
+        localize(
+          locale,
+          "此环境不支持设备安全密钥（需要安全上下文）。请在受支持的本机入口中打开 Friday 后重试。",
+          "Device security keys are not available in this context (a secure context is required). Reopen Friday from a supported local entrypoint and retry.",
+        ),
+      );
+      return;
+    }
+    setSubmitting(true);
+    try {
+      // 1) Generate/get the device key, claim the owner slot, and log in by PoP.
+      await deviceOwnerLogin();
+      // 2) Refresh bootstrap status so RequireAuth re-evaluates and SetupGate routes on.
+      await queryClient.invalidateQueries({ queryKey: ["auth", "bootstrap", "status"] });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Device setup failed";
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "100vh",
+        gap: "16px",
+        fontFamily: "system-ui, sans-serif",
+        padding: "24px",
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: "380px", display: "flex", flexDirection: "column", gap: "16px" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+          <span style={{ fontSize: "13px", letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--faint)" }}>Friday</span>
+          <h1 style={{ margin: 0, fontSize: "22px" }}>{localize(locale, "绑定本机设备所有者", "Bind this device as owner")}</h1>
+          <p style={{ margin: 0, color: "var(--muted)", fontSize: "14px", lineHeight: 1.5 }}>
+            {localize(
+              locale,
+              "这是本机 Friday 的一次性本地安全设置。Friday 会在本设备生成一把安全密钥并绑定为所有者，之后用它证明身份，无需口令。",
+              "This is the one-time local security setup for Friday on this machine. Friday generates a security key on this device and binds it as the owner, then proves your identity with it — no passphrase.",
+            )}
+          </p>
+        </div>
+        {!deviceKeyAvailable ? (
+          <p style={{ margin: 0, color: "var(--danger)", fontSize: "13px" }}>
+            {localize(
+              locale,
+              "此环境不支持设备安全密钥。请在受支持的本机入口中打开 Friday。",
+              "Device security keys are not available here. Open Friday from a supported local entrypoint.",
+            )}
+          </p>
+        ) : null}
+        {error ? <p style={{ margin: 0, color: "var(--danger)", fontSize: "13px" }}>{error}</p> : null}
+        <button
+          type="button"
+          onClick={() => void handleClaim()}
+          disabled={submitting}
+          aria-label={localize(locale, "绑定本机设备并继续", "Bind this device and continue")}
+          style={{
+            padding: "10px 12px",
+            borderRadius: "8px",
+            border: "none",
+            background: "var(--ink)",
+            color: "var(--paper-strong)",
+            fontSize: "14px",
+            cursor: submitting ? "not-allowed" : "pointer",
+            opacity: submitting ? 0.6 : 1,
+          }}
+        >
+          {submitting
+            ? localize(locale, "正在绑定设备…", "Binding device…")
+            : localize(locale, "绑定本机设备并继续", "Bind this device and continue")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -6,7 +6,8 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { healthApi } from "@/lib/api/health";
 import { providersApi } from "@/lib/api/providers";
-import { saveProviderWithValidation } from "@/lib/providers";
+import type { FridayProviderMutationPlan } from "@/lib/api/providers";
+import { ProviderMutationDeclinedError, saveProviderWithValidation } from "@/lib/providers";
 import { setupApi } from "@/lib/api/setup";
 import { discoveryApi } from "@/lib/api/discovery";
 import type { DiscoveredProgram, IntegrationRecommendation } from "@/lib/api/discovery";
@@ -405,6 +406,14 @@ export function SetupPage() {
   });
   const [pendingDefaultProviderChoice, setPendingDefaultProviderChoice] = useState<PendingDefaultProviderChoice | null>(null);
   const [routingUpdatePending, setRoutingUpdatePending] = useState(false);
+  // CORE-A CR-2: the server-derived provider mutation plan awaiting THIS owner's
+  // explicit confirmation. `resolve` is the pending `saveProviderWithValidation`
+  // handshake — resolving false aborts before any approval is minted or any
+  // mutation is sent. Never auto-confirmed.
+  const [pendingProviderPlan, setPendingProviderPlan] = useState<{
+    plan: FridayProviderMutationPlan;
+    resolve: (confirmed: boolean) => void;
+  } | null>(null);
   const hasSetupDeepLink = Boolean(
     searchParams.get("step")
       ?? searchParams.get("providerKind")
@@ -644,10 +653,15 @@ export function SetupPage() {
     // Validate-before-persist via the same live create/update path the Settings
     // page uses (validateOnSave: true). This is NOT the retired
     // POST /v1/providers/detect route.
-    const response = await saveProviderWithValidation(providersApi, existingSameKind, {
-      kind: draft.kind,
-      ...commonPayload,
-    });
+    const response = await saveProviderWithValidation(
+      providersApi,
+      existingSameKind,
+      { kind: draft.kind, ...commonPayload },
+      // CORE-A CR-2: the owner reviews the SERVER-derived, secret-free plan
+      // summary and explicitly confirms before any canonical approval is minted.
+      // Resolving false aborts the save with ProviderMutationDeclinedError.
+      (plan) => new Promise<boolean>((resolve) => setPendingProviderPlan({ plan, resolve })),
+    );
     const provider = response.provider;
 
     await providersApi.setRouting({
@@ -803,6 +817,19 @@ export function SetupPage() {
       void queryClient.invalidateQueries({ queryKey: ["shell", "provider-truth"] });
     },
     onError: (error) => {
+      // CORE-A CR-2: the owner reviewed the server-derived plan and declined it.
+      // No canonical approval was minted and no mutation was sent — this is a
+      // deliberate cancel, NOT a validation failure, so it must not be surfaced
+      // as an error state (which would wrongly imply the key was rejected).
+      if (error instanceof ProviderMutationDeclinedError) {
+        setProviderFeedback({
+          status: "idle",
+          kind: providerKind,
+          message: localize(locale, "已取消：未保存任何更改。", "Cancelled — nothing was saved."),
+          warnings: [],
+        });
+        return;
+      }
       // Validate-before-persist rejected the key (e.g. invalid / unreachable):
       // it was NOT persisted. Surface the invalid state, do not advance.
       setProviderValidated(false);
@@ -2012,6 +2039,30 @@ export function SetupPage() {
             void setProviderAsDefault(pending.providerId, pending.defaultModel).then(() => {
               setPendingDefaultProviderChoice(null);
             });
+          }}
+        />
+        {/*
+          CORE-A CR-2 owner-confirm gate. The summary lines are produced by the
+          SERVER from the sanitized parameters (secret-free); the owner must
+          explicitly confirm this exact plan before any canonical approval is
+          minted. Cancelling resolves false — nothing is minted, nothing is saved.
+        */}
+        <ConfirmDialog
+          open={pendingProviderPlan !== null}
+          title={localize(locale, "确认提供方变更", "Confirm provider change")}
+          description={pendingProviderPlan?.plan.humanReadableSummary.join(" · ")}
+          confirmLabel={localize(locale, "确认并保存", "Confirm and save")}
+          cancelLabel={localize(locale, "取消", "Cancel")}
+          tone="primary"
+          onCancel={() => {
+            const pending = pendingProviderPlan;
+            setPendingProviderPlan(null);
+            pending?.resolve(false);
+          }}
+          onConfirm={() => {
+            const pending = pendingProviderPlan;
+            setPendingProviderPlan(null);
+            pending?.resolve(true);
           }}
         />
         <BottomDots />

--- a/ui/src/routes/setup-page.tsx
+++ b/ui/src/routes/setup-page.tsx
@@ -7,7 +7,13 @@ import { toast } from "sonner";
 import { healthApi } from "@/lib/api/health";
 import { providersApi } from "@/lib/api/providers";
 import type { FridayProviderMutationPlan } from "@/lib/api/providers";
-import { ProviderMutationDeclinedError, saveProviderWithValidation } from "@/lib/providers";
+import {
+  ProviderMutationDeclinedError,
+  ProviderRoutingAfterSaveError,
+  saveProviderWithRouting,
+  setRoutingWithConfirmation,
+} from "@/lib/providers";
+import { createProviderApprovalAuthor, getDeviceKeyProvider } from "@/lib/auth/device-key";
 import { setupApi } from "@/lib/api/setup";
 import { discoveryApi } from "@/lib/api/discovery";
 import type { DiscoveredProgram, IntegrationRecommendation } from "@/lib/api/discovery";
@@ -635,6 +641,20 @@ export function SetupPage() {
     };
   }
 
+  // SEC-APPROVAL-AUTHORITY-001 (CR-2): the owner DEVICE authors provider approvals.
+  // The Hub holds no signing key — this author signs a P-256 transcript with the
+  // durable device key the owner bootstrap created.
+  const providerApprovalAuthor = useMemo(
+    () => createProviderApprovalAuthor(getDeviceKeyProvider()),
+    [],
+  );
+
+  // The owner reviews the SERVER-derived, secret-free plan summary and explicitly
+  // confirms before any device approval is authored. Resolving false aborts.
+  function confirmProviderPlan(plan: FridayProviderMutationPlan): Promise<boolean> {
+    return new Promise<boolean>((resolve) => setPendingProviderPlan({ plan, resolve }));
+  }
+
   async function saveProviderDraft(
     draft: ProviderSaveDraft,
   ): Promise<{ validation: FridayProviderValidationState | undefined }> {
@@ -651,26 +671,24 @@ export function SetupPage() {
     };
 
     // Validate-before-persist via the same live create/update path the Settings
-    // page uses (validateOnSave: true). This is NOT the retired
-    // POST /v1/providers/detect route.
-    const response = await saveProviderWithValidation(
+    // page uses (validateOnSave: true), then set default-routing as PART of the
+    // SAME owner-reviewed operation. Advisor #1628 finding #3: routing is a first
+    // class confirmed, device-authored mutation, so it can NEVER 403-after-persist
+    // and strand a created-but-unrouted provider.
+    const response = await saveProviderWithRouting(
       providersApi,
       existingSameKind,
       { kind: draft.kind, ...commonPayload },
-      // CORE-A CR-2: the owner reviews the SERVER-derived, secret-free plan
-      // summary and explicitly confirms before any canonical approval is minted.
-      // Resolving false aborts the save with ProviderMutationDeclinedError.
-      (plan) => new Promise<boolean>((resolve) => setPendingProviderPlan({ plan, resolve })),
+      (provider) => ({
+        defaultProviderId: provider.id,
+        defaultModel: draft.defaultModel,
+        fallbackProviderIds: [],
+        costMode: providerCostMode,
+        enforceRequestedModel: routingConfig?.enforceRequestedModel,
+      }),
+      confirmProviderPlan,
+      providerApprovalAuthor,
     );
-    const provider = response.provider;
-
-    await providersApi.setRouting({
-      defaultProviderId: provider.id,
-      defaultModel: draft.defaultModel,
-      fallbackProviderIds: [],
-      costMode: providerCostMode,
-      enforceRequestedModel: routingConfig?.enforceRequestedModel,
-    });
 
     return { validation: response.validation };
   }
@@ -678,13 +696,18 @@ export function SetupPage() {
   async function setProviderAsDefault(providerId: string, defaultModel?: string): Promise<void> {
     setRoutingUpdatePending(true);
     try {
-      await providersApi.setRouting({
-        defaultProviderId: providerId,
-        defaultModel,
-        fallbackProviderIds: (routingConfig?.fallbackProviderIds ?? []).filter((id) => id !== providerId),
-        costMode: providerCostMode,
-        enforceRequestedModel: routingConfig?.enforceRequestedModel,
-      });
+      await setRoutingWithConfirmation(
+        providersApi,
+        {
+          defaultProviderId: providerId,
+          defaultModel,
+          fallbackProviderIds: (routingConfig?.fallbackProviderIds ?? []).filter((id) => id !== providerId),
+          costMode: providerCostMode,
+          enforceRequestedModel: routingConfig?.enforceRequestedModel,
+        },
+        confirmProviderPlan,
+        providerApprovalAuthor,
+      );
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["setup", "routing-config"] }),
         queryClient.invalidateQueries({ queryKey: ["setup", "providers"] }),
@@ -828,6 +851,27 @@ export function SetupPage() {
           message: localize(locale, "已取消：未保存任何更改。", "Cancelled — nothing was saved."),
           warnings: [],
         });
+        return;
+      }
+      // Advisor #1628 finding #3: the provider WAS saved but its default-routing
+      // could not be set. Report the partial state TRUTHFULLY (the provider exists)
+      // instead of implying the key was rejected. The provider was validated, so
+      // mark it validated and tell the owner to finish routing from the list.
+      if (error instanceof ProviderRoutingAfterSaveError) {
+        setProviderValidated(true);
+        void queryClient.invalidateQueries({ queryKey: ["setup", "providers"] });
+        void queryClient.invalidateQueries({ queryKey: ["shell", "provider-truth"] });
+        setProviderFeedback({
+          status: "error",
+          kind: providerKind,
+          message: localize(
+            locale,
+            `提供方“${error.provider.name}”已保存，但默认路由未设置。请在提供方列表中将其设为默认。`,
+            `Provider "${error.provider.name}" was saved, but default routing was not set. Set it as default from the provider list.`,
+          ),
+          warnings: [],
+        });
+        toast.error(localize(locale, "提供方已保存，但路由未设置", "Provider saved, but routing was not set"));
         return;
       }
       // Validate-before-persist rejected the key (e.g. invalid / unreachable):


### PR DESCRIPTION
## R14 CORE-A (CR-0..CR-3) — round-3: production release-default wiring

Deployment restart required: Rust services (friday-hub plus the packaged hub_agent_run_server) must be restarted when this deploys so migrations v107 (setup-bootstrap login-challenge) and v108 (provider-mutation approval-consumption ledger) are applied and served consistently across the TS and Rust read paths.

### What this is
CORE-A makes Friday's core public user-path real on the release-default seam (owner bootstrap → provider setup → session/agent execution), per R14 CORE-RUNNABLE-001. Round 1 drew a 5-finding NEEDS_CHANGES (redesigned per the Advisor's Option-C ruling on the anchor fork); round 2 drew a 4-finding NEEDS_CHANGES because that redesign proved the mechanism in isolation but had not wired it into the production release-default path. This head closes those four production-wiring findings.

### Round-2 findings closed
- **#2 (foundational) — production principal binding.** `deviceKeyLogin` keeps `principalId=user.id`; the gate and `providers.plan.confirm` resolve the authenticated owner's durable device binding server-side from the `users.password_hash = device-owner$v1$<sentinelHash>` sentinel and bind the approval's signing key to it (`sha256Hex(approval.deviceProof.devicePublicKey.value) === boundSentinelHash`) — the same convention device-login already trusts (no new weakness), keeping the existing canonical self-consistency. The fabricated device-owner test token is deleted; a production public-seam test drives owner-bootstrap→deviceKeyLogin→plan→confirm→mutate through the real runtime with `principalId=user.id` and admits; different-device / passphrase-owner / cross-user are all refused.
- **#1 — CR-1 native surface wired.** `createFridayApiRuntime` now supplies `resolveNativeOwnerClaimContext` and `nativeOwnerClaimSurfaceAvailable`; on a release profile the surface is present (the UI routes to the device gate and fresh passphrase creation is retired) while the capability stays unmintable on an unsigned tree (honest-false; `NATIVE_IPC_ATTESTATION_AVAILABLE` unchanged `false as const`); dev/CI stays honest-false; legacy passphrase login and migration remain.
- **#3 — durable single-use approval.** Migration v108 adds a durable consumption ledger (mirrors DUR-OPERATION-JOURNAL-001); the consume runs in the same write transaction as the provider mutation (first statement of the service persist transaction) so a crash rolls both back and boot-reconcile marks the orphan indeterminate. Restart replay of a confirmed approval yields `canonical_approval_already_used` with zero second effect (proven via a real sqlite close+reopen); concurrent replay yields a single winner.
- **#4 — Rust server packaged and served.** The DMG and source-distribution builds stage `hub_agent_run_server` + `hub_agent_run_enroll` + the launchd plist; the installer launches and enrolls them; `install-smoke` step 9 launches the packaged server, enrolls a peer, and drives session create+append served by Rust with no route flag, mock, or TS fallback (real `rust_wired` receipts). The release profile routes agent-run to Rust with no `FRIDAY_*_VIA_RUST` flag; a missing server fails closed 503 rather than a silent TS fallback.

### Honesty (R14 §7) — external-leaf tails, flagged not faked
Every hop is real, not mocked, flag-gated, or fabricated. Three external tails remain, mapped to existing leaves: the signed DMG clean-install on a physical Mac (EXT-MAC-CANDIDATE-SIGNATURE-001 / EXT-MAC-PHYSICAL-INSTALL-LIFECYCLE-001) and a paid live provider turn (EXT-TEXT-PROVIDER-LIVE-EVIDENCE-001). The native capability is structurally unreachable on an unsigned tree. The authoritative 57 external leaves are unchanged; product_status=NO_GO, product_proof=false; no R13/R12/U19 requirement is removed or weakened. `CORE_RUNNABLE` stays 0/7 on evidence until a signed release + physical device + a paid turn complete the black-box loop.

### Verification
An independent fresh adversarial reviewer returned PASS on all six production-path probes (F2 binding sound with no fabricated principal; F1 honest-false-on-unsigned with the const untouched; F3 durable-across-restart via real sqlite readback + atomic consume-with-mutation; F4 install-smoke exit 0 with real Rust receipts; cross-lane green; the CORE-RUNNABLE path genuinely end-to-end). `typecheck:src` and the route-contract snapshot are clean; the affected vitest set plus three new production public-seam http-proof suites are green; `eslint` reports 0 errors; detect-secrets and the provider-key denylist are clean; the v107 and v108 migration tests pass.
